### PR TITLE
feat: Add balance to SwapAmountInput

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,20 +68,13 @@
   "packemon": [
     {
       "bundle": false,
-      "platform": [
-        "browser"
-      ]
+      "platform": ["browser"]
     }
   ],
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "esm/**/*",
-    "lib/**/*",
-    "src/",
-    "src/**/*"
-  ],
+  "files": ["esm/**/*", "lib/**/*", "src/", "src/**/*"],
   "main": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "module": "./esm/index.js",

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useContext, useEffect, useMemo } from "react";
+import { useCallback, useContext, useEffect, useMemo } from 'react';
 
-import { isValidAmount } from "../utils";
-import { TokenChip } from "../../token";
-import { cn } from "../../utils/cn";
-import { SwapContext } from "../context";
-import type { SwapAmountInputReact } from "../types";
-import { useBalance, type UseBalanceReturnType } from "wagmi";
+import { isValidAmount } from '../utils';
+import { TokenChip } from '../../token';
+import { cn } from '../../utils/cn';
+import { SwapContext } from '../context';
+import type { SwapAmountInputReact } from '../types';
+import { useBalance, type UseBalanceReturnType } from 'wagmi';
 
 export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
   const {
@@ -19,36 +19,38 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
   } = useContext(SwapContext);
 
   const amount = useMemo(() => {
-    if (type === "to") {
+    if (type === 'to') {
       return toAmount;
     }
     return fromAmount;
   }, [type, toAmount, fromAmount]);
 
   const setAmount = useMemo(() => {
-    if (type === "to") {
+    if (type === 'to') {
       return setToAmount;
     }
     return setFromAmount;
   }, [type, setToAmount, setFromAmount]);
 
   const setToken = useMemo(() => {
-    if (type === "to") {
+    if (type === 'to') {
       return setToToken;
     }
     return setFromToken;
   }, [type, setFromToken, setToToken]);
 
-  const { data: tokenBalanceData }: UseBalanceReturnType = useBalance({
+  const balanceResponse: UseBalanceReturnType = useBalance({
     address,
     ...(token?.address && { token: token.address }),
   });
 
   const roundedBalance = useMemo(() => {
-    if (tokenBalanceData?.formatted && token?.address) {
-      return Number(tokenBalanceData?.formatted)?.toPrecision(5).toString();
+    if (balanceResponse?.data?.formatted && token?.address) {
+      return Number(balanceResponse?.data?.formatted)
+        ?.toPrecision(5)
+        .toString();
     }
-  }, [tokenBalanceData]);
+  }, [balanceResponse?.data]);
 
   const handleAmountChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -56,14 +58,14 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
         setAmount?.(event.target.value);
       }
     },
-    [setAmount]
+    [setAmount],
   );
 
   const handleMaxButtonClick = useCallback(() => {
-    if (tokenBalanceData?.formatted) {
-      setAmount?.(tokenBalanceData?.formatted);
+    if (balanceResponse?.data?.formatted) {
+      setAmount?.(balanceResponse?.data?.formatted);
     }
-  }, [tokenBalanceData, setAmount]);
+  }, [balanceResponse?.data, setAmount]);
 
   useEffect(() => {
     if (token) {
@@ -74,8 +76,8 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
   return (
     <div
       className={cn(
-        "box-border flex w-full flex-col items-start",
-        "gap-[11px] border-b border-solid bg-[#FFF] p-4"
+        'box-border flex w-full flex-col items-start',
+        'gap-[11px] border-b border-solid bg-[#FFF] p-4',
       )}
       data-testid="ockSwapAmountInput_Container"
     >
@@ -87,7 +89,7 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
       </div>
       <div className="flex w-full items-center justify-between">
         <TokenChip token={token} />
-        {type === "from" && (
+        {type === 'from' && (
           <button
             className="flex h-8 w-[58px] max-w-[200px] items-center rounded-[40px] bg-gray-100 px-3 py-2 text-base font-medium not-italic leading-6 text-gray-500"
             data-testid="ockSwapAmountInput_MaxButton"

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -90,7 +90,11 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
         <TokenChip token={token} />
         {type === 'from' && (
           <button
-            className="flex h-8 w-[58px] max-w-[200px] items-center rounded-[40px] bg-gray-100 px-3 py-2 text-base font-medium not-italic leading-6 text-gray-500"
+            className={cn(
+              'flex h-8 w-[58px] max-w-[200px] items-center rounded-[40px]',
+              'bg-gray-100 px-3 py-2 text-base font-medium',
+              'not-italic leading-6 text-gray-500',
+            )}
             data-testid="ockSwapAmountInput_MaxButton"
             disabled={roundedBalance === undefined}
             onClick={handleMaxButtonClick}

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -1,13 +1,15 @@
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useContext, useEffect, useMemo } from "react";
 
-import { isValidAmount } from '../utils';
-import { TokenChip } from '../../token';
-import { cn } from '../../utils/cn';
-import { SwapContext } from '../context';
-import type { SwapAmountInputReact } from '../types';
+import { isValidAmount } from "../utils";
+import { TokenChip } from "../../token";
+import { cn } from "../../utils/cn";
+import { SwapContext } from "../context";
+import type { SwapAmountInputReact } from "../types";
+import { useBalance, type UseBalanceReturnType } from "wagmi";
 
 export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
   const {
+    address,
     fromAmount,
     setFromAmount,
     setFromToken,
@@ -16,22 +18,32 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
     toAmount,
   } = useContext(SwapContext);
 
+  const { data }: UseBalanceReturnType = useBalance({
+    address,
+  });
+
+  const roundedBalance = useMemo(() => {
+    if (data?.formatted) {
+      return Number(data?.formatted)?.toPrecision(5).toString();
+    }
+  }, [data]);
+
   const amount = useMemo(() => {
-    if (type === 'to') {
+    if (type === "to") {
       return toAmount;
     }
     return fromAmount;
   }, [type, toAmount, fromAmount]);
 
   const setAmount = useMemo(() => {
-    if (type === 'to') {
+    if (type === "to") {
       return setToAmount;
     }
     return setFromAmount;
   }, [type, setToAmount, setFromAmount]);
 
   const setToken = useMemo(() => {
-    if (type === 'to') {
+    if (type === "to") {
       return setToToken;
     }
     return setFromToken;
@@ -43,8 +55,14 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
         setAmount?.(event.target.value);
       }
     },
-    [setAmount],
+    [setAmount]
   );
+
+  const handleMaxButtonClick = useCallback(() => {
+    if (data?.formatted) {
+      setAmount?.(data?.formatted);
+    }
+  }, [data, setAmount]);
 
   useEffect(() => {
     if (token) {
@@ -55,16 +73,29 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
   return (
     <div
       className={cn(
-        'box-border flex w-full flex-col items-start',
-        'gap-[11px] border-b border-solid bg-[#FFF] p-4',
+        "box-border flex w-full flex-col items-start",
+        "gap-[11px] border-b border-solid bg-[#FFF] p-4"
       )}
       data-testid="ockSwapAmountInput_Container"
     >
       <div className="flex w-full items-center justify-between">
         <label className="text-sm font-semibold text-[#030712]">{label}</label>
+        {roundedBalance && (
+          <label className="text-sm font-normal text-gray-400">{`Balance: ${roundedBalance}`}</label>
+        )}
       </div>
       <div className="flex w-full items-center justify-between">
         <TokenChip token={token} />
+        {type === "from" && (
+          <button
+            className="flex h-8 w-[58px] max-w-[200px] items-center rounded-[40px] bg-gray-100 px-3 py-2 text-base font-medium not-italic leading-6 text-gray-500"
+            data-testid="ockSwapAmountInput_MaxButton"
+            disabled={roundedBalance === undefined}
+            onClick={handleMaxButtonClick}
+          >
+            Max
+          </button>
+        )}
       </div>
       <input
         className="w-full border-[none] bg-transparent text-5xl text-[black]"

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 
-import { isValidAmount } from '../utils';
+import { getRoundedAmount, isValidAmount } from '../utils';
 import { TokenChip } from '../../token';
 import { cn } from '../../utils/cn';
 import { SwapContext } from '../context';
+import { useBalance } from 'wagmi';
+import type { UseBalanceReturnType } from 'wagmi';
 import type { SwapAmountInputReact } from '../types';
-import { useBalance, type UseBalanceReturnType } from 'wagmi';
 
 export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
   const {
@@ -46,9 +47,7 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
 
   const roundedBalance = useMemo(() => {
     if (balanceResponse?.data?.formatted && token?.address) {
-      return Number(balanceResponse?.data?.formatted)
-        ?.toPrecision(5)
-        .toString();
+      return getRoundedAmount(balanceResponse?.data?.formatted, 8);
     }
   }, [balanceResponse?.data]);
 

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -18,16 +18,6 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
     toAmount,
   } = useContext(SwapContext);
 
-  const { data }: UseBalanceReturnType = useBalance({
-    address,
-  });
-
-  const roundedBalance = useMemo(() => {
-    if (data?.formatted) {
-      return Number(data?.formatted)?.toPrecision(5).toString();
-    }
-  }, [data]);
-
   const amount = useMemo(() => {
     if (type === "to") {
       return toAmount;
@@ -49,6 +39,17 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
     return setFromToken;
   }, [type, setFromToken, setToToken]);
 
+  const { data: tokenBalanceData }: UseBalanceReturnType = useBalance({
+    address,
+    ...(token?.address && { token: token.address }),
+  });
+
+  const roundedBalance = useMemo(() => {
+    if (tokenBalanceData?.formatted && token?.address) {
+      return Number(tokenBalanceData?.formatted)?.toPrecision(5).toString();
+    }
+  }, [tokenBalanceData]);
+
   const handleAmountChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       if (isValidAmount(event.target.value)) {
@@ -59,10 +60,10 @@ export function SwapAmountInput({ label, token, type }: SwapAmountInputReact) {
   );
 
   const handleMaxButtonClick = useCallback(() => {
-    if (data?.formatted) {
-      setAmount?.(data?.formatted);
+    if (tokenBalanceData?.formatted) {
+      setAmount?.(tokenBalanceData?.formatted);
     }
-  }, [data, setAmount]);
+  }, [tokenBalanceData, setAmount]);
 
   useEffect(() => {
     if (token) {

--- a/src/swap/utils.test.ts
+++ b/src/swap/utils.test.ts
@@ -1,4 +1,9 @@
-import { formatTokenAmount, isSwapError, isValidAmount } from './utils'; // Adjust the import path as needed
+import {
+  formatTokenAmount,
+  getRoundedAmount,
+  isSwapError,
+  isValidAmount,
+} from './utils'; // Adjust the import path as needed
 
 describe('isValidAmount', () => {
   it('should return true for an empty string', () => {
@@ -111,5 +116,21 @@ describe('formatTokenAmount', () => {
     const decimals = 18;
     const formattedAmount = formatTokenAmount(amount, decimals);
     expect(formattedAmount).toBe('1000000000');
+  });
+});
+
+describe('getRoundedAmount', () => {
+  it('returns a rounded number with specified decimal places', () => {
+    const balance = '0.0002851826238227';
+    const fractionDigits = 5;
+    const result = getRoundedAmount(balance, fractionDigits);
+    expect(result).toBe('0.00029');
+  });
+
+  it('returns a rounded number with more decimal places than available', () => {
+    const balance = '123.456';
+    const fractionDigits = 10;
+    const result = getRoundedAmount(balance, fractionDigits);
+    expect(result).toBe('123.456');
   });
 });

--- a/src/swap/utils.ts
+++ b/src/swap/utils.ts
@@ -25,3 +25,8 @@ export function formatTokenAmount(amount: string, decimals: number) {
   const roundedAmount = Number(numberAmount.toPrecision(11));
   return roundedAmount.toString();
 }
+
+export function getRoundedAmount(balance: string, fractionDigits: number) {
+  const parsedBalance = parseFloat(balance);
+  return Number(parsedBalance)?.toFixed(fractionDigits).replace(/0+$/, '');
+}


### PR DESCRIPTION
**What changed? Why?**
- integrate wagmi `useBalance` hook
- display balance and max button

![Screenshot 2024-06-13 at 5 15 33 PM](https://github.com/coinbase/onchainkit/assets/170486079/853c6b83-b2e5-425e-9217-9a838b4792a8)


**Notes to reviewers**
- balance will also appear on `to` token 

**How has it been tested?**
