### PR TITLE
docs: add `bun` usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ npm install @coinbase/onchainkit viem@2.x
 
 # Use PNPM
 pnpm add @coinbase/onchainkit viem@2.x
+
+# Use BUN
+bun add @coinbase/onchainkit viem@2.x
 ```
 
 ## Components

--- a/site/docs/pages/frame/framegear.mdx
+++ b/site/docs/pages/frame/framegear.mdx
@@ -36,6 +36,14 @@ pnpm install
 pnpm run dev
 ```
 
+```bash [bun]
+git clone https://github.com/coinbase/onchainkit.git
+
+cd onchainkit/framegear
+bun install
+bun run dev
+```
+
 :::
 
 Visit http://localhost:1337 to start the **Framegear** interface. Enter the URL of your locally

--- a/site/docs/pages/frame/introduction.mdx
+++ b/site/docs/pages/frame/introduction.mdx
@@ -31,3 +31,9 @@ yarn add @coinbase/onchainkit react@18 react-dom@18
 ```bash [pnpm]
 pnpm add @coinbase/onchainkit react@18 react-dom@18
 ```
+
+```bash [bun]
+bun add @coinbase/onchainkit react@18 react-dom@18
+```
+
+:::

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -18,6 +18,10 @@ yarn add @coinbase/onchainkit viem@2.x
 pnpm add @coinbase/onchainkit viem@2.x
 ```
 
+```bash [bun]
+bun add @coinbase/onchainkit viem@2.x
+```
+
 :::
 
 OnchainKit is divided into various theme utilities and components that are available for your use:

--- a/site/docs/pages/identity/introduction.mdx
+++ b/site/docs/pages/identity/introduction.mdx
@@ -142,6 +142,11 @@ pnpm add @coinbase/onchainkit
 pnpm add viem@2.x react@18 react-dom@18 @tanstack/react-query graphql@14 graphql-request@6
 ```
 
+```bash [bun]
+bun add @coinbase/onchainkit
+bun add viem@2.x react@18 react-dom@18 @tanstack/react-query graphql@14 graphql-request@6
+```
+
 :::
 
 ## Required providers

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -64,6 +64,10 @@ yarn add @coinbase/onchainkit viem@2.x
 pnpm add @coinbase/onchainkit viem@2.x
 ```
 
+```bash [bun]
+bun add @coinbase/onchainkit viem@2.x
+```
+
 :::
 
       </div>

--- a/site/docs/pages/token/introduction.mdx
+++ b/site/docs/pages/token/introduction.mdx
@@ -280,6 +280,11 @@ pnpm add @coinbase/onchainkit
 pnpm add viem@2.x react@18 react-dom@18
 ```
 
+```bash [bun]
+bun add @coinbase/onchainkit
+bun add viem@2.x react@18 react-dom@18
+```
+
 :::
 
 ## Required providers

--- a/site/docs/pages/wallet/introduction.mdx
+++ b/site/docs/pages/wallet/introduction.mdx
@@ -87,6 +87,11 @@ pnpm add @coinbase/onchainkit
 pnpm add react@18 react-dom@18 wagmi@2 @coinbase/wallet-sdk@4 permissionless
 ```
 
+```bash [bun]
+bun add @coinbase/onchainkit
+bun add react@18 react-dom@18 wagmi@2 @coinbase/wallet-sdk@4 permissionless
+```
+
 :::
 
 ## Required providers

--- a/site/docs/pages/xmtp/introduction.mdx
+++ b/site/docs/pages/xmtp/introduction.mdx
@@ -53,6 +53,10 @@ yarn add @coinbase/onchainkit @xmtp/frames-validator
 pnpm add @coinbase/onchainkit @xmtp/frames-validator
 ```
 
+```bash [bun]
+bun add @coinbase/onchainkit @xmtp/frames-validator
+```
+
 :::
 
 To assist you in handling interactions from XMTP, and extracting the `verifiedWalletAddress` from a POST payload, here is the XMTP Kit which includes:


### PR DESCRIPTION
**What changed? Why?**

Add `bun` usage to code groups. Feels good to have it for bun users.

**Notes to reviewers**

Looks like this

![image](https://github.com/coinbase/onchainkit/assets/155655425/bf7a68c6-a47a-4cf8-b666-7041cdbaabfa)

**How has it been tested?**

Launched docs locally with `yarn dev`
