### PR TITLE
chore: Update isWalletASmartWallet to isWalletACoinbaseSmartWallet

### DIFF
--- a/.changeset/ninety-windows-cheer.md
+++ b/.changeset/ninety-windows-cheer.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+**chore**: Update isWalletASmartWallet name to be isWalletACoinbaseSmartWallet. We want to explicitly state that this is checking for Coinbase Smart Wallets. By @cpcramer #562

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Coming soon
 ##### Wallet
 
 - [isValidAAEntrypoint](/wallet/is-valid-aa-entrypoint)
-- [isWalletASmartWallet](/wallet/is-wallet-a-smart-wallet)
+- [isWalletACoinbaseSmartWallet](/wallet/is-wallet-a-coinbase-smart-wallet)
 
 ##### Farcaster
 

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -255,7 +255,7 @@ setFilteredTokens(filteredTokens);
         <h3>Wallet</h3>
       </li>
       <li>[isValidAAEntrypoint](/wallet/is-valid-aa-entrypoint)</li>
-      <li>[isWalletASmartWallet](/wallet/is-wallet-a-smart-wallet)</li>
+      <li>[isWalletACoinbaseSmartWallet](/wallet/is-wallet-a-coinbase-smart-wallet)</li>
     </ul>
     <ul>
       <li>

--- a/site/docs/pages/wallet/is-wallet-a-coinbase-smart-wallet.mdx
+++ b/site/docs/pages/wallet/is-wallet-a-coinbase-smart-wallet.mdx
@@ -1,13 +1,13 @@
-# `isWalletASmartWallet`
+# `isWalletASmartCoinbaseWallet`
 
-The `isWalletASmartWallet` utility is designed to verify if a given sender address is a Smart Wallet proxy with the expected implementation before sponsoring a transaction.
+The `isWalletASmartCoinbaseWallet` utility is designed to verify if a given sender address is a Smart Wallet proxy with the expected implementation before sponsoring a transaction.
 
 ## Usage
 
 :::code-group
 
 ```tsx [code]
-import { isWalletASmartWallet } from '@coinbase/onchainkit/wallet';
+import { isWalletACoinbaseSmartWallet } from '@coinbase/onchainkit/wallet';
 import { http } from 'viem';
 import { baseSepolia } from 'viem/chains';
 import type { UserOperation } from 'permissionless';
@@ -20,7 +20,7 @@ export const publicClient = createPublicClient({
 
 const userOperation = { sender: '0x123' } as UserOperation<'v0.6'>;
 
-if (isWalletASmartWallet({ client: publicClient, userOp: userOperation })) {
+if (isWalletACoinbaseSmartWallet({ client: publicClient, userOp: userOperation })) {
   console.log('The sender address is a valid smart wallet proxy.');
 } else {
   console.log('The sender address is not a valid smart wallet proxy.');
@@ -35,8 +35,8 @@ true;
 
 ## Returns
 
-[`IsWalletASmartWalletResponse`](/wallet/types#iswalletasmartwalletresponse)
+[`IsWalletACoinbaseSmartWalletResponse`](/wallet/types#iswalletacoinbasesmartwalletresponse)
 
 ## Parameters
 
-[`isWalletASmartWalletOptions`](/wallet/types#iswalletasmartwalletoptions)
+[`isWalletACoinbaseSmartWalletOptions`](/wallet/types#iswalletacoinbasesmartwalletoptions)

--- a/site/docs/pages/wallet/types.mdx
+++ b/site/docs/pages/wallet/types.mdx
@@ -21,19 +21,19 @@ export type IsValidAAEntrypointOptions = {
 };
 ```
 
-## `IsWalletASmartWalletOptions`
+## `IsWalletACoinbaseSmartWalletOptions`
 
 ```ts
-export type IsWalletASmartWalletOptions = {
+export type IsWalletACoinbaseSmartWalletOptions = {
   client: PublicClient;
   userOp: UserOperation<'v0.6'>;
 };
 ```
 
-## `IsWalletASmartWalletResponse`
+## `IsWalletACoinbaseSmartWalletResponse`
 
 ```ts
-export type IsWalletASmartWalletResponse =
-  | { isSmartWallet: true }
-  | { isSmartWallet: false; error: string; code: string };
+export type IsWalletACoinbaseSmartWalletResponse =
+  | { isCoinbaseSmartWallet: true }
+  | { isCoinbaseSmartWallet: false; error: string; code: string };
 ```

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -234,8 +234,8 @@ export const sidebar = [
             link: '/wallet/is-valid-aa-entrypoint',
           },
           {
-            text: 'isWalletASmartWallet',
-            link: '/wallet/is-wallet-a-smart-wallet',
+            text: 'isWalletACoinbaseSmartWallet',
+            link: '/wallet/is-wallet-a-coinbase-smart-wallet',
           },
         ],
       },

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -1,10 +1,10 @@
 // 🌲☀️🌲
 export { ConnectAccount } from './components/ConnectAccount';
 export { isValidAAEntrypoint } from './isValidAAEntrypoint';
-export { isWalletASmartWallet } from './isWalletASmartWallet';
+export { isWalletACoinbaseSmartWallet } from './isWalletACoinbaseSmartWallet';
 export type {
   ConnectAccountReact,
   IsValidAAEntrypointOptions,
-  IsWalletASmartWalletOptions,
-  IsWalletASmartWalletResponse,
+  IsWalletACoinbaseSmartWalletOptions,
+  IsWalletACoinbaseSmartWalletResponse,
 } from './types';

--- a/src/wallet/isWalletACoinbaseSmartWallet.test.ts
+++ b/src/wallet/isWalletACoinbaseSmartWallet.test.ts
@@ -2,11 +2,11 @@ import {
   CB_SW_PROXY_BYTECODE,
   CB_SW_V1_IMPLEMENTATION_ADDRESS,
 } from './constants';
-import { isWalletASmartWallet } from './isWalletASmartWallet';
+import { isWalletACoinbaseSmartWallet } from './isWalletACoinbaseSmartWallet';
 import type { UserOperation } from 'permissionless';
 import type { PublicClient } from 'viem';
 
-describe('isWalletASmartWallet', () => {
+describe('isWalletACoinbaseSmartWallet', () => {
   const client = {
     getBytecode: jest.fn(),
     request: jest.fn(),
@@ -50,9 +50,9 @@ describe('isWalletASmartWallet', () => {
       '0x0000000000000000000000000000000000000000000000000000000000000000',
     );
 
-    const result = await isWalletASmartWallet({ client, userOp });
+    const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
-      isSmartWallet: false,
+      isCoinbaseSmartWallet: false,
       error: 'Invalid bytecode',
       code: 'W_ERR_2',
     });
@@ -71,9 +71,9 @@ describe('isWalletASmartWallet', () => {
       differentImplementationAddress,
     );
 
-    const result = await isWalletASmartWallet({ client, userOp });
+    const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
-      isSmartWallet: false,
+      isCoinbaseSmartWallet: false,
       error: 'Invalid implementation address',
       code: 'W_ERR_5',
     });
@@ -94,8 +94,8 @@ describe('isWalletASmartWallet', () => {
       `0x${CB_SW_V1_IMPLEMENTATION_ADDRESS.slice(2).padStart(64, '0')}`,
     );
 
-    const result = await isWalletASmartWallet({ client, userOp });
-    expect(result).toEqual({ isSmartWallet: true });
+    const result = await isWalletACoinbaseSmartWallet({ client, userOp });
+    expect(result).toEqual({ isCoinbaseSmartWallet: true });
   });
 
   it('should return false when there is an error retrieving bytecode', async () => {
@@ -110,9 +110,9 @@ describe('isWalletASmartWallet', () => {
       '0x0000000000000000000000000000000000000000000000000000000000000000',
     );
 
-    const result = await isWalletASmartWallet({ client, userOp });
+    const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
-      isSmartWallet: false,
+      isCoinbaseSmartWallet: false,
       error: 'Error retrieving bytecode',
       code: 'W_ERR_3',
     });
@@ -128,9 +128,9 @@ describe('isWalletASmartWallet', () => {
       new Error('Failed to fetch implementation address'),
     );
 
-    const result = await isWalletASmartWallet({ client, userOp });
+    const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
-      isSmartWallet: false,
+      isCoinbaseSmartWallet: false,
       error: 'Error retrieving implementation address',
       code: 'W_ERR_4',
     });

--- a/src/wallet/isWalletACoinbaseSmartWallet.test.ts
+++ b/src/wallet/isWalletACoinbaseSmartWallet.test.ts
@@ -19,9 +19,9 @@ describe('isWalletACoinbaseSmartWallet', () => {
 
     (client.getBytecode as jest.Mock).mockReturnValue(undefined);
 
-    const result = await isWalletASmartWallet({ client, userOp });
+    const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
-      isSmartWallet: false,
+      isCoinbaseSmartWallet: false,
       error: 'Invalid factory address',
       code: 'W_ERR_1',
     });
@@ -34,9 +34,9 @@ describe('isWalletACoinbaseSmartWallet', () => {
 
     (client.getBytecode as jest.Mock).mockReturnValue(undefined);
 
-    const result = await isWalletASmartWallet({ client, userOp });
+    const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
-      isSmartWallet: true,
+      isCoinbaseSmartWallet: true,
     });
   });
 

--- a/src/wallet/isWalletACoinbaseSmartWallet.ts
+++ b/src/wallet/isWalletACoinbaseSmartWallet.ts
@@ -7,18 +7,18 @@ import {
 } from './constants';
 import type { Address, BlockTag, Hex } from 'viem';
 import type {
-  IsWalletASmartWalletOptions,
-  IsWalletASmartWalletResponse,
+  IsWalletACoinbaseSmartWalletOptions,
+  IsWalletACoinbaseSmartWalletResponse,
 } from './types';
 
 /**
  * Validates a User Operation by checking if the sender address
  * is a proxy with the expected bytecode.
  */
-export async function isWalletASmartWallet({
+export async function isWalletACoinbaseSmartWallet({
   client,
   userOp,
-}: IsWalletASmartWalletOptions): Promise<IsWalletASmartWalletResponse> {
+}: IsWalletACoinbaseSmartWalletOptions): Promise<IsWalletACoinbaseSmartWalletResponse> {
   try {
     const code = await client.getBytecode({ address: userOp.sender });
 
@@ -42,7 +42,7 @@ export async function isWalletASmartWallet({
     // Verify if the sender address bytecode matches the Coinbase Smart Wallet proxy bytecode
     if (code !== CB_SW_PROXY_BYTECODE) {
       return {
-        isSmartWallet: false,
+        isCoinbaseSmartWallet: false,
         error: 'Invalid bytecode',
         code: 'W_ERR_2',
       };
@@ -50,7 +50,7 @@ export async function isWalletASmartWallet({
   } catch (error) {
     console.error('Error retrieving bytecode:', error);
     return {
-      isSmartWallet: false,
+      isCoinbaseSmartWallet: false,
       error: 'Error retrieving bytecode',
       code: 'W_ERR_3',
     };
@@ -68,7 +68,7 @@ export async function isWalletASmartWallet({
   } catch (error) {
     console.error('Error retrieving implementation address:', error);
     return {
-      isSmartWallet: false,
+      isCoinbaseSmartWallet: false,
       error: 'Error retrieving implementation address',
       code: 'W_ERR_4',
     };
@@ -86,11 +86,11 @@ export async function isWalletASmartWallet({
     checksumAddress(CB_SW_V1_IMPLEMENTATION_ADDRESS)
   ) {
     return {
-      isSmartWallet: false,
+      isCoinbaseSmartWallet: false,
       error: 'Invalid implementation address',
       code: 'W_ERR_5',
     };
   }
 
-  return { isSmartWallet: true };
+  return { isCoinbaseSmartWallet: true };
 }

--- a/src/wallet/isWalletACoinbaseSmartWallet.ts
+++ b/src/wallet/isWalletACoinbaseSmartWallet.ts
@@ -31,12 +31,12 @@ export async function isWalletACoinbaseSmartWallet({
         checksumAddress(CB_SW_FACTORY_ADDRESS)
       ) {
         return {
-          isSmartWallet: false,
+          isCoinbaseSmartWallet: false,
           error: 'Invalid factory address',
           code: 'W_ERR_1',
         };
       }
-      return { isSmartWallet: true };
+      return { isCoinbaseSmartWallet: true };
     }
 
     // Verify if the sender address bytecode matches the Coinbase Smart Wallet proxy bytecode

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -18,7 +18,7 @@ export type IsValidAAEntrypointOptions = {
 /**
  * Note: exported as public Type
  */
-export type IsWalletASmartWalletOptions = {
+export type IsWalletACoinbaseSmartWalletOptions = {
   client: PublicClient;
   userOp: UserOperation<'v0.6'>;
 };
@@ -26,6 +26,6 @@ export type IsWalletASmartWalletOptions = {
 /**
  * Note: exported as public Type
  */
-export type IsWalletASmartWalletResponse =
-  | { isSmartWallet: true }
-  | { isSmartWallet: false; error: string; code: string };
+export type IsWalletACoinbaseSmartWalletResponse =
+  | { isCoinbaseSmartWallet: true }
+  | { isCoinbaseSmartWallet: false; error: string; code: string };


### PR DESCRIPTION
**What changed? Why?**
Update `isWalletASmartWallet` naming to be `isWalletACoinbaseSmartWallet` so we explicitly state what the function is doing. 
**Notes to reviewers**

**How has it been tested?**
