### PR TITLE
fix: update neynar frame validation type

### DIFF
--- a/src/utils/neynar/frame/types.ts
+++ b/src/utils/neynar/frame/types.ts
@@ -38,6 +38,9 @@ export interface NeynarFrameValidationInternalModel {
       text: string;
     };
     url: string;
+    state: {
+      serialized: string;
+    };
     cast: {
       object: string;
       hash: string;
@@ -79,11 +82,18 @@ export interface NeynarFrameValidationInternalModel {
         version: string;
         title: string;
         image: string;
+        image_aspect_ratio: string;
         buttons: {
           index: number;
           title: string;
           action_type: string;
         }[];
+        input: {
+          text: string;
+        };
+        state: {
+          serialized: string;
+        };
         post_url: string;
         frames_url: string;
       }[];
@@ -123,5 +133,6 @@ export interface NeynarFrameValidationInternalModel {
         recasted: boolean;
       };
     };
+    timestamp: string;
   };
 }


### PR DESCRIPTION
**What changed? Why?**

updated NeynarFrameValidationInternalModel type, for type safe handling of state and input in a validated message
