### PR TITLE
feat: add pull request labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,59 @@
+root:
+- changed-files:
+  - any-glob-to-any-file: '*'
+
+framegear:
+- changed-files:
+  - any-glob-to-any-file: framegear/**
+
+documentation:
+- changed-files:
+  - any-glob-to-any-file: site/**
+
+'pkg: core':
+- changed-files:
+  - any-glob-to-any-file: src/core/**
+
+'pkg: definitions':
+- changed-files:
+  - any-glob-to-any-file: src/definitions/**
+
+'pkg: farcaster':
+- changed-files:
+  - any-glob-to-any-file: src/farcaster/**
+
+'pkg: frame':
+- changed-files:
+  - any-glob-to-any-file: src/frame/**
+
+'pkg: identity':
+- changed-files:
+  - any-glob-to-any-file: src/identity/**
+
+'pkg: network':
+- changed-files:
+  - any-glob-to-any-file: src/network/**
+
+'pkg: styles':
+- changed-files:
+  - any-glob-to-any-file: src/styles/**
+
+'pkg: swap':
+- changed-files:
+  - any-glob-to-any-file: src/swap/**
+
+'pkg: token':
+- changed-files:
+  - any-glob-to-any-file: src/token/**
+
+'pkg: utils':
+- changed-files:
+  - any-glob-to-any-file: src/utils/**
+
+'pkg: wallet':
+- changed-files:
+  - any-glob-to-any-file: src/wallet/**
+
+'pkg: xmtp':
+- changed-files:
+  - any-glob-to-any-file: src/xmtp/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+  pull_request:
+    branches: ['main']
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
This PR adds a pull request labeler workflow using https://github.com/actions/labeler to make easier to see which packages are impacted. Labels are sorted alphabetically so it matches file tree.