### PR TITLE
[WIP] Add Open Frames Neynar validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",
+    "@open-frames/types": "^0.0.5",
     "@testing-library/jest-dom": "^6.4.0",
     "@testing-library/react": "^14.2.0",
     "@types/jest": "^29.5.11",

--- a/src/utils/neynar/openframes/neynarValidator.ts
+++ b/src/utils/neynar/openframes/neynarValidator.ts
@@ -1,0 +1,54 @@
+import { OpenFramesRequest, RequestValidator, ValidationResponse } from '@open-frames/types';
+import { FarcasterOpenFramesRequest, FrameRequest, FrameValidationData } from '../../../core/types';
+import { NEYNAR_DEFAULT_API_KEY, neynarFrameValidation } from '../frame/neynarFrameFunctions';
+import { Options } from './types';
+
+export class NeynarValidator
+  implements RequestValidator<FarcasterOpenFramesRequest, FrameValidationData, 'farcaster'>
+{
+  readonly protocolIdentifier = 'farcaster';
+  private options: Required<Options>;
+
+  constructor(options?: Options) {
+    this.options = {
+      neynarApiKey: options?.neynarApiKey || NEYNAR_DEFAULT_API_KEY,
+      castReactionContext: options?.castReactionContext || true,
+      followContext: options?.followContext || true,
+    };
+  }
+
+  minProtocolVersion(): string {
+    return `${this.protocolIdentifier}@VNext`;
+  }
+
+  isSupported(payload: OpenFramesRequest): payload is FarcasterOpenFramesRequest {
+    const isCorrectClientProtocol =
+      !!payload.clientProtocol && payload.clientProtocol.startsWith('farcaster@');
+    const isTrustedDataValid = typeof payload.trustedData?.messageBytes === 'string';
+
+    return isCorrectClientProtocol && isTrustedDataValid;
+  }
+
+  async validate(
+    payload: FarcasterOpenFramesRequest,
+  ): Promise<ValidationResponse<FrameValidationData, typeof this.protocolIdentifier>> {
+    const response = await neynarFrameValidation(
+      payload.trustedData?.messageBytes,
+      this.options.neynarApiKey,
+      this.options.castReactionContext,
+      this.options.followContext,
+    );
+
+    if (response?.valid) {
+      return {
+        isValid: true,
+        clientProtocol: payload.clientProtocol,
+        message: response,
+      };
+    }
+
+    return {
+      isValid: false,
+    };
+  }
+}

--- a/src/utils/neynar/openframes/types.ts
+++ b/src/utils/neynar/openframes/types.ts
@@ -1,0 +1,5 @@
+export type Options = {
+  neynarApiKey?: string;
+  castReactionContext?: boolean;
+  followContext?: boolean;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -875,6 +875,7 @@ __metadata:
   dependencies:
     "@changesets/changelog-github": "npm:^0.4.8"
     "@changesets/cli": "npm:^2.26.2"
+    "@open-frames/types": "npm:^0.0.5"
     "@testing-library/jest-dom": "npm:^6.4.0"
     "@testing-library/react": "npm:^14.2.0"
     "@types/jest": "npm:^29.5.11"
@@ -1505,6 +1506,13 @@ __metadata:
   dependencies:
     semver: "npm:^7.3.5"
   checksum: 162b4a0b8705cd6f5c2470b851d1dc6cd228c86d2170e1769d738c1fbb69a87160901411c3c035331e9e99db72f1f1099a8b734bf1637cc32b9a5be1660e4e1e
+  languageName: node
+  linkType: hard
+
+"@open-frames/types@npm:^0.0.5":
+  version: 0.0.5
+  resolution: "@open-frames/types@npm:0.0.5"
+  checksum: 971153e1ba5af69f54df0ebe65ce6dcc15163675abe097d3d9454a0552d9181207d89bf64ff1e30859b49f77cdac286baac6bbc42b8df112b1977fc35b8e4ac5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**

This PR adds a proof-of-concept for support of Open Frames. Opening it up for discussion. It shows a path for how `onchainkit` can be extended to support multiple types of Frames client beyond just Farcaster.

The PR adds no new runtime dependencies. It just picks up some common types from [`@open-frames/types`](https://www.npmjs.com/package/@open-frames/types).

**Notes to reviewers**

If we decide this approach is reasonable, I'll add some tests. And we can discuss how we can add some better examples for extensibility.

**How has it been tested?**

Not at all
