### PR TITLE
Checksum address before querying GQL endpoint

### DIFF
--- a/src/queries/easAttestations.test.ts
+++ b/src/queries/easAttestations.test.ts
@@ -10,7 +10,8 @@ import { base } from 'viem/chains';
 jest.mock('../network/easGraphQL');
 
 describe('EAS Attestation Service', () => {
-  const mockAddress = '0x123';
+  const mockAddress = '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb';
+  const mockChecksummedAddress = '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB';
   const mockFilters: GetEASAttestationsByFilterOptions = {
     limit: 10,
     revoked: false,
@@ -25,7 +26,7 @@ describe('EAS Attestation Service', () => {
         where: {
           AND: [
             {
-              recipient: { equals: mockAddress },
+              recipient: { equals: mockChecksummedAddress },
               revoked: { equals: mockFilters.revoked },
               OR: [
                 { expirationTime: { equals: 0 } },

--- a/src/queries/easAttestations.ts
+++ b/src/queries/easAttestations.ts
@@ -1,5 +1,6 @@
 import { gql } from 'graphql-request';
 import type { Address, Chain } from 'viem';
+import { getAddress } from 'viem';
 import { EASSchemaUid, EASAttestation } from '../identity/types';
 import { createEasGraphQLClient } from '../network/easGraphQL';
 
@@ -86,8 +87,9 @@ export function getEASAttestationQueryVariables(
   address: Address,
   filters: GetEASAttestationQueryVariablesFilters,
 ): EASAttestationsQueryVariables {
+  const checksummedAddress = getAddress(address);
   const conditions: Record<string, any> = {
-    recipient: { equals: address },
+    recipient: { equals: checksummedAddress },
     revoked: { equals: filters.revoked },
   };
 


### PR DESCRIPTION
**What changed? Why?**
When onchain kit processes an FC users verified addresses from Neynar, they are all lowercase. EAS' GQL endpoint is case sensitive, so it will not return any attestations for addresses that are not checksummed. 

This PR leverages viem's [getAddress](https://viem.sh/docs/utilities/getAddress.html) function to make sure addresses passed to `getEASAttestationQueryVariables()` are checksummed before being included in the GQL query.

**Notes to reviewers**

**How has it been tested?**
