### PR TITLE
Move text out of code-group

### DIFF
--- a/site/docs/pages/xmtpkit/introduction.mdx
+++ b/site/docs/pages/xmtpkit/introduction.mdx
@@ -25,7 +25,13 @@ pnpm add @coinbase/onchainkit @xmtp/frames-validator
 
 :::
 
-To assist you in engaging with XMTP, here is the XMTP Kit which includes:
+[XMTP](https://xmtp.org/) is a wallet to wallet messaging protocol, and many XMTP client applications are adding Frames support.
+
+When a user interacts with a Frame inside an XMTP client application, you will need to handle the payload slightly differently from an interaction coming from Farcaster. The primary identifier for a user on Farcaster is the `fid`, while in XMTP it is the `verifiedWalletAddress`.
+
+You can learn more about how XMTP works with frames in [their documentation here](https://xmtp.org/docs/build/frames).
+
+To assist you in handling interactions from XMTP, and extracting the `verifiedWalletAddress` from a POST payload, here is the XMTP Kit which includes:
 
 - [XMTP Kit](/xmtpkit/introduction)
   - Utilities:


### PR DESCRIPTION
**What changed? Why?**

I'm a `vocs` n00b and accidentally put some text inside the code group. 🤦 . This should make the text visible to users.

**Notes to reviewers**

**How has it been tested?**
