### PR TITLE
chore: deprecated a few utilities from root level imports

### DIFF
--- a/.changeset/sixty-snails-act.md
+++ b/.changeset/sixty-snails-act.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+- **chore**: deprecated root level imports for `getFrameMetadata`, `FrameMetadata`, `Avatar`, `Name`, `useAvatar`, `useName` utilities and components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Minor Changes
 
-- 249e1ac: - **feat**: added `showAddress` as an option to the `Name` component. By @zizzamia #322
+- **feat**: added `showAddress` as an option to the `Name` component. By @zizzamia #322 249e1ac
 
-  Breaking Changes
+Breaking Changes
 
-  The `Name` component will use `showAddress` to override the default ENS behavior, and `getName`. It will have multiple options as input, which means to pass the address you have to do `getName({ address })` instead of `getName(address)`.
+- The `Name` component will use `showAddress` to override the default ENS behavior, and `getName`. It will have multiple options as input, which means to pass the address you have to do `getName({ address })` instead of `getName(address)`.
+- Removed `getFrameMetadata`, `FrameMetadata`, `Avatar`, `Name`, `useAvatar`, `useName` from the root level exports. And you can find them going forward in either `@coinbase/onchainkit/frame` or `@coinbase/onchainkit/identity`.
 
 ## 0.13.4
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,22 +6,10 @@ export { version } from './version';
 
 /** @deprecated Prefer `import { getFrameHtmlResponse } from '@coinbase/onchainkit/frame';` */
 export { getFrameHtmlResponse } from './frame/getFrameHtmlResponse';
-/** @deprecated Prefer `import { getFrameMetadata } from '@coinbase/onchainkit/frame';` */
-export { getFrameMetadata } from './frame/getFrameMetadata';
 /** @deprecated Prefer `import { getFrameMessage } from '@coinbase/onchainkit/frame';` */
 export { getFrameMessage } from './frame/getFrameMessage';
 /** @deprecated Prefer `import { getMockFrameRequest } from '@coinbase/onchainkit/frame';` */
 export { getMockFrameRequest } from './frame/getMockFrameRequest';
-/** @deprecated Prefer `import { FrameMetadata } from '@coinbase/onchainkit/frame';` */
-export { FrameMetadata } from './frame/components/FrameMetadata';
-/** @deprecated Prefer `import { Avatar } from '@coinbase/onchainkit/identity';` */
-export { Avatar } from './identity/components/Avatar';
-/** @deprecated Prefer `import { Name } from '@coinbase/onchainkit/identity';` */
-export { Name } from './identity/components/Name';
-/** @deprecated Prefer `import { useAvatar } from '@coinbase/onchainkit/identity';` */
-export { useAvatar } from './identity/hooks/useAvatar';
-/** @deprecated Prefer `import { useName } from '@coinbase/onchainkit/identity';` */
-export { useName } from './identity/hooks/useName';
 /** @deprecated Prefer `import type { ... } from '@coinbase/onchainkit/frame';` */
 export type {
   FrameButtonMetadata,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.14.0';
+export const version = '0.14.1';


### PR DESCRIPTION
**What changed? Why?**
Deprecated root level imports for `getFrameMetadata`, `FrameMetadata`, `Avatar`, `Name`, `useAvatar`, `useName` utilities and components.

**Notes to reviewers**

**How has it been tested?**
