### PR TITLE
feat: TokenKit style update

### DIFF
--- a/.changeset/big-worms-lie.md
+++ b/.changeset/big-worms-lie.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: update TokenKit styles. By @kyhyco #482

--- a/site/docs/pages/token/token-row.mdx
+++ b/site/docs/pages/token/token-row.mdx
@@ -25,7 +25,7 @@ const token = { ... };
     <img
       data-testid="ockTokenImage_Image"
       src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
+      style="width: 48px; height: 48px; border-radius: 50%; overflow: hidden;"
     />
     <span class="ock-tokenrow-body">
       <span class="ock-tokenrow-name">Ethereum</span>
@@ -69,9 +69,9 @@ const token = { ... };
   <span class="ock-tokenrow-left">
     <div
       data-testid="ockTokenImage_NoImage"
-      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
+      style="width: 48px; height: 48px; border-radius: 50%; overflow: hidden;"
     >
-      <div style="background: rgb(26, 219, 158); width: 32px; height: 32px;"></div>
+      <div style="background: rgb(26, 219, 158); width: 48px; height: 48px;"></div>
     </div>
     <span class="ock-tokenrow-body">
       <span class="ock-tokenrow-name">Ethereum</span>
@@ -117,7 +117,7 @@ const token = { ... };
     <img
       data-testid="ockTokenImage_Image"
       src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
+      style="width: 48px; height: 48px; border-radius: 50%; overflow: hidden;"
     />
     <span class="ock-tokenrow-body">
       <span class="ock-tokenrow-name">Ethereum</span>
@@ -132,7 +132,7 @@ const token = { ... };
     <img
       data-testid="ockTokenImage_Image"
       src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
+      style="width: 48px; height: 48px; border-radius: 50%; overflow: hidden;"
     />
     <span class="ock-tokenrow-body">
       <span class="ock-tokenrow-name">Ethereum</span>
@@ -192,7 +192,7 @@ const token = { ... };
     <img
       data-testid="ockTokenImage_Image"
       src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
-      style="width: 32px; height: 32px; border-radius: 50%; overflow: hidden;"
+      style="width: 48px; height: 48px; border-radius: 50%; overflow: hidden;"
     />
     <span class="ock-tokenrow-body">
       <span class="ock-tokenrow-name">Ethereum</span>

--- a/site/docs/pages/token/token-search.mdx
+++ b/site/docs/pages/token/token-search.mdx
@@ -40,8 +40,8 @@ const handleChange = useCallback((value) => {
 ```
 
 ```html [return html]
-<div style="position: relative;">
-  <div style="position: absolute; left: 16px; top: 14px;">
+<div class="ock-textinput-container">
+  <div class="ock-textinput-iconsearch">
     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M16 14.23L11.89 10.12C12.59 9.09 13 7.84 13 6.5C13 2.91 10.09 0 6.5 0C2.91 0 0 2.91 0 6.5C0 10.09 2.91 13 6.5 13C7.84 13 9.09 12.59 10.13 11.89L14.23 16L16 14.23ZM6.5 10.5C4.29 10.5 2.5 8.71 2.5 6.5C2.5 4.29 4.29 2.5 6.5 2.5C8.71 2.5 10.5 4.29 10.5 6.5C10.5 8.71 8.71 10.5 6.5 10.5Z"
@@ -52,9 +52,9 @@ const handleChange = useCallback((value) => {
   <input
     data-testid="ockTextInput_Search"
     type="text"
-    placeholder="Search name or paste address"
+    class="ock-textinput-input"
+    placeholder="Search for a token"
     value=""
-    style="border-radius: 1000px; padding: 8px 20px 8px 48px; width: 100%; background: rgb(238, 240, 243); color: rgb(91, 97, 110);"
   />
 </div>
 ```
@@ -81,17 +81,13 @@ const handleChange = useCallback((value) => {
 .ock-textinput-input {
   @apply w-full rounded-full border-2 border-solid border-[#eef0f3] py-2  pl-12 pr-5 text-[#0A0B0D];
   background: #eef0f3;
+  outline: none;
 
   &::placeholder {
     @apply text-[#5B616E];
   }
   &:hover {
-    @apply border-[#cacbce];
     background: #cacbce;
-  }
-  &:focus {
-    @apply border-[#0052FF];
-    outline: none;
   }
   &:hover:focus {
     background: #eef0f3;

--- a/site/docs/pages/token/token-selector.mdx
+++ b/site/docs/pages/token/token-selector.mdx
@@ -34,51 +34,68 @@ import App from '../App';
 ```
 
 ```html [return html]
-<button data-testid="ockTokenSelector_Button" class="ock-tokenselector-button">
-  <span class="ock-tokenselector-label">Select</span>
-  <svg
-    data-testid="ockTokenSelector_CaretUp"
-    width="16"
-    height="16"
-    viewBox="0 0 16 16"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M3.05329 10.9866L7.99996 6.03997L12.9466 10.9866L14.1266 9.80663L7.99996 3.67997L1.87329 9.80663L3.05329 10.9866Z"
-      fill="#0A0B0D"
-    ></path>
-  </svg>
-</button>
-<div class="ock-tokenselectordropdown-container">
-  <div class="ock-tokenselectordropdown-scroll">
-    <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
-      <span class="ock-tokenrow-left">
-        <span class="ock-tokenrow-body">
-          <span class="ock-tokenrow-name">Ethereum</span>
-          <span class="ock-tokenrow-symbol">ETH</span>
+<div class="ock-tokenselector-container">
+  <button data-testid="ockTokenSelector_Button" class="ock-tokenselector-button">
+    <span class="ock-tokenselector-label">Select</span>
+    <svg
+      data-testid="ockTokenSelector_CaretUp"
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3.05329 10.9866L7.99996 6.03997L12.9466 10.9866L14.1266 9.80663L7.99996 3.67997L1.87329 9.80663L3.05329 10.9866Z"
+        fill="#0A0B0D"
+      ></path>
+    </svg>
+  </button>
+  <div class="ock-tokenselectordropdown-container">
+    <div class="ock-tokenselectordropdown-scroll">
+      <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+        <span class="ock-tokenrow-left">
+          <img
+            data-testid="ockTokenImage_Image"
+            src="https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png"
+            style="width: 48px; height: 48px; border-radius: 50%; overflow: hidden;"
+          />
+          <span class="ock-tokenrow-body">
+            <span class="ock-tokenrow-name">Ethereum</span>
+            <span class="ock-tokenrow-symbol">ETH</span>
+          </span>
         </span>
-      </span>
-      <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
-    </button>
-    <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
-      <span class="ock-tokenrow-left">
-        <span class="ock-tokenrow-body">
-          <span class="ock-tokenrow-name">USDC</span>
-          <span class="ock-tokenrow-symbol">USDC</span>
+        <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+      </button>
+      <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+        <span class="ock-tokenrow-left">
+          <img
+            data-testid="ockTokenImage_Image"
+            src="https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2"
+            style="width: 48px; height: 48px; border-radius: 50%; overflow: hidden;"
+          />
+          <span class="ock-tokenrow-body">
+            <span class="ock-tokenrow-name">USDC</span>
+            <span class="ock-tokenrow-symbol">USDC</span>
+          </span>
         </span>
-      </span>
-      <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
-    </button>
-    <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
-      <span class="ock-tokenrow-left">
-        <span class="ock-tokenrow-body">
-          <span class="ock-tokenrow-name">Dai</span>
-          <span class="ock-tokenrow-symbol">DAI</span>
+        <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+      </button>
+      <button data-testid="ockTokenRow_Container" class="ock-tokenrow-button">
+        <span class="ock-tokenrow-left">
+          <img
+            data-testid="ockTokenImage_Image"
+            src="https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/d0/d7/d0d7784975771dbbac9a22c8c0c12928cc6f658cbcf2bbbf7c909f0fa2426dec-NmU4ZWViMDItOTQyYy00Yjk5LTkzODUtNGJlZmJiMTUxOTgy"
+            style="width: 48px; height: 48px; border-radius: 50%; overflow: hidden;"
+          />
+          <span class="ock-tokenrow-body">
+            <span class="ock-tokenrow-name">Dai</span>
+            <span class="ock-tokenrow-symbol">DAI</span>
+          </span>
         </span>
-      </span>
-      <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
-    </button>
+        <span data-testid="ockTokenRow_Amount" class="ock-tokenrow-data"></span>
+      </button>
+    </div>
   </div>
 </div>
 ```

--- a/site/docs/pages/token/types.mdx
+++ b/site/docs/pages/token/types.mdx
@@ -93,7 +93,7 @@ export type TokenSearchReact = {
 
 ```ts
 export type TokenSelectorReact = {
-  children: ReactElement<{ setToken: (token: Token) => void; onToggle: () => void }>; // Should either be a dropdown or modal that handle token selection
+  children: ReactElement<{ onToggle: () => void }>; // Should either be a dropdown or modal that handle token selection
   setToken: (token: Token) => void; // Token setter
   token?: Token; // Selected token
 };

--- a/src/token/components/TextInput.css
+++ b/src/token/components/TextInput.css
@@ -7,17 +7,13 @@
 .ock-textinput-input {
   @apply w-full rounded-full border-2 border-solid border-[#eef0f3] py-2  pl-12 pr-5 text-[#0A0B0D];
   background: #eef0f3;
+  outline: none;
 
   &::placeholder {
     @apply text-[#5B616E];
   }
   &:hover {
-    @apply border-[#cacbce];
     background: #cacbce;
-  }
-  &:focus {
-    @apply border-[#0052FF];
-    outline: none;
   }
   &:hover:focus {
     background: #eef0f3;

--- a/src/token/components/TokenRow.tsx
+++ b/src/token/components/TokenRow.tsx
@@ -17,7 +17,7 @@ export const TokenRow = memo(function TokenRow({
       onClick={() => onClick?.(token)}
     >
       <span className="ock-tokenrow-left">
-        {!hideImage && <TokenImage token={token} size={32} />}
+        {!hideImage && <TokenImage token={token} size={48} />}
         <span className="ock-tokenrow-body">
           <span className="ock-tokenrow-name">{token.name}</span>
           {!hideSymbol && <span className="ock-tokenrow-symbol">{token.symbol}</span>}

--- a/src/token/components/TokenSelectorDropdown.tsx
+++ b/src/token/components/TokenSelectorDropdown.tsx
@@ -35,7 +35,6 @@ export function TokenSelectorDropdown({ setToken, options, onToggle }: TokenSele
               setToken(token);
               onToggle();
             }}
-            hideImage
           />
         ))}
       </div>


### PR DESCRIPTION
**What changed? Why?**
- `TokenSelectorDropdown` shows token image

| Old | New |
| ---- | ---- |
| <img width="276" alt="Screenshot 2024-06-07 at 1 36 16 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/46c6826c-5a89-4c38-a5cd-5fe4ccd40cdc"> | <img width="276" alt="Screenshot 2024-06-07 at 1 34 30 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/dc280902-6ff1-44b5-9ff3-7026244d3e69"> |

- Remove border from `TokenSearch`

| Old | New |
| --- | --- |
| <img width="896" alt="Screenshot 2024-06-07 at 1 38 18 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/7a56fc7e-8655-4c7a-8378-a0f077824610"> | <img width="719" alt="Screenshot 2024-06-07 at 1 38 49 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/469f6d9e-5388-45d5-a484-b0b5acd362b0"> |

- Increase image size on `TokenRow`

| Old | New |
| --- | --- |
| <img width="901" alt="Screenshot 2024-06-07 at 1 39 39 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/d42cd762-6e29-48a8-93b0-7dad6667b560"> | <img width="720" alt="Screenshot 2024-06-07 at 1 40 05 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/a375ebb2-e0f2-4349-a73f-426e79f25a33"> |


**Notes to reviewers**

**How has it been tested?**
locally
