### PR TITLE
fix: add tailwind utility classes to exported styles.css

### DIFF
--- a/.changeset/small-cooks-wave.md
+++ b/.changeset/small-cooks-wave.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix**: add tailwind utilities to exported styles.css. By @kyhyco #515

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "packemon build --addEngines --addFiles --declaration && npx packemon validate --no-license --no-people --no-repo && tailwindcss -i ./src/styles/index.css -o ./src/tailwind.css --minify && tailwindcss -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --minify",
-    "watch": "tailwind -i ./src/styles/index.css -o ./src/tailwind.css --watch",
+    "watch": "tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch",
     "check": "yarn format",
     "format": "prettier --log-level warn --write .",
     "format:check": "prettier --check .",

--- a/src/styles/tailwind-base.css
+++ b/src/styles/tailwind-base.css
@@ -1,1 +1,2 @@
 @tailwind base;
+@tailwind utilities;


### PR DESCRIPTION
**What changed? Why?**
- add tailwind utility classes to exported styles.css

**Notes to reviewers**

**How has it been tested?**
locally
