### PR TITLE
word-break break-all for validator entry values

### DIFF
--- a/framegear/components/ValidationResults/ValidationResults.tsx
+++ b/framegear/components/ValidationResults/ValidationResults.tsx
@@ -82,7 +82,7 @@ function ValidationEntry({ name, value, error }: ValidationEntryProps) {
         <span>{name}</span>
         <span>{error ? '🔴' : '🟢'}</span>
       </div>
-      <div className="font-mono">{value || 'Not set'}</div>
+      <div className="font-mono break-all">{value || 'Not set'}</div>
       {!!error && <div className="font-mono italic">{error}</div>}
     </div>
   );


### PR DESCRIPTION
**What changed? Why?**

Added `break-all` to frame `ValidationEntry` value container to allow longer values to freely wrap without breaking the layout.

**Notes to reviewers**

Before
![before](https://github.com/coinbase/onchainkit/assets/129006499/6f0c47fc-9bc9-4882-a143-4d1eb206ab71)

After
![after](https://github.com/coinbase/onchainkit/assets/129006499/be65fc56-0bc9-4642-9c6e-73d3755783f6)


**How has it been tested?**

Visually. 


