### PR TITLE
feat: always show required tag status

### DIFF
--- a/framegear/components/Frame/Frame.tsx
+++ b/framegear/components/Frame/Frame.tsx
@@ -48,7 +48,11 @@ function ValidFrame({ tags }: { tags: Record<string, string> }) {
   return (
     <div>
       {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img className={`w-full rounded-t-xl aspect-[${imageAspectRatio}]`} src={image} alt="" />
+      <img
+        className={`w-full rounded-t-xl aspect-[${imageAspectRatio}] object-cover`}
+        src={image}
+        alt=""
+      />
       <div className="bg-content-light flex flex-col gap-2 rounded-b-xl px-4 py-2">
         {!!input && (
           <input
@@ -121,12 +125,14 @@ function FrameButton({
   }, [button, setResults]);
   return (
     <button
-      className="border-button w-[45%] grow rounded-lg border bg-white p-2 text-black"
+      className="border-button w-[45%] grow rounded-lg border bg-white px-4 py-2 text-black"
       type="button"
       onClick={handleClick}
       disabled={button?.action !== 'post'}
     >
-      <span>{children}</span>
+      <span className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap">
+        {children}
+      </span>
     </button>
   );
 }

--- a/framegear/components/ValidationResults/ValidationResults.tsx
+++ b/framegear/components/ValidationResults/ValidationResults.tsx
@@ -1,7 +1,7 @@
 import { frameResultsAtom } from '@/utils/store';
 import { vNextSchema } from '@/utils/validation';
 import { useAtom } from 'jotai';
-import { PropsWithChildren, useMemo } from 'react';
+import { useMemo } from 'react';
 import { type SchemaDescription } from 'yup';
 
 const REQUIRED_FIELD_NAMES = Object.entries(vNextSchema.describe().fields).reduce(
@@ -51,7 +51,7 @@ function ValidationResultsContent() {
         )}
       </h2>
       <div className="bg-content flex w-full flex-col gap-4 rounded-xl p-6">
-        <ValidationEntriesWrapper title="Required Fields">
+        <ul className="flex list-none flex-col gap-4 p-0">
           {REQUIRED_FIELD_NAMES.map((name) => {
             const value = latestResult.tags[name];
             return (
@@ -63,32 +63,12 @@ function ValidationResultsContent() {
               />
             );
           })}
-        </ValidationEntriesWrapper>
-        {optionalTags.length > 0 && (
-          <ValidationEntriesWrapper title="Optional Fields">
-            {optionalTags.map(([key, value]) => (
-              <ValidationEntry
-                key={key}
-                name={key}
-                value={value}
-                error={latestResult.errors[key]}
-              />
-            ))}
-          </ValidationEntriesWrapper>
-        )}
+          {optionalTags.map(([key, value]) => (
+            <ValidationEntry key={key} name={key} value={value} error={latestResult.errors[key]} />
+          ))}
+        </ul>
       </div>
     </div>
-  );
-}
-
-function ValidationEntriesWrapper({ title, children }: PropsWithChildren<{ title: string }>) {
-  return (
-    <figure>
-      <figcaption className="border-pallette-line mb-4 border-b pb-4 pt-4 text-center font-bold first:pt-0">
-        {title}
-      </figcaption>
-      <ul className="flex list-none flex-col gap-4 p-0">{children}</ul>
-    </figure>
   );
 }
 

--- a/framegear/components/ValidationResults/ValidationResults.tsx
+++ b/framegear/components/ValidationResults/ValidationResults.tsx
@@ -1,9 +1,53 @@
 import { frameResultsAtom } from '@/utils/store';
+import { vNextSchema } from '@/utils/validation';
 import { useAtom } from 'jotai';
+import { PropsWithChildren, useMemo } from 'react';
+import { type SchemaDescription } from 'yup';
+
+const REQUIRED_FIELD_NAMES = new Set(
+  Object.entries(vNextSchema.describe().fields).reduce(
+    (acc, [name, description]) =>
+      (description as SchemaDescription).optional ? acc : [...acc, name],
+    [] as string[],
+  ),
+);
 
 export function ValidationResults() {
   const [results] = useAtom(frameResultsAtom);
+
+  if (results.length === 0) {
+    return <ValidationResultsPlaceholder />;
+  }
+
+  return <ValidationResultsContent />;
+}
+
+function ValidationResultsPlaceholder() {
+  return (
+    <div className="flex flex-col gap-4">
+      <h2>Frame validations</h2>
+      <div className="bg-content flex w-full flex-col gap-4 rounded-xl p-6">
+        <p>No data yet.</p>
+      </div>
+    </div>
+  );
+}
+
+function ValidationResultsContent() {
+  const [results] = useAtom(frameResultsAtom);
   const latestResult = results[results.length - 1];
+  const { requiredTags, optionalTags } = useMemo(() => {
+    const tagEntries = Object.entries(latestResult?.tags);
+    const requiredTags: typeof tagEntries = [];
+    const optionalTags: typeof tagEntries = [];
+    tagEntries.forEach((tag) =>
+      (REQUIRED_FIELD_NAMES.has(tag[0]) ? requiredTags : optionalTags).push(tag),
+    );
+    return { requiredTags, optionalTags };
+  }, [latestResult]);
+
+  console.log({ requiredTags, optionalTags, latestResult });
+
   return (
     <div className="flex flex-col gap-4">
       <h2>
@@ -15,24 +59,34 @@ export function ValidationResults() {
         )}
       </h2>
       <div className="bg-content flex w-full flex-col gap-4 rounded-xl p-6">
-        {latestResult && (
-          <dl className="flex flex-col gap-4">
-            {Object.entries(latestResult.tags).map(([key, value]) => (
-              <ValidationEntry
-                key={key}
-                name={key}
-                value={value}
-                error={latestResult.errors[key]}
-              />
-            ))}
-          </dl>
-        )}
+        <ValidationEntriesWrapper title="Required Fields">
+          {requiredTags.map(([key, value]) => (
+            <ValidationEntry key={key} name={key} value={value} error={latestResult.errors[key]} />
+          ))}
+        </ValidationEntriesWrapper>
+        <ValidationEntriesWrapper title="Optional Fields">
+          {optionalTags.map(([key, value]) => (
+            <ValidationEntry key={key} name={key} value={value} error={latestResult.errors[key]} />
+          ))}
+        </ValidationEntriesWrapper>
       </div>
     </div>
   );
 }
 
-function ValidationEntry({ name, value, error }: { name: string; value: string; error?: string }) {
+function ValidationEntriesWrapper({ title, children }: PropsWithChildren<{ title: string }>) {
+  return (
+    <figure>
+      <figcaption className="border-pallette-line mb-4 border-b pb-4 pt-4 font-bold first:pt-0">
+        {title}
+      </figcaption>
+      <ul className="flex list-none flex-col gap-4 p-0">{children}</ul>
+    </figure>
+  );
+}
+
+type ValidationEntryProps = { name: string; value: string; error?: string };
+function ValidationEntry({ name, value, error }: ValidationEntryProps) {
   return (
     <div
       className={`border-pallette-line flex flex-col gap-2 border-b pb-4 last:border-b-0 last:pb-0`}

--- a/framegear/utils/validation.ts
+++ b/framegear/utils/validation.ts
@@ -2,8 +2,8 @@ import * as yup from 'yup';
 
 export const vNextSchema = yup.object({
   'fc:frame': yup.string().required().matches(/vNext/, '"fc:frame" must be "vNext"'),
-  'fc:frame:image': yup.string().defined(),
-  'og:image': yup.string().defined(),
+  'fc:frame:image': yup.string().required(),
+  'og:image': yup.string().required(),
   'fc:frame:button:1': yup.string().optional(),
   // TODO: yup doesn't infer type well from this concise definition
   ...[2, 3, 4].reduce(


### PR DESCRIPTION
**What changed? Why?**
Part of #146. Changes in this PR:

- always show required tags, even when not present
- show error message when relevant in verification
- add placeholder message when no frame has been loaded
- update schema for more consistent error messages (wording around "required" vs "defined")

Small improvements while I was in there:

- we didn't gracefully handle wrong aspect-ratio image, now using `object-cover` to clip the edges to fit. This is consistent with Warpcast behavior.
- Handled long frame button text with ellipsis

| no results | invalid results | valid results |
| ----- | ----- | ----- | 
| <img width="1584" alt="image" src="https://github.com/coinbase/onchainkit/assets/9300702/00e048ee-c0bb-4833-b233-14fdc758ec0e"> | <img width="1584" alt="image" src="https://github.com/coinbase/onchainkit/assets/9300702/b8f0316c-2dad-4509-916a-afdb1ce86510"> | <img width="1584" alt="image" src="https://github.com/coinbase/onchainkit/assets/9300702/257927e3-d299-450b-a247-0eb5af995298"> |




**Notes to reviewers**

**How has it been tested?**
