### PR TITLE
fix: get quote logic in Swap component

### DIFF
--- a/.changeset/rich-dolls-sort.md
+++ b/.changeset/rich-dolls-sort.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix**: fix get quote logic in Swap component. By @kyhyco #568

--- a/package.json
+++ b/package.json
@@ -67,20 +67,13 @@
   "packemon": [
     {
       "bundle": false,
-      "platform": [
-        "browser"
-      ]
+      "platform": ["browser"]
     }
   ],
   "publishConfig": {
     "access": "public"
   },
-  "files": [
-    "esm/**/*",
-    "lib/**/*",
-    "src/",
-    "src/**/*"
-  ],
+  "files": ["esm/**/*", "lib/**/*", "src/", "src/**/*"],
   "main": "./esm/index.js",
   "types": "./esm/index.d.ts",
   "module": "./esm/index.js",

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -14,7 +14,6 @@ export function Swap({ address, children, onError }: SwapReact) {
 
   const handleFromAmountChange = useCallback(
     async (amount: string) => {
-      setFromAmount(amount);
       const hasRequiredFields = fromToken && toToken && amount;
       if (!hasRequiredFields) {
         return;
@@ -44,7 +43,6 @@ export function Swap({ address, children, onError }: SwapReact) {
 
   const handleToAmountChange = useCallback(
     async (amount: string) => {
-      setToAmount(amount);
       const hasRequiredFields = fromToken && toToken && amount;
       if (!hasRequiredFields) {
         return;

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -40,7 +40,7 @@ export function SwapAmountInput({
           selectedToken: toToken,
           setAmount: setToAmount,
           setToken: setToToken,
-          handleAmountChange: handleFromAmountChange,
+          handleAmountChange: handleToAmountChange,
         };
       }
       return {
@@ -48,7 +48,7 @@ export function SwapAmountInput({
         selectedToken: fromToken,
         setAmount: setFromAmount,
         setToken: setFromToken,
-        handleAmountChange: handleToAmountChange,
+        handleAmountChange: handleFromAmountChange,
       };
     }, [
       fromAmount,


### PR DESCRIPTION
**What changed? Why?**
- fix get quote logic in Swap component

**Notes to reviewers**

**How has it been tested?**
locally
