### PR TITLE
docs: add back TokenSelectorDropdown example to docs

### DIFF
--- a/.changeset/olive-keys-repair.md
+++ b/.changeset/olive-keys-repair.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **docs**: add back TokenSelectorDropdown example. By @kyhyco #487

--- a/site/docs/pages/token/token-selector.mdx
+++ b/site/docs/pages/token/token-selector.mdx
@@ -1,4 +1,4 @@
-{/* import { TokenSelector, TokenSelectorDropdown } from '../../../../src/token'; */}
+import { TokenSelector, TokenSelectorDropdown } from '@coinbase/onchainkit/token';
 import TokenSelectorContainer from '../../components/TokenSelectorContainer.tsx';
 import App from '../App';
 
@@ -101,6 +101,49 @@ import App from '../App';
 ```
 
 :::
+
+<App>
+  <TokenSelectorContainer>
+    {(token, setToken) => (
+      <TokenSelector token={token}>
+        <TokenSelectorDropdown
+          setToken={setToken}
+          options={[
+            {
+              name: 'Ethereum',
+              address: '',
+              symbol: 'ETH',
+              decimals: 18,
+              image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+              blockchain: 'eth',
+              chainId: 8453,
+            },
+            {
+              name: 'USDC',
+              address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+              symbol: 'USDC',
+              decimals: 6,
+              image:
+                'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
+              blockchain: 'eth',
+              chainId: 8453,
+            },
+            {
+              name: 'Dai',
+              address: '0x50c5725949a6f0c72e6c4a641f24049a917db0cb',
+              symbol: 'DAI',
+              decimals: 18,
+              image:
+                'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/d0/d7/d0d7784975771dbbac9a22c8c0c12928cc6f658cbcf2bbbf7c909f0fa2426dec-NmU4ZWViMDItOTQyYy00Yjk5LTkzODUtNGJlZmJiMTUxOTgy',
+              blockchain: 'eth',
+              chainId: 8453,
+            },
+          ]}
+        />
+      </TokenSelector>
+    )}
+  </TokenSelectorContainer>
+</App>
 
 ## Props
 


### PR DESCRIPTION
**What changed? Why?**
- add back `TokenSelectorDropdown` example

**Notes to reviewers**

**How has it been tested?**
locally
