### PR TITLE
chore: pin onchainkit, update aspect ratio classname

### DIFF
--- a/framegear/components/Frame/Frame.tsx
+++ b/framegear/components/Frame/Frame.tsx
@@ -22,7 +22,8 @@ export function Frame() {
 function ValidFrame({ tags }: { tags: Record<string, string> }) {
   const { image, imageAspectRatioClassname, input, buttons } = useMemo(() => {
     const image = tags['fc:frame:image'];
-    const imageAspectRatioClassname = tags['fc:frame:image:aspect_ratio'] === '1:1' ? 'aspect-square' : 'aspect-[1.91/1]';
+    const imageAspectRatioClassname =
+      tags['fc:frame:image:aspect_ratio'] === '1:1' ? 'aspect-square' : 'aspect-[1.91/1]';
     const input = tags['fc:frame:input:text'];
     // TODO: when debugger is live we will also need to extract actions, etc.
     const buttons = [1, 2, 3, 4].map((index) => {

--- a/framegear/components/Frame/Frame.tsx
+++ b/framegear/components/Frame/Frame.tsx
@@ -20,9 +20,9 @@ export function Frame() {
 }
 
 function ValidFrame({ tags }: { tags: Record<string, string> }) {
-  const { image, imageAspectRatio, input, buttons } = useMemo(() => {
+  const { image, imageAspectRatioClassname, input, buttons } = useMemo(() => {
     const image = tags['fc:frame:image'];
-    const imageAspectRatio = tags['fc:frame:image:aspect_ratio'] === '1:1' ? '1/1' : '1.91/1';
+    const imageAspectRatioClassname = tags['fc:frame:image:aspect_ratio'] === '1:1' ? 'aspect-square' : 'aspect-[1.91/1]';
     const input = tags['fc:frame:input:text'];
     // TODO: when debugger is live we will also need to extract actions, etc.
     const buttons = [1, 2, 3, 4].map((index) => {
@@ -39,7 +39,7 @@ function ValidFrame({ tags }: { tags: Record<string, string> }) {
     });
     return {
       image,
-      imageAspectRatio,
+      imageAspectRatioClassname,
       input,
       buttons,
     };
@@ -49,7 +49,7 @@ function ValidFrame({ tags }: { tags: Record<string, string> }) {
     <div>
       {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        className={`w-full rounded-t-xl aspect-[${imageAspectRatio}] object-cover`}
+        className={`w-full rounded-t-xl ${imageAspectRatioClassname} object-cover`}
         src={image}
         alt=""
       />

--- a/framegear/package.json
+++ b/framegear/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "^0.9.4",
+    "@coinbase/onchainkit": "0.9.4",
     "@radix-ui/react-icons": "^1.3.0",
     "jotai": "^2.6.4",
     "next": "14.1.0",

--- a/framegear/yarn.lock
+++ b/framegear/yarn.lock
@@ -438,7 +438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:^0.9.4":
+"@coinbase/onchainkit@npm:0.9.4":
   version: 0.9.4
   resolution: "@coinbase/onchainkit@npm:0.9.4"
   peerDependencies:
@@ -3193,7 +3193,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "framegear@workspace:."
   dependencies:
-    "@coinbase/onchainkit": "npm:^0.9.4"
+    "@coinbase/onchainkit": "npm:0.9.4"
     "@radix-ui/react-icons": "npm:^1.3.0"
     "@testing-library/jest-dom": "npm:^6.4.2"
     "@testing-library/react": "npm:^14.2.1"


### PR DESCRIPTION
**What changed? Why?**
Pinning onchainkit within `framegear`, I think having the caret is what made it so that different people saw different results (e.g., regarding `viem` import) (even though the caret shouldn't have any impact pre-1.0 for non-patch versions 🤷‍♂️)

Additionally, #185 pointed out that that was a bug in the aspect ratio classnames. I always forget this, but tailwind needs to see the full dynamic classnamein order to generate it, so `aspect-[1/1]` wasn't doing anything because that literal string never showed up. 

**Notes to reviewers**

**How has it been tested?**
