### PR TITLE
Update type for consent proofs

### DIFF
--- a/.changeset/fifty-adults-rest.md
+++ b/.changeset/fifty-adults-rest.md
@@ -1,5 +1,5 @@
 ---
-"@coinbase/onchainkit": patch
+'@coinbase/onchainkit': patch
 ---
 
 update transaction types to enable consent proofs

--- a/.changeset/fifty-adults-rest.md
+++ b/.changeset/fifty-adults-rest.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+update transaction types to enable consent proofs

--- a/src/frame/types.ts
+++ b/src/frame/types.ts
@@ -168,7 +168,7 @@ export type FrameTransactionResponse = {
  */
 export type FrameTransactionEthSendParams = {
   abi: Abi; // The contract ABI for the contract to call.
-  data?: Hex | string; // The data to send with the transaction.
+  data?: Hex; // The data to send with the transaction.
   to: Address; // The address of the contract to call.
   value: string; // The amount of Wei to send with the transaction
 };

--- a/src/frame/types.ts
+++ b/src/frame/types.ts
@@ -159,7 +159,7 @@ type ChainNamespace = 'eip155' | 'solana';
 type ChainReference = string;
 export type FrameTransactionResponse = {
   chainId: `${ChainNamespace}:${ChainReference}`; // A CAIP-2 chain ID to identify the tx network
-  method: 'eth_sendTransaction'; // A method ID to identify the type of tx request.
+  method: 'eth_sendTransaction' | 'eth_personalSign'; // A method ID to identify the type of tx request.
   params: FrameTransactionEthSendParams; // Specific parameters for chainId and method
 };
 
@@ -168,7 +168,7 @@ export type FrameTransactionResponse = {
  */
 export type FrameTransactionEthSendParams = {
   abi: Abi; // The contract ABI for the contract to call.
-  data?: Hex; // The data to send with the transaction.
+  data?: Hex | string; // The data to send with the transaction.
   to: Address; // The address of the contract to call.
   value: string; // The amount of Wei to send with the transaction
 };


### PR DESCRIPTION
**What changed? Why?**
This PR updates the `FrameTransactionResponse` type to accommodate an `eth_personalSign` method needed for XMTP consent proofs.