### PR TITLE
fix: install framegear deps during CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
           cache: 'npm'
       - name: Kit Install dependencies
         run: npm install
+        run: npm install --prefix ./framegear
       - name: Kit Test Check
         # When fails, please check your tests
         run: npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Kit Install dependencies
-        run: npm install
-        run: npm install --prefix ./framegear
+        run: npm install && npm install --prefix ./framegear
       - name: Kit Test Check
         # When fails, please check your tests
         run: npm run test


### PR DESCRIPTION
**What changed? Why?**
Didn't realize global tests would run on this directory, adding installing `framegear` deps to the workflow

**Notes to reviewers**

**How has it been tested?**
