### PR TITLE
chore: remove Yarn classic from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "ts-jest": "^29.1.2",
     "typescript": "~5.3.3",
     "viem": "^2.10.5",
-    "wagmi": "^2.8.7",
-    "yarn": "^1.22.21"
+    "wagmi": "^2.8.7"
   },
   "resolutions": {
     "@coinbase/wallet-sdk": "npm:@coinbase/wallet-sdk@4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,7 +2054,6 @@ __metadata:
     typescript: "npm:~5.3.3"
     viem: "npm:^2.10.5"
     wagmi: "npm:^2.8.7"
-    yarn: "npm:^1.22.21"
   peerDependencies:
     "@coinbase/wallet-sdk": ^4
     "@tanstack/react-query": ^5
@@ -13364,16 +13363,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
   checksum: ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
-  languageName: node
-  linkType: hard
-
-"yarn@npm:^1.22.21":
-  version: 1.22.22
-  resolution: "yarn@npm:1.22.22"
-  bin:
-    yarn: bin/yarn.js
-    yarnpkg: bin/yarn.js
-  checksum: 8c77198c93d7542e7f4e131c63b66de357b7076ecfbcfe709ec0d674115c2dd9edaa45196e5510e6e9366d368707a802579e3402071002e1c9d9a99d491478de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**

Removed Yarn classic from dependencies since Yarn berry is used in this repository.

https://github.com/coinbase/onchainkit/blob/409503c3352f595591013fcca6bd4ec2bf36850e/.yarnrc.yml#L3

**Notes to reviewers**

**How has it been tested?**
