### PR TITLE
feat: formatAmount utility function

### DIFF
--- a/.changeset/old-carrots-design.md
+++ b/.changeset/old-carrots-design.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+feat: formatAmount utility function to assist in formatting token amounts

--- a/site/docs/pages/token/format-amount.mdx
+++ b/site/docs/pages/token/format-amount.mdx
@@ -1,0 +1,28 @@
+# `formatAmount`
+
+The `formatAmount` utility is designed for consistent number formatting.
+
+## Usage
+
+:::code-group
+
+```tsx [code]
+import { formatAmount } from '@coinbase/onchainkit/token';
+
+const amount = formatAmount(10000, { minimumFractionDigits: 2 });
+```
+
+```ts [return value]
+'10,000.00'; // if in U.S. English locale
+'10.000,00'; // if in EU country locale
+```
+
+:::
+
+## Returns
+
+Formatted string
+
+## Parameters
+
+[`FormatAmountOptions`](/token/types#formatamountoptions)

--- a/site/docs/pages/token/types.mdx
+++ b/site/docs/pages/token/types.mdx
@@ -30,6 +30,16 @@ type GetTokensOptions = {
 };
 ```
 
+## `FormatAmountOptions`
+
+```ts
+export type FormatAmountOptions = {
+  locale?: string; // User locale (default: browser locale)
+  minimumFractionDigits?: number; // Minimum fraction digits for number decimals (default: 0)
+  maximumFractionDigits?: number; // Maximum fraction digits for number decimals (default: 0)
+};
+```
+
 ## `Token`
 
 ```ts

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -130,6 +130,10 @@ export const sidebar = [
             text: 'getTokens',
             link: '/token/get-tokens',
           },
+          {
+            text: 'formatAmount',
+            link: '/token/format-amount',
+          },
         ],
       },
       {

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -127,12 +127,12 @@ export const sidebar = [
         collapsed: true,
         items: [
           {
-            text: 'getTokens',
-            link: '/token/get-tokens',
-          },
-          {
             text: 'formatAmount',
             link: '/token/format-amount',
+          },
+          {
+            text: 'getTokens',
+            link: '/token/get-tokens',
           },
         ],
       },

--- a/src/token/core/formatAmount.test.ts
+++ b/src/token/core/formatAmount.test.ts
@@ -1,0 +1,47 @@
+import { FormatAmountOptions } from '../types';
+import { formatAmount } from './formatAmount';
+
+describe('formatAmount', () => {
+  it('should return with commas with default options', () => {
+    expect(formatAmount('12')).toEqual('12');
+    expect(formatAmount('123')).toEqual('123');
+    expect(formatAmount('1234')).toEqual('1,234');
+    expect(formatAmount('12345')).toEqual('12,345');
+    expect(formatAmount('123456')).toEqual('123,456');
+    expect(formatAmount('1234567')).toEqual('1,234,567');
+    expect(formatAmount('12345678')).toEqual('12,345,678');
+    expect(formatAmount('123456789')).toEqual('123,456,789');
+    expect(formatAmount('1234567890')).toEqual('1,234,567,890');
+  });
+
+  it('should format decimals with minimum of 2 and maximum of 4 fraction digits', () => {
+    const options = {
+      locale: 'en-US',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 4,
+    } as FormatAmountOptions;
+    expect(formatAmount('123.1', options)).toEqual('123.10');
+    expect(formatAmount('123.01', options)).toEqual('123.01');
+    expect(formatAmount('123.012', options)).toEqual('123.012');
+    expect(formatAmount('123.0123', options)).toEqual('123.0123');
+    expect(formatAmount('123.01234', options)).toEqual('123.0123');
+    expect(formatAmount('123.01236', options)).toEqual('123.0124');
+    expect(formatAmount('123.00001', options)).toEqual('123.00');
+  });
+
+  it('should return with period and 2 decimal point for EU countries like Germany', () => {
+    const options = {
+      locale: 'de-DE',
+      minimumFractionDigits: 2,
+    } as FormatAmountOptions;
+    expect(formatAmount('12', options)).toEqual('12,00');
+    expect(formatAmount('123', options)).toEqual('123,00');
+    expect(formatAmount('1234', options)).toEqual('1.234,00');
+    expect(formatAmount('12345', options)).toEqual('12.345,00');
+    expect(formatAmount('123456', options)).toEqual('123.456,00');
+    expect(formatAmount('1234567', options)).toEqual('1.234.567,00');
+    expect(formatAmount('12345678', options)).toEqual('12.345.678,00');
+    expect(formatAmount('123456789', options)).toEqual('123.456.789,00');
+    expect(formatAmount('1234567890', options)).toEqual('1.234.567.890,00');
+  });
+});

--- a/src/token/core/formatAmount.ts
+++ b/src/token/core/formatAmount.ts
@@ -1,9 +1,12 @@
-import type { FormatAmountOptions } from '../types';
+import type { FormatAmountOptions, FormatAmountResponse } from '../types';
 
 /**
  * Retrieves a list of tokens on Base.
  */
-export function formatAmount(amount: string, options: FormatAmountOptions = {}) {
+export function formatAmount(
+  amount: string,
+  options: FormatAmountOptions = {},
+): FormatAmountResponse {
   const { locale, minimumFractionDigits, maximumFractionDigits } = options;
 
   return Number(amount).toLocaleString(locale, {

--- a/src/token/core/formatAmount.ts
+++ b/src/token/core/formatAmount.ts
@@ -1,0 +1,13 @@
+import type { FormatAmountOptions } from '../types';
+
+/**
+ * Retrieves a list of tokens on Base.
+ */
+export function formatAmount(amount: string, options: FormatAmountOptions = {}) {
+  const { locale, minimumFractionDigits, maximumFractionDigits } = options;
+
+  return Number(amount).toLocaleString(locale, {
+    minimumFractionDigits,
+    maximumFractionDigits,
+  });
+}

--- a/src/token/index.ts
+++ b/src/token/index.ts
@@ -1,6 +1,6 @@
 // 🌲☀️🌲
-export { getTokens } from './core/getTokens';
 export { formatAmount } from './core/formatAmount';
+export { getTokens } from './core/getTokens';
 export type {
   GetTokensError,
   GetTokensOptions,

--- a/src/token/index.ts
+++ b/src/token/index.ts
@@ -1,5 +1,6 @@
 // 🌲☀️🌲
 export { getTokens } from './core/getTokens';
+export { formatAmount } from './core/formatAmount';
 export type {
   GetTokensError,
   GetTokensOptions,

--- a/src/token/types.ts
+++ b/src/token/types.ts
@@ -19,6 +19,20 @@ export type LegacyTokenData = {
 /**
  * Note: exported as public Type
  */
+export type FormatAmountOptions = {
+  locale?: string; // User locale (default: browser locale)
+  minimumFractionDigits?: number; // Minimum fraction digits for number decimals
+  maximumFractionDigits?: number; // Maximum fraction digits for number decimals
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type FormatAmountResponse = string; // See Number.prototype.toLocaleString for more info
+
+/**
+ * Note: exported as public Type
+ */
 export type GetTokensError = {
   code: number; // The Error code
   error: string; // The Error message
@@ -36,15 +50,6 @@ export type GetTokensOptions = {
   limit?: string; // The maximum number of tokens to return (default: 50)
   search?: string; // A string to search for in the token name or symbol
   page?: string; // The page number to return (default: 1)
-};
-
-/**
- * Note: exported as public Type
- */
-export type FormatAmountOptions = {
-  locale?: string; // User locale (default: browser locale)
-  minimumFractionDigits?: number; // Minimum fraction digits for number decimals
-  maximumFractionDigits?: number; // Maximum fraction digits for number decimals
 };
 
 /**

--- a/src/token/types.ts
+++ b/src/token/types.ts
@@ -41,6 +41,15 @@ export type GetTokensOptions = {
 /**
  * Note: exported as public Type
  */
+export type FormatAmountOptions = {
+  locale?: string; // User locale (default: browser locale)
+  minimumFractionDigits?: number; // Minimum fraction digits for number decimals
+  maximumFractionDigits?: number; // Maximum fraction digits for number decimals
+};
+
+/**
+ * Note: exported as public Type
+ */
 export type Token = {
   address: Address; // The address of the token contract
   chainId: number; // The chain id of the token contract


### PR DESCRIPTION
**What changed? Why?**
- Adding a utility function to format numbers

**Notes to reviewers**
- Should info like `locale` be stored in the OnchainKitProvider?

**How has it been tested?**
locally
