### PR TITLE
fix: update smart wallet util

### DIFF
--- a/src/wallet/constants.ts
+++ b/src/wallet/constants.ts
@@ -7,3 +7,6 @@ export const CB_SW_V1_IMPLEMENTATION_ADDRESS =
 // The storage slot in the proxy contract that points to the implementation address.
 export const ERC_1967_PROXY_IMPLEMENTATION_SLOT =
   '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc';
+// The Coinbase Smart Wallet factory address.
+export const CB_SW_FACTORY_ADDRESS =
+  '0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a';

--- a/src/wallet/isWalletASmartWallet.test.ts
+++ b/src/wallet/isWalletASmartWallet.test.ts
@@ -12,6 +12,34 @@ describe('isWalletASmartWallet', () => {
     request: jest.fn(),
   } as unknown as PublicClient;
 
+  it('should return false for an undeployed account that does not use the Smart Wallet factory', async () => {
+    const userOp = {
+      initCode: 'other-factory',
+    } as unknown as UserOperation<'v0.6'>;
+
+    (client.getBytecode as jest.Mock).mockReturnValue(undefined);
+
+    const result = await isWalletASmartWallet({ client, userOp });
+    expect(result).toEqual({
+      isSmartWallet: false,
+      error: 'Invalid factory address',
+      code: 'W_ERR_1',
+    });
+  });
+
+  it('should return true for an undeployed account that does use the Smart Wallet factory', async () => {
+    const userOp = {
+      initCode: '0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a1234',
+    } as unknown as UserOperation<'v0.6'>;
+
+    (client.getBytecode as jest.Mock).mockReturnValue(undefined);
+
+    const result = await isWalletASmartWallet({ client, userOp });
+    expect(result).toEqual({
+      isSmartWallet: true,
+    });
+  });
+
   it('should return false for an invalid sender proxy address', async () => {
     const userOp = {
       sender: 'invalid-proxy-address',
@@ -26,7 +54,7 @@ describe('isWalletASmartWallet', () => {
     expect(result).toEqual({
       isSmartWallet: false,
       error: 'Invalid bytecode',
-      code: 'W_ERR_1',
+      code: 'W_ERR_2',
     });
   });
 
@@ -47,7 +75,7 @@ describe('isWalletASmartWallet', () => {
     expect(result).toEqual({
       isSmartWallet: false,
       error: 'Invalid implementation address',
-      code: 'W_ERR_4',
+      code: 'W_ERR_5',
     });
   });
 
@@ -86,7 +114,7 @@ describe('isWalletASmartWallet', () => {
     expect(result).toEqual({
       isSmartWallet: false,
       error: 'Error retrieving bytecode',
-      code: 'W_ERR_2',
+      code: 'W_ERR_3',
     });
   });
 
@@ -104,7 +132,7 @@ describe('isWalletASmartWallet', () => {
     expect(result).toEqual({
       isSmartWallet: false,
       error: 'Error retrieving implementation address',
-      code: 'W_ERR_3',
+      code: 'W_ERR_4',
     });
   });
 });


### PR DESCRIPTION
**What changed? Why?**
- updated `isWalletASmartWallet` to check `initCode` for undeployed accounts

**Notes to reviewers**

**How has it been tested?**
unit tests
