### PR TITLE
feat: convert TokenSearch to css and add modifier styles

### DIFF
--- a/.changeset/hot-balloons-wave.md
+++ b/.changeset/hot-balloons-wave.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+- **feat**: convert TokeSearch to css and add modifier styles. By @kyhyco #460

--- a/site/docs/pages/App.tsx
+++ b/site/docs/pages/App.tsx
@@ -5,8 +5,8 @@ import { WagmiProvider, createConfig, http } from 'wagmi';
 import { baseSepolia } from 'wagmi/chains';
 import { coinbaseWallet } from 'wagmi/connectors';
 
-// Uncomment the line below after new release is cut
 import '@coinbase/onchainkit/styles.css';
+// import '../../../src/styles.css';
 
 const queryClient = new QueryClient();
 

--- a/site/docs/pages/token/token-search.mdx
+++ b/site/docs/pages/token/token-search.mdx
@@ -87,17 +87,14 @@ const handleChange = useCallback((value) => {
   &::placeholder {
     @apply text-[#5B616E];
   }
-
   &:hover {
     @apply border-[#cacbce];
     background: #cacbce;
   }
-
   &:focus {
     @apply border-[#0052FF];
     outline: none;
   }
-
   &:hover:focus {
     background: #eef0f3;
   }

--- a/site/docs/pages/token/token-search.mdx
+++ b/site/docs/pages/token/token-search.mdx
@@ -68,3 +68,42 @@ const handleChange = useCallback((value) => {
 ## Props
 
 [`TokenSearch`](/token/types#tokensearchreact)
+
+# CSS
+
+```css
+.ock-textinput-container {
+  @apply relative flex items-center;
+}
+
+.ock-textinput-iconsearch {
+  @apply absolute left-4 top-2/4 -translate-y-2/4;
+}
+
+.ock-textinput-input {
+  @apply w-full rounded-full border-2 border-solid border-[#eef0f3] py-2  pl-12 pr-5 text-[#0A0B0D];
+  background: #eef0f3;
+
+  &::placeholder {
+    @apply text-[#5B616E];
+  }
+
+  &:hover {
+    @apply border-[#cacbce];
+    background: #cacbce;
+  }
+
+  &:focus {
+    @apply border-[#0052FF];
+    outline: none;
+  }
+
+  &:hover:focus {
+    background: #eef0f3;
+  }
+}
+
+.ock-textinput-clearbutton {
+  @apply absolute right-4 top-2/4 -translate-y-2/4;
+}
+```

--- a/src/index.css
+++ b/src/index.css
@@ -1,2 +1,2 @@
-@import url('./token/components/TokenChip.css');
 @import url('./token/components/TextInput.css');
+@import url('./token/components/TokenChip.css');

--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,2 @@
 @import url('./token/components/TokenChip.css');
+@import url('./token/components/TextInput.css');

--- a/src/token/components/TextInput.css
+++ b/src/token/components/TextInput.css
@@ -1,0 +1,34 @@
+.ock-textinput-container {
+  @apply relative flex items-center;
+}
+
+.ock-textinput-iconsearch {
+  @apply absolute left-4 top-2/4 -translate-y-2/4;
+}
+
+.ock-textinput-input {
+  @apply w-full rounded-full border-2 border-solid border-[#eef0f3] py-2  pl-12 pr-5 text-[#0A0B0D];
+  background: #eef0f3;
+
+  &::placeholder {
+    @apply text-[#5B616E];
+  }
+
+  &:hover {
+    @apply border-[#cacbce];
+    background: #cacbce;
+  }
+
+  &:focus {
+    @apply border-[#0052FF];
+    outline: none;
+  }
+
+  &:hover:focus {
+    background: #eef0f3;
+  }
+}
+
+.ock-textinput-clearbutton {
+  @apply absolute right-4 top-2/4 -translate-y-2/4;
+}

--- a/src/token/components/TextInput.css
+++ b/src/token/components/TextInput.css
@@ -13,17 +13,14 @@
   &::placeholder {
     @apply text-[#5B616E];
   }
-
   &:hover {
     @apply border-[#cacbce];
     background: #cacbce;
   }
-
   &:focus {
     @apply border-[#0052FF];
     outline: none;
   }
-
   &:hover:focus {
     background: #eef0f3;
   }

--- a/src/token/components/TextInput.tsx
+++ b/src/token/components/TextInput.tsx
@@ -1,23 +1,5 @@
-import { CSSProperties, ChangeEvent, useCallback } from 'react';
+import { ChangeEvent, useCallback } from 'react';
 import { SearchIcon } from './SearchIcon';
-
-const styles = {
-  container: {
-    position: 'relative',
-  },
-  icon: {
-    position: 'absolute',
-    left: '16px',
-    top: '14px',
-  },
-  input: {
-    borderRadius: '1000px',
-    padding: '8px 20px 8px 48px',
-    width: '100%',
-    background: '#EEF0F3',
-    color: '#5B616E',
-  },
-} as Record<string, CSSProperties>;
 
 type TextInputReact = {
   placeholder: string;
@@ -30,19 +12,39 @@ export function TextInput({ placeholder, value, onChange }: TextInputReact) {
     onChange(evt.target.value);
   }, []);
 
+  const handleClear = useCallback(() => {
+    onChange('');
+  }, []);
+
   return (
-    <div style={styles.container}>
-      <div style={styles.icon}>
+    <div className="ock-textinput-container">
+      <div className="ock-textinput-iconsearch">
         <SearchIcon />
       </div>
       <input
         data-testid="ockTextInput_Search"
         type="text"
-        style={styles.input}
+        className="ock-textinput-input"
         placeholder={placeholder}
         value={value}
         onChange={handleChange}
       />
+      {value && (
+        <button className="ock-textinput-clearbutton" onClick={handleClear}>
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M2.3352 1L1 2.33521L6.66479 8L1 13.6648L2.3352 15L8 9.33521L13.6648 15L15 13.6648L9.33521 8L15 2.33521L13.6648 1L8 6.6648L2.3352 1Z"
+              fill="#0A0B0D"
+            />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/token/components/TextInput.tsx
+++ b/src/token/components/TextInput.tsx
@@ -30,7 +30,11 @@ export function TextInput({ placeholder, value, onChange }: TextInputReact) {
         onChange={handleChange}
       />
       {value && (
-        <button className="ock-textinput-clearbutton" onClick={handleClear}>
+        <button
+          data-testid="ockTextInput_Clear"
+          className="ock-textinput-clearbutton"
+          onClick={handleClear}
+        >
           <svg
             width="16"
             height="16"

--- a/src/token/components/TokenSearch.test.tsx
+++ b/src/token/components/TokenSearch.test.tsx
@@ -10,9 +10,9 @@ describe('TokenSearch component', () => {
   it('should call onChange after the specified debounce delay', async () => {
     const handleChange = jest.fn();
 
-    const { getByPlaceholderText } = render(<TokenSearch onChange={handleChange} />);
+    const { getByRole } = render(<TokenSearch onChange={handleChange} />);
 
-    const input = getByPlaceholderText('Search name or paste address');
+    const input = getByRole('textbox');
 
     fireEvent.change(input, { target: { value: 'test' } });
 
@@ -26,12 +26,25 @@ describe('TokenSearch component', () => {
   it('should call onChange immediately with no debounce delay', async () => {
     const handleChange = jest.fn();
 
-    const { getByPlaceholderText } = render(<TokenSearch onChange={handleChange} delayMs={0} />);
+    const { getByRole } = render(<TokenSearch onChange={handleChange} delayMs={0} />);
 
-    const input = getByPlaceholderText('Search name or paste address');
+    const input = getByRole('textbox');
 
     fireEvent.change(input, { target: { value: 'test' } });
 
     await waitFor(() => expect(handleChange).toHaveBeenCalledWith('test'));
+  });
+
+  it('clears the input when the clear button is clicked', async () => {
+    const handleChange = jest.fn();
+    const { getByTestId, getByRole } = render(<TokenSearch onChange={handleChange} />);
+
+    const input = getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    const clearButton = getByTestId('ockTextInput_Clear');
+    fireEvent.click(clearButton);
+
+    await waitFor(() => expect(handleChange).toHaveBeenCalledWith(''));
   });
 });

--- a/src/token/components/TokenSearch.tsx
+++ b/src/token/components/TokenSearch.tsx
@@ -20,7 +20,5 @@ export function TokenSearch({ onChange, delayMs = 200 }: TokenSearchReact) {
     }
   }, []);
 
-  return (
-    <TextInput placeholder="Search name or paste address" value={value} onChange={handleChange} />
-  );
+  return <TextInput placeholder="Search for a token" value={value} onChange={handleChange} />;
 }


### PR DESCRIPTION
**What changed? Why?**
- convert `TokenSearch` to css
- add modifier styles
- update placeholder text
- add clear button to `TextInput`
- add commented import to `site/docs/pages/App.tsx`

Default state
<img width="586" alt="Screenshot 2024-06-05 at 4 37 59 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/92e484b2-1410-452c-8767-2bb39073e6b8">

Hover
<img width="580" alt="Screenshot 2024-06-05 at 4 38 22 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/7591f605-c49b-4951-90e2-02e795574f62">

Focus
<img width="580" alt="Screenshot 2024-06-05 at 4 39 35 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/f793e0df-ec1a-4f7d-b17c-ebc8cc2f5a30">

Clear button
<img width="581" alt="Screenshot 2024-06-05 at 4 39 57 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/95a16eaa-d527-4bb0-9973-ed7141aa6fdc">

**Notes to reviewers**

**How has it been tested?**
locally
