### PR TITLE
chore: specify package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,5 +143,5 @@
       "default": "./lib/wallet/index.js"
     }
   },
-  "packageManager": "yarn@1.22.22"
+  "packageManager": "yarn@4.0.2"
 }

--- a/package.json
+++ b/package.json
@@ -142,5 +142,6 @@
       "import": "./esm/wallet/index.js",
       "default": "./lib/wallet/index.js"
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
**What changed? Why?**

Added `packageManager` field to `package.json`

It helps for reproducibility.

And some people (like me) use [corepack](https://nodejs.org/api/corepack.html) to handle package managers between repositories.

**Notes to reviewers**

I specified the latest version `1.22.22` of Yarn. Feel free to specify the one you prefer.

**How has it been tested?**
