### PR TITLE
fix: SwapAmountInput styling

### DIFF
--- a/.changeset/quick-moles-taste.md
+++ b/.changeset/quick-moles-taste.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix**: SwapAmountInput now correctly displays text styles. By @kyhyco #581

--- a/src/internal/text/TextLabel1.tsx
+++ b/src/internal/text/TextLabel1.tsx
@@ -1,14 +1,15 @@
 import type { ReactNode } from 'react';
+import { cn } from '../../utils/cn';
 
 type TextLabel1React = {
   children: ReactNode;
-  color?: string;
+  className: string;
 };
 
 /* istanbul ignore next */
-export function TextLabel1({ children, color = 'black' }: TextLabel1React) {
+export function TextLabel1({ children, className }: TextLabel1React) {
   return (
-    <span className={`text-${color} font-bold text-sans text-sm leading-5`}>
+    <span className={cn('font-bold text-sans text-sm leading-5', className)}>
       {children}
     </span>
   );

--- a/src/internal/text/TextLabel2.tsx
+++ b/src/internal/text/TextLabel2.tsx
@@ -1,12 +1,14 @@
 import type { ReactNode } from 'react';
+import { cn } from '../../utils/cn';
 
 type TextLabel2React = {
   children: ReactNode;
+  className?: string;
 };
 
-export function TextLabel2({ children }: TextLabel2React) {
+export function TextLabel2({ children, className }: TextLabel2React) {
   return (
-    <span className="text-gray-500 text-sans text-sm leading-5">
+    <span className={cn('text-sans text-sm leading-5', className)}>
       {children}
     </span>
   );

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -128,7 +128,7 @@ export function SwapAmountInput({
       data-testid="ockSwapAmountInput_Container"
     >
       <div className="flex w-full items-center justify-between">
-        <TextLabel2>{label}</TextLabel2>
+        <TextLabel2 className="text-gray-500">{label}</TextLabel2>
       </div>
       <div className="flex w-full items-center justify-between">
         <TextInput
@@ -154,9 +154,9 @@ export function SwapAmountInput({
       </div>
       <div className="mt-4 flex w-full justify-between">
         <TextLabel2>{''}</TextLabel2>
-        <div>
+        <div className="flex items-center">
           {roundedBalance && (
-            <TextLabel2>{`Balance: ${roundedBalance}`}</TextLabel2>
+            <TextLabel2 className="text-gray-500">{`Balance: ${roundedBalance}`}</TextLabel2>
           )}
           {type === 'from' && (
             <button
@@ -165,7 +165,7 @@ export function SwapAmountInput({
               data-testid="ockSwapAmountInput_MaxButton"
               onClick={handleMaxButtonClick}
             >
-              <TextLabel1 color="indigo-600">Max</TextLabel1>
+              <TextLabel1 className="text-indigo-600">Max</TextLabel1>
             </button>
           )}
         </div>


### PR DESCRIPTION
**What changed? Why?**
Fix SwapAmountInput text styles

<img width="564" alt="Screenshot 2024-06-14 at 5 11 16 PM" src="https://github.com/coinbase/onchainkit/assets/132851666/41343d16-9449-466e-bf21-9d3ed4cca69e">

**Notes to reviewers**
Turns out tailwind compiler does not work with dynamically generated class names

**How has it been tested?**
locally
