### PR TITLE
chore: add jsdoc to `prettier` config file

### DIFF
--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,3 +1,4 @@
+/** @type {import("prettier").Config} */
 module.exports = {
   arrowParens: 'always',
   bracketSameLine: false,


### PR DESCRIPTION
**What changed? Why?**

Added JSDOC typing to prettier config file for completion

**Notes to reviewers**

![image](https://github.com/coinbase/onchainkit/assets/155655425/5b665891-3467-486a-a434-9be7efa4b79d)

**How has it been tested?**

Open editor then try completion
