### PR TITLE
Update getFrameMetadata.ts

### DIFF
--- a/src/core/getFrameMetadata.ts
+++ b/src/core/getFrameMetadata.ts
@@ -41,7 +41,7 @@ export const getFrameMetadata = function ({
       if (button.action) {
         metadata[`fc:frame:button:${index + 1}:action`] = button.action;
       }
-      if ((button.action == 'link' || button.action == 'mint') && button.target) {
+      if ((button.action == 'link' || button.action == 'mint' || button.action == 'post') && button.target) {
         metadata[`fc:frame:button:${index + 1}:target`] = button.target;
       }
     });


### PR DESCRIPTION
`button.target == 'post'` should also be added based on documentation here. I ran into this problem in a Frame I was building where I could only adjust the logic for all my buttons in the `postUrl`. https://docs.farcaster.xyz/reference/frames/spec#handling-clicks

```
Handling Clicks
If the button clicked is a post or post_redirect, apps must:

1. Construct a Frame Signature Packet.
2. POST the packet to fc:frame:button:$idx:target if present
3. POST the packet to fc:frame:post_url if target was not present.
4. POST the packet to or the frame's embed URL if neither target nor action were present.
5. Wait at least 5 seconds for a response from the frame server.
```

**What changed? Why?**
- `button.target == 'post'` added to logic check to handle buttons that are action type `post` and have a defined `target` link. This avoids handling all logic in `postUrl` for the buttons.

**Notes to reviewers**
- Test out in your stack as our stack from FrameHub Template here https://github.com/Phala-Network/framehub-template supports a subset of onchainkit `core` with `getFrameMetadata` and `getFrameMessage`
**How has it been tested?**
- Tested locally, but best to test in your environment to ensure this works with the extended functionalities provided in your  onchainkit repo