### PR TITLE
feat: framegear supports mock following option

### DIFF
--- a/framegear/utils/store.ts
+++ b/framegear/utils/store.ts
@@ -1,6 +1,9 @@
 import { atom } from 'jotai';
 import { fetchFrame } from './fetchFrame';
+import { MockFrameRequestOptions } from '@coinbase/onchainkit';
 
 // We store an array here so that we can step through history, e.g. seeing the
 // chain of responses through a number of frame actions.
 export const frameResultsAtom = atom<Awaited<ReturnType<typeof fetchFrame>>[]>([]);
+
+export const mockFrameOptionsAtom = atom<MockFrameRequestOptions>({});


### PR DESCRIPTION
**What changed? Why?**
Added:
- an atom to track mock frame options
- a checkbox to toggle the `following` option
- passed this value through in `postFrame`

Will add others as the need becomes apparent.

**Notes to reviewers**

**How has it been tested?**
