### PR TITLE
feat: `getFrameMessage` can now handle mock frame messages.

### DIFF
--- a/.changeset/cuddly-frogs-flow.md
+++ b/.changeset/cuddly-frogs-flow.md
@@ -2,4 +2,4 @@
 '@coinbase/onchainkit': minor
 ---
 
-- **feat**: `getFrameMessage` can now handle mock frame messages. When `allowDebug` is passed as an option (defaults to `false`), it will skip validating which facilitates testing locally running apps with future releases of `framegear`.
+- **feat**: `getFrameMessage` can now handle mock frame messages. When `allowFramegear` is passed as an option (defaults to `false`), it will skip validating which facilitates testing locally running apps with future releases of `framegear`.

--- a/.changeset/cuddly-frogs-flow.md
+++ b/.changeset/cuddly-frogs-flow.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': minor
+---
+
+- **feat**: `getFrameMessage` can now handle mock frame messages. When `allowDebug` is passed as an option (defaults to `false`), it will skip validating which facilitates testing locally running apps with future releases of `framegear`.

--- a/src/core/getFrameMessage.test.ts
+++ b/src/core/getFrameMessage.test.ts
@@ -30,7 +30,7 @@ describe('getFrameValidatedMessage', () => {
       {
         trustedData: { messageBytes: 'invalid' },
       } as FrameRequest,
-      { allowDebug: true },
+      { allowFramegear: true },
     );
     expect(result?.isValid).toEqual(false);
     expect(result.message).toBeUndefined();
@@ -56,7 +56,7 @@ describe('getFrameValidatedMessage', () => {
           messageBytes: '0xthisisnotreal',
         },
       }),
-      { allowDebug: true },
+      { allowFramegear: true },
     );
     expect(result?.isValid).toEqual(true);
     expect(result.message?.button).toEqual(1);

--- a/src/core/getFrameMessage.test.ts
+++ b/src/core/getFrameMessage.test.ts
@@ -1,5 +1,6 @@
 import { mockNeynarResponse } from './mock';
 import { getFrameMessage } from './getFrameMessage';
+import { getMockFrameRequest } from './getMockFrameRequest';
 import { neynarBulkUserLookup } from '../utils/neynar/user/neynarUserFunctions';
 import { FrameRequest } from './types';
 import { neynarFrameValidation } from '../utils/neynar/frame/neynarFrameFunctions';
@@ -22,6 +23,68 @@ describe('getFrameValidatedMessage', () => {
       trustedData: { messageBytes: 'invalid' },
     } as FrameRequest);
     expect(result?.isValid).toEqual(false);
+  });
+
+  it('should consider invalid non-mock requests as invalid, even if mock requests are allowed', async () => {
+    const result = await getFrameMessage(
+      {
+        trustedData: { messageBytes: 'invalid' },
+      } as FrameRequest,
+      { allowDebug: true },
+    );
+    expect(result?.isValid).toEqual(false);
+    expect(result.message).toBeUndefined();
+  });
+
+  it('should consider mock messages valid, if allowed', async () => {
+    const result = await getFrameMessage(
+      getMockFrameRequest({
+        untrustedData: {
+          buttonIndex: 1,
+          castId: {
+            fid: 0,
+            hash: '0xthisisnotreal',
+          },
+          inputText: '',
+          fid: 0,
+          network: 0,
+          messageHash: '0xthisisnotreal',
+          timestamp: 0,
+          url: 'https://localhost:3000',
+        },
+        trustedData: {
+          messageBytes: '0xthisisnotreal',
+        },
+      }),
+      { allowDebug: true },
+    );
+    expect(result?.isValid).toEqual(true);
+    expect(result.message?.button).toEqual(1);
+  });
+
+  it('should consider mock messages invalid, if not allowed (default)', async () => {
+    const result = await getFrameMessage(
+      getMockFrameRequest({
+        untrustedData: {
+          buttonIndex: 1,
+          castId: {
+            fid: 0,
+            hash: '0xthisisnotreal',
+          },
+          inputText: '',
+          fid: 0,
+          network: 0,
+          messageHash: '0xthisisnotreal',
+          timestamp: 0,
+          url: 'https://localhost:3000',
+        },
+        trustedData: {
+          messageBytes: '0xthisisnotreal',
+        },
+      }),
+    );
+    expect(result?.isValid).toEqual(false);
+    expect(result.message).toBeUndefined();
   });
 
   it('should return the message if the message is valid', async () => {

--- a/src/core/getFrameMessage.ts
+++ b/src/core/getFrameMessage.ts
@@ -1,4 +1,4 @@
-import { FrameRequest, FrameValidationResponse } from './types';
+import { FrameRequest, FrameValidationResponse, MockFrameRequest } from './types';
 import {
   NEYNAR_DEFAULT_API_KEY,
   neynarFrameValidation,
@@ -9,6 +9,7 @@ type FrameMessageOptions =
       neynarApiKey?: string;
       castReactionContext?: boolean;
       followContext?: boolean;
+      allowDebug?: boolean;
     }
   | undefined;
 
@@ -20,9 +21,19 @@ type FrameMessageOptions =
  * @param body The JSON received by server on frame callback
  */
 async function getFrameMessage(
-  body: FrameRequest,
+  body: FrameRequest | MockFrameRequest,
   messageOptions?: FrameMessageOptions,
 ): Promise<FrameValidationResponse> {
+  // Skip validation only when allowed and when receiving a debug request
+  if (messageOptions?.allowDebug) {
+    if ((body as MockFrameRequest).onchainkitDebug) {
+      return {
+        isValid: true,
+        message: (body as MockFrameRequest).onchainkitDebug,
+      };
+    }
+  }
+
   // Validate the message
   const response = await neynarFrameValidation(
     body?.trustedData?.messageBytes,

--- a/src/core/getFrameMessage.ts
+++ b/src/core/getFrameMessage.ts
@@ -24,7 +24,7 @@ async function getFrameMessage(
   body: FrameRequest | MockFrameRequest,
   messageOptions?: FrameMessageOptions,
 ): Promise<FrameValidationResponse> {
-  // Skip validation only when allowed and when receiving a debug request
+  // Skip validation only when allowed and when receiving a request from framegear
   if (messageOptions?.allowFramegear) {
     if ((body as MockFrameRequest).mockFrameData) {
       return {

--- a/src/core/getFrameMessage.ts
+++ b/src/core/getFrameMessage.ts
@@ -9,7 +9,7 @@ type FrameMessageOptions =
       neynarApiKey?: string;
       castReactionContext?: boolean;
       followContext?: boolean;
-      allowDebug?: boolean;
+      allowFramegear?: boolean;
     }
   | undefined;
 
@@ -25,11 +25,11 @@ async function getFrameMessage(
   messageOptions?: FrameMessageOptions,
 ): Promise<FrameValidationResponse> {
   // Skip validation only when allowed and when receiving a debug request
-  if (messageOptions?.allowDebug) {
-    if ((body as MockFrameRequest).onchainkitDebug) {
+  if (messageOptions?.allowFramegear) {
+    if ((body as MockFrameRequest).mockFrameData) {
       return {
         isValid: true,
-        message: (body as MockFrameRequest).onchainkitDebug,
+        message: (body as MockFrameRequest).mockFrameData,
       };
     }
   }

--- a/src/core/getMockFrameRequest.ts
+++ b/src/core/getMockFrameRequest.ts
@@ -13,7 +13,7 @@ function getMockFrameRequest(
 ): MockFrameRequest {
   return {
     ...request,
-    onchainkitDebug: {
+    mockFrameData: {
       button: request.untrustedData.buttonIndex,
       input: request.untrustedData.inputText,
       following: !!options?.following,

--- a/src/core/getMockFrameRequest.ts
+++ b/src/core/getMockFrameRequest.ts
@@ -1,0 +1,37 @@
+import { FrameRequest, MockFrameRequest, MockFrameRequestOptions } from './types';
+
+/**
+ * Modify a standard frame request to include simulated values (e.g., indicate the viewer
+ * follows the cast author) for development/debugging purposes.
+ * @param request A standard frame request.
+ * @param options An object containing values we will pretend are real for the purposes of debugging.
+ * @returns
+ */
+function getMockFrameRequest(
+  request: FrameRequest,
+  options?: MockFrameRequestOptions,
+): MockFrameRequest {
+  return {
+    ...request,
+    onchainkitDebug: {
+      button: request.untrustedData.buttonIndex,
+      input: request.untrustedData.inputText,
+      following: !!options?.following,
+      interactor: {
+        fid: options?.interactor?.fid || 0,
+        custody_address: options?.interactor?.custody_address || '0xnotarealaddress',
+        verified_accounts: options?.interactor?.verified_accounts || [],
+      },
+      liked: !!options?.liked,
+      recasted: !!options?.recasted,
+      valid: true,
+      raw: {
+        valid: true,
+        // TODO: unjank
+        action: {} as any,
+      },
+    },
+  };
+}
+
+export { getMockFrameRequest };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -197,4 +197,4 @@ export type MockFrameRequestOptions = {
  *
  * Note: exported as public Type
  */
-export type MockFrameRequest = FrameRequest & { onchainkitDebug: Required<FrameValidationData> };
+export type MockFrameRequest = FrameRequest & { mockFrameData: Required<FrameValidationData> };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -175,3 +175,26 @@ export type EASChainDefinition = {
   id: number; // blockchain source id
   schemaUids: EASSchemaUid[]; // Array of EAS Schema UIDs
 };
+
+/**
+ * Settings to simulate statuses on mock frames.
+ *
+ * Note: exported as public Type
+ */
+export type MockFrameRequestOptions = {
+  following?: boolean; // Indicates if the viewer clicking the frame follows the cast author
+  interactor?: {
+    fid?: number; // Viewer Farcaster ID
+    custody_address?: string; // Viewer custody address
+    verified_accounts?: string[]; // Viewer account addresses
+  };
+  liked?: boolean; // Indicates if the viewer clicking the frame liked the cast
+  recasted?: boolean; // Indicates if the viewer clicking the frame recasted the cast
+};
+
+/**
+ * A mock frame request payload
+ *
+ * Note: exported as public Type
+ */
+export type MockFrameRequest = FrameRequest & { onchainkitDebug: Required<FrameValidationData> };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { getEASAttestations } from './core/getEASAttestations';
 export { getFrameHtmlResponse } from './core/getFrameHtmlResponse';
 export { getFrameMetadata } from './core/getFrameMetadata';
 export { getFrameMessage } from './core/getFrameMessage';
+export { getMockFrameRequest } from './core/getMockFrameRequest';
 export { FrameMetadata } from './components/FrameMetadata';
 export { Avatar } from './components/Avatar';
 export { Name } from './components/Name';

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,6 @@ export type {
   FrameMetadataType,
   FrameRequest,
   FrameValidationData,
+  MockFrameRequest,
+  MockFrameRequestOptions,
 } from './core/types';


### PR DESCRIPTION
**What changed? Why?**
Taken from #148, this PR introduces the concept of mock frame messages, which facilitates testing locally running frames in future releases of `framegear`. This is MVP-quality, keeping track of enhancements for fast followup in #146.

**Notes to reviewers**
This PR has to be merged and released before we can add the second part.

**How has it been tested?**
Unit tests, manual end-to-end testing with locally-installed package and modified `framegear`.