### PR TITLE
feat: TokenImage and TokenSelector components

### DIFF
--- a/.changeset/wild-dragons-sleep.md
+++ b/.changeset/wild-dragons-sleep.md
@@ -1,0 +1,6 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+**feat**: add TokenImage to render token image. By @kyhyco #438
+**feat**: add TokenSelector, a button component to render token info or placeholder text. By @kyhyco #438

--- a/site/docs/pages/token/introduction.mdx
+++ b/site/docs/pages/token/introduction.mdx
@@ -15,8 +15,10 @@ TokenKit enables you to effortlessly create user experiences using Token compone
 The available components are:
 
 - [`<TokenChip />`](/token/token-chip): Small button component for a given token.
+- [`<TokenImage />`](/token/token-image): Image component for token image.
 - [`<TokenRow />`](/token/token-row): Row component for a given token.
 - [`<TokenSearch />`](/token/token-search): Search component to search by name, symbol and address for a given list of tokens.
+- [`<TokenSelector />`](/token/token-selector): Stylized button component to display token info or placeholder text.
 
 :::code-group
 

--- a/site/docs/pages/token/token-image.mdx
+++ b/site/docs/pages/token/token-image.mdx
@@ -62,12 +62,12 @@ The `TokenImage` component is an image that crops token image to a circle with a
 
 ```tsx [code]
 <TokenImage
-  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  src={null}
   size={16}
 />
 
 <TokenImage
-  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  src={null}
   size={24}
 />
 ```

--- a/site/docs/pages/token/token-image.mdx
+++ b/site/docs/pages/token/token-image.mdx
@@ -1,0 +1,110 @@
+import { TokenImage } from '../../../../src/token/components/TokenImage';
+import App from '../App';
+
+# `<TokenImage />`
+
+### Warning: component under development, may change in coming weeks
+
+The `TokenImage` component is an image that crops token image to a circle with an adjustable size.
+
+## Usage
+
+`TokenImage` with an url
+
+:::code-group
+
+```tsx [code]
+<TokenImage
+  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  size={16}
+/>
+
+<TokenImage
+  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  size={24}
+/>
+```
+
+```html [return html]
+<img
+  data-testid="ockTokenImage_Image"
+  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  style="width: 16px; height: 16px; border-radius: 50%; overflow: hidden; background: blue;"
+/>
+
+<img
+  data-testid="ockTokenImage_Image"
+  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  style="width: 24px; height: 24px; border-radius: 50%; overflow: hidden; background: blue;"
+/>
+```
+
+:::
+
+<App>
+  <div style={{ display: 'flex', gap: '8px', flexDirection: 'column'}}>
+    <TokenImage
+      src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+      size={16}
+    />
+
+    <TokenImage
+      src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+      size={24}
+    />
+
+  </div>
+</App>
+
+`TokenImage` with null as src
+
+:::code-group
+
+```tsx [code]
+<TokenImage
+  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  size={16}
+/>
+
+<TokenImage
+  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  size={24}
+/>
+```
+
+```html [return html]
+<div
+  data-testid="ockTokenImage_NoImage"
+  style="width: 16px; height: 16px; border-radius: 50%; overflow: hidden; background: blue;"
+>
+  <div style="background: blue; width: 16px; height: 16px;"></div>
+</div>
+
+<div
+  data-testid="ockTokenImage_NoImage"
+  style="width: 24px; height: 24px; border-radius: 50%; overflow: hidden; background: blue;"
+>
+  <div style="background: blue; width: 24px; height: 24px;"></div>
+</div>
+```
+
+:::
+
+<App>
+  <div style={{ display: 'flex', gap: '8px', flexDirection: 'column'}}>
+    <TokenImage
+      src={null}
+      size={16}
+    />
+
+    <TokenImage
+      src={null}
+      size={24}
+    />
+
+  </div>
+</App>
+
+## Props
+
+[`TokenImageReact`](/token/types#tokenselectorreact)

--- a/site/docs/pages/token/token-selector.mdx
+++ b/site/docs/pages/token/token-selector.mdx
@@ -1,0 +1,109 @@
+import { TokenSelector } from '../../../../src/token/components/TokenSelector';
+import App from '../App';
+
+# `<TokenSelector />`
+
+### Warning: component under development, may change in coming weeks
+
+`TokenSelector` component is stylized button component that displays the token info or placeholder text.
+
+## Usage
+
+`TokenSelector` with token prop
+
+:::code-group
+
+```tsx [code]
+<TokenSelector
+  token={{
+    address: '0x1234',
+    chainId: 1,
+    decimals: 18,
+    image:
+      'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
+    name: 'Ethereum',
+    symbol: 'ETH',
+  }}
+  onClick={() => {}}
+/>
+```
+
+```html [return html]
+<button
+  data-testid="ockTokenSelector_Button"
+  style="border-radius: 16px; padding: 4px 12px; display: flex; align-items: center; background: rgb(238, 240, 243); width: fit-content;"
+>
+  <img
+    data-testid="ockTokenImage_Image"
+    src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+    style="width: 16px; height: 16px; border-radius: 50%; overflow: hidden; background: blue;"
+  /><span
+    data-testid="ockTokenSelector_Symbol"
+    style="color: rgb(10, 11, 13); font-size: 16px; line-height: 1.5; font-weight: 500; margin-left: 4px;"
+    >ETH</span
+  >
+  <span style="margin-left: 8px;">
+    <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12.95 4.85999L8.00001 9.80999L3.05001 4.85999L1.64001 6.27999L8.00001 12.64L14.36 6.27999L12.95 4.85999Z"
+        fill="#0A0B0D"
+      ></path>
+    </svg>
+  </span>
+</button>
+```
+
+:::
+
+<App>
+  <TokenSelector
+    token={{
+      address: '0x1234',
+      chainId: 1,
+      decimals: 18,
+      image:
+        'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
+      name: 'Ethereum',
+      symbol: 'ETH',
+    }}
+    onClick={() => {}}
+  />
+</App>
+
+`TokenSelector` with no token prop
+
+:::code-group
+
+```tsx [code]
+<TokenSelector token={undefined} onClick={() => {}} />
+```
+
+```html [return html]
+<button
+  data-testid="ockTokenSelector_Button"
+  style="border-radius: 16px; padding: 4px 12px; display: flex; align-items: center; background: rgb(238, 240, 243); width: fit-content;"
+>
+  <span
+    style="color: rgb(10, 11, 13); font-size: 16px; line-height: 1.5; font-weight: 500; margin-left: 4px;"
+    >Select</span
+  >
+  <span style="margin-left: 8px;">
+    <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12.95 4.85999L8.00001 9.80999L3.05001 4.85999L1.64001 6.27999L8.00001 12.64L14.36 6.27999L12.95 4.85999Z"
+        fill="#0A0B0D"
+      ></path>
+    </svg>
+  </span>
+</button>
+```
+
+:::
+
+<App>
+  <TokenSelector token={undefined} onClick={() => {}} />
+</App>
+
+## Props
+
+[`TokenSelectorReact`](/token/types#tokenselectorreact)

--- a/site/docs/pages/token/types.mdx
+++ b/site/docs/pages/token/types.mdx
@@ -61,6 +61,15 @@ type TokenChipReact = {
 };
 ```
 
+## `TokenImageReact`
+
+```ts
+type TokenImageReact = {
+  src: string | null; // url for the token images
+  size: number; // size of the image in px (default: 24)
+};
+```
+
 ## `TokenRowReact`
 
 ```ts
@@ -77,5 +86,14 @@ type TokenRowReact = {
 export type TokenSearchReact = {
   onChange: (value: string) => void; // Search callback function
   delayMs?: number; // Debounce delay in milliseconds
+};
+```
+
+## `TokenSelectorReact`
+
+```ts
+export type TokenSelectorReact = {
+  token: Token; // Rendered token
+  onClick: () => void; // Component on click handler
 };
 ```

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -146,12 +146,20 @@ export const sidebar = [
             link: '/token/token-chip',
           },
           {
+            text: 'TokenImage',
+            link: '/token/token-image',
+          },
+          {
             text: 'TokenRow',
             link: '/token/token-row',
           },
           {
             text: 'TokenSearch',
             link: '/token/token-search',
+          },
+          {
+            text: 'TokenSelector',
+            link: '/token/token-selector',
           },
         ],
       },

--- a/src/token/components/TokenImage.test.tsx
+++ b/src/token/components/TokenImage.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { TokenImage } from './TokenImage';
+
+describe('TokenImage Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with src prop', async () => {
+    render(<TokenImage src="https://link/to/image.png" />);
+    const imgElement = screen.getByTestId('ockTokenImage_Image');
+    const noImgElement = screen.queryByTestId('ockTokenImage_NoImage');
+
+    expect(imgElement).toBeInTheDocument();
+    expect(noImgElement).toBeNull();
+  });
+
+  it('should render with no src prop', async () => {
+    render(<TokenImage src={null} />);
+    const imgElement = screen.queryByTestId('ockTokenImage_Image');
+    const noImgElement = screen.getByTestId('ockTokenImage_NoImage');
+
+    expect(imgElement).toBeNull();
+    expect(noImgElement).toBeInTheDocument();
+  });
+
+  it('should render with size prop', async () => {
+    render(<TokenImage src={null} size={16} />);
+    const imgElement = screen.queryByTestId('ockTokenImage_Image');
+    const noImgElement = screen.getByTestId('ockTokenImage_NoImage');
+
+    expect(imgElement).toBeNull();
+    expect(noImgElement).toBeInTheDocument();
+  });
+});

--- a/src/token/components/TokenImage.tsx
+++ b/src/token/components/TokenImage.tsx
@@ -1,9 +1,5 @@
 import { useMemo } from 'react';
-
-type TokenImageReact = {
-  src: string | null;
-  size?: number;
-};
+import { TokenImageReact } from '../types';
 
 export function TokenImage({ src, size = 24 }: TokenImageReact) {
   const styles = useMemo(() => {

--- a/src/token/components/TokenImage.tsx
+++ b/src/token/components/TokenImage.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+
+type TokenImageReact = {
+  src: string | null;
+  size?: number;
+};
+
+export function TokenImage({ src, size = 24 }: TokenImageReact) {
+  const styles = useMemo(() => {
+    return {
+      image: {
+        width: `${size}px`,
+        height: `${size}px`,
+        borderRadius: '50%',
+        overflow: 'hidden',
+        background: 'blue',
+      },
+      placeholderImage: {
+        background: 'blue',
+        width: `${size}px`,
+        height: `${size}px`,
+      },
+    };
+  }, [size]);
+
+  if (!src) {
+    return (
+      <div data-testid="ockTokenImage_NoImage" style={styles.image}>
+        <div style={styles.placeholderImage} />
+      </div>
+    );
+  }
+
+  return <img data-testid="ockTokenImage_Image" style={styles.image} src={src} />;
+}

--- a/src/token/components/TokenSelector.test.tsx
+++ b/src/token/components/TokenSelector.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { Address } from 'viem';
+import { TokenSelector } from './TokenSelector';
+
+describe('TokenSelector Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render with token prop', async () => {
+    const token = {
+      address: '0x123' as Address,
+      chainId: 1,
+      decimals: 2,
+      image: 'imageURL',
+      name: 'Ether',
+      symbol: 'ETH',
+    };
+    const handleClick = jest.fn();
+
+    render(<TokenSelector token={token} onClick={handleClick} />);
+    const buttonElement = screen.getByRole('button');
+    expect(buttonElement).toBeInTheDocument();
+
+    const imgElement = within(buttonElement).getByRole('img');
+    const spanElement = within(buttonElement).getByText(token.symbol);
+
+    expect(imgElement).toBeInTheDocument();
+    expect(spanElement).toBeInTheDocument();
+  });
+
+  it('should render with no token prop with placeholder text', async () => {
+    const handleClick = jest.fn();
+
+    render(<TokenSelector token={undefined} onClick={handleClick} />);
+    const buttonElement = screen.getByRole('button');
+    expect(buttonElement).toBeInTheDocument();
+
+    const imgElement = within(buttonElement).queryByRole('img');
+    const spanElement = within(buttonElement).queryByTestId('ockTokenSelector_Symbol');
+    const placeholderElement = within(buttonElement).getByText('Select');
+
+    expect(imgElement).toBeNull();
+    expect(spanElement).toBeNull();
+    expect(placeholderElement).toBeInTheDocument();
+  });
+
+  it('should register a click on press', async () => {
+    const token = {
+      address: '0x123' as Address,
+      chainId: 1,
+      decimals: 2,
+      image: 'imageURL',
+      name: 'Ether',
+      symbol: 'ETH',
+    };
+    const handleClick = jest.fn();
+    render(<TokenSelector token={token} onClick={handleClick} />);
+
+    const button = screen.getByTestId('ockTokenSelector_Button');
+
+    fireEvent.click(button);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/token/components/TokenSelector.tsx
+++ b/src/token/components/TokenSelector.tsx
@@ -1,4 +1,4 @@
-import { Token } from '../types';
+import { TokenSelectorReact } from '../types';
 import { TokenImage } from './TokenImage';
 
 function CaretDown() {
@@ -35,11 +35,6 @@ const styles = {
   caret: {
     marginLeft: '8px',
   },
-};
-
-type TokenSelectorReact = {
-  token?: Token;
-  onClick: () => void;
 };
 
 export function TokenSelector({ token, onClick }: TokenSelectorReact) {

--- a/src/token/components/TokenSelector.tsx
+++ b/src/token/components/TokenSelector.tsx
@@ -1,0 +1,63 @@
+import { Token } from '../types';
+import { TokenImage } from './TokenImage';
+
+function CaretDown() {
+  return (
+    <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12.95 4.85999L8.00001 9.80999L3.05001 4.85999L1.64001 6.27999L8.00001 12.64L14.36 6.27999L12.95 4.85999Z"
+        fill="#0A0B0D"
+      />
+    </svg>
+  );
+}
+
+const styles = {
+  button: {
+    borderRadius: '16px',
+    padding: '4px 12px 4px 12px',
+    display: 'flex',
+    alignItems: 'center',
+    background: '#EEF0F3',
+    width: 'fit-content',
+  },
+  image: {
+    height: '16px',
+    width: '16px',
+  },
+  label: {
+    color: '#0A0B0D',
+    fontSize: '16px',
+    lineHeight: '1.5',
+    fontWeight: '500',
+    marginLeft: '4px',
+  },
+  caret: {
+    marginLeft: '8px',
+  },
+};
+
+type TokenSelectorReact = {
+  token?: Token;
+  onClick: () => void;
+};
+
+export function TokenSelector({ token, onClick }: TokenSelectorReact) {
+  return (
+    <button data-testid="ockTokenSelector_Button" style={styles.button} onClick={onClick}>
+      {token ? (
+        <>
+          <TokenImage src={token.image} size={16} />
+          <span data-testid="ockTokenSelector_Symbol" style={styles.label}>
+            {token.symbol}
+          </span>
+        </>
+      ) : (
+        <span style={styles.label}>Select</span>
+      )}
+      <span style={styles.caret}>
+        <CaretDown />
+      </span>
+    </button>
+  );
+}

--- a/src/token/index.ts
+++ b/src/token/index.ts
@@ -1,7 +1,9 @@
 // 🌲☀️🌲
 export { TokenChip } from './components/TokenChip';
+export { TokenImage } from './components/TokenImage';
 export { TokenRow } from './components/TokenRow';
 export { TokenSearch } from './components/TokenSearch';
+export { TokenSelector } from './components/TokenSelector';
 export { formatAmount } from './core/formatAmount';
 export { getTokens } from './core/getTokens';
 export type {

--- a/src/token/types.ts
+++ b/src/token/types.ts
@@ -75,6 +75,14 @@ export type TokenChipReact = {
 /**
  * Note: exported as public Type
  */
+export type TokenImageReact = {
+  src: string | null;
+  size?: number;
+};
+
+/**
+ * Note: exported as public Type
+ */
 export type TokenRowReact = {
   token: Token;
   amount?: string;
@@ -93,6 +101,6 @@ export type TokenSearchReact = {
  * Note: exported as public Type
  */
 export type TokenSelectorReact = {
-  onSelect: (token: Token) => void;
-  tokens: Token[];
+  token?: Token;
+  onClick: () => void;
 };


### PR DESCRIPTION
**What changed? Why?**

- add TokenImage to render token image
<img width="300" alt="Screenshot 2024-06-03 at 4 28 17 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/272a3ae4-e95f-4747-860c-90050af42dac">

- add TokenSelector to render a button displaying token info or placeholder text
<img width="300" alt="Screenshot 2024-06-03 at 4 29 08 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/5af8d13d-3130-435d-84e7-18352a0e5d58">

**Notes to reviewers**

**How has it been tested?**
locally
