### PR TITLE
feat: TokenSelectorDropdown

### DIFF
--- a/.changeset/tasty-pants-eat.md
+++ b/.changeset/tasty-pants-eat.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: add TokenSelectorDropdown to use with TokenSelector. By @kyhyco #475

--- a/site/docs/components/TokenSelectorContainer.tsx
+++ b/site/docs/components/TokenSelectorContainer.tsx
@@ -1,11 +1,12 @@
-import { ReactElement, cloneElement, useState } from 'react';
+import { ReactElement, useState } from 'react';
+import type { Token } from '@coinbase/onchainkit/token';
 
 type TokenSelectorContainer = {
-  children: ReactElement;
+  children: (token: Token, setToken: (t: Token) => void) => ReactElement;
 };
 
 export default function TokenSelectorContainer({ children }: TokenSelectorContainer) {
   const [token, setToken] = useState();
 
-  return cloneElement(children, { token, setToken });
+  return children(token, setToken);
 }

--- a/site/docs/components/TokenSelectorContainer.tsx
+++ b/site/docs/components/TokenSelectorContainer.tsx
@@ -1,0 +1,11 @@
+import { ReactElement, cloneElement, useState } from 'react';
+
+type TokenSelectorContainer = {
+  children: ReactElement;
+};
+
+export default function TokenSelectorContainer({ children }: TokenSelectorContainer) {
+  const [token, setToken] = useState();
+
+  return cloneElement(children, { token, setToken });
+}

--- a/site/docs/pages/token/token-selector.mdx
+++ b/site/docs/pages/token/token-selector.mdx
@@ -1,4 +1,4 @@
-import { TokenSelector, TokenSelectorDropdown } from '../../../../src/token';
+{/* import { TokenSelector, TokenSelectorDropdown } from '../../../../src/token'; */}
 import TokenSelectorContainer from '../../components/TokenSelectorContainer.tsx';
 import App from '../App';
 
@@ -15,18 +15,22 @@ import App from '../App';
 :::code-group
 
 ```tsx [code]
-<TokenSelector
-  token={{
-    address: '0x1234',
-    chainId: 1,
-    decimals: 18,
-    image:
-      'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
-    name: 'Ethereum',
-    symbol: 'ETH',
-  }}
-  onClick={() => {}}
-/>
+<TokenSelector token={token}> // [!code focus]
+  <TokenSelectorDropdown // [!code focus]
+    setToken={setToken} // [!code focus]
+    options={[ // [!code focus]
+      {
+        name: 'Ethereum',
+        address: '',
+        symbol: 'ETH',
+        decimals: 18,
+        image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+        chainId: 8453,
+      },
+      ...
+    ]} // [!code focus]
+  /> // [!code focus]
+</TokenSelector> // [!code focus]
 ```
 
 ```html [return html]
@@ -80,46 +84,6 @@ import App from '../App';
 ```
 
 :::
-
-<App>
-  <TokenSelectorContainer>
-    <TokenSelector>
-      <TokenSelectorDropdown
-        options={[
-          {
-            name: 'Ethereum',
-            address: '',
-            symbol: 'ETH',
-            decimals: 18,
-            image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
-            blockchain: 'eth',
-            chainId: 8453,
-          },
-          {
-            name: 'USDC',
-            address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
-            symbol: 'USDC',
-            decimals: 6,
-            image:
-              'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
-            blockchain: 'eth',
-            chainId: 8453,
-          },
-          {
-            name: 'Dai',
-            address: '0x50c5725949a6f0c72e6c4a641f24049a917db0cb',
-            symbol: 'DAI',
-            decimals: 18,
-            image:
-              'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/d0/d7/d0d7784975771dbbac9a22c8c0c12928cc6f658cbcf2bbbf7c909f0fa2426dec-NmU4ZWViMDItOTQyYy00Yjk5LTkzODUtNGJlZmJiMTUxOTgy',
-            blockchain: 'eth',
-            chainId: 8453,
-          },
-        ]}
-      />
-    </TokenSelector>
-  </TokenSelectorContainer>
-</App>
 
 ## Props
 

--- a/site/docs/pages/token/token-selector.mdx
+++ b/site/docs/pages/token/token-selector.mdx
@@ -1,13 +1,16 @@
-import { TokenSelector } from '@coinbase/onchainkit/token';
+import { TokenSelector, TokenSelectorDropdown } from '../../../../src/token';
+import TokenSelectorContainer from '../../components/TokenSelectorContainer.tsx';
 import App from '../App';
 
 # `<TokenSelector />`
 
 `TokenSelector` component is stylized button component that displays the token info or placeholder text.
 
+`TokenSelectorDropdown` component is a dropdown component for `TokenSelector`.
+
 ## Usage
 
-`TokenSelector` with token prop
+`TokenSelector` with `TokenSelectorDropdown`
 
 :::code-group
 
@@ -27,81 +30,136 @@ import App from '../App';
 ```
 
 ```html [return html]
-<button
-  data-testid="ockTokenSelector_Button"
-  style="border-radius: 16px; padding: 4px 12px; display: flex; align-items: center; background: rgb(238, 240, 243); width: fit-content;"
->
-  <img
-    data-testid="ockTokenImage_Image"
-    src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-    style="width: 16px; height: 16px; border-radius: 50%; overflow: hidden; background: blue;"
-  /><span
-    data-testid="ockTokenSelector_Symbol"
-    style="color: rgb(10, 11, 13); font-size: 16px; line-height: 1.5; font-weight: 500; margin-left: 4px;"
-    >ETH</span
+<button data-testid="ockTokenSelector_Button" class="ock-tokenselector-button">
+  <span class="ock-tokenselector-label">Select</span>
+  <svg
+    data-testid="ockTokenSelector_CaretUp"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
   >
-  <span style="margin-left: 8px;">
-    <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M12.95 4.85999L8.00001 9.80999L3.05001 4.85999L1.64001 6.27999L8.00001 12.64L14.36 6.27999L12.95 4.85999Z"
-        fill="#0A0B0D"
-      ></path>
-    </svg>
-  </span>
+    <path
+      d="M3.05329 10.9866L7.99996 6.03997L12.9466 10.9866L14.1266 9.80663L7.99996 3.67997L1.87329 9.80663L3.05329 10.9866Z"
+      fill="#0A0B0D"
+    ></path>
+  </svg>
 </button>
+<div class="ock-tokenselectordropdown-container">
+  <div class="ock-tokenselectordropdown-scroll">
+    <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+      <span class="ock-tokenrow-left">
+        <span class="ock-tokenrow-body">
+          <span class="ock-tokenrow-name">Ethereum</span>
+          <span class="ock-tokenrow-symbol">ETH</span>
+        </span>
+      </span>
+      <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+    </button>
+    <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+      <span class="ock-tokenrow-left">
+        <span class="ock-tokenrow-body">
+          <span class="ock-tokenrow-name">USDC</span>
+          <span class="ock-tokenrow-symbol">USDC</span>
+        </span>
+      </span>
+      <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+    </button>
+    <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+      <span class="ock-tokenrow-left">
+        <span class="ock-tokenrow-body">
+          <span class="ock-tokenrow-name">Dai</span>
+          <span class="ock-tokenrow-symbol">DAI</span>
+        </span>
+      </span>
+      <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+    </button>
+  </div>
+</div>
 ```
 
 :::
 
 <App>
-  <TokenSelector
-    token={{
-      address: '0x1234',
-      chainId: 1,
-      decimals: 18,
-      image:
-        'https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png',
-      name: 'Ethereum',
-      symbol: 'ETH',
-    }}
-    onClick={() => {}}
-  />
-</App>
-
-`TokenSelector` with no token prop
-
-:::code-group
-
-```tsx [code]
-<TokenSelector token={undefined} onClick={() => {}} />
-```
-
-```html [return html]
-<button
-  data-testid="ockTokenSelector_Button"
-  style="border-radius: 16px; padding: 4px 12px; display: flex; align-items: center; background: rgb(238, 240, 243); width: fit-content;"
->
-  <span
-    style="color: rgb(10, 11, 13); font-size: 16px; line-height: 1.5; font-weight: 500; margin-left: 4px;"
-    >Select</span
-  >
-  <span style="margin-left: 8px;">
-    <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path
-        d="M12.95 4.85999L8.00001 9.80999L3.05001 4.85999L1.64001 6.27999L8.00001 12.64L14.36 6.27999L12.95 4.85999Z"
-        fill="#0A0B0D"
-      ></path>
-    </svg>
-  </span>
-</button>
-```
-
-:::
-
-<App>
-  <TokenSelector token={undefined} onClick={() => {}} />
+  <TokenSelectorContainer>
+    <TokenSelector>
+      <TokenSelectorDropdown
+        options={[
+          {
+            name: 'Ethereum',
+            address: '',
+            symbol: 'ETH',
+            decimals: 18,
+            image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+            blockchain: 'eth',
+            chainId: 8453,
+          },
+          {
+            name: 'USDC',
+            address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+            symbol: 'USDC',
+            decimals: 6,
+            image:
+              'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
+            blockchain: 'eth',
+            chainId: 8453,
+          },
+          {
+            name: 'Dai',
+            address: '0x50c5725949a6f0c72e6c4a641f24049a917db0cb',
+            symbol: 'DAI',
+            decimals: 18,
+            image:
+              'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/d0/d7/d0d7784975771dbbac9a22c8c0c12928cc6f658cbcf2bbbf7c909f0fa2426dec-NmU4ZWViMDItOTQyYy00Yjk5LTkzODUtNGJlZmJiMTUxOTgy',
+            blockchain: 'eth',
+            chainId: 8453,
+          },
+        ]}
+      />
+    </TokenSelector>
+  </TokenSelectorContainer>
 </App>
 
 ## Props
 
 [`TokenSelectorReact`](/token/types#tokenselectorreact)
+[`TokenSelectorDropdownReact`](/token/types#tokenselectordropdownreact)
+
+## CSS
+
+`TokenSelector`
+
+```css
+.ock-tokenselector-container {
+  @apply relative;
+}
+.ock-tokenselector-button {
+  @apply flex w-fit items-center rounded-2xl px-3 py-1;
+  background: #eef0f3;
+  gap: 8px;
+  outline: none;
+  &:hover {
+    background: #cacbce;
+  }
+  &:active {
+    background: #bfc1c3;
+  }
+}
+.ock-tokenselector-label {
+  @apply text-base font-medium leading-normal text-[#0a0b0d];
+}
+```
+
+`TokenSelectorDropdown`
+
+```css
+.ock-tokenselectordropdown-container {
+  @apply absolute z-10 mt-[11px] flex max-h-80 w-[250px] flex-col overflow-y-hidden rounded-lg;
+  scrollbar-width: thin;
+  scrollbar-color: #eef0f3 #ffffff;
+}
+.ock-tokenselectordropdown-scroll {
+  @apply overflow-y-auto;
+}
+```

--- a/site/docs/pages/token/types.mdx
+++ b/site/docs/pages/token/types.mdx
@@ -103,8 +103,8 @@ export type TokenSelectorReact = {
 
 ```ts
 export type TokenSelectorDropdownReact = {
-  onToggle: () => void; // Injected by TokenSelector
+  onToggle: () => void; // Injected by TokenSelector. To be removed.
   options: Token[]; // List of tokens
-  setToken: (token: Token) => void; // Injected by TokenSelector
+  setToken: (token: Token) => void; // Token setter
 };
 ```

--- a/site/docs/pages/token/types.mdx
+++ b/site/docs/pages/token/types.mdx
@@ -93,7 +93,18 @@ export type TokenSearchReact = {
 
 ```ts
 export type TokenSelectorReact = {
-  token: Token; // Rendered token
-  onClick: () => void; // Component on click handler
+  children: ReactElement<{ setToken: (token: Token) => void; onToggle: () => void }>; // Should either be a dropdown or modal that handle token selection
+  setToken: (token: Token) => void; // Token setter
+  token?: Token; // Selected token
+};
+```
+
+## `TokenSelectorDropdownReact`
+
+```ts
+export type TokenSelectorDropdownReact = {
+  onToggle: () => void; // Injected by TokenSelector
+  options: Token[]; // List of tokens
+  setToken: (token: Token) => void; // Injected by TokenSelector
 };
 ```

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
 @import url('./token/components/TextInput.css');
 @import url('./token/components/TokenChip.css');
 @import url('./token/components/TokenRow.css');
+@import url('./token/components/TokenSelector.css');
+@import url('./token/components/TokenSelectorDropdown.css');

--- a/src/token/components/TokenRow.tsx
+++ b/src/token/components/TokenRow.tsx
@@ -1,27 +1,7 @@
-import { memo, CSSProperties } from 'react';
+import { memo } from 'react';
 import { TokenRowReact } from '../types';
 import { formatAmount } from '../core/formatAmount';
 import { TokenImage } from './TokenImage';
-
-const styles = {
-  column: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-  },
-  label1: {
-    fontSize: '16px',
-    lineHeight: '1.5',
-    fontWeight: 500,
-    color: '#0A0B0D',
-  },
-  label2: {
-    fontSize: '16px',
-    lineHeight: '1.5',
-    fontWeight: 400,
-    color: '#5B616E',
-  },
-} as Record<string, CSSProperties>;
 
 export const TokenRow = memo(function TokenRow({
   token,

--- a/src/token/components/TokenSelector.css
+++ b/src/token/components/TokenSelector.css
@@ -1,0 +1,22 @@
+.ock-tokenselector-container {
+  @apply relative;
+}
+
+.ock-tokenselector-button {
+  @apply flex w-fit items-center rounded-2xl px-3 py-1;
+  background: #eef0f3;
+  outline: none;
+  gap: 8px;
+
+  &:hover {
+    background: #cacbce;
+  }
+
+  &:active {
+    background: #bfc1c3;
+  }
+}
+
+.ock-tokenselector-label {
+  @apply text-base font-medium leading-normal text-[#0a0b0d];
+}

--- a/src/token/components/TokenSelector.test.tsx
+++ b/src/token/components/TokenSelector.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Address } from 'viem';
 import { TokenSelector } from './TokenSelector';
 
@@ -21,7 +21,7 @@ describe('TokenSelector', () => {
   const setToken = jest.fn();
   const children = <div data-testid="ockTokenSelector_MockChildren">component</div>;
 
-  test('renders correctly without a token', () => {
+  it('renders correctly without a token', () => {
     render(
       <TokenSelector token={undefined} setToken={setToken}>
         {children}
@@ -33,7 +33,7 @@ describe('TokenSelector', () => {
     expect(screen.getByTestId('ockTokenSelector_CaretDown')).toBeInTheDocument();
   });
 
-  test('renders correctly with a token', () => {
+  it('renders correctly with a token', () => {
     render(
       <TokenSelector token={token} setToken={setToken}>
         {children}
@@ -45,7 +45,7 @@ describe('TokenSelector', () => {
     expect(screen.queryByText('Select')).toBeNull();
   });
 
-  test('toggles dropdown on button click', () => {
+  it('toggles dropdown on button click', () => {
     render(
       <TokenSelector token={token} setToken={setToken}>
         {children}

--- a/src/token/components/TokenSelector.test.tsx
+++ b/src/token/components/TokenSelector.test.tsx
@@ -7,65 +7,60 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { Address } from 'viem';
 import { TokenSelector } from './TokenSelector';
 
-describe('TokenSelector Component', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+describe('TokenSelector', () => {
+  const token = {
+    name: 'Ethereum',
+    address: '0x123' as Address,
+    symbol: 'ETH',
+    decimals: 18,
+    image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+    blockchain: 'eth',
+    chainId: 8453,
+  };
+
+  const setToken = jest.fn();
+  const children = <div data-testid="ockTokenSelector_MockChildren">component</div>;
+
+  test('renders correctly without a token', () => {
+    render(
+      <TokenSelector token={undefined} setToken={setToken}>
+        {children}
+      </TokenSelector>,
+    );
+
+    expect(screen.getByText('Select')).toBeInTheDocument();
+    expect(screen.queryByTestId('ockTokenSelector_Symbol')).toBeNull();
+    expect(screen.getByTestId('ockTokenSelector_CaretDown')).toBeInTheDocument();
   });
 
-  it('should render with token prop', async () => {
-    const token = {
-      address: '0x123' as Address,
-      chainId: 1,
-      decimals: 2,
-      image: 'imageURL',
-      name: 'Ether',
-      symbol: 'ETH',
-    };
-    const handleClick = jest.fn();
+  test('renders correctly with a token', () => {
+    render(
+      <TokenSelector token={token} setToken={setToken}>
+        {children}
+      </TokenSelector>,
+    );
 
-    render(<TokenSelector token={token} onClick={handleClick} />);
-    const buttonElement = screen.getByRole('button');
-    expect(buttonElement).toBeInTheDocument();
-
-    const imgElement = within(buttonElement).getByRole('img');
-    const spanElement = within(buttonElement).getByText(token.symbol);
-
-    expect(imgElement).toBeInTheDocument();
-    expect(spanElement).toBeInTheDocument();
+    expect(screen.getByText('ETH')).toBeInTheDocument();
+    expect(screen.getByTestId('ockTokenSelector_CaretDown')).toBeInTheDocument();
+    expect(screen.queryByText('Select')).toBeNull();
   });
 
-  it('should render with no token prop with placeholder text', async () => {
-    const handleClick = jest.fn();
-
-    render(<TokenSelector token={undefined} onClick={handleClick} />);
-    const buttonElement = screen.getByRole('button');
-    expect(buttonElement).toBeInTheDocument();
-
-    const imgElement = within(buttonElement).queryByRole('img');
-    const spanElement = within(buttonElement).queryByTestId('ockTokenSelector_Symbol');
-    const placeholderElement = within(buttonElement).getByText('Select');
-
-    expect(imgElement).toBeNull();
-    expect(spanElement).toBeNull();
-    expect(placeholderElement).toBeInTheDocument();
-  });
-
-  it('should register a click on press', async () => {
-    const token = {
-      address: '0x123' as Address,
-      chainId: 1,
-      decimals: 2,
-      image: 'imageURL',
-      name: 'Ether',
-      symbol: 'ETH',
-    };
-    const handleClick = jest.fn();
-    render(<TokenSelector token={token} onClick={handleClick} />);
+  test('toggles dropdown on button click', () => {
+    render(
+      <TokenSelector token={token} setToken={setToken}>
+        {children}
+      </TokenSelector>,
+    );
 
     const button = screen.getByTestId('ockTokenSelector_Button');
+    fireEvent.click(button);
+
+    expect(screen.getByTestId('ockTokenSelector_CaretUp')).toBeInTheDocument();
+    expect(screen.getByTestId('ockTokenSelector_MockChildren')).toBeInTheDocument();
 
     fireEvent.click(button);
 
-    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('ockTokenSelector_CaretDown')).toBeInTheDocument();
+    expect(screen.queryByTestId('ockTokenSelector_MockChildren')).toBeNull();
   });
 });

--- a/src/token/components/TokenSelector.tsx
+++ b/src/token/components/TokenSelector.tsx
@@ -1,9 +1,35 @@
+import { cloneElement, isValidElement, useCallback, useState } from 'react';
 import { TokenSelectorReact } from '../types';
 import { TokenImage } from './TokenImage';
 
+function CaretUp() {
+  return (
+    <svg
+      data-testid="ockTokenSelector_CaretUp"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3.05329 10.9866L7.99996 6.03997L12.9466 10.9866L14.1266 9.80663L7.99996 3.67997L1.87329 9.80663L3.05329 10.9866Z"
+        fill="#0A0B0D"
+      />
+    </svg>
+  );
+}
+
 function CaretDown() {
   return (
-    <svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      data-testid="ockTokenSelector_CaretDown"
+      width="16"
+      height="17"
+      viewBox="0 0 16 17"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
       <path
         d="M12.95 4.85999L8.00001 9.80999L3.05001 4.85999L1.64001 6.27999L8.00001 12.64L14.36 6.27999L12.95 4.85999Z"
         fill="#0A0B0D"
@@ -12,47 +38,35 @@ function CaretDown() {
   );
 }
 
-const styles = {
-  button: {
-    borderRadius: '16px',
-    padding: '4px 12px 4px 12px',
-    display: 'flex',
-    alignItems: 'center',
-    background: '#EEF0F3',
-    width: 'fit-content',
-  },
-  image: {
-    height: '16px',
-    width: '16px',
-  },
-  label: {
-    color: '#0A0B0D',
-    fontSize: '16px',
-    lineHeight: '1.5',
-    fontWeight: '500',
-    marginLeft: '4px',
-  },
-  caret: {
-    marginLeft: '8px',
-  },
-};
+export function TokenSelector({ token, children, setToken }: TokenSelectorReact) {
+  const [isOpen, setIsOpen] = useState(false);
 
-export function TokenSelector({ token, onClick }: TokenSelectorReact) {
+  const handleToggle = useCallback(() => {
+    setIsOpen(!isOpen);
+  }, [isOpen]);
+
   return (
-    <button data-testid="ockTokenSelector_Button" style={styles.button} onClick={onClick}>
-      {token ? (
-        <>
-          <TokenImage token={token} size={16} />
-          <span data-testid="ockTokenSelector_Symbol" style={styles.label}>
-            {token.symbol}
-          </span>
-        </>
-      ) : (
-        <span style={styles.label}>Select</span>
-      )}
-      <span style={styles.caret}>
-        <CaretDown />
-      </span>
-    </button>
+    <div className="ock-tokenselector-container">
+      <button
+        data-testid="ockTokenSelector_Button"
+        className="ock-tokenselector-button"
+        onClick={handleToggle}
+      >
+        {token ? (
+          <>
+            <TokenImage token={token} size={16} />
+            <span data-testid="ockTokenSelector_Symbol" className="ock-tokenselector-label">
+              {token.symbol}
+            </span>
+          </>
+        ) : (
+          <span className="ock-tokenselector-label">Select</span>
+        )}
+        {isOpen ? <CaretUp /> : <CaretDown />}
+      </button>
+      {isOpen &&
+        isValidElement(children) &&
+        cloneElement(children, { setToken, onToggle: handleToggle })}
+    </div>
   );
 }

--- a/src/token/components/TokenSelector.tsx
+++ b/src/token/components/TokenSelector.tsx
@@ -38,7 +38,7 @@ function CaretDown() {
   );
 }
 
-export function TokenSelector({ token, children, setToken }: TokenSelectorReact) {
+export function TokenSelector({ token, children }: TokenSelectorReact) {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleToggle = useCallback(() => {
@@ -66,7 +66,9 @@ export function TokenSelector({ token, children, setToken }: TokenSelectorReact)
       </button>
       {isOpen &&
         isValidElement(children) &&
-        cloneElement(children, { setToken, onToggle: handleToggle })}
+        cloneElement(children, {
+          onToggle: handleToggle,
+        })}
     </div>
   );
 }

--- a/src/token/components/TokenSelectorDropdown.css
+++ b/src/token/components/TokenSelectorDropdown.css
@@ -1,0 +1,9 @@
+.ock-tokenselectordropdown-container {
+  @apply absolute z-10 mt-[11px] flex max-h-80 w-[250px] flex-col overflow-y-hidden rounded-lg;
+  scrollbar-width: thin;
+  scrollbar-color: #eef0f3 #ffffff;
+}
+
+.ock-tokenselectordropdown-scroll {
+  @apply overflow-y-auto;
+}

--- a/src/token/components/TokenSelectorDropdown.css
+++ b/src/token/components/TokenSelectorDropdown.css
@@ -1,7 +1,7 @@
 .ock-tokenselectordropdown-container {
   @apply absolute z-10 mt-[11px] flex max-h-80 w-[250px] flex-col overflow-y-hidden rounded-lg;
   scrollbar-width: thin;
-  scrollbar-color: #eef0f3 #ffffff;
+  scrollbar-color: #d1d5db #ffffff;
 }
 
 .ock-tokenselectordropdown-scroll {

--- a/src/token/components/TokenSelectorDropdown.test.tsx
+++ b/src/token/components/TokenSelectorDropdown.test.tsx
@@ -2,15 +2,15 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Address } from 'viem';
 import { TokenSelectorDropdown } from './TokenSelectorDropdown';
 import { Token } from '../types';
 
 describe('TokenSelectorDropdown', () => {
-  const handleSetToken = jest.fn();
-  const handleToggle = jest.fn();
-  const tokens: Token[] = [
+  const setToken = jest.fn();
+  const onToggle = jest.fn();
+  const options: Token[] = [
     {
       name: 'Ethereum',
       address: '' as Address,
@@ -31,26 +31,30 @@ describe('TokenSelectorDropdown', () => {
   ];
 
   it('renders the TokenSelectorDropdown component', () => {
-    render(
-      <TokenSelectorDropdown setToken={handleSetToken} options={tokens} onToggle={handleToggle} />,
-    );
+    render(<TokenSelectorDropdown setToken={setToken} options={options} onToggle={onToggle} />);
 
     const result = screen.getAllByTestId('ockTokenRow_Container');
-    expect(result.length).toEqual(tokens.length);
+    expect(result.length).toEqual(options.length);
   });
 
-  test('calls setToken and onToggle when a TokenRow is clicked', () => {
-    render(
-      <TokenSelectorDropdown setToken={handleSetToken} options={tokens} onToggle={handleToggle} />,
-    );
+  it('calls setToken and onToggle when clicking on a token', async () => {
+    render(<TokenSelectorDropdown setToken={setToken} onToggle={onToggle} options={options} />);
 
-    const elements = screen.getAllByTestId('ockTokenRow_Container');
+    await waitFor(() => {
+      fireEvent.click(screen.getByText(options[0].name));
 
-    elements.forEach((element) => {
-      fireEvent.click(element);
+      expect(setToken).toHaveBeenCalledWith(options[0]);
+      expect(onToggle).toHaveBeenCalled();
     });
+  });
 
-    expect(handleSetToken).toHaveBeenCalledTimes(tokens.length);
-    expect(handleToggle).toHaveBeenCalledTimes(tokens.length);
+  it('calls onToggle when clicking outside the component', async () => {
+    render(<TokenSelectorDropdown setToken={setToken} onToggle={onToggle} options={options} />);
+
+    await waitFor(() => {
+      fireEvent.click(document);
+
+      expect(onToggle).toHaveBeenCalled();
+    });
   });
 });

--- a/src/token/components/TokenSelectorDropdown.test.tsx
+++ b/src/token/components/TokenSelectorDropdown.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Address } from 'viem';
+import { TokenSelectorDropdown } from './TokenSelectorDropdown';
+import { Token } from '../types';
+
+describe('TokenSelectorDropdown', () => {
+  const handleSetToken = jest.fn();
+  const handleToggle = jest.fn();
+  const tokens: Token[] = [
+    {
+      name: 'Ethereum',
+      address: '' as Address,
+      symbol: 'ETH',
+      decimals: 18,
+      image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+      chainId: 8453,
+    },
+    {
+      name: 'USDC',
+      address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913' as Address,
+      symbol: 'USDC',
+      decimals: 6,
+      image:
+        'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
+      chainId: 8453,
+    },
+  ];
+
+  it('renders the TokenSelectorDropdown component', () => {
+    render(
+      <TokenSelectorDropdown setToken={handleSetToken} options={tokens} onToggle={handleToggle} />,
+    );
+
+    const result = screen.getAllByTestId('ockTokenRow_Container');
+    expect(result.length).toEqual(tokens.length);
+  });
+
+  test('calls setToken and onToggle when a TokenRow is clicked', () => {
+    render(
+      <TokenSelectorDropdown setToken={handleSetToken} options={tokens} onToggle={handleToggle} />,
+    );
+
+    const elements = screen.getAllByTestId('ockTokenRow_Container');
+
+    elements.forEach((element) => {
+      fireEvent.click(element);
+    });
+
+    expect(handleSetToken).toHaveBeenCalledTimes(tokens.length);
+    expect(handleToggle).toHaveBeenCalledTimes(tokens.length);
+  });
+});

--- a/src/token/components/TokenSelectorDropdown.tsx
+++ b/src/token/components/TokenSelectorDropdown.tsx
@@ -1,15 +1,31 @@
-import { Token } from '../types';
+import { useCallback, useEffect, useRef } from 'react';
+import { TokenSelectorDropdownReact } from '../types';
 import { TokenRow } from './TokenRow';
 
-type TokenSelectorDropdownReact = {
-  setToken: (token: Token) => void;
-  options: Token[];
-  onToggle: () => void;
-};
-
 export function TokenSelectorDropdown({ setToken, options, onToggle }: TokenSelectorDropdownReact) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const handleBlur = useCallback((event: MouseEvent) => {
+    /* istanbul ignore next */
+    if (ref.current && !ref.current.contains(event.target as Node)) {
+      onToggle();
+    }
+  }, []);
+
+  useEffect(() => {
+    // NOTE: this ensures that handleBlur doesn't get called on initial mount
+    //       We need to use non-div elements to properly handle onblur events
+    setTimeout(() => {
+      document.addEventListener('click', handleBlur);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('click', handleBlur);
+    };
+  }, []);
+
   return (
-    <div className="ock-tokenselectordropdown-container">
+    <div ref={ref} className="ock-tokenselectordropdown-container">
       <div className="ock-tokenselectordropdown-scroll">
         {options.map((token) => (
           <TokenRow

--- a/src/token/components/TokenSelectorDropdown.tsx
+++ b/src/token/components/TokenSelectorDropdown.tsx
@@ -1,0 +1,28 @@
+import { Token } from '../types';
+import { TokenRow } from './TokenRow';
+
+type TokenSelectorDropdownReact = {
+  setToken: (token: Token) => void;
+  options: Token[];
+  onToggle: () => void;
+};
+
+export function TokenSelectorDropdown({ setToken, options, onToggle }: TokenSelectorDropdownReact) {
+  return (
+    <div className="ock-tokenselectordropdown-container">
+      <div className="ock-tokenselectordropdown-scroll">
+        {options.map((token) => (
+          <TokenRow
+            key={token.name + token.address}
+            token={token}
+            onClick={() => {
+              setToken(token);
+              onToggle();
+            }}
+            hideImage
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/token/index.ts
+++ b/src/token/index.ts
@@ -4,6 +4,7 @@ export { TokenImage } from './components/TokenImage';
 export { TokenRow } from './components/TokenRow';
 export { TokenSearch } from './components/TokenSearch';
 export { TokenSelector } from './components/TokenSelector';
+export { TokenSelectorDropdown } from './components/TokenSelectorDropdown';
 export { formatAmount } from './core/formatAmount';
 export { getTokens } from './core/getTokens';
 export type {

--- a/src/token/types.ts
+++ b/src/token/types.ts
@@ -104,7 +104,7 @@ export type TokenSearchReact = {
  * Note: exported as public Type
  */
 export type TokenSelectorReact = {
-  children: ReactElement<{ setToken: (token: Token) => void; onToggle: () => void }>;
+  children: ReactElement<{ onToggle: () => void }>;
   setToken: (token: Token) => void;
   token?: Token;
 };
@@ -115,5 +115,5 @@ export type TokenSelectorReact = {
 export type TokenSelectorDropdownReact = {
   onToggle: () => void; // Injected by TokenSelector
   options: Token[]; // List of tokens
-  setToken: (token: Token) => void; // Injected by TokenSelector
+  setToken: (token: Token) => void; // Token setter
 };

--- a/src/token/types.ts
+++ b/src/token/types.ts
@@ -1,4 +1,5 @@
 // 🌲☀️🌲
+import { ReactElement } from 'react';
 import { Address } from 'viem';
 
 // The raw response from the Swap API
@@ -103,6 +104,16 @@ export type TokenSearchReact = {
  * Note: exported as public Type
  */
 export type TokenSelectorReact = {
+  children: ReactElement<{ setToken: (token: Token) => void; onToggle: () => void }>;
+  setToken: (token: Token) => void;
   token?: Token;
-  onClick: () => void;
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type TokenSelectorDropdownReact = {
+  onToggle: () => void; // Injected by TokenSelector
+  options: Token[]; // List of tokens
+  setToken: (token: Token) => void; // Injected by TokenSelector
 };


### PR DESCRIPTION
**What changed? Why?**
- add `TokenSelectorDropdown` to be used with `TokenSelectorDropdown`

<img width="500" alt="Screenshot 2024-06-07 at 10 43 55 AM" src="https://github.com/coinbase/onchainkit/assets/132851666/8ac2c08b-8d88-401f-9041-0e88282dfa26">

With scrollbar
<img width="275" alt="Screenshot 2024-06-07 at 10 42 00 AM" src="https://github.com/coinbase/onchainkit/assets/132851666/39bdadf0-27c4-46a8-a31c-21c2de9d459c">


**Notes to reviewers**
`TokenSelector` and `TokenSelectorDropdown` should be built with non-div elements like `select` and `option`. I will address this in future PRs.

**How has it been tested?**
locally
