### PR TITLE
add content type to framegear post frame request

### DIFF
--- a/framegear/app/api/postFrame/route.ts
+++ b/framegear/app/api/postFrame/route.ts
@@ -12,6 +12,9 @@ export async function POST(req: NextRequest) {
 
   const res = await fetch(postUrl, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(debugPayload),
   });
 


### PR DESCRIPTION
**What changed? Why?**
- added `'Content-Type': 'application/json'` to post frame request headers.
- sending this request without the content-type  can cause server parsing issues. happened for me with express `4.17.21`

**Notes to reviewers**

**How has it been tested?**
- tested locally using express server. don't think this should cause issues with other servers, but you might want to do further testing. 
