### PR TITLE
feat: new function `getEASAttestations` to fetch attestation from Ethereum Attestation Service (EAS) - part 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "release:version": "changeset version && yarn install --immutable"
   },
   "peerDependencies": {
+    "graphql": "^14",
+    "graphql-request": "^6",
     "react": "^18",
     "react-dom": "^18",
     "viem": "^2.7.0"
@@ -29,6 +31,8 @@
     "@types/jest": "^29.5.12",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "graphql": "^14",
+    "graphql-request": "^6.1.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-extended": "^4.0.2",

--- a/src/core/getEASAttestations.test.ts
+++ b/src/core/getEASAttestations.test.ts
@@ -2,26 +2,97 @@
  * @jest-environment jsdom
  */
 
+import { getEASAttestationsByFilter } from '../queries/easAttestations';
 import { getEASAttestations, GetEASAttestationsOptions } from './getEASAttestations';
 import { easSupportedChains } from '../utils/easAttestation';
 import { base, opBNBTestnet } from 'viem/chains';
 
+jest.mock('../queries/easAttestations');
+
 describe('getEASAttestations', () => {
   const mockAddress = '0x1234567890abcdef1234567890abcdef12345678';
   const mockOptions: GetEASAttestationsOptions = { schemas: ['0x12345'] };
+  const mockAttestations = [
+    {
+      attester: '0x357458739F90461b99789350868CD7CF330Dd7EE',
+      expirationTime: 0,
+      id: '0x93016a60f13e7cfe0257116aedfce7088c2c0020787a325ea9f6b4ba11d07598',
+      recipient: '0x44a7D120beA87455071cebB841eF91E6Ae21bC1a',
+      revocationTime: 0,
+      schemaId: '0x1801901fabd0e6189356b4fb52bb0ab855276d84f7ec140839fbd1f6801ca065',
+      timeCreated: 1707269100,
+      txid: '0x88448267566c9546ff31b9e6be229fb960f12bec8bc441259c7b064ae4159d34',
+    },
+  ];
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('throws an error for unsupported chains', async () => {
-    await expect(getEASAttestations(mockAddress, opBNBTestnet, mockOptions)).rejects.toThrow(
-      `Chain is not supported. Supported chains: ${Object.keys(easSupportedChains).join(', ')}`,
-    );
+  it('throws an error for unsupported chains', () => {
+    try {
+      getEASAttestations(mockAddress, opBNBTestnet, mockOptions);
+    } catch (e) {
+      expect(e).toHaveProperty(
+        'message',
+        `Chain is not supported. Supported chains: ${Object.keys(easSupportedChains).join(', ')}`,
+      );
+    }
   });
 
   it('fetches attestations for supported chains', async () => {
+    (getEASAttestationsByFilter as jest.Mock).mockResolvedValue(mockAttestations);
+
     const result = await getEASAttestations(mockAddress, base, mockOptions);
-    expect(result).toEqual([]); // Replace [] with expected mockAttestations once implemented
+    expect(result).toEqual(mockAttestations); // Replace [] with expected mockAttestations once implemented
+  });
+
+  it('uses default values when options are not provided', async () => {
+    // Call the function without the options parameter
+    await getEASAttestations(mockAddress, base);
+    // Check if getEASAttestationsByFilter is called with default values
+    expect(getEASAttestationsByFilter).toHaveBeenCalledWith(mockAddress, base, {
+      revoked: false,
+      expirationTime: expect.any(Number),
+      limit: 10,
+    });
+  });
+
+  it('handles errors from getEASAttestationsByFilter correctly', async () => {
+    (getEASAttestationsByFilter as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+    const result = await getEASAttestations(mockAddress, base);
+
+    expect(result).toEqual([]);
+  });
+
+  it('uses defaultQueryVariablesFilter when no options are provided', async () => {
+    const mockAddress = '0x1234567890abcdef1234567890abcdef12345678';
+    const chain = base; // assuming 'base' is a supported chain
+
+    // Call the function without options
+    await getEASAttestations(mockAddress, chain);
+
+    // Check if getEASAttestationsByFilter is called with the correct default values
+    expect(getEASAttestationsByFilter).toHaveBeenCalledWith(mockAddress, chain, {
+      revoked: false, // Default value for revoked
+      expirationTime: expect.any(Number), // Should be a timestamp
+      limit: 10, // Default limit
+    });
+  });
+
+  it('uses custom filter options when provided', async () => {
+    const customOptions = {
+      schemas: ['0x98765'],
+      revoked: true,
+      expirationTime: 1234567890,
+      limit: 5,
+    } as GetEASAttestationsOptions;
+
+    // Call the function with custom options
+    await getEASAttestations(mockAddress, base, customOptions);
+
+    // Check if getEASAttestationsByFilter is called with the custom options
+    expect(getEASAttestationsByFilter).toHaveBeenCalledWith(mockAddress, base, customOptions);
   });
 });

--- a/src/core/getEASAttestations.ts
+++ b/src/core/getEASAttestations.ts
@@ -61,7 +61,9 @@ export async function getEASAttestations<TChain extends Chain>(
       limit: 10,
     };
 
-    return await getEASAttestationsByFilter(address, chain, defaultQueryVariablesFilter);
+    const queryVariablesFilter = { ...defaultQueryVariablesFilter, ...options };
+
+    return await getEASAttestationsByFilter(address, chain, queryVariablesFilter);
   } catch (error) {
     console.log(`Error in getEASAttestation: ${(error as Error).message}`);
     return [];

--- a/src/core/getEASAttestations.ts
+++ b/src/core/getEASAttestations.ts
@@ -1,5 +1,4 @@
-import { createEasGraphQLClient } from '../network/easGraphQL';
-import { easAttestationQuery, getEASAttestationQueryVariables, GetEASAttestationQueryResponse, EASAttestationsQueryVariables } from '../queries/easAttestations';
+import { getEASAttestationsByFilter } from '../queries/easAttestations';
 import { isChainSupported, easSupportedChains } from '../utils/easAttestation';
 import { EASAttestation, EASSchemaUid } from './types';
 import type { Address, Chain } from 'viem';
@@ -55,23 +54,14 @@ export async function getEASAttestations<TChain extends Chain>(
       );
     }
 
-     // Default query filter values
-     const defaultQueryVariablesFilter = {
+    // Default query filter values
+    const defaultQueryVariablesFilter = {
       revoked: false,
       expirationTime: Math.round(Date.now() / 1000),
-      limit: 10
+      limit: 10,
     };
 
-    // Merge options with default values
-    const queryVariablesFilters = { ...defaultQueryVariablesFilter, ...options };
-
-    const easGraphqlClient = createEasGraphQLClient(chain);
-    const easAttestationQueryVariables = getEASAttestationQueryVariables(address, queryVariablesFilters);
-
-    const { attestations } = await easGraphqlClient.request<GetEASAttestationQueryResponse, EASAttestationsQueryVariables>(easAttestationQuery, easAttestationQueryVariables);
-  
-    return attestations;
-
+    return await getEASAttestationsByFilter(address, chain, defaultQueryVariablesFilter);
   } catch (error) {
     console.log(`Error in getEASAttestation: ${(error as Error).message}`);
     return [];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -138,7 +138,7 @@ type EASAttesterAddress = Address;
  * The schema identifier associated with the EAS attestation.
  * Note: exported as public Type
  */
-export type EASSchemaUid = `0x${string}`;
+export type EASSchemaUid = Address;
 
 /**
  * Ethereum Attestation Service (EAS) Attestation
@@ -146,15 +146,15 @@ export type EASSchemaUid = `0x${string}`;
  * Note: exported as public Type
  */
 export type EASAttestation = {
-  id: string; // The unique identifier of the attestation.
-  decodedDataJson: string; // The attestation data decoded to JSON.
-  recipient: Address; // The Ethereum address of the recipient of the attestation.
   attester: EASAttesterAddress; // the attester who created the attestation.
-  time: number; // The Unix timestamp when the attestation was created.
+  decodedDataJson: string; // The attestation data decoded to JSON.
   expirationTime: number; // The Unix timestamp when the attestation expires (0 for no expiration).
+  id: string; // The unique identifier of the attestation.
+  recipient: Address; // The Ethereum address of the recipient of the attestation.
   revocationTime: number; // The Unix timestamp when the attestation was revoked, if applicable.
   revoked: boolean; // A boolean indicating whether the attestation is revocable or not.
   schemaId: EASSchemaUid; // The schema identifier associated with the attestation.
+  time: number; // The Unix timestamp when the attestation was created.
 };
 
 /**
@@ -163,8 +163,7 @@ export type EASAttestation = {
  * Note: exported as public Type
  */
 export type EASChainDefinition = {
-  id: number; // blockchain source id
   easGraphqlAPI: string; // EAS GraphQL API endpoint
-  schemaUids: EASSchemaUid[];
-  attesterAddresses: EASAttesterAddress[];
+  id: number; // blockchain source id
+  schemaUids: EASSchemaUid[]; // Array of EAS Schema UIDs
 };

--- a/src/definitions/base.ts
+++ b/src/definitions/base.ts
@@ -11,5 +11,5 @@ export const easChainBase: EASChainDefinition = {
     // VERIFIED_ACCOUNT
     // https://base.easscan.org/schema/view/0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9
     '0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9',
-  ]
+  ],
 };

--- a/src/definitions/base.ts
+++ b/src/definitions/base.ts
@@ -11,9 +11,5 @@ export const easChainBase: EASChainDefinition = {
     // VERIFIED_ACCOUNT
     // https://base.easscan.org/schema/view/0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9
     '0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9',
-  ],
-  attesterAddresses: [
-    // https://base.easscan.org/address/0x357458739F90461b99789350868CD7CF330Dd7EE
-    '0x357458739F90461b99789350868CD7CF330Dd7EE',
-  ],
+  ]
 };

--- a/src/definitions/baseSepolia.ts
+++ b/src/definitions/baseSepolia.ts
@@ -11,5 +11,5 @@ export const easChainBaseSepolia: EASChainDefinition = {
     // VERIFIED_ACCOUNT
     // https://base-sepolia.easscan.org/schema/view/0x2f34a2ffe5f87b2f45fbc7c784896b768d77261e2f24f77341ae43751c765a69
     '0x2f34a2ffe5f87b2f45fbc7c784896b768d77261e2f24f77341ae43751c765a69',
-  ]
+  ],
 };

--- a/src/definitions/baseSepolia.ts
+++ b/src/definitions/baseSepolia.ts
@@ -1,0 +1,15 @@
+import { baseSepolia } from 'viem/chains';
+import { EASChainDefinition } from '../core/types';
+
+export const easChainBaseSepolia: EASChainDefinition = {
+  id: baseSepolia.id,
+  easGraphqlAPI: 'https://base-sepolia.easscan.org/graphql',
+  schemaUids: [
+    // VERIFIED_COUNTRY
+    // https://base-sepolia.easscan.org/schema/view/0xef54ae90f47a187acc050ce631c55584fd4273c0ca9456ab21750921c3a84028
+    '0xef54ae90f47a187acc050ce631c55584fd4273c0ca9456ab21750921c3a84028',
+    // VERIFIED_ACCOUNT
+    // https://base-sepolia.easscan.org/schema/view/0x2f34a2ffe5f87b2f45fbc7c784896b768d77261e2f24f77341ae43751c765a69
+    '0x2f34a2ffe5f87b2f45fbc7c784896b768d77261e2f24f77341ae43751c765a69',
+  ]
+};

--- a/src/definitions/optimism.ts
+++ b/src/definitions/optimism.ts
@@ -15,17 +15,5 @@ export const easChainOptimism: EASChainDefinition = {
     // OPTIMISM_GOVERNANCE_SEASON_4_CO_GRANT_PARTICIPANT:
     // https://optimism.easscan.org/schema/view/0x401a80196f3805c57b00482ae2b575a9f270562b6b6de7711af9837f08fa0faf
     '0x401a80196f3805c57b00482ae2b575a9f270562b6b6de7711af9837f08fa0faf',
-  ],
-  attesterAddresses: [
-    // https://optimism.easscan.org/address/0x38e9ef91f1a96aca71e2c5f7abfea45536b995a2
-    '0x38e9ef91f1a96aca71e2c5f7abfea45536b995a2',
-    // https://optimism.easscan.org/address/0x2a0eb7cae52b68e94ff6ab0bfcf0df8eeeb624be
-    '0x2a0eb7cae52b68e94ff6ab0bfcf0df8eeeb624be',
-    // https://optimism.easscan.org/address/0x2d93c2f74b2c4697f9ea85d0450148aa45d4d5a2
-    '0x2d93c2f74b2c4697f9ea85d0450148aa45d4d5a2',
-    // https://optimism.easscan.org/address/0x843829986e895facd330486a61Ebee9E1f1adB1a
-    '0x843829986e895facd330486a61Ebee9E1f1adB1a',
-    // https://optimism.easscan.org/address/0x3C7820f2874b665AC7471f84f5cbd6E12871F4cC
-    '0x3C7820f2874b665AC7471f84f5cbd6E12871F4cC',
-  ],
+  ]
 };

--- a/src/definitions/optimism.ts
+++ b/src/definitions/optimism.ts
@@ -15,5 +15,5 @@ export const easChainOptimism: EASChainDefinition = {
     // OPTIMISM_GOVERNANCE_SEASON_4_CO_GRANT_PARTICIPANT:
     // https://optimism.easscan.org/schema/view/0x401a80196f3805c57b00482ae2b575a9f270562b6b6de7711af9837f08fa0faf
     '0x401a80196f3805c57b00482ae2b575a9f270562b6b6de7711af9837f08fa0faf',
-  ]
+  ],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // 🌲☀️🌲
 export { version } from './version';
+export { getEASAttestations } from './core/getEASAttestations';
 export { getFrameHtmlResponse } from './core/getFrameHtmlResponse';
 export { getFrameMetadata } from './core/getFrameMetadata';
 export { getFrameMessage } from './core/getFrameMessage';

--- a/src/network/easGraphQL.ts
+++ b/src/network/easGraphQL.ts
@@ -1,0 +1,8 @@
+import { GraphQLClient } from 'graphql-request';
+import type { Chain } from 'viem';
+import { getChainEASGraphQLAPI } from '../utils/easAttestation'; // Adjust the import path as needed
+
+export function createEasGraphQLClient(chain: Chain): GraphQLClient {
+    const endpoint = getChainEASGraphQLAPI(chain);
+    return new GraphQLClient(endpoint);
+}

--- a/src/network/easGraphQL.ts
+++ b/src/network/easGraphQL.ts
@@ -3,6 +3,6 @@ import type { Chain } from 'viem';
 import { getChainEASGraphQLAPI } from '../utils/easAttestation'; // Adjust the import path as needed
 
 export function createEasGraphQLClient(chain: Chain): GraphQLClient {
-    const endpoint = getChainEASGraphQLAPI(chain);
-    return new GraphQLClient(endpoint);
+  const endpoint = getChainEASGraphQLAPI(chain);
+  return new GraphQLClient(endpoint);
 }

--- a/src/queries/easAttestations.test.ts
+++ b/src/queries/easAttestations.test.ts
@@ -1,0 +1,60 @@
+import {
+  GetEASAttestationsByFilterOptions,
+  getEASAttestationQueryVariables,
+  getEASAttestationsByFilter,
+  easAttestationQuery,
+} from './easAttestations';
+import { createEasGraphQLClient } from '../network/easGraphQL';
+import { base } from 'viem/chains';
+
+jest.mock('../network/easGraphQL');
+
+describe('EAS Attestation Service', () => {
+  const mockAddress = '0x123';
+  const mockFilters: GetEASAttestationsByFilterOptions = {
+    limit: 10,
+    revoked: false,
+    expirationTime: 1234567890,
+    schemas: ['0x1', '0x2'],
+  };
+
+  describe('getEASAttestationQueryVariables', () => {
+    it('should create correct query variables', () => {
+      const variables = getEASAttestationQueryVariables(mockAddress, mockFilters);
+      expect(variables).toEqual({
+        where: {
+          AND: [
+            {
+              recipient: { equals: mockAddress },
+              revoked: { equals: mockFilters.revoked },
+              OR: [
+                { expirationTime: { equals: 0 } },
+                { expirationTime: { gt: mockFilters.expirationTime } },
+              ],
+              schemaId: { in: mockFilters.schemas },
+            },
+          ],
+        },
+        distinct: ['schemaId'],
+        take: mockFilters.limit,
+      });
+    });
+  });
+
+  describe('getEASAttestationsByFilter', () => {
+    it('should fetch attestations correctly', async () => {
+      const mockClient = {
+        request: jest.fn().mockResolvedValue({
+          attestations: [],
+        }),
+      };
+      (createEasGraphQLClient as jest.Mock).mockReturnValue(mockClient);
+
+      const result = await getEASAttestationsByFilter(mockAddress, base, mockFilters);
+
+      expect(createEasGraphQLClient).toHaveBeenCalledWith(base);
+      expect(mockClient.request).toHaveBeenCalledWith(easAttestationQuery, expect.any(Object));
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/queries/easAttestations.ts
+++ b/src/queries/easAttestations.ts
@@ -1,75 +1,85 @@
 import { gql } from 'graphql-request';
-import type { Address } from 'viem';
+import type { Address, Chain } from 'viem';
 import { EASSchemaUid, EASAttestation } from '../core/types';
-
+import { createEasGraphQLClient } from '../network/easGraphQL';
 
 /**
- * Type for the input filters to the GraphQL query.
+ * Type representing the filter options used for querying EAS Attestations.
  * @typedef {Object} GetEASAttestationQueryVariablesFilters
- * @property {EASSchemaUid[]} [schemas] - Optional array of schema UIDs to filter attestations.
- * @property {boolean} [revoked] - Optional boolean to filter attestations based on their revoked status.
  * @property {number} [expirationTime] - Optional Unix timestamp to filter attestations based on expiration time.
  * @property {number} [limit] - Optional limit for the number of results returned.
+ * @property {boolean} [revoked] - Optional boolean to filter attestations based on their revoked status.
+ * @property {EASSchemaUid[]} [schemas] - Optional array of schema UIDs to filter attestations.
  */
 type GetEASAttestationQueryVariablesFilters = {
-    schemas?: EASSchemaUid[];
-    revoked: boolean;
-    expirationTime?: number;
-    limit: number;
+  expirationTime?: number;
+  limit: number;
+  revoked: boolean;
+  schemas?: EASSchemaUid[];
 };
 
 /**
- * Type for the variables passed to the GraphQL query.
+ * Alias type for filter options when fetching attestations by filter.
+ */
+type GetEASAttestationsByFilterOptions = GetEASAttestationQueryVariablesFilters;
+
+/**
+ * Type representing the variables passed to the EAS Attestations GraphQL query.
  * @typedef {Object} EASAttestationsQueryVariables
- * @property {Record<string, any>} where - Conditions for filtering the attestations.
  * @property {string[]} distinct - Fields for which to get distinct records.
  * @property {number} take - Number of records to retrieve.
+ * @property {Record<string, any>} where - Conditions for filtering the attestations.
  */
 export type EASAttestationsQueryVariables = {
-    where: Record<string, any>;
-    distinct: string[];
-    take: number;
+  distinct: string[];
+  take: number;
+  where: Record<string, any>;
 };
 
 /**
- * Type for the response of the GraphQL query.
+ * Type representing the response of the EAS Attestation GraphQL query.
  * @typedef {Object} GetEASAttestationQueryResponse
  * @property {EASAttestation[]} attestations - Array of attestation objects.
  */
 export type GetEASAttestationQueryResponse = {
-    attestations: EASAttestation[];
+  attestations: EASAttestation[];
 };
+
+/**
+ * Type representing the response when fetching attestations by filter.
+ */
+export type GetEASAttestationsByFilterResponse = EASAttestation[];
 
 /**
  * GraphQL query definition for fetching EAS Attestations for users.
  */
 export const easAttestationQuery = gql`
-    query EASAttestationsForUsers(
-        $where: EASAttestationWhereInput
-        $distinct: [EASAttestationScalarFieldEnum!]
-        $take: Int
-    ) {
-        attestations(where: $where, distinct: $distinct, take: $take) {
-            id
-            txid
-            schemaId
-            attester
-            recipient
-            revoked
-            revocationTime
-            expirationTime
-            time
-            timeCreated
-            decodedDataJson
-        }
+  query EASAttestationsForUsers(
+    $where: EASAttestationWhereInput
+    $distinct: [EASAttestationScalarFieldEnum!]
+    $take: Int
+  ) {
+    attestations(where: $where, distinct: $distinct, take: $take) {
+      id
+      txid
+      schemaId
+      attester
+      recipient
+      revoked
+      revocationTime
+      expirationTime
+      time
+      timeCreated
+      decodedDataJson
     }
+  }
 `;
 
 /**
- * Generates query variables for the EAS Attestation GraphQL query.
- * 
+ * Generates query variables for the EAS Attestation GraphQL query based on the given address and filters.
+ *
  * @param {Address} address - The Ethereum address of the recipient.
- * @param {GetEASAttestationQueryVariablesFilters} [filters] - Optional filters to apply to the query.
+ * @param {GetEASAttestationQueryVariablesFilters} filters - Filters to apply to the query.
  * @returns {EASAttestationsQueryVariables} The query variables for the GraphQL query.
  */
 export function getEASAttestationQueryVariables(
@@ -80,8 +90,7 @@ export function getEASAttestationQueryVariables(
     recipient: { equals: address },
     revoked: { equals: filters.revoked },
   };
-    
-  // Handle the expiration time if passed as filter
+
   if (typeof filters.expirationTime === 'number') {
     conditions.OR = [
       { expirationTime: { equals: 0 } },
@@ -98,4 +107,29 @@ export function getEASAttestationQueryVariables(
     distinct: ['schemaId'],
     take: filters.limit,
   };
+}
+
+/**
+ * Fetches Ethereum Attestation Service (EAS) attestations for a given address and chain,
+ * optionally filtered by the provided filter options.
+ *
+ * @param {Address} address - The Ethereum address for which attestations are being queried.
+ * @param {Chain} chain - The blockchain chain of interest.
+ * @param {GetEASAttestationsByFilterOptions} filters - Filter options for querying attestations.
+ * @returns {Promise<GetEASAttestationsByFilterResponse>} A promise that resolves to an array of EAS Attestations.
+ */
+export async function getEASAttestationsByFilter<TChain extends Chain>(
+  address: Address,
+  chain: TChain,
+  filters: GetEASAttestationsByFilterOptions,
+): Promise<GetEASAttestationsByFilterResponse> {
+  const easGraphqlClient = createEasGraphQLClient(chain);
+  const easAttestationQueryVariables = getEASAttestationQueryVariables(address, filters);
+
+  const { attestations } = await easGraphqlClient.request<
+    GetEASAttestationQueryResponse,
+    EASAttestationsQueryVariables
+  >(easAttestationQuery, easAttestationQueryVariables);
+
+  return attestations;
 }

--- a/src/queries/easAttestations.ts
+++ b/src/queries/easAttestations.ts
@@ -21,7 +21,7 @@ type GetEASAttestationQueryVariablesFilters = {
 /**
  * Alias type for filter options when fetching attestations by filter.
  */
-type GetEASAttestationsByFilterOptions = GetEASAttestationQueryVariablesFilters;
+export type GetEASAttestationsByFilterOptions = GetEASAttestationQueryVariablesFilters;
 
 /**
  * Type representing the variables passed to the EAS Attestations GraphQL query.

--- a/src/queries/easAttestations.ts
+++ b/src/queries/easAttestations.ts
@@ -1,0 +1,101 @@
+import { gql } from 'graphql-request';
+import type { Address } from 'viem';
+import { EASSchemaUid, EASAttestation } from '../core/types';
+
+
+/**
+ * Type for the input filters to the GraphQL query.
+ * @typedef {Object} GetEASAttestationQueryVariablesFilters
+ * @property {EASSchemaUid[]} [schemas] - Optional array of schema UIDs to filter attestations.
+ * @property {boolean} [revoked] - Optional boolean to filter attestations based on their revoked status.
+ * @property {number} [expirationTime] - Optional Unix timestamp to filter attestations based on expiration time.
+ * @property {number} [limit] - Optional limit for the number of results returned.
+ */
+type GetEASAttestationQueryVariablesFilters = {
+    schemas?: EASSchemaUid[];
+    revoked: boolean;
+    expirationTime?: number;
+    limit: number;
+};
+
+/**
+ * Type for the variables passed to the GraphQL query.
+ * @typedef {Object} EASAttestationsQueryVariables
+ * @property {Record<string, any>} where - Conditions for filtering the attestations.
+ * @property {string[]} distinct - Fields for which to get distinct records.
+ * @property {number} take - Number of records to retrieve.
+ */
+export type EASAttestationsQueryVariables = {
+    where: Record<string, any>;
+    distinct: string[];
+    take: number;
+};
+
+/**
+ * Type for the response of the GraphQL query.
+ * @typedef {Object} GetEASAttestationQueryResponse
+ * @property {EASAttestation[]} attestations - Array of attestation objects.
+ */
+export type GetEASAttestationQueryResponse = {
+    attestations: EASAttestation[];
+};
+
+/**
+ * GraphQL query definition for fetching EAS Attestations for users.
+ */
+export const easAttestationQuery = gql`
+    query EASAttestationsForUsers(
+        $where: EASAttestationWhereInput
+        $distinct: [EASAttestationScalarFieldEnum!]
+        $take: Int
+    ) {
+        attestations(where: $where, distinct: $distinct, take: $take) {
+            id
+            txid
+            schemaId
+            attester
+            recipient
+            revoked
+            revocationTime
+            expirationTime
+            time
+            timeCreated
+            decodedDataJson
+        }
+    }
+`;
+
+/**
+ * Generates query variables for the EAS Attestation GraphQL query.
+ * 
+ * @param {Address} address - The Ethereum address of the recipient.
+ * @param {GetEASAttestationQueryVariablesFilters} [filters] - Optional filters to apply to the query.
+ * @returns {EASAttestationsQueryVariables} The query variables for the GraphQL query.
+ */
+export function getEASAttestationQueryVariables(
+  address: Address,
+  filters: GetEASAttestationQueryVariablesFilters,
+): EASAttestationsQueryVariables {
+  const conditions: Record<string, any> = {
+    recipient: { equals: address },
+    revoked: { equals: filters.revoked },
+  };
+    
+  // Handle the expiration time if passed as filter
+  if (typeof filters.expirationTime === 'number') {
+    conditions.OR = [
+      { expirationTime: { equals: 0 } },
+      { expirationTime: { gt: filters.expirationTime } },
+    ];
+  }
+
+  if (filters?.schemas && filters.schemas.length > 0) {
+    conditions.schemaId = { in: filters.schemas };
+  }
+
+  return {
+    where: { AND: [conditions] },
+    distinct: ['schemaId'],
+    take: filters.limit,
+  };
+}

--- a/src/utils/easAttestation.ts
+++ b/src/utils/easAttestation.ts
@@ -2,11 +2,13 @@ import type { Chain } from 'viem';
 import { EASChainDefinition } from '../core/types';
 import { easChainBase } from '../definitions/base';
 import { easChainOptimism } from '../definitions/optimism';
+import { easChainBaseSepolia } from '../definitions/baseSepolia';
 
 export type EASSupportedChains = Record<number, EASChainDefinition>;
 
 export const easSupportedChains: EASSupportedChains = {
   [easChainBase.id]: easChainBase,
+  [easChainBaseSepolia.id]: easChainBaseSepolia,
   [easChainOptimism.id]: easChainOptimism,
 };
 
@@ -18,4 +20,15 @@ export const easSupportedChains: EASSupportedChains = {
  */
 export function isChainSupported(chain: Chain): boolean {
   return chain.id in easSupportedChains;
+}
+
+/**
+ * Function to get the EAS GraphQL API endpoint for a given blockchain.
+ *
+ * @param {Chain} chain - The chain to be checked for support.
+ * @returns {string} GraphQL endpoint
+ */
+
+export function getChainEASGraphQLAPI(chain: Chain): string {
+  return easSupportedChains[chain.id]?.easGraphqlAPI ?? '';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2013,6 +2013,8 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/react": "npm:^18"
     "@types/react-dom": "npm:^18"
+    graphql: "npm:^14"
+    graphql-request: "npm:^6.1.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
     jest-extended: "npm:^4.0.2"
@@ -2027,11 +2029,22 @@ __metadata:
     viem: "npm:^2.7.0"
     yarn: "npm:^1.22.21"
   peerDependencies:
+    graphql: ^14
+    graphql-request: ^6
     react: ^18
     react-dom: ^18
     viem: ^2.7.0
   languageName: unknown
   linkType: soft
+
+"@graphql-typed-document-node/core@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@graphql-typed-document-node/core@npm:3.2.0"
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+  checksum: 94e9d75c1f178bbae8d874f5a9361708a3350c8def7eaeb6920f2c820e82403b7d4f55b3735856d68e145e86c85cbfe2adc444fdc25519cd51f108697e99346c
+  languageName: node
+  linkType: hard
 
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
@@ -4005,6 +4018,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-fetch@npm:^3.1.5":
+  version: 3.1.8
+  resolution: "cross-fetch@npm:3.1.8"
+  dependencies:
+    node-fetch: "npm:^2.6.12"
+  checksum: 4c5e022ffe6abdf380faa6e2373c0c4ed7ef75e105c95c972b6f627c3f083170b6886f19fb488a7fa93971f4f69dcc890f122b0d97f0bf5f41ca1d9a8f58c8af
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^5.1.0":
   version: 5.1.0
   resolution: "cross-spawn@npm:5.1.0"
@@ -5027,6 +5049,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphql-request@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "graphql-request@npm:6.1.0"
+  dependencies:
+    "@graphql-typed-document-node/core": "npm:^3.2.0"
+    cross-fetch: "npm:^3.1.5"
+  peerDependencies:
+    graphql: 14 - 16
+  checksum: f8167925a110e8e1de93d56c14245e7e64391dc8dce5002dd01bf24a3059f345d4ca1bb6ce2040e2ec78264211b0704e75da3e63984f0f74d2042f697a4e8cc6
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^14":
+  version: 14.7.0
+  resolution: "graphql@npm:14.7.0"
+  dependencies:
+    iterall: "npm:^1.2.2"
+  checksum: 7f8085d4d8f4cd20bde0a2c327d21a0beaf2d0539775dc4fc093d2193c51f3c268ab43d11d539ce0ef26ffea227de7c7bd47788636bd66c5a944c95ad0870727
+  languageName: node
+  linkType: hard
+
 "hard-rejection@npm:^2.1.0":
   version: 2.1.0
   resolution: "hard-rejection@npm:2.1.0"
@@ -5739,6 +5782,13 @@ __metadata:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
   checksum: ec3f1bdbc51b3e0b325a5b9f4ad31a247697f31001df4e81075f7980413f14da1b5adfec574fd156efd3b0464023f61320f6718efc66ee72b32d89611cef99dd
+  languageName: node
+  linkType: hard
+
+"iterall@npm:^1.2.2":
+  version: 1.3.0
+  resolution: "iterall@npm:1.3.0"
+  checksum: 40de624e5fe937c4c0e511981b91caea9ff2142bfc0316cccc8506eaa03aa253820cc17c5bc5f0a98706c7268a373e5ebee9af9a0c8a359730cf7c05938b57b5
   languageName: node
   linkType: hard
 
@@ -6832,7 +6882,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.5.0":
+"node-fetch@npm:^2.5.0, node-fetch@npm:^2.6.12":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:


### PR DESCRIPTION
The new `getEASAttestations` function fetches Ethereum Attestation Service (EAS) attestations for a given address and chain. Optionally filtered by schemas associated with the attestation.

Example:

```javascript
import { getEASAttestations } from '@coinbase/onchainkit'
import { base } from "viem/chains";

const attestations = await getEASAttestations("0x1234567890abcdef1234567890abcdef12345678", base)
// returns [
//   {
//       "attester": "0x357458739F90461b99789350868CD7CF330Dd7EE",
//       "expirationTime": 0,
//       "id": "0x93016a60f13e7cfe0257116aedfce7088c2c0020787a325ea9f6b4ba11d07598",
//       "recipient": "0x44a7D120beA87455071cebB841eF91E6Ae21bC1a",
//       "revocationTime": 0,
//       "schemaId": "0x1801901fabd0e6189356b4fb52bb0ab855276d84f7ec140839fbd1f6801ca065",
//       "timeCreated": 1707269100,
//       "txid": "0x88448267566c9546ff31b9e6be229fb960f12bec8bc441259c7b064ae4159d34"
//   },
// ]
```

**Notes to reviewers**

**How has it been tested?**
