### PR TITLE
feat: TokenImage with no image renders partial token symbol and deterministic dark color

### DIFF
--- a/site/docs/pages/contribution-guide.mdx
+++ b/site/docs/pages/contribution-guide.mdx
@@ -5,7 +5,7 @@ description: Learn how to contribute to OnchainKit
 
 # OnchainKit Contribution Guide
 
-Welcome to OnchainKit! So you want to contribute to this project? You can to the right place.
+Welcome to OnchainKit! So you want to contribute to this project? You came to the right place.
 
 In this guide, you will learn how to:
 

--- a/site/docs/pages/token/token-image.mdx
+++ b/site/docs/pages/token/token-image.mdx
@@ -1,4 +1,3 @@
-{/* import { TokenImage } from '../../../../src/token'; */}
 import { TokenImage } from '@coinbase/onchainkit/token';
 import App from '../App';
 
@@ -110,22 +109,14 @@ With `token` props has no image, render partial token symbol and deterministic d
   data-testid="ockTokenImage_NoImage"
   style="width: 24px; height: 24px; border-radius: 50%; overflow: hidden; background: blue;"
 >
-  <div
-    style="background: rgb(37, 91, 157); width: 24px; height: 24px; color: white; font-size: 6px; display: flex; justify-content: center; align-items: center; line-height: 1;"
-  >
-    USD
-  </div>
+  <div style="background: rgb(81, 141, 214); width: 24px; height: 24px;"></div>
 </div>
 
 <div
   data-testid="ockTokenImage_NoImage"
-  style="width: 24px; height: 24px; border-radius: 50%; overflow: hidden; background: blue;"
+  style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden; background: blue;"
 >
-  <div
-    style="background: rgb(37, 91, 157); width: 24px; height: 24px; color: white; font-size: 6px; display: flex; justify-content: center; align-items: center; line-height: 1;"
-  >
-    USD
-  </div>
+  <div style="background: rgb(81, 141, 214); width: 32px; height: 32px;"></div>
 </div>
 ```
 

--- a/site/docs/pages/token/token-image.mdx
+++ b/site/docs/pages/token/token-image.mdx
@@ -1,9 +1,12 @@
+{/* import { TokenImage } from '../../../../src/token'; */}
 import { TokenImage } from '@coinbase/onchainkit/token';
 import App from '../App';
 
 # `<TokenImage />`
 
 The `TokenImage` component is an image that crops token image to a circle with an adjustable size.
+
+With `token` props has no image, render partial token symbol and deterministic dark color.
 
 ## Usage
 
@@ -14,12 +17,12 @@ The `TokenImage` component is an image that crops token image to a circle with a
 ```tsx [code]
 <TokenImage
   src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-  size={16}
+  size={24}
 />
 
 <TokenImage
   src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-  size={24}
+  size={32}
 />
 ```
 
@@ -27,13 +30,13 @@ The `TokenImage` component is an image that crops token image to a circle with a
 <img
   data-testid="ockTokenImage_Image"
   src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-  style="width: 16px; height: 16px; border-radius: 50%; overflow: hidden; background: blue;"
+  style="width: 24px; height: 24px; border-radius: 50%; overflow: hidden; background: blue;"
 />
 
 <img
   data-testid="ockTokenImage_Image"
   src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-  style="width: 24px; height: 24px; border-radius: 50%; overflow: hidden; background: blue;"
+  style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden; background: blue;"
 />
 ```
 
@@ -42,13 +45,29 @@ The `TokenImage` component is an image that crops token image to a circle with a
 <App>
   <div style={{ display: 'flex', gap: '8px', flexDirection: 'column'}}>
     <TokenImage
-      src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      size={16}
+      token={{
+        name: 'Ethereum',
+        address: '',
+        symbol: 'ETH',
+        decimals: 18,
+        image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+        blockchain: 'eth',
+        chainId: 8453,
+      }}
+      size={24}
     />
 
     <TokenImage
-      src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      size={24}
+      token={{
+        name: 'Ethereum',
+        address: '',
+        symbol: 'ETH',
+        decimals: 18,
+        image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+        blockchain: 'eth',
+        chainId: 8453,
+      }}
+      size={32}
     />
 
   </div>
@@ -60,29 +79,53 @@ The `TokenImage` component is an image that crops token image to a circle with a
 
 ```tsx [code]
 <TokenImage
-  src={null}
-  size={16}
+  token={{
+    name: 'USDC',
+    address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    symbol: 'USDC',
+    decimals: 6,
+    image: null,
+    blockchain: 'eth',
+    chainId: 8453,
+  }}
+  size={24}
 />
 
 <TokenImage
-  src={null}
-  size={24}
+  token={{
+    name: 'USDC',
+    address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    symbol: 'USDC',
+    decimals: 6,
+    image: null,
+    blockchain: 'eth',
+    chainId: 8453,
+  }}
+  size={32}
 />
 ```
 
 ```html [return html]
 <div
   data-testid="ockTokenImage_NoImage"
-  style="width: 16px; height: 16px; border-radius: 50%; overflow: hidden; background: blue;"
+  style="width: 24px; height: 24px; border-radius: 50%; overflow: hidden; background: blue;"
 >
-  <div style="background: blue; width: 16px; height: 16px;"></div>
+  <div
+    style="background: rgb(37, 91, 157); width: 24px; height: 24px; color: white; font-size: 6px; display: flex; justify-content: center; align-items: center; line-height: 1;"
+  >
+    USD
+  </div>
 </div>
 
 <div
   data-testid="ockTokenImage_NoImage"
   style="width: 24px; height: 24px; border-radius: 50%; overflow: hidden; background: blue;"
 >
-  <div style="background: blue; width: 24px; height: 24px;"></div>
+  <div
+    style="background: rgb(37, 91, 157); width: 24px; height: 24px; color: white; font-size: 6px; display: flex; justify-content: center; align-items: center; line-height: 1;"
+  >
+    USD
+  </div>
 </div>
 ```
 
@@ -91,13 +134,29 @@ The `TokenImage` component is an image that crops token image to a circle with a
 <App>
   <div style={{ display: 'flex', gap: '8px', flexDirection: 'column'}}>
     <TokenImage
-      src={null}
-      size={16}
+      token={{
+        name: 'USDC',
+        address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        symbol: 'USDC',
+        decimals: 6,
+        image: null,
+        blockchain: 'eth',
+        chainId: 8453,
+      }}
+      size={24}
     />
 
     <TokenImage
-      src={null}
-      size={24}
+      token={{
+        name: 'USDC',
+        address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        symbol: 'USDC',
+        decimals: 6,
+        image: null,
+        blockchain: 'eth',
+        chainId: 8453,
+      }}
+      size={32}
     />
 
   </div>

--- a/src/token/components/TokenImage.test.tsx
+++ b/src/token/components/TokenImage.test.tsx
@@ -5,14 +5,33 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { TokenImage } from './TokenImage';
+import { Token } from '../types';
+
+const tokenWithImage: Token = {
+  name: 'Ethereum',
+  address: '0x123',
+  symbol: 'ETH',
+  decimals: 18,
+  image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+  chainId: 8453,
+};
+
+const tokenWithNoImage: Token = {
+  name: 'Ethereum',
+  address: '0x123',
+  symbol: 'ETH',
+  decimals: 18,
+  image: null,
+  chainId: 8453,
+};
 
 describe('TokenImage Component', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should render with src prop', async () => {
-    render(<TokenImage src="https://link/to/image.png" />);
+  it('should render token with image', async () => {
+    render(<TokenImage token={tokenWithImage} />);
     const imgElement = screen.getByTestId('ockTokenImage_Image');
     const noImgElement = screen.queryByTestId('ockTokenImage_NoImage');
 
@@ -20,8 +39,8 @@ describe('TokenImage Component', () => {
     expect(noImgElement).toBeNull();
   });
 
-  it('should render with no src prop', async () => {
-    render(<TokenImage src={null} />);
+  it('should render token with no image', async () => {
+    render(<TokenImage token={tokenWithNoImage} />);
     const imgElement = screen.queryByTestId('ockTokenImage_Image');
     const noImgElement = screen.getByTestId('ockTokenImage_NoImage');
 
@@ -30,7 +49,7 @@ describe('TokenImage Component', () => {
   });
 
   it('should render with size prop', async () => {
-    render(<TokenImage src={null} size={16} />);
+    render(<TokenImage token={tokenWithNoImage} size={16} />);
     const imgElement = screen.queryByTestId('ockTokenImage_Image');
     const noImgElement = screen.getByTestId('ockTokenImage_NoImage');
 

--- a/src/token/components/TokenImage.tsx
+++ b/src/token/components/TokenImage.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from 'react';
 import { TokenImageReact } from '../types';
+import { getTokenImageColor } from './getTokenImageColor';
 
-export function TokenImage({ src, size = 24 }: TokenImageReact) {
+export function TokenImage({ token, size = 24 }: TokenImageReact) {
+  const { image, symbol, name } = token;
+
   const styles = useMemo(() => {
     return {
       image: {
@@ -12,20 +15,26 @@ export function TokenImage({ src, size = 24 }: TokenImageReact) {
         background: 'blue',
       },
       placeholderImage: {
-        background: 'blue',
+        background: getTokenImageColor(name),
         width: `${size}px`,
         height: `${size}px`,
+        color: 'white',
+        fontSize: `${size / 4}px`,
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        lineHeight: 1,
       },
     };
   }, [size]);
 
-  if (!src) {
+  if (!image) {
     return (
       <div data-testid="ockTokenImage_NoImage" style={styles.image}>
-        <div style={styles.placeholderImage} />
+        <div style={styles.placeholderImage}>{symbol.slice(0, 3)}</div>
       </div>
     );
   }
 
-  return <img data-testid="ockTokenImage_Image" style={styles.image} src={src} />;
+  return <img data-testid="ockTokenImage_Image" style={styles.image} src={image} />;
 }

--- a/src/token/components/TokenImage.tsx
+++ b/src/token/components/TokenImage.tsx
@@ -3,7 +3,7 @@ import { TokenImageReact } from '../types';
 import { getTokenImageColor } from './getTokenImageColor';
 
 export function TokenImage({ token, size = 24 }: TokenImageReact) {
-  const { image, symbol, name } = token;
+  const { image, name } = token;
 
   const styles = useMemo(() => {
     return {
@@ -12,18 +12,11 @@ export function TokenImage({ token, size = 24 }: TokenImageReact) {
         height: `${size}px`,
         borderRadius: '50%',
         overflow: 'hidden',
-        background: 'blue',
       },
       placeholderImage: {
         background: getTokenImageColor(name),
         width: `${size}px`,
         height: `${size}px`,
-        color: 'white',
-        fontSize: `${size / 4}px`,
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        lineHeight: 1,
       },
     };
   }, [size]);
@@ -31,7 +24,7 @@ export function TokenImage({ token, size = 24 }: TokenImageReact) {
   if (!image) {
     return (
       <div data-testid="ockTokenImage_NoImage" style={styles.image}>
-        <div style={styles.placeholderImage}>{symbol.slice(0, 3)}</div>
+        <div style={styles.placeholderImage} />
       </div>
     );
   }

--- a/src/token/components/TokenSelector.tsx
+++ b/src/token/components/TokenSelector.tsx
@@ -42,7 +42,7 @@ export function TokenSelector({ token, onClick }: TokenSelectorReact) {
     <button data-testid="ockTokenSelector_Button" style={styles.button} onClick={onClick}>
       {token ? (
         <>
-          <TokenImage src={token.image} size={16} />
+          <TokenImage token={token} size={16} />
           <span data-testid="ockTokenSelector_Symbol" style={styles.label}>
             {token.symbol}
           </span>

--- a/src/token/components/getTokenImageColor.test.ts
+++ b/src/token/components/getTokenImageColor.test.ts
@@ -1,0 +1,16 @@
+import { getTokenImageColor } from './getTokenImageColor';
+
+describe('getTokenImageColor', () => {
+  it('should return a consistent color for the same string', () => {
+    const str = 'test';
+    const color1 = getTokenImageColor(str);
+    const color2 = getTokenImageColor(str);
+    expect(color1).toBe(color2);
+  });
+
+  it('should return different colors for different strings', () => {
+    const color1 = getTokenImageColor('test1');
+    const color2 = getTokenImageColor('test2');
+    expect(color1).not.toBe(color2);
+  });
+});

--- a/src/token/components/getTokenImageColor.ts
+++ b/src/token/components/getTokenImageColor.ts
@@ -1,0 +1,19 @@
+export function getTokenImageColor(str: string) {
+  function hashStringToNumber(str: string) {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return hash;
+  }
+
+  function numberToRGB(hash: number) {
+    const h = Math.abs(hash) % 360;
+    const s = (Math.abs(hash >> 8) % 31) + 50;
+    const l = (Math.abs(hash >> 16) % 21) + 20;
+    return `hsl(${h}, ${s}%, ${l}%)`;
+  }
+
+  const hash = hashStringToNumber(`${str}`);
+  return numberToRGB(hash);
+}

--- a/src/token/components/getTokenImageColor.ts
+++ b/src/token/components/getTokenImageColor.ts
@@ -1,19 +1,19 @@
+function hashStringToNumber(str: string) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return hash;
+}
+
+function numberToRGB(hash: number) {
+  const h = Math.abs(hash) % 360;
+  const s = (Math.abs(hash >> 8) % 31) + 50;
+  const l = (Math.abs(hash >> 16) % 21) + 40;
+  return `hsl(${h}, ${s}%, ${l}%)`;
+}
+
 export function getTokenImageColor(str: string) {
-  function hashStringToNumber(str: string) {
-    let hash = 0;
-    for (let i = 0; i < str.length; i++) {
-      hash = str.charCodeAt(i) + ((hash << 5) - hash);
-    }
-    return hash;
-  }
-
-  function numberToRGB(hash: number) {
-    const h = Math.abs(hash) % 360;
-    const s = (Math.abs(hash >> 8) % 31) + 50;
-    const l = (Math.abs(hash >> 16) % 21) + 20;
-    return `hsl(${h}, ${s}%, ${l}%)`;
-  }
-
   const hash = hashStringToNumber(`${str}`);
   return numberToRGB(hash);
 }

--- a/src/token/types.ts
+++ b/src/token/types.ts
@@ -76,7 +76,7 @@ export type TokenChipReact = {
  * Note: exported as public Type
  */
 export type TokenImageReact = {
-  src: string | null;
+  token: Token;
   size?: number;
 };
 


### PR DESCRIPTION
**What changed? Why?**
- TokenImage with no image renders partial token symbol and deterministic dark color
- fix typo in contribution-guide.mdx

<img width="59" alt="Screenshot 2024-06-06 at 12 20 44 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/80b901c7-2ba5-40cc-b73d-15eb4b9d7d4d">

**Notes to reviewers**
Can't use the usual className approach to override `TokenImage` due to adjusting styles depending on prop values

**How has it been tested?**
locally