### PR TITLE
Fix EAS graphql types

### DIFF
--- a/src/queries/easAttestations.ts
+++ b/src/queries/easAttestations.ts
@@ -55,8 +55,8 @@ export type GetEASAttestationsByFilterResponse = EASAttestation[];
  */
 export const easAttestationQuery = gql`
   query EASAttestationsForUsers(
-    $where: EASAttestationWhereInput
-    $distinct: [EASAttestationScalarFieldEnum!]
+    $where: AttestationWhereInput
+    $distinct: [AttestationScalarFieldEnum!]
     $take: Int
   ) {
     attestations(where: $where, distinct: $distinct, take: $take) {


### PR DESCRIPTION
**What changed? Why?**
Fix for `Error in getEASAttestation: Unknown type "EASAttestationWhereInput"`

The gql types are [AttestationWhereInput](https://studio.apollographql.com/sandbox/schema/reference/inputs/AttestationWhereInput) and [AttestationScalarFieldEnum](https://studio.apollographql.com/sandbox/schema/reference/enums/AttestationScalarFieldEnum?query=returnType%3AAttestationScalarFieldEnum) without the `EAS` prefix.

**Notes to reviewers**

**How has it been tested?**
