### PR TITLE
feat: factor out parseFrameMessage

### DIFF
--- a/src/core/getFrameAccountAddress.ts
+++ b/src/core/getFrameAccountAddress.ts
@@ -1,18 +1,9 @@
-import { HubRpcClient, Message, getSSLHubRpcClient } from '@farcaster/hub-nodejs';
-
-/**
- * Farcaster Hub for signature verification, consider using a private hub if needed:
- * https://docs.farcaster.xyz/hubble/hubble
- */
-const HUB_URL = 'nemes.farcaster.xyz:2283';
+import { parseFrameMessage } from './parseFrameMessage';
 
 type FidResponse = {
   verifications: string[];
 };
 
-function getHubClient(): HubRpcClient {
-  return getSSLHubRpcClient(HUB_URL);
-}
 /**
  * Get the Account Address from the Farcaster ID using the Frame.  This uses a Neynar api
  * to get verified addresses belonging to the user wht that FID.  This is using a demo api
@@ -25,22 +16,9 @@ async function getFrameAccountAddress(
   body: { trustedData?: { messageBytes?: string } },
   { NEYNAR_API_KEY = 'NEYNAR_API_DOCS' },
 ): Promise<string | undefined> {
-  let farcasterID = 0;
-  let validatedMessage: Message | undefined = undefined;
-  // Get the message from the request body
-  const frameMessage: Message = Message.decode(
-    Buffer.from(body?.trustedData?.messageBytes ?? '', 'hex'),
-  );
-  // Validate the message
-  const client = getHubClient();
-  const result = await client.validateMessage(frameMessage);
-  if (result.isOk() && result.value.valid && result.value.message) {
-    validatedMessage = result.value.message;
-  } else {
-    return;
-  }
+  const validatedMessage = await parseFrameMessage(body);
   // Get the Farcaster ID from the message
-  farcasterID = validatedMessage?.data?.fid ?? 0;
+  const farcasterID = validatedMessage?.data?.fid ?? 0;
   // Get the user verifications from the Farcaster Indexer
   const options = {
     method: 'GET',

--- a/src/core/parseFrameMessage.ts
+++ b/src/core/parseFrameMessage.ts
@@ -1,0 +1,33 @@
+import { HubRpcClient, Message, getSSLHubRpcClient } from '@farcaster/hub-nodejs';
+
+/**
+ * Farcaster Hub for signature verification, consider using a private hub if needed:
+ * https://docs.farcaster.xyz/hubble/hubble
+ */
+const HUB_URL = 'nemes.farcaster.xyz:2283';
+
+function getHubClient(): HubRpcClient {
+  return getSSLHubRpcClient(HUB_URL);
+}
+
+/**
+ * Given a frame message, decode and validate it. If message is valid,
+ * return the message. Otherwise undefined.
+ * @param body The JSON received by server on frame callback
+ */
+async function parseFrameMessage(body: { trustedData?: { messageBytes?: string } }) {
+  let validatedMessage: Message | undefined = undefined;
+  // Get the message from the request body
+  const frameMessage: Message = Message.decode(
+    Buffer.from(body?.trustedData?.messageBytes ?? '', 'hex'),
+  );
+  // Validate the message
+  const client = getHubClient();
+  const result = await client.validateMessage(frameMessage);
+  if (result.isOk() && result.value.valid && result.value.message) {
+    validatedMessage = result.value.message;
+  }
+  return validatedMessage;
+}
+
+export { parseFrameMessage };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ const version = '0.1.5';
 export { version };
 export { getFrameAccountAddress } from './core/getFrameAccountAddress';
 export { getFrameMetadata } from './core/getFrameMetadata';
+export { parseFrameMessage } from './core/parseFrameMessage';


### PR DESCRIPTION
**What changed? Why?**
While working with frames, it's beneficial to be able to get the whole validated message. Since we parse and validate the message as part of `getFrameAccountAddress`, I pulled the relevant code out into a new function.

**Notes to reviewers**

**How has it been tested?**
yolo'd this, would love to hear any strategies for testing
edit: did manually test in a frame by copying code over and it appears to work
