### PR TITLE
feat: css variables

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,4 @@
+@import url('./variables.css');
 @import url('./identity/components/Avatar.css');
 @import url('./identity/components/Badge.css');
 @import url('./identity/components/WithAvatarBadge.css');

--- a/src/variables.css
+++ b/src/variables.css
@@ -1,0 +1,4 @@
+:root {
+  --ock-spacing-1: 8px;
+  --ock-spacing-2: 12px;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,12 @@
 export default {
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      spacing: {
+        1: 'var(--ock-spacing-1)',
+        2: 'var(--ock-spacing-2)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
**What changed? Why?**
Example of how we can address css variables.

Compiled css looks like this:

```css
:root {
  --ock-spacing-1: 8px;
  --ock-spacing-2: 12px;
}

...

.ock-withnamebadge-inner {
  margin-left: var(--ock-spacing-1);
}

.ock-tokenchip-button {
  display: flex;
  width: -moz-fit-content;
  width: fit-content;
  align-items: center;
  border-radius: 1rem;
  padding-top: var(--ock-spacing-1);
  padding-bottom: var(--ock-spacing-1);
  padding-left: var(--ock-spacing-1);
  padding-right: 0.75rem;
  background: #eef0f3;
  &:hover {
    background: #cacbce;
  }
  &:active {
    background: #bfc1c3;
  }
}
```

**Notes to reviewers**
This is an example PR and not meant to be merged to `main` branch as-is. Shadcn does something similar - https://ui.shadcn.com/themes
We can use this address dark mode as well

**How has it been tested?**
locally
