### PR TITLE
feat: update TokenRow

### DIFF
--- a/.changeset/five-sloths-battle.md
+++ b/.changeset/five-sloths-battle.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: convert TokenRow to css, add modifier state and add additinal display controls. By @kyhyco #473

--- a/site/docs/pages/token/token-row.mdx
+++ b/site/docs/pages/token/token-row.mdx
@@ -14,62 +14,42 @@ Token with an image url
 ```tsx [code]
 import { TokenRow } from '@coinbase/onchainkit/token';
 
-const token = {
-  address: '0x1234',
-  chainId: 1,
-  decimals: 18,
-  image:
-    'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
-  name: 'Ether',
-  symbol: 'ETH',
-};
+const token = { ... };
 
 <TokenRow token={token} />; // [!code focus]
 ```
 
 ```html [return html]
-<button
-  data-testid="ockTokenRow_Container"
-  style="display: flex; align-items: center; justify-content: space-between; cursor: pointer; padding: 4px 8px; width: 100%;"
->
-  <span style="display: flex; align-items: center;">
+<button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+  <span class="ock-tokenrow-left">
     <img
-      data-testid="ockTokenRow_Image"
+      data-testid="ockTokenImage_Image"
       src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      style="height: 32px; width: 32px; margin-right: 12px;"
+      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
     />
-    <span style="display: flex; flex-direction: column; align-items: flex-start;">
-      <span style="font-size: 16px; line-height: 1.5; font-weight: 500; color: rgb(10, 11, 13);"
-        >Ether</span
-      >
-      <span style="font-size: 16px; line-height: 1.5; font-weight: 400; color: rgb(91, 97, 110);"
-        >ETH</span
-      >
+    <span class="ock-tokenrow-body">
+      <span class="ock-tokenrow-name">Ethereum</span>
+      <span class="ock-tokenrow-symbol">ETH</span>
     </span>
   </span>
-  <span
-    data-testid="ockTokenRow_Amount"
-    style="font-size: 16px; line-height: 1.5; font-weight: 400; color: rgb(91, 97, 110);"
-  ></span>
+  <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
 </button>
 ```
 
 :::
 
 <App>
-  <div className="pane">
-    <TokenRow
-      token={{
-        address: '0x1234',
-        chainId: 1,
-        decimals: 18,
-        image:
-          'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
-        name: 'Ether',
-        symbol: 'ETH',
-      }}
-    />
-  </div>
+  <TokenRow
+    token={{
+      address: '0x1234',
+      chainId: 1,
+      decimals: 18,
+      image:
+        'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
+      name: 'Ethereum',
+      symbol: 'ETH',
+    }}
+  />
 </App>
 
 Token without an image url
@@ -79,61 +59,43 @@ Token without an image url
 ```tsx [code]
 import { TokenRow } from '@coinbase/onchainkit/token';
 
-const token = {
-  address: '0x1234',
-  chainId: 1,
-  decimals: 18,
-  image: null,
-  name: 'Ether',
-  symbol: 'ETH',
-};
+const token = { ... };
 
 <TokenRow token={token} />; // [!code focus]
 ```
 
 ```html [return html]
-<button
-  data-testid="ockTokenRow_Container"
-  style="display: flex; align-items: center; justify-content: space-between; cursor: pointer; padding: 4px 8px; width: 100%;"
->
-  <span style="display: flex; align-items: center;">
-    <span
-      data-testid="ockTokenRow_PlaceholderImage"
-      style="height: 32px; width: 32px; border-radius: 99999px; background: gray; margin-right: 12px;"
-    ></span>
-    <span style="display: flex; flex-direction: column; align-items: flex-start;">
-      <span style="font-size: 16px; line-height: 1.5; font-weight: 500; color: rgb(10, 11, 13);"
-        >Ether</span
-      >
-      <span style="font-size: 16px; line-height: 1.5; font-weight: 400; color: rgb(91, 97, 110);"
-        >ETH</span
-      >
+<button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+  <span class="ock-tokenrow-left">
+    <div
+      data-testid="ockTokenImage_NoImage"
+      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
+    >
+      <div style="background: rgb(26, 219, 158); width: 32px; height: 32px;"></div>
+    </div>
+    <span class="ock-tokenrow-body">
+      <span class="ock-tokenrow-name">Ethereum</span>
+      <span class="ock-tokenrow-symbol">ETH</span>
     </span>
   </span>
-  <span
-    data-testid="ockTokenRow_Amount"
-    style="font-size: 16px; line-height: 1.5; font-weight: 400; color: rgb(91, 97, 110);"
-    >1,000.00</span
-  >
+  <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data">1,000.00</span>
 </button>
 ```
 
 :::
 
 <App>
-  <div className="pane">
-    <TokenRow
-      token={{
-        address: '0x1234',
-        chainId: 1,
-        decimals: 18,
-        image: null,
-        name: 'Ether',
-        symbol: 'ETH',
-      }}
-      amount="1000.00234"
-    />
-  </div>
+  <TokenRow
+    token={{
+      address: '0x1234',
+      chainId: 1,
+      decimals: 18,
+      image: null,
+      name: 'Ethereum',
+      symbol: 'ETH',
+    }}
+    amount="1000.00234"
+  />
 </App>
 
 Token with an amount
@@ -143,106 +105,205 @@ Token with an amount
 ```tsx [code]
 import { TokenRow } from '@coinbase/onchainkit/token';
 
-const token = {
-  address: '0x1234',
-  chainId: 1,
-  decimals: 18,
-  image:
-    'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
-  name: 'Ether',
-  symbol: 'ETH',
-};
+const token = { ... };
 
 <TokenRow token={token} amount="1000" />; // [!code focus]
 <TokenRow token={token} amount="0.00234567" />; // [!code focus]
 ```
 
 ```html [return html]
-<button
-  data-testid="ockTokenRow_Container"
-  style="display: flex; align-items: center; justify-content: space-between; cursor: pointer; padding: 4px 8px; width: 100%;"
->
-  <span style="display: flex; align-items: center;">
+<button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+  <span class="ock-tokenrow-left">
     <img
-      data-testid="ockTokenRow_Image"
+      data-testid="ockTokenImage_Image"
       src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      style="height: 32px; width: 32px; margin-right: 12px;"
+      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
     />
-    <span style="display: flex; flex-direction: column; align-items: flex-start;">
-      <span style="font-size: 16px; line-height: 1.5; font-weight: 500; color: rgb(10, 11, 13);"
-        >Ether</span
-      >
-      <span style="font-size: 16px; line-height: 1.5; font-weight: 400; color: rgb(91, 97, 110);"
-        >ETH</span
-      >
+    <span class="ock-tokenrow-body">
+      <span class="ock-tokenrow-name">Ethereum</span>
+      <span class="ock-tokenrow-symbol">ETH</span>
     </span>
   </span>
-  <span
-    data-testid="ockTokenRow_Amount"
-    style="font-size: 16px; line-height: 1.5; font-weight: 400; color: rgb(91, 97, 110);"
-    >1,000.00</span
-  >
+  <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data">1,000.00</span>
 </button>
-<button
-  data-testid="ockTokenRow_Container"
-  style="display: flex; align-items: center; justify-content: space-between; cursor: pointer; padding: 4px 8px; width: 100%;"
->
-  <span style="display: flex; align-items: center;">
+
+<button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+  <span class="ock-tokenrow-left">
     <img
-      data-testid="ockTokenRow_Image"
+      data-testid="ockTokenImage_Image"
       src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      style="height: 32px; width: 32px; margin-right: 12px;"
+      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
     />
-    <span style="display: flex; flex-direction: column; align-items: flex-start;">
-      <span style="font-size: 16px; line-height: 1.5; font-weight: 500; color: rgb(10, 11, 13);"
-        >Ether</span
-      >
-      <span style="font-size: 16px; line-height: 1.5; font-weight: 400; color: rgb(91, 97, 110);"
-        >ETH</span
-      >
+    <span class="ock-tokenrow-body">
+      <span class="ock-tokenrow-name">Ethereum</span>
+      <span class="ock-tokenrow-symbol">ETH</span>
     </span>
   </span>
-  <span
-    data-testid="ockTokenRow_Amount"
-    style="font-size: 16px; line-height: 1.5; font-weight: 400; color: rgb(91, 97, 110);"
-    >0.00235</span
-  >
+  <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data">0.00235</span>
 </button>
 ```
 
 :::
 
 <App>
-  <div className="pane">
-    <TokenRow
-      token={{
-        address: '0x1234',
-        chainId: 1,
-        decimals: 18,
-        image:
-          'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
-        name: 'Ether',
-        symbol: 'ETH',
-      }}
-      amount="1000"
+  <TokenRow
+    token={{
+      address: '0x1234',
+      chainId: 1,
+      decimals: 18,
+      image:
+        'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
+      name: 'Ethereum',
+      symbol: 'ETH',
+    }}
+    amount="1000"
+  />
+  <TokenRow
+    token={{
+      address: '0x1234',
+      chainId: 1,
+      decimals: 18,
+      image:
+        'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
+      name: 'Ethereum',
+      symbol: 'ETH',
+    }}
+    amount="0.00234567"
+  />
+</App>
+
+Variations with `hideImage` and `hideSymbol`
+
+:::code-group
+
+```tsx [code]
+import { TokenRow } from '@coinbase/onchainkit/token';
+
+const token = { ... };
+
+<TokenRow token={token} hideSymbol />; // [!code focus]
+<TokenRow token={token} hideImage />; // [!code focus]
+<TokenRow token={token} hideSymbol hideImage />; // [!code focus]
+```
+
+```html [return html]
+<button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+  <span class="ock-tokenrow-left">
+    <img
+      data-testid="ockTokenImage_Image"
+      src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
     />
-  </div>
-  <div className="pane">
-    <TokenRow
-      token={{
-        address: '0x1234',
-        chainId: 1,
-        decimals: 18,
-        image:
-          'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
-        name: 'Ether',
-        symbol: 'ETH',
-      }}
-      amount="0.00234567"
-    />
-  </div>
+    <span class="ock-tokenrow-body">
+      <span class="ock-tokenrow-name">Ethereum</span>
+    </span>
+  </span>
+  <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+</button>
+
+<button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+  <span class="ock-tokenrow-left">
+    <span class="ock-tokenrow-body">
+      <span class="ock-tokenrow-name">Ethereum</span>
+      <span class="ock-tokenrow-symbol">ETH</span>
+    </span>
+  </span>
+  <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+</button>
+
+<button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+  <span class="ock-tokenrow-left">
+    <span class="ock-tokenrow-body">
+      <span class="ock-tokenrow-name">Ethereum</span>
+    </span>
+  </span>
+  <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+</button>
+```
+
+:::
+
+<App>
+  <TokenRow
+    token={{
+      address: '0x1234',
+      chainId: 1,
+      decimals: 18,
+      image:
+        'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
+      name: 'Ethereum',
+      symbol: 'ETH',
+    }}
+    hideSymbol
+  />
+
+{' '}
+
+<TokenRow
+  token={{
+    address: '0x1234',
+    chainId: 1,
+    decimals: 18,
+    image:
+      'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
+    name: 'Ethereum',
+    symbol: 'ETH',
+  }}
+  hideImage
+/>
+
+  <TokenRow
+    token={{
+      address: '0x1234',
+      chainId: 1,
+      decimals: 18,
+      image:
+        'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
+      name: 'Ethereum',
+      symbol: 'ETH',
+    }}
+    hideSymbol
+    hideImage
+  />
 </App>
 
 ## Props
 
 [`TokenRowReact`](/token/types#tokenrowreact)
+
+## CSS
+
+```css
+.ock-tokenrow-button {
+  @apply flex h-16 w-full cursor-pointer items-center justify-between px-2 py-1;
+  background: #ffffff;
+
+  &:hover {
+    background: #cacbce;
+  }
+
+  &:active {
+    background: #bfc1c3;
+  }
+}
+
+.ock-tokenrow-left {
+  @apply flex items-center gap-3;
+}
+
+.ock-tokenrow-body {
+  @apply flex flex-col items-start;
+}
+
+.ock-tokenrow-name {
+  @apply text-base font-medium leading-normal text-[#0A0B0D];
+}
+
+.ock-tokenrow-symbol {
+  @apply text-base font-normal leading-normal text-[#5B616E];
+}
+
+.ock-tokenrow-data {
+  @apply text-base font-normal leading-normal text-[#5B616E];
+}
+```

--- a/src/index.css
+++ b/src/index.css
@@ -1,2 +1,3 @@
 @import url('./token/components/TextInput.css');
 @import url('./token/components/TokenChip.css');
+@import url('./token/components/TokenRow.css');

--- a/src/token/components/TokenRow.css
+++ b/src/token/components/TokenRow.css
@@ -1,0 +1,32 @@
+.ock-tokenrow-button {
+  @apply flex h-16 w-full cursor-pointer items-center justify-between px-2 py-1;
+  background: #ffffff;
+
+  &:hover {
+    background: #cacbce;
+  }
+
+  &:active {
+    background: #bfc1c3;
+  }
+}
+
+.ock-tokenrow-left {
+  @apply flex items-center gap-3;
+}
+
+.ock-tokenrow-body {
+  @apply flex flex-col items-start;
+}
+
+.ock-tokenrow-name {
+  @apply text-base font-medium leading-normal text-[#0A0B0D];
+}
+
+.ock-tokenrow-symbol {
+  @apply text-base font-normal leading-normal text-[#5B616E];
+}
+
+.ock-tokenrow-data {
+  @apply text-base font-normal leading-normal text-[#5B616E];
+}

--- a/src/token/components/TokenRow.test.tsx
+++ b/src/token/components/TokenRow.test.tsx
@@ -27,7 +27,7 @@ describe('TokenRow component', () => {
     render(<TokenRow token={token} />);
 
     await waitFor(() => {
-      const circle = screen.getByTestId('ockTokenRow_PlaceholderImage');
+      const circle = screen.getByTestId('ockTokenImage_NoImage');
       expect(circle).toBeInTheDocument();
     });
   });
@@ -36,7 +36,7 @@ describe('TokenRow component', () => {
     render(<TokenRow token={EXAMPLE_TOKEN} />);
 
     await waitFor(() => {
-      const tokenImage = screen.getByTestId('ockTokenRow_Image');
+      const tokenImage = screen.getByTestId('ockTokenImage_Image');
       expect(tokenImage).toBeInTheDocument();
     });
   });

--- a/src/token/components/TokenRow.tsx
+++ b/src/token/components/TokenRow.tsx
@@ -1,32 +1,9 @@
 import { memo, CSSProperties } from 'react';
 import { TokenRowReact } from '../types';
 import { formatAmount } from '../core/formatAmount';
+import { TokenImage } from './TokenImage';
 
 const styles = {
-  row: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    cursor: 'pointer',
-    padding: '4px 8px',
-    width: '100%',
-  },
-  left: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  image: {
-    height: '32px',
-    width: '32px',
-    marginRight: '12px',
-  },
-  circle: {
-    height: '32px',
-    width: '32px',
-    borderRadius: '99999px',
-    background: 'gray',
-    marginRight: '12px',
-  },
   column: {
     display: 'flex',
     flexDirection: 'column',
@@ -46,21 +23,27 @@ const styles = {
   },
 } as Record<string, CSSProperties>;
 
-export const TokenRow = memo(function TokenRow({ token, amount, onClick }: TokenRowReact) {
+export const TokenRow = memo(function TokenRow({
+  token,
+  amount,
+  onClick,
+  hideImage,
+  hideSymbol,
+}: TokenRowReact) {
   return (
-    <button data-testid="ockTokenRow_Container" style={styles.row} onClick={() => onClick?.(token)}>
-      <span style={styles.left}>
-        {token.image === null ? (
-          <span data-testid="ockTokenRow_PlaceholderImage" style={styles.circle} />
-        ) : (
-          <img data-testid="ockTokenRow_Image" style={styles.image} src={token.image} />
-        )}
-        <span style={styles.column}>
-          <span style={styles.label1}>{token.name}</span>
-          <span style={styles.label2}>{token.symbol}</span>
+    <button
+      data-testid="ockTokenRow_Container"
+      className="ock-tokenrow-button"
+      onClick={() => onClick?.(token)}
+    >
+      <span className="ock-tokenrow-left">
+        {!hideImage && <TokenImage token={token} size={32} />}
+        <span className="ock-tokenrow-body">
+          <span className="ock-tokenrow-name">{token.name}</span>
+          {!hideSymbol && <span className="ock-tokenrow-symbol">{token.symbol}</span>}
         </span>
       </span>
-      <span data-testid="ockTokenRow_Amount" style={styles.label2}>
+      <span data-testid="ockTokenRow_Amount" className="ock-tokenrow-data">
         {formatAmount(amount, {
           minimumFractionDigits: 2,
           maximumFractionDigits: Number(amount) < 1 ? 5 : 2,

--- a/src/token/types.ts
+++ b/src/token/types.ts
@@ -87,6 +87,8 @@ export type TokenRowReact = {
   token: Token;
   amount?: string;
   onClick?: (token: Token) => void;
+  hideSymbol?: boolean;
+  hideImage?: boolean;
 };
 
 /**


### PR DESCRIPTION
**What changed? Why?**
- convert TokenRow to css
- add modifier states
- add display controls

TokenRow display controls
<img width="725" alt="Screenshot 2024-06-06 at 2 52 11 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/ed6d7b23-450e-48f5-92ff-8d4e68d7d2da">

Hover
<img width="725" alt="Screenshot 2024-06-06 at 2 52 55 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/20e7c152-bd7d-4233-9b90-e8a3b4123585">

Active
<img width="723" alt="Screenshot 2024-06-06 at 2 53 18 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/604cd717-9c4c-4ab3-9586-a48659e72078">

**Notes to reviewers**

**How has it been tested?**
locally
