### PR TITLE
fix: adjust TokenSelectorDropdown margin-top

### DIFF
--- a/.changeset/dirty-rice-grow.md
+++ b/.changeset/dirty-rice-grow.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix**: reduce gap between TokenSelector and TokenSelectorDropdown. By @kyhyco #489

--- a/site/docs/pages/token/token-selector.mdx
+++ b/site/docs/pages/token/token-selector.mdx
@@ -179,7 +179,7 @@ import App from '../App';
 
 ```css
 .ock-tokenselectordropdown-container {
-  @apply absolute z-10 mt-[11px] flex max-h-80 w-[250px] flex-col overflow-y-hidden rounded-lg;
+  @apply absolute z-10 mt-1 flex max-h-80 w-[250px] flex-col overflow-y-hidden rounded-lg;
   scrollbar-width: thin;
   scrollbar-color: #eef0f3 #ffffff;
 }

--- a/src/token/components/TokenSelectorDropdown.css
+++ b/src/token/components/TokenSelectorDropdown.css
@@ -1,5 +1,5 @@
 .ock-tokenselectordropdown-container {
-  @apply absolute z-10 mt-[11px] flex max-h-80 w-[250px] flex-col overflow-y-hidden rounded-lg;
+  @apply absolute z-10 mt-1 flex max-h-80 w-[250px] flex-col overflow-y-hidden rounded-lg;
   scrollbar-width: thin;
   scrollbar-color: #d1d5db #ffffff;
 }


### PR DESCRIPTION
**What changed? Why?**
- Reduce the gap between `TokenSelector` and `TokenSelectorDropdown`

| Old | New |
| --- | --- |
| <img width="330" alt="Screenshot 2024-06-07 at 5 27 21 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/2666b580-0006-4808-9fe0-8a32abc99d40"> | <img width="330" alt="Screenshot 2024-06-07 at 5 19 05 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/31c14f3f-964a-4d3f-aa44-faffe25b1131"> |

**Notes to reviewers**

**How has it been tested?**
locally
