### PR TITLE
fix: have `getFrameAccountAddress` reading from the `message`

### DIFF
--- a/src/core/getFrameAccountAddress.test.ts
+++ b/src/core/getFrameAccountAddress.test.ts
@@ -1,7 +1,7 @@
 import { getFrameAccountAddress } from './getFrameAccountAddress';
 import { mockNeynarResponse } from './mock';
 import { neynarBulkUserLookup } from '../utils/neynar/user/neynarUserFunctions';
-import { FrameRequest } from './farcasterTypes';
+import { FrameData } from './farcasterTypes';
 
 jest.mock('../utils/neynar/user/neynarUserFunctions', () => {
   return {
@@ -21,33 +21,25 @@ jest.mock('@farcaster/hub-nodejs', () => {
 });
 
 describe('getFrameAccountAddress', () => {
-  const fakeFrameData = {
-    trustedData: {},
+  const fakeMessage = {
+    fid: 1234,
   };
   const fakeApiKey = {
     NEYNAR_API_KEY: '1234',
   };
 
   it('should return the first verification for valid input', async () => {
-    const fid = 1234;
     const addresses = ['0xaddr1'];
-    mockNeynarResponse(fid, addresses, neynarBulkUserLookup as jest.Mock);
+    mockNeynarResponse(fakeMessage.fid, addresses, neynarBulkUserLookup as jest.Mock);
 
-    const response = await getFrameAccountAddress(fakeFrameData as FrameRequest, fakeApiKey);
+    const response = await getFrameAccountAddress(fakeMessage as FrameData, fakeApiKey);
     expect(response).toEqual(addresses[0]);
   });
 
-  it('when the call from farcaster fails we should return undefined', async () => {
-    const fid = 1234;
-    const addresses = ['0xaddr1'];
-    const { validateMock } = mockNeynarResponse(fid, addresses, neynarBulkUserLookup as jest.Mock);
-    validateMock.mockClear();
-    validateMock.mockResolvedValue({
-      isOk: () => {
-        return false;
-      },
-    });
-    const response = await getFrameAccountAddress(fakeFrameData as FrameRequest, fakeApiKey);
-    expect(response).toEqual(undefined);
+  it('should return undefined for invalid input', async () => {
+    mockNeynarResponse(fakeMessage.fid, undefined, neynarBulkUserLookup as jest.Mock);
+
+    const response = await getFrameAccountAddress(fakeMessage as FrameData, fakeApiKey);
+    expect(response).toBeUndefined();
   });
 });

--- a/src/core/getFrameAccountAddress.ts
+++ b/src/core/getFrameAccountAddress.ts
@@ -1,6 +1,5 @@
-import { getFrameMessage } from './getFrameMessage';
 import { neynarBulkUserLookup } from '../utils/neynar/user/neynarUserFunctions';
-import { FrameRequest } from './farcasterTypes';
+import { FrameData } from './farcasterTypes';
 
 type FidResponse = {
   verifications: string[];
@@ -15,20 +14,16 @@ type AccountAddressResponse = Promise<string | undefined>;
  *
  * This is using a demo api key so please register
  * on through https://neynar.com/.
- * @param body The JSON received by server on frame callback
+ * @param message The validated message from the Frame
  * @param NEYNAR_API_KEY The api key for the Neynar API
  * @returns The account address or undefined
  */
 async function getFrameAccountAddress(
-  body: FrameRequest,
+  message: FrameData,
   { NEYNAR_API_KEY = 'NEYNAR_API_DOCS' },
 ): AccountAddressResponse {
-  const validatedMessage = await getFrameMessage(body);
-  if (!validatedMessage?.isValid) {
-    return;
-  }
   // Get the Farcaster ID from the message
-  const farcasterID = validatedMessage?.message?.fid ?? 0;
+  const farcasterID = message.fid ?? 0;
   // Get the user verifications from the Farcaster Indexer
   const bulkUserLookupResponse = await neynarBulkUserLookup([farcasterID], NEYNAR_API_KEY);
   if (bulkUserLookupResponse?.users) {

--- a/src/core/mock.ts
+++ b/src/core/mock.ts
@@ -14,7 +14,11 @@ export function buildFarcasterResponse(fid: number) {
   };
 }
 
-export function mockNeynarResponse(fid: number, addresses: string[], lookupMock: jest.Mock) {
+export function mockNeynarResponse(
+  fid: number,
+  addresses: string[] | undefined,
+  lookupMock: jest.Mock,
+) {
   const neynarResponse = {
     users: [
       {


### PR DESCRIPTION
**What changed? Why?**
Have `getFrameAccountAddress` reading from the `message` instead of the `body`.

The idea is that the `body` should be read only from `getFrameMessage`, and then the `message` is re-used in different places.

**Notes to reviewers**

**How has it been tested?**
