### PR TITLE
docs: fix `getAvatar(...)` documentation

### DIFF
--- a/site/docs/pages/identity/get-avatar.mdx
+++ b/site/docs/pages/identity/get-avatar.mdx
@@ -15,7 +15,7 @@ Supported providers:
 ```tsx
 import { getAvatar } from '@coinbase/onchainkit/identity';
 
-const avatar = await getAvatar({ ensName: 'vitalik.eth' });
+const avatar = await getAvatar('vitalik.eth');
 ```
 
 ## Returns


### PR DESCRIPTION
**What changed? Why?**

This fixes the documentation of `getAvatar(...)` as it accepts a `string` and not `{ ensName: string }`.
https://github.com/coinbase/onchainkit/blob/172faf809c87ff85077a013649f8e255a6255e9f/src/identity/core/getAvatar.ts#L5

**Notes to reviewers**

FWIW using a `string` is not very explicit since it could be an `address` too. Same with the wording `getAvatar()`

What do you think of following Viem?

`getAvatar(ensName: string)` -> `getEnsAvatar({ name: string })`

**How has it been tested?**
