### PR TITLE
fix: Refactor Farcaster typing to be explicit

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prebuild": "rimraf dist",
     "test": "jest --testPathIgnorePatterns=\\.integ\\.",
     "test:integration": "jest --testPathIgnorePatterns=\\.test\\.",
+    "test:all": "jest .",
     "test:coverage": "jest . --coverage ",
     "release:check": "changeset status --verbose --since=origin/main",
     "release:publish": "yarn install && yarn build && changeset publish",

--- a/src/core/farcaster.integ.ts
+++ b/src/core/farcaster.integ.ts
@@ -1,0 +1,29 @@
+import { getFrameValidatedMessage } from './getFrameValidatedMessage';
+
+describe('getFrameValidatedMessage integration tests', () => {
+  it('bulk data lookup should find all users', async () => {
+    const body = {
+      untrustedData: {
+        fid: 194519,
+        url: 'https://frame-demo.vercel.app/2',
+        messageHash: '0x7099de8afb08984d53f56a02b28d0f96097bfd82',
+        timestamp: 1706559790000,
+        network: 1,
+        buttonIndex: 1,
+        castId: { fid: 194519, hash: '0x3d7c0dac1dd0ee588eb58d07105b14786cfca976' },
+      },
+      trustedData: {
+        messageBytes:
+          '0a4f080d10d7ef0b18aec6a62e200182013f0a1f68747470733a2f2f6672616d652d64656d6f2e76657263656c2e6170702f321001' +
+          '1a1a08d7ef0b12143d7c0dac1dd0ee588eb58d07105b14786cfca97612147099de8afb08984d53f56a02b28d0f96097bfd82180122' +
+          '40f40c2e4221589ed569c76fdb285ee2a0ccb1b65954d4c879db6af051c3dd3135655b2f0df1a846d7255194c232072219e8192635' +
+          '3120c8908678a00f4f42e805280132208d36f374eb10e27853496cfa342b9021acc7bf3c26262501259657c4bb15a149',
+      },
+    };
+    const response = await getFrameValidatedMessage(body);
+    expect(response?.data.url).toEqual(body.untrustedData.url);
+    expect(response?.data.fid).toEqual(body.untrustedData.fid);
+    expect(response?.data.network).toEqual(body.untrustedData.network);
+    expect(response?.data.castId.fid).toEqual(body.untrustedData.castId.fid);
+  });
+});

--- a/src/core/farcaster.integ.ts
+++ b/src/core/farcaster.integ.ts
@@ -21,9 +21,10 @@ describe('getFrameValidatedMessage integration tests', () => {
       },
     };
     const response = await getFrameValidatedMessage(body);
-    expect(response?.data.url).toEqual(body.untrustedData.url);
-    expect(response?.data.fid).toEqual(body.untrustedData.fid);
-    expect(response?.data.network).toEqual(body.untrustedData.network);
-    expect(response?.data.castId.fid).toEqual(body.untrustedData.castId.fid);
+    expect(response?.isValid).toEqual(true);
+    expect(response?.data?.url).toEqual(body.untrustedData.url);
+    expect(response?.data?.fid).toEqual(body.untrustedData.fid);
+    expect(response?.data?.network).toEqual(body.untrustedData.network);
+    expect(response?.data?.castId.fid).toEqual(body.untrustedData.castId.fid);
   });
 });

--- a/src/core/farcaster.integ.ts
+++ b/src/core/farcaster.integ.ts
@@ -1,4 +1,4 @@
-import { getFrameValidatedMessage } from './getFrameValidatedMessage';
+import { getFrameMessage } from './getFrameMessage';
 
 describe('getFrameValidatedMessage integration tests', () => {
   it('bulk data lookup should find all users', async () => {
@@ -20,11 +20,11 @@ describe('getFrameValidatedMessage integration tests', () => {
           '3120c8908678a00f4f42e805280132208d36f374eb10e27853496cfa342b9021acc7bf3c26262501259657c4bb15a149',
       },
     };
-    const response = await getFrameValidatedMessage(body);
+    const response = await getFrameMessage(body);
     expect(response?.isValid).toEqual(true);
-    expect(response?.data?.url).toEqual(body.untrustedData.url);
-    expect(response?.data?.fid).toEqual(body.untrustedData.fid);
-    expect(response?.data?.network).toEqual(body.untrustedData.network);
-    expect(response?.data?.castId.fid).toEqual(body.untrustedData.castId.fid);
+    expect(response?.message?.url).toEqual(body.untrustedData.url);
+    expect(response?.message?.fid).toEqual(body.untrustedData.fid);
+    expect(response?.message?.network).toEqual(body.untrustedData.network);
+    expect(response?.message?.castId.fid).toEqual(body.untrustedData.castId.fid);
   });
 });

--- a/src/core/farcasterTypes.ts
+++ b/src/core/farcasterTypes.ts
@@ -1,0 +1,38 @@
+export interface FrameRequest {
+  untrustedData: FrameData;
+  trustedData: {
+    messageBytes: string;
+  };
+}
+
+export interface FrameResponse {
+  data: FrameData;
+}
+
+export interface FrameData {
+  fid: number;
+  url: string;
+  messageHash: string;
+  timestamp: number;
+  network: number;
+  buttonIndex: number;
+  castId: {
+    fid: number;
+    hash: string;
+  };
+}
+
+export function convertToFrame(json: any) {
+  return {
+    fid: json.fid,
+    url: json.frameActionBody?.url.toString(),
+    messageHash: json.messageHash,
+    timestamp: json.timestamp,
+    network: json.network,
+    buttonIndex: json.frameActionBody?.buttonIndex,
+    castId: {
+      fid: json.frameActionBody?.castId?.fid,
+      hash: json.frameActionBody?.castId?.hash,
+    },
+  };
+}

--- a/src/core/farcasterTypes.ts
+++ b/src/core/farcasterTypes.ts
@@ -5,10 +5,9 @@ export interface FrameRequest {
   };
 }
 
-export interface FrameValidationResponse {
-  isValid: boolean;
-  data?: FrameData;
-}
+export type FrameValidationResponse =
+  | { isValid: true; message: FrameData }
+  | { isValid: false; message: undefined };
 
 export interface FrameData {
   fid: number;

--- a/src/core/farcasterTypes.ts
+++ b/src/core/farcasterTypes.ts
@@ -5,8 +5,9 @@ export interface FrameRequest {
   };
 }
 
-export interface FrameResponse {
-  data: FrameData;
+export interface FrameValidationResponse {
+  isValid: boolean;
+  data?: FrameData;
 }
 
 export interface FrameData {

--- a/src/core/getFrameAccountAddress.test.ts
+++ b/src/core/getFrameAccountAddress.test.ts
@@ -1,6 +1,7 @@
 import { getFrameAccountAddress } from './getFrameAccountAddress';
 import { mockNeynarResponse } from './mock';
 import { neynarBulkUserLookup } from '../utils/neynar/user/neynarUserFunctions';
+import { FrameRequest } from './farcasterTypes';
 
 jest.mock('../utils/neynar/user/neynarUserFunctions', () => {
   return {
@@ -32,7 +33,7 @@ describe('getFrameAccountAddress', () => {
     const addresses = ['0xaddr1'];
     mockNeynarResponse(fid, addresses, neynarBulkUserLookup as jest.Mock);
 
-    const response = await getFrameAccountAddress(fakeFrameData, fakeApiKey);
+    const response = await getFrameAccountAddress(fakeFrameData as FrameRequest, fakeApiKey);
     expect(response).toEqual(addresses[0]);
   });
 
@@ -46,7 +47,7 @@ describe('getFrameAccountAddress', () => {
         return false;
       },
     });
-    const response = await getFrameAccountAddress(fakeFrameData, fakeApiKey);
+    const response = await getFrameAccountAddress(fakeFrameData as FrameRequest, fakeApiKey);
     expect(response).toEqual(undefined);
   });
 });

--- a/src/core/getFrameAccountAddress.ts
+++ b/src/core/getFrameAccountAddress.ts
@@ -1,4 +1,4 @@
-import { getFrameValidatedMessage } from './getFrameValidatedMessage';
+import { getFrameMessage } from './getFrameMessage';
 import { neynarBulkUserLookup } from '../utils/neynar/user/neynarUserFunctions';
 import { FrameRequest } from './farcasterTypes';
 
@@ -21,12 +21,12 @@ async function getFrameAccountAddress(
   body: FrameRequest,
   { NEYNAR_API_KEY = 'NEYNAR_API_DOCS' },
 ): Promise<string | undefined> {
-  const validatedMessage = await getFrameValidatedMessage(body);
+  const validatedMessage = await getFrameMessage(body);
   if (!validatedMessage?.isValid) {
     return;
   }
   // Get the Farcaster ID from the message
-  const farcasterID = validatedMessage?.data?.fid ?? 0;
+  const farcasterID = validatedMessage?.message?.fid ?? 0;
   // Get the user verifications from the Farcaster Indexer
   const bulkUserLookupResponse = await neynarBulkUserLookup([farcasterID]);
   if (bulkUserLookupResponse?.users) {

--- a/src/core/getFrameAccountAddress.ts
+++ b/src/core/getFrameAccountAddress.ts
@@ -1,5 +1,6 @@
 import { getFrameValidatedMessage } from './getFrameValidatedMessage';
 import { neynarBulkUserLookup } from '../utils/neynar/user/neynarUserFunctions';
+import { FrameRequest } from './farcasterTypes';
 
 type FidResponse = {
   verifications: string[];
@@ -17,7 +18,7 @@ type FidResponse = {
  * @returns
  */
 async function getFrameAccountAddress(
-  body: { trustedData?: { messageBytes?: string } },
+  body: FrameRequest,
   { NEYNAR_API_KEY = 'NEYNAR_API_DOCS' },
 ): Promise<string | undefined> {
   const validatedMessage = await getFrameValidatedMessage(body);

--- a/src/core/getFrameAccountAddress.ts
+++ b/src/core/getFrameAccountAddress.ts
@@ -22,7 +22,7 @@ async function getFrameAccountAddress(
   { NEYNAR_API_KEY = 'NEYNAR_API_DOCS' },
 ): Promise<string | undefined> {
   const validatedMessage = await getFrameValidatedMessage(body);
-  if (!validatedMessage) {
+  if (!validatedMessage?.isValid) {
     return;
   }
   // Get the Farcaster ID from the message

--- a/src/core/getFrameMessage.ts
+++ b/src/core/getFrameMessage.ts
@@ -19,9 +19,7 @@ export function getHubClient(): HubRpcClient {
  *
  * @param body The JSON received by server on frame callback
  */
-async function getFrameValidatedMessage(
-  body: FrameRequest,
-): Promise<FrameValidationResponse | undefined> {
+async function getFrameMessage(body: FrameRequest): Promise<FrameValidationResponse | undefined> {
   // Get the message from the request body
   const frameMessage: Message = Message.decode(
     Buffer.from(body?.trustedData?.messageBytes ?? '', 'hex'),
@@ -32,12 +30,13 @@ async function getFrameValidatedMessage(
   if (result.isOk() && result.value.valid && result.value.message) {
     return {
       isValid: result.value?.valid,
-      data: convertToFrame(result?.value?.message?.data),
+      message: convertToFrame(result?.value?.message?.data),
     };
   }
   return {
     isValid: false,
+    message: undefined,
   };
 }
 
-export { getFrameValidatedMessage };
+export { getFrameMessage };

--- a/src/core/getFrameValidatedMessage.test.ts
+++ b/src/core/getFrameValidatedMessage.test.ts
@@ -34,7 +34,7 @@ describe('getFrameValidatedMessage', () => {
     const result = await getFrameValidatedMessage({
       trustedData: { messageBytes: 'invalid' },
     } as FrameRequest);
-    expect(result).toBeUndefined();
+    expect(result?.isValid).toEqual(false);
   });
 
   it('should return the message if the message is valid', async () => {
@@ -45,6 +45,6 @@ describe('getFrameValidatedMessage', () => {
       trustedData: {},
     };
     const result = await getFrameValidatedMessage(fakeFrameData as FrameRequest);
-    expect(result?.data.fid).toEqual(fid);
+    expect(result?.data?.fid).toEqual(fid);
   });
 });

--- a/src/core/getFrameValidatedMessage.test.ts
+++ b/src/core/getFrameValidatedMessage.test.ts
@@ -1,5 +1,5 @@
 import { mockNeynarResponse } from './mock';
-import { getFrameValidatedMessage } from './getFrameValidatedMessage';
+import { getFrameMessage } from './getFrameMessage';
 import { neynarBulkUserLookup } from '../utils/neynar/user/neynarUserFunctions';
 import { FrameRequest } from './farcasterTypes';
 
@@ -31,7 +31,7 @@ describe('getFrameValidatedMessage', () => {
         return false;
       },
     });
-    const result = await getFrameValidatedMessage({
+    const result = await getFrameMessage({
       trustedData: { messageBytes: 'invalid' },
     } as FrameRequest);
     expect(result?.isValid).toEqual(false);
@@ -44,7 +44,7 @@ describe('getFrameValidatedMessage', () => {
     const fakeFrameData = {
       trustedData: {},
     };
-    const result = await getFrameValidatedMessage(fakeFrameData as FrameRequest);
-    expect(result?.data?.fid).toEqual(fid);
+    const result = await getFrameMessage(fakeFrameData as FrameRequest);
+    expect(result?.message?.fid).toEqual(fid);
   });
 });

--- a/src/core/getFrameValidatedMessage.test.ts
+++ b/src/core/getFrameValidatedMessage.test.ts
@@ -1,6 +1,7 @@
 import { mockNeynarResponse } from './mock';
 import { getFrameValidatedMessage } from './getFrameValidatedMessage';
 import { neynarBulkUserLookup } from '../utils/neynar/user/neynarUserFunctions';
+import { FrameRequest } from './farcasterTypes';
 
 jest.mock('../utils/neynar/user/neynarUserFunctions', () => {
   return {
@@ -32,7 +33,7 @@ describe('getFrameValidatedMessage', () => {
     });
     const result = await getFrameValidatedMessage({
       trustedData: { messageBytes: 'invalid' },
-    });
+    } as FrameRequest);
     expect(result).toBeUndefined();
   });
 
@@ -43,7 +44,7 @@ describe('getFrameValidatedMessage', () => {
     const fakeFrameData = {
       trustedData: {},
     };
-    const result = await getFrameValidatedMessage(fakeFrameData);
-    expect(result).toEqual({ data: { fid } });
+    const result = await getFrameValidatedMessage(fakeFrameData as FrameRequest);
+    expect(result?.data.fid).toEqual(fid);
   });
 });

--- a/src/core/getFrameValidatedMessage.ts
+++ b/src/core/getFrameValidatedMessage.ts
@@ -1,4 +1,5 @@
 import { HubRpcClient, Message, getSSLHubRpcClient } from '@farcaster/hub-nodejs';
+import { convertToFrame, FrameRequest, FrameResponse } from './farcasterTypes';
 
 /**
  * Farcaster Hub for signature verification,
@@ -18,9 +19,7 @@ export function getHubClient(): HubRpcClient {
  *
  * @param body The JSON received by server on frame callback
  */
-async function getFrameValidatedMessage(body: {
-  trustedData?: { messageBytes?: string };
-}): Promise<Message | undefined> {
+async function getFrameValidatedMessage(body: FrameRequest): Promise<FrameResponse | undefined> {
   // Get the message from the request body
   const frameMessage: Message = Message.decode(
     Buffer.from(body?.trustedData?.messageBytes ?? '', 'hex'),
@@ -29,7 +28,9 @@ async function getFrameValidatedMessage(body: {
   const client = getHubClient();
   const result = await client.validateMessage(frameMessage);
   if (result.isOk() && result.value.valid && result.value.message) {
-    return result.value.message;
+    return {
+      data: convertToFrame(result?.value?.message?.data),
+    };
   }
   return;
 }

--- a/src/core/getFrameValidatedMessage.ts
+++ b/src/core/getFrameValidatedMessage.ts
@@ -1,5 +1,5 @@
 import { HubRpcClient, Message, getSSLHubRpcClient } from '@farcaster/hub-nodejs';
-import { convertToFrame, FrameRequest, FrameResponse } from './farcasterTypes';
+import { convertToFrame, FrameRequest, FrameValidationResponse } from './farcasterTypes';
 
 /**
  * Farcaster Hub for signature verification,
@@ -19,7 +19,9 @@ export function getHubClient(): HubRpcClient {
  *
  * @param body The JSON received by server on frame callback
  */
-async function getFrameValidatedMessage(body: FrameRequest): Promise<FrameResponse | undefined> {
+async function getFrameValidatedMessage(
+  body: FrameRequest,
+): Promise<FrameValidationResponse | undefined> {
   // Get the message from the request body
   const frameMessage: Message = Message.decode(
     Buffer.from(body?.trustedData?.messageBytes ?? '', 'hex'),
@@ -29,10 +31,13 @@ async function getFrameValidatedMessage(body: FrameRequest): Promise<FrameRespon
   const result = await client.validateMessage(frameMessage);
   if (result.isOk() && result.value.valid && result.value.message) {
     return {
+      isValid: result.value?.valid,
       data: convertToFrame(result?.value?.message?.data),
     };
   }
-  return;
+  return {
+    isValid: false,
+  };
 }
 
 export { getFrameValidatedMessage };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@ const version = '0.1.6';
 export { version };
 export { getFrameAccountAddress } from './core/getFrameAccountAddress';
 export { getFrameMetadata } from './core/getFrameMetadata';
-export { getFrameValidatedMessage } from './core/getFrameValidatedMessage';
+export { getFrameMessage } from './core/getFrameMessage';

--- a/src/utils/neynar/neynar.integ.ts
+++ b/src/utils/neynar/neynar.integ.ts
@@ -1,6 +1,6 @@
 import { neynarBulkUserLookup } from './user/neynarUserFunctions';
 
-describe('integration tests', () => {
+describe('neynar integration tests', () => {
   it('bulk data lookup should find all users', async () => {
     const fidsToLookup = [3, 194519]; // dwr and polak.eth fids
     const response = await neynarBulkUserLookup(fidsToLookup);


### PR DESCRIPTION
**What changed? Why?**
1. Be more explicit on our Farcaster request / response types.
   2.  Decided against importing the Farcaster types from @farcaster/hub-nodejs as the object types were more complex and could confuse consumers.  Extract + simplify the interface.
1.   Added a farcaster message verification integration test.

**Notes to reviewers**

**How has it been tested?**

```
 yarn test
 PASS  src/utils/neynar/user/neynarUserFunctions.test.ts
 PASS  src/core/getFrameValidatedMessage.test.ts
 PASS  src/core/getFrameMetadata.test.ts
 PASS  src/core/getFrameAccountAddress.test.ts

Test Suites: 4 passed, 4 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        1.876 s, estimated 2 s
Ran all test suites.

```

```
❯ yarn test:integration         
 PASS  src/utils/neynar/neynar.integ.ts
 PASS  src/core/farcaster.integ.ts

Test Suites: 2 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        2.399 s
Ran all test suites.

```