### PR TITLE
feat: add DM Sans font

### DIFF
--- a/.changeset/bright-tigers-try.md
+++ b/.changeset/bright-tigers-try.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: add DM Sans. By @kyhyco #574

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "release:check": "changeset status --verbose --since=origin/main",
     "release:publish": "yarn install && yarn build && changeset publish",
     "release:version": "changeset version && yarn install --immutable",
-    "watch": "tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch"
+    "watch": "tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch",
+    "watch:tailwind": "tailwind -i ./src/styles/index.css -o ./src/tailwind.css --watch"
   },
   "peerDependencies": {
     "@xmtp/frames-validator": "^0.6.0",

--- a/src/internal/text/TextLabel2.tsx
+++ b/src/internal/text/TextLabel2.tsx
@@ -2,13 +2,11 @@ import type { ReactNode } from 'react';
 
 type TextLabel2React = {
   children: ReactNode;
-  color?: string;
 };
 
-/* istanbul ignore next */
-export function TextLabel2({ children, color = 'gray-500' }: TextLabel2React) {
+export function TextLabel2({ children }: TextLabel2React) {
   return (
-    <span className={`text-${color} text-sans text-sm leading-5`}>
+    <span className="text-gray-500 text-sans text-sm leading-5">
       {children}
     </span>
   );

--- a/src/internal/text/TextTitle3.tsx
+++ b/src/internal/text/TextTitle3.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+
+type TextTitle3React = {
+  children: ReactNode;
+};
+
+/* istanbul ignore next */
+export function TextTitle3({ children }: TextTitle3React) {
+  return (
+    <span className="font-bold text-display text-gray-900 text-sans text-xl leading-7">
+      {children}
+    </span>
+  );
+}

--- a/src/internal/text/TextTitle3.tsx
+++ b/src/internal/text/TextTitle3.tsx
@@ -7,7 +7,7 @@ type TextTitle3React = {
 /* istanbul ignore next */
 export function TextTitle3({ children }: TextTitle3React) {
   return (
-    <span className="font-bold text-display text-gray-900 text-sans text-xl leading-7">
+    <span className="text-display text-gray-900 text-sans text-xl leading-7">
       {children}
     </span>
   );

--- a/src/internal/text/index.ts
+++ b/src/internal/text/index.ts
@@ -2,3 +2,4 @@ export { TextBody } from './TextBody';
 export { TextHeadline } from './TextHeadline';
 export { TextLabel1 } from './TextLabel1';
 export { TextLabel2 } from './TextLabel2';
+export { TextTitle3 } from './TextTitle3';

--- a/src/internal/text/index.ts
+++ b/src/internal/text/index.ts
@@ -2,4 +2,3 @@ export { TextBody } from './TextBody';
 export { TextHeadline } from './TextHeadline';
 export { TextLabel1 } from './TextLabel1';
 export { TextLabel2 } from './TextLabel2';
-export { TextTitle3 } from './TextTitle3';

--- a/src/styles/index-with-tailwind.css
+++ b/src/styles/index-with-tailwind.css
@@ -1,4 +1,7 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap');
-@import url('./tailwind-base.css');
-@import url('./index.css');
+@import url("https://fonts.googleapis.com/css2?family=Inter&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz@0,9..40;1,9..40&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,700;1,9..40,700&display=swap");
+@import url("./tailwind-base.css");
+@import url("./index.css");
+

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,1 +1,5 @@
-@import url('../token/components/TokenSelectDropdown.css');
+@import url("../token/components/TokenSelectDropdown.css");
+
+.text-display {
+  font-family: DM Sans, sans-serif;
+}

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -122,7 +122,7 @@ export function Swap({ address, children, onError }: SwapReact) {
 
   return (
     <SwapContext.Provider value={value}>
-      <div className="flex w-[400px] flex-col rounded-xl bg-gray-100 px-6 pt-6 pb-4">
+      <div className="flex w-[500px] flex-col rounded-xl bg-gray-100 px-6 pt-6 pb-4">
         <div className="mb-4">
           <TextTitle3>Swap</TextTitle3>
         </div>

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -8,7 +8,7 @@ import { isSwapError } from '../core/isSwapError';
 import { SwapAmountInput } from './SwapAmountInput';
 import { SwapToggleButton } from './SwapToggleButton';
 import { SwapButton } from './SwapButton';
-import { TextTitle3 } from '../../internal/text';
+import { TextTitle3 } from '../../internal/text/TextTitle3';
 
 export function Swap({ address, children, onError }: SwapReact) {
   const [fromAmount, setFromAmount] = useState('');

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -8,6 +8,7 @@ import { isSwapError } from '../core/isSwapError';
 import { SwapAmountInput } from './SwapAmountInput';
 import { SwapToggleButton } from './SwapToggleButton';
 import { SwapButton } from './SwapButton';
+import { TextTitle3 } from '../../internal/text';
 
 export function Swap({ address, children, onError }: SwapReact) {
   const [fromAmount, setFromAmount] = useState('');
@@ -122,9 +123,9 @@ export function Swap({ address, children, onError }: SwapReact) {
   return (
     <SwapContext.Provider value={value}>
       <div className="flex w-[400px] flex-col rounded-xl bg-gray-100 px-6 pt-6 pb-4">
-        <label className="mb-4 font-semibold text-[#030712] text-base leading-6">
-          Swap
-        </label>
+        <div className="mb-4">
+          <TextTitle3>Swap</TextTitle3>
+        </div>
         {inputs[0]}
         <div className="relative h-1">{toggleButton}</div>
         {inputs[1]}

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -112,7 +112,7 @@ export function SwapAmountInput({
       </div>
       <div className="flex w-full items-center justify-between">
         <TextInput
-          className="w-full border-[none] bg-transparent text-5xl text-gray-500 outline-none"
+          className="w-full border-[none] bg-transparent text-[2.5rem] text-display text-gray-900 text-sans leading-none outline-none"
           data-testid="ockSwapAmountInput_Input"
           onChange={handleAmountChange}
           placeholder="0.0"


### PR DESCRIPTION
**What changed? Why?**
- add `DM Sans` font
- For tailwind users, it will default to `text-sans` unless they modify import `DM Sans` via
```css
@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz@0,9..40;1,9..40&display=swap");
@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,700;1,9..40,700&display=swap");
```
- Tailwind users can also override `text-display` class to use whatever font-family they want
- For non-tailwind users, it will use `DM Sans` correctly

<img width="421" alt="Screenshot 2024-06-14 at 3 26 52 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/061ccbdc-3a89-46e5-bcc8-9b8bc55e9936">

**Notes to reviewers**

**How has it been tested?**
locally
