### PR TITLE
Add Text Input metadata support

### DIFF
--- a/src/core/farcasterTypes.ts
+++ b/src/core/farcasterTypes.ts
@@ -61,9 +61,14 @@ export type FrameButtonMetadata = {
   action?: 'post' | 'post_redirect';
 };
 
+export type FrameInputMetadata = {
+  prompt_text: string;
+};
+
 export type FrameMetadata = {
-  buttons?: [FrameButtonMetadata, ...FrameButtonMetadata[]];
   image: string;
+  input?: FrameInputMetadata;
+  buttons?: [FrameButtonMetadata, ...FrameButtonMetadata[]];
   post_url?: string;
   refresh_period?: number;
 };

--- a/src/core/farcasterTypes.ts
+++ b/src/core/farcasterTypes.ts
@@ -66,9 +66,9 @@ export type FrameInputMetadata = {
 };
 
 export type FrameMetadata = {
+  buttons?: [FrameButtonMetadata, ...FrameButtonMetadata[]];
   image: string;
   input?: FrameInputMetadata;
-  buttons?: [FrameButtonMetadata, ...FrameButtonMetadata[]];
   post_url?: string;
   refresh_period?: number;
 };

--- a/src/core/farcasterTypes.ts
+++ b/src/core/farcasterTypes.ts
@@ -62,7 +62,7 @@ export type FrameButtonMetadata = {
 };
 
 export type FrameInputMetadata = {
-  prompt_text: string;
+  text: string;
 };
 
 export type FrameMetadata = {

--- a/src/core/getFrameHtmlResponse.test.ts
+++ b/src/core/getFrameHtmlResponse.test.ts
@@ -42,9 +42,9 @@ describe('getFrameHtmlResponse', () => {
     expect(html).toContain('<meta property="fc:frame" content="vNext" />');
     expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).toContain(
-    expect(html).toContain(
       '<meta property="fc:frame:image" content="https://example.com/image.png" />',
     );
+    expect(html).toContain(
       '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />',
     );
     expect(html).not.toContain('fc:frame:input:text');

--- a/src/core/getFrameHtmlResponse.test.ts
+++ b/src/core/getFrameHtmlResponse.test.ts
@@ -19,13 +19,13 @@ describe('getFrameHtmlResponse', () => {
 
     expect(html).toBe(
       '<!DOCTYPE html><html><head><meta property="fc:frame" content="vNext" />' +
+        '<meta property="fc:frame:image" content="https://example.com/image.png" />' +
         '<meta property="fc:frame:button:1" content="button1" />' +
         '<meta property="fc:frame:button:1:action" content="post" />' +
         '<meta property="fc:frame:button:2" content="button2" />' +
         '<meta property="fc:frame:button:3" content="button3" />' +
         '<meta property="fc:frame:button:3:action" content="post_redirect" />' +
         '<meta property="fc:frame:button:4" content="button4" />' +
-        '<meta property="fc:frame:image" content="https://example.com/image.png" />' +
         '<meta property="fc:frame:input:text" content="Enter a message..." />' +
         '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />' +
         '<meta property="fc:frame:refresh_period" content="10" /></head></html>',
@@ -73,10 +73,10 @@ describe('getFrameHtmlResponse', () => {
     });
 
     expect(html).toContain('<meta property="fc:frame" content="vNext" />');
-    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).toContain(
       '<meta property="fc:frame:image" content="https://example.com/image.png" />',
     );
+    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).not.toContain('fc:frame:post_url');
   });
 
@@ -88,10 +88,10 @@ describe('getFrameHtmlResponse', () => {
     });
 
     expect(html).toContain('<meta property="fc:frame" content="vNext" />');
-    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).toContain(
       '<meta property="fc:frame:image" content="https://example.com/image.png" />',
     );
+    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).toContain(
       '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />',
     );

--- a/src/core/getFrameHtmlResponse.test.ts
+++ b/src/core/getFrameHtmlResponse.test.ts
@@ -3,30 +3,30 @@ import { getFrameHtmlResponse } from './getFrameHtmlResponse';
 describe('getFrameHtmlResponse', () => {
   it('should return correct HTML with all parameters', () => {
     const html = getFrameHtmlResponse({
-      image: 'https://example.com/image.png',
-      input: {
-        prompt_text: 'Enter a message...',
-      },
       buttons: [
         { label: 'button1', action: 'post' },
         { label: 'button2' },
         { label: 'button3', action: 'post_redirect' },
         { label: 'button4' },
       ],
+      image: 'https://example.com/image.png',
+      input: {
+        text: 'Enter a message...',
+      },
       post_url: 'https://example.com/api/frame',
       refresh_period: 10,
     });
 
     expect(html).toBe(
       '<!DOCTYPE html><html><head><meta property="fc:frame" content="vNext" />' +
-        '<meta property="fc:frame:image" content="https://example.com/image.png" />' +
-        '<meta property="fc:frame:input:text" content="Enter a message..." />' +
         '<meta property="fc:frame:button:1" content="button1" />' +
         '<meta property="fc:frame:button:1:action" content="post" />' +
         '<meta property="fc:frame:button:2" content="button2" />' +
         '<meta property="fc:frame:button:3" content="button3" />' +
         '<meta property="fc:frame:button:3:action" content="post_redirect" />' +
         '<meta property="fc:frame:button:4" content="button4" />' +
+        '<meta property="fc:frame:image" content="https://example.com/image.png" />' +
+        '<meta property="fc:frame:input:text" content="Enter a message..." />' +
         '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />' +
         '<meta property="fc:frame:refresh_period" content="10" /></head></html>',
     );
@@ -34,17 +34,17 @@ describe('getFrameHtmlResponse', () => {
 
   it('should handle no input', () => {
     const html = getFrameHtmlResponse({
-      image: 'https://example.com/image.png',
       buttons: [{ label: 'button1' }],
+      image: 'https://example.com/image.png',
       post_url: 'https://example.com/api/frame',
     });
 
     expect(html).toContain('<meta property="fc:frame" content="vNext" />');
+    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
+    expect(html).toContain(
     expect(html).toContain(
       '<meta property="fc:frame:image" content="https://example.com/image.png" />',
     );
-    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
-    expect(html).toContain(
       '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />',
     );
     expect(html).not.toContain('fc:frame:input:text');
@@ -73,10 +73,10 @@ describe('getFrameHtmlResponse', () => {
     });
 
     expect(html).toContain('<meta property="fc:frame" content="vNext" />');
+    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).toContain(
       '<meta property="fc:frame:image" content="https://example.com/image.png" />',
     );
-    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).not.toContain('fc:frame:post_url');
   });
 
@@ -88,10 +88,10 @@ describe('getFrameHtmlResponse', () => {
     });
 
     expect(html).toContain('<meta property="fc:frame" content="vNext" />');
+    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).toContain(
       '<meta property="fc:frame:image" content="https://example.com/image.png" />',
     );
-    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
     expect(html).toContain(
       '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />',
     );

--- a/src/core/getFrameHtmlResponse.test.ts
+++ b/src/core/getFrameHtmlResponse.test.ts
@@ -3,13 +3,16 @@ import { getFrameHtmlResponse } from './getFrameHtmlResponse';
 describe('getFrameHtmlResponse', () => {
   it('should return correct HTML with all parameters', () => {
     const html = getFrameHtmlResponse({
+      image: 'https://example.com/image.png',
+      input: {
+        prompt_text: 'Enter a message...',
+      },
       buttons: [
         { label: 'button1', action: 'post' },
         { label: 'button2' },
         { label: 'button3', action: 'post_redirect' },
         { label: 'button4' },
       ],
-      image: 'https://example.com/image.png',
       post_url: 'https://example.com/api/frame',
       refresh_period: 10,
     });
@@ -17,6 +20,7 @@ describe('getFrameHtmlResponse', () => {
     expect(html).toBe(
       '<!DOCTYPE html><html><head><meta property="fc:frame" content="vNext" />' +
         '<meta property="fc:frame:image" content="https://example.com/image.png" />' +
+        '<meta property="fc:frame:input:text" content="Enter a message..." />' +
         '<meta property="fc:frame:button:1" content="button1" />' +
         '<meta property="fc:frame:button:1:action" content="post" />' +
         '<meta property="fc:frame:button:2" content="button2" />' +
@@ -26,6 +30,24 @@ describe('getFrameHtmlResponse', () => {
         '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />' +
         '<meta property="fc:frame:refresh_period" content="10" /></head></html>',
     );
+  });
+
+  it('should handle no input', () => {
+    const html = getFrameHtmlResponse({
+      image: 'https://example.com/image.png',
+      buttons: [{ label: 'button1' }],
+      post_url: 'https://example.com/api/frame',
+    });
+
+    expect(html).toContain('<meta property="fc:frame" content="vNext" />');
+    expect(html).toContain(
+      '<meta property="fc:frame:image" content="https://example.com/image.png" />',
+    );
+    expect(html).toContain('<meta property="fc:frame:button:1" content="button1" />');
+    expect(html).toContain(
+      '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />',
+    );
+    expect(html).not.toContain('fc:frame:input:text');
   });
 
   it('should handle no buttons', () => {

--- a/src/core/getFrameHtmlResponse.test.ts
+++ b/src/core/getFrameHtmlResponse.test.ts
@@ -20,13 +20,13 @@ describe('getFrameHtmlResponse', () => {
     expect(html).toBe(
       '<!DOCTYPE html><html><head><meta property="fc:frame" content="vNext" />' +
         '<meta property="fc:frame:image" content="https://example.com/image.png" />' +
+        '<meta property="fc:frame:input:text" content="Enter a message..." />' +
         '<meta property="fc:frame:button:1" content="button1" />' +
         '<meta property="fc:frame:button:1:action" content="post" />' +
         '<meta property="fc:frame:button:2" content="button2" />' +
         '<meta property="fc:frame:button:3" content="button3" />' +
         '<meta property="fc:frame:button:3:action" content="post_redirect" />' +
         '<meta property="fc:frame:button:4" content="button4" />' +
-        '<meta property="fc:frame:input:text" content="Enter a message..." />' +
         '<meta property="fc:frame:post_url" content="https://example.com/api/frame" />' +
         '<meta property="fc:frame:refresh_period" content="10" /></head></html>',
     );

--- a/src/core/getFrameHtmlResponse.ts
+++ b/src/core/getFrameHtmlResponse.ts
@@ -3,15 +3,27 @@ import { FrameMetadata } from './farcasterTypes';
 /**
  * Returns an HTML string containing metadata for a new valid frame.
  *
- * @param buttons: The buttons to use for the frame.
  * @param image: The image to use for the frame.
+ * @param input: The text input to use for the frame.
+ * @param buttons: The buttons to use for the frame.
  * @param post_url: The URL to post the frame to.
  * @param refresh_period: The refresh period for the image used.
  * @returns An HTML string containing metadata for the frame.
  */
-function getFrameHtmlResponse({ buttons, image, post_url, refresh_period }: FrameMetadata): string {
+function getFrameHtmlResponse({
+  image,
+  input,
+  buttons,
+  post_url,
+  refresh_period,
+}: FrameMetadata): string {
   // Set the image metadata if it exists.
   const imageHtml = image ? `<meta property="fc:frame:image" content="${image}" />` : '';
+
+  // Set the input metadata if it exists.
+  const inputHtml = input
+    ? `<meta property="fc:frame:input:text" content="${input.prompt_text}" />`
+    : '';
 
   // Set the button metadata if it exists.
   let buttonsHtml = '';
@@ -37,7 +49,7 @@ function getFrameHtmlResponse({ buttons, image, post_url, refresh_period }: Fram
 
   // Return the HTML string containing all the metadata.
   let html = '<!DOCTYPE html><html><head><meta property="fc:frame" content="vNext" />';
-  html += `${imageHtml}${buttonsHtml}${postUrlHtml}${refreshPeriodHtml}</head></html>`;
+  html += `${imageHtml}${inputHtml}${buttonsHtml}${postUrlHtml}${refreshPeriodHtml}</head></html>`;
 
   return html;
 }

--- a/src/core/getFrameHtmlResponse.ts
+++ b/src/core/getFrameHtmlResponse.ts
@@ -3,17 +3,17 @@ import { FrameMetadata } from './farcasterTypes';
 /**
  * Returns an HTML string containing metadata for a new valid frame.
  *
+ * @param buttons: The buttons to use for the frame.
  * @param image: The image to use for the frame.
  * @param input: The text input to use for the frame.
- * @param buttons: The buttons to use for the frame.
  * @param post_url: The URL to post the frame to.
  * @param refresh_period: The refresh period for the image used.
  * @returns An HTML string containing metadata for the frame.
  */
 function getFrameHtmlResponse({
+  buttons,
   image,
   input,
-  buttons,
   post_url,
   refresh_period,
 }: FrameMetadata): string {
@@ -22,7 +22,7 @@ function getFrameHtmlResponse({
 
   // Set the input metadata if it exists.
   const inputHtml = input
-    ? `<meta property="fc:frame:input:text" content="${input.prompt_text}" />`
+    ? `<meta property="fc:frame:input:text" content="${input.text}" />`
     : '';
 
   // Set the button metadata if it exists.

--- a/src/core/getFrameHtmlResponse.ts
+++ b/src/core/getFrameHtmlResponse.ts
@@ -21,9 +21,7 @@ function getFrameHtmlResponse({
   const imageHtml = image ? `<meta property="fc:frame:image" content="${image}" />` : '';
 
   // Set the input metadata if it exists.
-  const inputHtml = input
-    ? `<meta property="fc:frame:input:text" content="${input.text}" />`
-    : '';
+  const inputHtml = input ? `<meta property="fc:frame:input:text" content="${input.text}" />` : '';
 
   // Set the button metadata if it exists.
   let buttonsHtml = '';

--- a/src/core/getFrameMetadata.test.ts
+++ b/src/core/getFrameMetadata.test.ts
@@ -4,22 +4,22 @@ describe('getFrameMetadata', () => {
   it('should return the correct metadata', () => {
     expect(
       getFrameMetadata({
-        image: 'image',
         buttons: [
           { label: 'button1', action: 'post' },
           { label: 'button2', action: 'post_redirect' },
           { label: 'button3' },
         ],
+        image: 'image',
         post_url: 'post_url',
       }),
     ).toEqual({
       'fc:frame': 'vNext',
-      'fc:frame:image': 'image',
       'fc:frame:button:1': 'button1',
       'fc:frame:button:1:action': 'post',
       'fc:frame:button:2': 'button2',
       'fc:frame:button:2:action': 'post_redirect',
       'fc:frame:button:3': 'button3',
+      'fc:frame:image': 'image',
       'fc:frame:post_url': 'post_url',
     });
   });
@@ -27,14 +27,14 @@ describe('getFrameMetadata', () => {
   it('should return the correct metadata with one button', () => {
     expect(
       getFrameMetadata({
-        image: 'image',
         buttons: [{ label: 'button1' }],
+        image: 'image',
         post_url: 'post_url',
       }),
     ).toEqual({
       'fc:frame': 'vNext',
-      'fc:frame:image': 'image',
       'fc:frame:button:1': 'button1',
+      'fc:frame:image': 'image',
       'fc:frame:post_url': 'post_url',
     });
   });
@@ -42,15 +42,15 @@ describe('getFrameMetadata', () => {
   it('should return the correct metadata with refresh_period', () => {
     expect(
       getFrameMetadata({
-        image: 'image',
         buttons: [{ label: 'button1' }],
+        image: 'image',
         post_url: 'post_url',
         refresh_period: 10,
       }),
     ).toEqual({
       'fc:frame': 'vNext',
-      'fc:frame:image': 'image',
       'fc:frame:button:1': 'button1',
+      'fc:frame:image': 'image',
       'fc:frame:post_url': 'post_url',
       'fc:frame:refresh_period': '10',
     });
@@ -59,19 +59,19 @@ describe('getFrameMetadata', () => {
   it('should return the correct metadata with input', () => {
     expect(
       getFrameMetadata({
+        buttons: [{ label: 'button1' }],
         image: 'image',
         input: {
-          prompt_text: 'Enter a message...',
+          text: 'Enter a message...',
         },
-        buttons: [{ label: 'button1' }],
         post_url: 'post_url',
         refresh_period: 10,
       }),
     ).toEqual({
       'fc:frame': 'vNext',
+      'fc:frame:button:1': 'button1',
       'fc:frame:image': 'image',
       'fc:frame:input:text': 'Enter a message...',
-      'fc:frame:button:1': 'button1',
       'fc:frame:post_url': 'post_url',
       'fc:frame:refresh_period': '10',
     });

--- a/src/core/getFrameMetadata.test.ts
+++ b/src/core/getFrameMetadata.test.ts
@@ -4,22 +4,22 @@ describe('getFrameMetadata', () => {
   it('should return the correct metadata', () => {
     expect(
       getFrameMetadata({
+        image: 'image',
         buttons: [
           { label: 'button1', action: 'post' },
           { label: 'button2', action: 'post_redirect' },
           { label: 'button3' },
         ],
-        image: 'image',
         post_url: 'post_url',
       }),
     ).toEqual({
       'fc:frame': 'vNext',
+      'fc:frame:image': 'image',
       'fc:frame:button:1': 'button1',
       'fc:frame:button:1:action': 'post',
       'fc:frame:button:2': 'button2',
       'fc:frame:button:2:action': 'post_redirect',
       'fc:frame:button:3': 'button3',
-      'fc:frame:image': 'image',
       'fc:frame:post_url': 'post_url',
     });
   });
@@ -27,14 +27,14 @@ describe('getFrameMetadata', () => {
   it('should return the correct metadata with one button', () => {
     expect(
       getFrameMetadata({
-        buttons: [{ label: 'button1' }],
         image: 'image',
+        buttons: [{ label: 'button1' }],
         post_url: 'post_url',
       }),
     ).toEqual({
       'fc:frame': 'vNext',
-      'fc:frame:button:1': 'button1',
       'fc:frame:image': 'image',
+      'fc:frame:button:1': 'button1',
       'fc:frame:post_url': 'post_url',
     });
   });
@@ -42,32 +42,38 @@ describe('getFrameMetadata', () => {
   it('should return the correct metadata with refresh_period', () => {
     expect(
       getFrameMetadata({
-        buttons: [{ label: 'button1' }],
         image: 'image',
+        buttons: [{ label: 'button1' }],
         post_url: 'post_url',
         refresh_period: 10,
       }),
     ).toEqual({
       'fc:frame': 'vNext',
-      'fc:frame:button:1': 'button1',
       'fc:frame:image': 'image',
+      'fc:frame:button:1': 'button1',
       'fc:frame:post_url': 'post_url',
       'fc:frame:refresh_period': '10',
     });
   });
 
-  it('should return the correct metadata with no refresh_period', () => {
+  it('should return the correct metadata with input', () => {
     expect(
       getFrameMetadata({
-        buttons: [{ label: 'button1' }],
         image: 'image',
+        input: {
+          prompt_text: 'Enter a message...',
+        },
+        buttons: [{ label: 'button1' }],
         post_url: 'post_url',
+        refresh_period: 10,
       }),
     ).toEqual({
       'fc:frame': 'vNext',
-      'fc:frame:button:1': 'button1',
       'fc:frame:image': 'image',
+      'fc:frame:input:text': 'Enter a message...',
+      'fc:frame:button:1': 'button1',
       'fc:frame:post_url': 'post_url',
+      'fc:frame:refresh_period': '10',
     });
   });
 });

--- a/src/core/getFrameMetadata.ts
+++ b/src/core/getFrameMetadata.ts
@@ -4,17 +4,17 @@ type FrameMetadataResponse = Record<string, string>;
 
 /**
  * This function generates the metadata for a Farcaster Frame.
+ * @param buttons: The buttons to use for the frame.
  * @param image: The image to use for the frame.
  * @param input: The text input to use for the frame.
- * @param buttons: The buttons to use for the frame.
  * @param post_url: The URL to post the frame to.
  * @param refresh_period: The refresh period for the image used.
  * @returns The metadata for the frame.
  */
 export const getFrameMetadata = function ({
+  buttons,
   image,
   input,
-  buttons,
   post_url,
   refresh_period,
 }: FrameMetadata): FrameMetadataResponse {
@@ -23,7 +23,7 @@ export const getFrameMetadata = function ({
   };
   metadata['fc:frame:image'] = image;
   if (input) {
-    metadata['fc:frame:input:text'] = input.prompt_text;
+    metadata['fc:frame:input:text'] = input.text;
   }
   if (buttons) {
     buttons.forEach((button, index) => {

--- a/src/core/getFrameMetadata.ts
+++ b/src/core/getFrameMetadata.ts
@@ -4,15 +4,17 @@ type FrameMetadataResponse = Record<string, string>;
 
 /**
  * This function generates the metadata for a Farcaster Frame.
- * @param buttons: The buttons to use for the frame.
  * @param image: The image to use for the frame.
+ * @param input: The text input to use for the frame.
+ * @param buttons: The buttons to use for the frame.
  * @param post_url: The URL to post the frame to.
  * @param refresh_period: The refresh period for the image used.
  * @returns The metadata for the frame.
  */
 export const getFrameMetadata = function ({
-  buttons,
   image,
+  input,
+  buttons,
   post_url,
   refresh_period,
 }: FrameMetadata): FrameMetadataResponse {
@@ -20,6 +22,9 @@ export const getFrameMetadata = function ({
     'fc:frame': 'vNext',
   };
   metadata['fc:frame:image'] = image;
+  if (input) {
+    metadata['fc:frame:input:text'] = input.prompt_text;
+  }
   if (buttons) {
     buttons.forEach((button, index) => {
       metadata[`fc:frame:button:${index + 1}`] = button.label;


### PR DESCRIPTION
**What changed? Why?**
Add support for Text Input metadata for Farcaster Frames

**Screenshots**
![carbon](https://github.com/coinbase/onchainkit/assets/3264051/7defd8bb-abd8-42cd-9812-6add8202c1ff)
![carbon (1)](https://github.com/coinbase/onchainkit/assets/3264051/37ab1be1-a36d-4342-948f-85bd7432107b)

**Notes to reviewers**
Preemptively derived from spec defined in the [public proposal](https://warpcast.notion.site/Frames-Text-Input-Public-27c9f0d61903486d89b6d932dd0d6a22).

**How has it been tested?**
Manually
