### PR TITLE
Add support for image aspect ratio metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ export default function HomePage() {
           label: 'Redirect to cute pictures',
         },
       ]}
-      image="https://zizzamia.xyz/park-1.png"
+      image='https://zizzamia.xyz/park-1.png'
       input={{
         text: 'Tell me a boat story',
       }}
@@ -116,7 +116,7 @@ export default function HomePage() {
 **@Props**
 
 ```ts
-type Button =
+type ButtonMetadata =
   | {
       action: 'link' | 'mint';
       label: string;
@@ -131,11 +131,16 @@ type InputMetadata = {
   text: string;
 };
 
+type ImageMetadata = {
+  src: string;
+  aspectRatio?: '1.91:1' | '1.1';
+};
+
 type FrameMetadataType = {
   // A list of strings which are the label for the buttons in the frame (max 4 buttons).
-  buttons?: [Button, ...Button[]];
-  // An image which must be smaller than 10MB and should have an aspect ratio of 1.91:1
-  image: string;
+  buttons?: [ButtonMetadata, ...ButtonMetadata[]];
+  // An image which must be smaller than 10MB and should have an aspect ratio of 1.91:1 or 1:1
+  image: ImageMetadata;
   // The text input to use for the Frame.
   input?: InputMetadata;
   // A valid POST URL to send the Signature Packet to.
@@ -189,7 +194,7 @@ async function getResponse(req: NextRequest): Promise<NextResponse> {
           label: `We love BOAT`,
         },
       ],
-      image:'https://build-onchain-apps.vercel.app/release/v-0-17.png',
+      image: 'https://build-onchain-apps.vercel.app/release/v-0-17.png',
       postUrl: 'https://build-onchain-apps.vercel.app/api/frame',
     }),
   );
@@ -203,7 +208,7 @@ export async function POST(req: NextRequest): Promise<Response> {
 **@Param**
 
 ```ts
-type Button =
+type ButtonMetadata =
   | {
       action: 'link' | 'mint';
       label: string;
@@ -218,11 +223,16 @@ type InputMetadata = {
   text: string;
 };
 
+type ImageMetadata = {
+  src: string;
+  aspectRatio?: '1.91:1' | '1.1';
+};
+
 type FrameMetadataType = {
   // A list of strings which are the label for the buttons in the frame (max 4 buttons).
-  buttons?: [Button, ...Button[]];
-  // An image which must be smaller than 10MB and should have an aspect ratio of 1.91:1
-  image: string;
+  buttons?: [ButtonMetadata, ...ButtonMetadata[]];
+  // An image which must be smaller than 10MB and should have an aspect ratio of 1.91:1 or 1:1
+  image: ImageMetadata;
   // The text input to use for the Frame.
   input?: InputMetadata;
   // A valid POST URL to send the Signature Packet to.
@@ -368,7 +378,7 @@ export default function Page() {
 **@Param**
 
 ```ts
-type Button =
+type ButtonMetadata =
   | {
       action: 'link' | 'mint';
       label: string;
@@ -383,11 +393,16 @@ type InputMetadata = {
   text: string;
 };
 
+type ImageMetadata = {
+  src: string;
+  aspectRatio?: '1.91:1' | '1.1';
+};
+
 type FrameMetadataType = {
   // A list of strings which are the label for the buttons in the frame (max 4 buttons).
-  buttons?: [Button, ...Button[]];
+  buttons?: [ButtonMetadata, ...ButtonMetadata[]];
   // An image which must be smaller than 10MB and should have an aspect ratio of 1.91:1
-  image: string;
+  image: ImageMetadata;
   // The text input to use for the Frame.
   input?: InputMetadata;
   // A valid POST URL to send the Signature Packet to.

--- a/docs/frame-kit.md
+++ b/docs/frame-kit.md
@@ -168,16 +168,21 @@ export default function Page() {
 **@Param**
 
 ```ts
-type Button = {
+type ButtonMetadata = {
   label: string;
   action?: 'post' | 'post_redirect';
 };
 
+type ImageMetadata = {
+  src: string;
+  aspectRatio?: '1.91:1' | '1:1';
+};
+
 type FrameMetadata = {
   // A list of strings which are the label for the buttons in the frame (max 4 buttons).
-  buttons: [Button, ...Button[]];
+  buttons: [ButtonMetadata, ...ButtonMetadata[]];
   // An image which must be smaller than 10MB and should have an aspect ratio of 1.91:1
-  image: string;
+  image: string | ImageMetadata;
   // A valid POST URL to send the Signature Packet to.
   post_url: string;
   // A period in seconds at which the app should expect the image to update.

--- a/src/components/FrameMetadata.test.tsx
+++ b/src/components/FrameMetadata.test.tsx
@@ -18,6 +18,29 @@ describe('FrameMetadata', () => {
     expect(meta.container.querySelectorAll('meta').length).toBe(2);
   });
 
+  it('renders with image src', () => {
+    const meta = render(<FrameMetadata image={{ src: 'https://example.com/image.png' }} />);
+    expect(
+      meta.container.querySelector('meta[property="fc:frame:image"]')?.getAttribute('content'),
+    ).toBe('https://example.com/image.png');
+    expect(meta.container.querySelectorAll('meta').length).toBe(2);
+  });
+
+  it('renders with image aspect ratio', () => {
+    const meta = render(
+      <FrameMetadata image={{ src: 'https://example.com/image.png', aspectRatio: '1:1' }} />,
+    );
+    expect(
+      meta.container.querySelector('meta[property="fc:frame:image:aspect_ratio"]'),
+    ).not.toBeNull();
+    expect(
+      meta.container
+        .querySelector('meta[property="fc:frame:image:aspect_ratio"]')
+        ?.getAttribute('content'),
+    ).toBe('1:1');
+    expect(meta.container.querySelectorAll('meta').length).toBe(3);
+  });
+
   it('renders with input', () => {
     const meta = render(
       <FrameMetadata image="https://example.com/image.png" input={{ text: 'test' }} />,
@@ -238,7 +261,7 @@ describe('FrameMetadata', () => {
   it('should not render action target if action is not link or mint', () => {
     const meta = render(
       <FrameMetadata
-        image="image"
+        image="https://example.com/image.png"
         buttons={[{ label: 'button1', action: 'post' }]}
         postUrl="post_url"
       />,

--- a/src/components/FrameMetadata.tsx
+++ b/src/components/FrameMetadata.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import type { FrameMetadataType } from '../core/types';
+import type { FrameMetadataType, FrameImageMetadata } from '../core/types';
 
 type FrameMetadataReact = FrameMetadataType & {
   wrapper?: React.ComponentType<any>;
@@ -38,7 +38,7 @@ type FrameMetadataReact = FrameMetadataType & {
  *
  * @param {FrameMetadataReact} props - The metadata for the frame.
  * @param {Array<{ label: string, action?: string }>} props.buttons - The buttons.
- * @param {string} props.image - The image URL.
+ * @param {string | { src: string, aspectRatio?: string }} props.image - The image URL.
  * @param {string} props.input - The input text.
  * @param {string} props.postUrl - The post URL.
  * @param {number} props.refreshPeriod - The refresh period.
@@ -61,13 +61,17 @@ export function FrameMetadata({
   const button4 = buttons && buttons[3];
   const postUrlToUse = postUrl || post_url;
   const refreshPeriodToUse = refreshPeriod || refresh_period;
+  const imageSrc = typeof image === 'string' ? image : image.src;
+  const aspectRatio = typeof image === 'string' ? undefined : image.aspectRatio;
 
   // Important: To ensure smooth functionality when used
   // with Helmet as a wrapper component, it is crucial to flatten the Buttons loop.
   return (
     <Wrapper>
       <meta property="fc:frame" content="vNext" />
-      {!!image && <meta property="fc:frame:image" content={image} />}
+      {!!imageSrc && <meta property="fc:frame:image" content={imageSrc} />}
+      {!!aspectRatio && <meta property="fc:frame:image:aspect_ratio" content={aspectRatio} />}
+
       {!!input && <meta property="fc:frame:input:text" content={input.text} />}
 
       {!!button1 && <meta property="fc:frame:button:1" content={button1.label} />}

--- a/src/core/getFrameHtmlResponse.test.ts
+++ b/src/core/getFrameHtmlResponse.test.ts
@@ -9,7 +9,10 @@ describe('getFrameHtmlResponse', () => {
         { label: 'button3', action: 'post_redirect' },
         { label: 'button4' },
       ],
-      image: 'https://example.com/image.png',
+      image: {
+        src: 'https://example.com/image.png',
+        aspectRatio: '1.91:1',
+      },
       input: {
         text: 'Enter a message...',
       },
@@ -30,9 +33,54 @@ describe('getFrameHtmlResponse', () => {
   <meta property="fc:frame:button:3:action" content="post_redirect" />
   <meta property="fc:frame:button:4" content="button4" />
   <meta property="fc:frame:image" content="https://example.com/image.png" />
+  <meta property="fc:frame:image:aspect_ratio" content="1.91:1" />
   <meta property="fc:frame:input:text" content="Enter a message..." />
   <meta property="fc:frame:post_url" content="https://example.com/api/frame" />
   <meta property="fc:frame:refresh_period" content="10" />
+
+</head>
+</html>`);
+  });
+
+  it('should return correct HTML with image src', () => {
+    const html = getFrameHtmlResponse({
+      buttons: [{ label: 'Mint', action: 'mint', target: 'https://zizzamia.xyz/api/frame/mint' }],
+      image: {
+        src: 'https://zizzamia.xyz/park-1.png',
+      },
+    });
+
+    expect(html).toBe(`<!DOCTYPE html>
+<html>
+<head>
+  <meta property="fc:frame" content="vNext" />
+  <meta property="fc:frame:button:1" content="Mint" />
+  <meta property="fc:frame:button:1:action" content="mint" />
+  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/mint" />
+  <meta property="fc:frame:image" content="https://zizzamia.xyz/park-1.png" />
+
+</head>
+</html>`);
+  });
+
+  it('should return correct HTML with 1:1 image aspect ratio', () => {
+    const html = getFrameHtmlResponse({
+      buttons: [{ label: 'Mint', action: 'mint', target: 'https://zizzamia.xyz/api/frame/mint' }],
+      image: {
+        src: 'https://zizzamia.xyz/park-1.png',
+        aspectRatio: '1:1',
+      },
+    });
+
+    expect(html).toBe(`<!DOCTYPE html>
+<html>
+<head>
+  <meta property="fc:frame" content="vNext" />
+  <meta property="fc:frame:button:1" content="Mint" />
+  <meta property="fc:frame:button:1:action" content="mint" />
+  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/mint" />
+  <meta property="fc:frame:image" content="https://zizzamia.xyz/park-1.png" />
+  <meta property="fc:frame:image:aspect_ratio" content="1:1" />
 
 </head>
 </html>`);

--- a/src/core/getFrameHtmlResponse.ts
+++ b/src/core/getFrameHtmlResponse.ts
@@ -1,4 +1,4 @@
-import { FrameMetadataType } from './types';
+import { FrameMetadataType, FrameImageMetadata } from './types';
 
 /**
  * Returns an HTML string containing metadata for a new valid frame.
@@ -20,8 +20,15 @@ function getFrameHtmlResponse({
   refresh_period,
 }: FrameMetadataType): string {
   // Set the image metadata if it exists.
-  const imageHtml = image ? `  <meta property="fc:frame:image" content="${image}" />\n` : '';
-
+  let imageHtml = '';
+  if (typeof image === 'string') {
+    imageHtml = `  <meta property="fc:frame:image" content="${image}" />\n`;
+  } else {
+    imageHtml = `  <meta property="fc:frame:image" content="${image.src}" />\n`;
+    if (image.aspectRatio) {
+      imageHtml += `  <meta property="fc:frame:image:aspect_ratio" content="${image.aspectRatio}" />\n`;
+    }
+  }
   // Set the input metadata if it exists.
   const inputHtml = input
     ? `  <meta property="fc:frame:input:text" content="${input.text}" />\n`

--- a/src/core/getFrameMetadata.test.ts
+++ b/src/core/getFrameMetadata.test.ts
@@ -9,7 +9,7 @@ describe('getFrameMetadata', () => {
           { label: 'button2', action: 'post_redirect' },
           { label: 'button3' },
         ],
-        image: 'image',
+        image: { src: 'image', aspectRatio: '1.91:1' },
         postUrl: 'post_url',
       }),
     ).toEqual({
@@ -20,6 +20,38 @@ describe('getFrameMetadata', () => {
       'fc:frame:button:2:action': 'post_redirect',
       'fc:frame:button:3': 'button3',
       'fc:frame:image': 'image',
+      'fc:frame:image:aspect_ratio': '1.91:1',
+      'fc:frame:post_url': 'post_url',
+    });
+  });
+
+  it('should return the correct metadata with image src', () => {
+    expect(
+      getFrameMetadata({
+        buttons: [{ label: 'button1' }],
+        image: { src: 'image' },
+        postUrl: 'post_url',
+      }),
+    ).toEqual({
+      'fc:frame': 'vNext',
+      'fc:frame:button:1': 'button1',
+      'fc:frame:image': 'image',
+      'fc:frame:post_url': 'post_url',
+    });
+  });
+
+  it('should return the correct metadata with image aspect ratio', () => {
+    expect(
+      getFrameMetadata({
+        buttons: [{ label: 'button1' }],
+        image: { src: 'image', aspectRatio: '1:1' },
+        postUrl: 'post_url',
+      }),
+    ).toEqual({
+      'fc:frame': 'vNext',
+      'fc:frame:button:1': 'button1',
+      'fc:frame:image': 'image',
+      'fc:frame:image:aspect_ratio': '1:1',
       'fc:frame:post_url': 'post_url',
     });
   });

--- a/src/core/getFrameMetadata.ts
+++ b/src/core/getFrameMetadata.ts
@@ -1,4 +1,4 @@
-import { FrameMetadataResponse, FrameMetadataType } from './types';
+import { FrameMetadataResponse, FrameMetadataType, FrameImageMetadata } from './types';
 
 /**
  * This function generates the metadata for a Farcaster Frame.
@@ -24,7 +24,14 @@ export const getFrameMetadata = function ({
   const metadata: Record<string, string> = {
     'fc:frame': 'vNext',
   };
-  metadata['fc:frame:image'] = image;
+  if (typeof image === 'string') {
+    metadata['fc:frame:image'] = image;
+  } else {
+    metadata['fc:frame:image'] = image.src;
+    if (image.aspectRatio) {
+      metadata['fc:frame:image:aspect_ratio'] = image.aspectRatio;
+    }
+  }
   if (input) {
     metadata['fc:frame:input:text'] = input.text;
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -83,6 +83,11 @@ export type FrameInputMetadata = {
   text: string;
 };
 
+export type FrameImageMetadata = {
+  src: string;
+  aspectRatio?: '1.91:1' | '1:1';
+};
+
 /**
  * Frame Request
  *
@@ -90,7 +95,7 @@ export type FrameInputMetadata = {
  */
 export type FrameMetadataType = {
   buttons?: [FrameButtonMetadata, ...FrameButtonMetadata[]];
-  image: string;
+  image: string | FrameImageMetadata;
   input?: FrameInputMetadata;
   /** @deprecated Prefer `postUrl` */
   post_url?: string;


### PR DESCRIPTION
**What changed? Why?**
Add support for optional metadata tag `fc:frame:image:aspect_ratio`

See: https://docs.farcaster.xyz/reference/frames/spec

**Screenshot**

Aspect Ratio: "1:1"

<img width="356" alt="Screenshot 2024-02-08 at 7 56 20 PM" src="https://github.com/coinbase/onchainkit/assets/3264051/1f5097c7-41c6-4847-961c-04f56b526f0c">

<img width="621" alt="Screenshot 2024-02-08 at 7 55 05 PM" src="https://github.com/coinbase/onchainkit/assets/3264051/57dfa23e-7017-4fec-a749-31150ad2aaae">


**Notes to reviewers**
Backwards compatible. Image metadata can be defined as a string (defaults to aspectRatio of `1.91:1`) or an object with a `src` URL string and `aspectRatio` of `1.91:1` or `1:1`.

**How has it been tested?**
Manually