### PR TITLE
fix: economize vertical space in framegear header

### DIFF
--- a/framegear/components/Header/Header.tsx
+++ b/framegear/components/Header/Header.tsx
@@ -4,35 +4,19 @@ import Link from 'next/link';
 
 export function Header() {
   return (
-    <div className={`border-pallette-line flex w-full flex-col items-center gap-8 border-b py-8`}>
-      <h1 className={`max-w-layout-max w-full`}>
-        <AppName className="px-6 text-4xl" />
-      </h1>
-      <Banner />
-    </div>
-  );
-}
-
-function Banner() {
-  return (
-    <div
-      className={`max-w-layout-max border-pallette-line bg-content-light dark:bg-banner flex w-full items-center justify-between rounded-lg border p-6`}
-    >
-      <div className="flex items-center gap-4">
-        <div className="text-3xl">⚒️</div>
-        <section className="flex flex-col gap-2">
-          <h1 className="font-bold">This is a Frames debugger</h1>
-          <p>
-            Use <AppName /> to test out your Farcaster Frames and catch bugs!
-          </p>
-        </section>
+    <div className={`border-pallette-line flex w-full justify-center border-b py-8`}>
+      <div className="max-w-layout-max flex w-full items-center justify-between">
+        <h1>
+          <AppName className="px-6 text-4xl" />
+        </h1>
+        <Link
+          className="bg-content-light dark:bg-link-button flex items-center gap-1 rounded-full px-4 py-2"
+          href="https://docs.farcaster.xyz/reference/frames/spec"
+          target="_blank"
+        >
+          <span>Farcaster Frames specs</span> <ArrowTopRightIcon />
+        </Link>
       </div>
-      <Link
-        className="bg-content-light dark:bg-link-button flex items-center gap-1 rounded-full px-4 py-2"
-        href="https://docs.farcaster.xyz/reference/frames/spec"
-      >
-        <span>Farcaster Frames specs</span> <ArrowTopRightIcon />
-      </Link>
     </div>
   );
 }


### PR DESCRIPTION
**What changed? Why?**
per feedback from @huntertdiamond, the header now takes up less space. In particular, removed the banner because the information it provides other than the link to the spec is not very useful.

<img width="1584" alt="image" src="https://github.com/coinbase/onchainkit/assets/9300702/6b2efa37-512b-4457-a798-3cf52f74ac6e">


**Notes to reviewers**

**How has it been tested?**
