### PR TITLE
chore: make provider page clearer

### DIFF
--- a/site/docs/pages/onchainkit-provider.mdx
+++ b/site/docs/pages/onchainkit-provider.mdx
@@ -5,12 +5,12 @@ Provides the OnchainKit React Context to the app.
 ## Usage
 
 ```tsx [code]
-import { base } from 'viem/chains';
+import { base } from 'viem/chains'; // [!code focus]
 import { OnchainKitProvider } from '@coinbase/onchainkit'; // [!code focus]
 
 const App = () => {
   return (
-    <OnchainKitProvider chain="base">
+    <OnchainKitProvider chain={base}>
       {' '}
       // [!code focus]
       <MyComponent />


### PR DESCRIPTION
**What changed? Why?**

This PR makes the `/onchainkit-provider` documentation page clearer by:

- highlighting forgotten line
- fixing a typo: chain="base" -> chain={base}

**Notes to reviewers**

This is actually a reopen of my previous PR https://github.com/coinbase/onchainkit/pull/450 as I messed up syncing my fork.

It doesn't include the changes that make `prettier` angry. For more context, see my comment https://github.com/coinbase/onchainkit/pull/450#issuecomment-2151484639

**How has it been tested?**
