### PR TITLE
chore: `framegear` uses latest `onchainkit`

### DIFF
--- a/framegear/package.json
+++ b/framegear/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "0.10.0",
+    "@coinbase/onchainkit": "0.10.2",
     "@radix-ui/react-icons": "^1.3.0",
     "jotai": "^2.6.4",
     "next": "14.1.0",

--- a/framegear/yarn.lock
+++ b/framegear/yarn.lock
@@ -438,9 +438,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:0.10.0":
-  version: 0.10.0
-  resolution: "@coinbase/onchainkit@npm:0.10.0"
+"@coinbase/onchainkit@npm:0.10.2":
+  version: 0.10.2
+  resolution: "@coinbase/onchainkit@npm:0.10.2"
   peerDependencies:
     "@tanstack/react-query": ^5
     "@xmtp/frames-validator": ^0.5.0
@@ -449,7 +449,7 @@ __metadata:
     react: ^18
     react-dom: ^18
     viem: ^2.7.0
-  checksum: f1b3bb3d805703c3fcb5e28821971efbaa098cd7729995ac8a8502cdec38395cbcbcac81442f8ce45a30c333ecafaaeaa368fce77ca69732f045c88ec93342e8
+  checksum: c71466cb287b1f2740e127b16022145d9108f8b7745e93cec926c0d2f0befdf5dafe05c4b8bda722ef2d1ee52ca9890057a2ee11a625cdfebf269a2323f4fdfc
   languageName: node
   linkType: hard
 
@@ -3194,7 +3194,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "framegear@workspace:."
   dependencies:
-    "@coinbase/onchainkit": "npm:0.10.0"
+    "@coinbase/onchainkit": "npm:0.10.2"
     "@radix-ui/react-icons": "npm:^1.3.0"
     "@testing-library/jest-dom": "npm:^6.4.2"
     "@testing-library/react": "npm:^14.2.1"


### PR DESCRIPTION
**What changed? Why?**
Updating to latest patch version of `onchainkit`

**Notes to reviewers**

**How has it been tested?**
