### PR TITLE
fix: error message from unset api key

### DIFF
--- a/.changeset/strong-walls-film.md
+++ b/.changeset/strong-walls-film.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+fix: error message from an unset api key

--- a/src/OnchainKitConfig.test.ts
+++ b/src/OnchainKitConfig.test.ts
@@ -15,7 +15,7 @@ describe('OnchainKitConfig', () => {
     const chain = baseSepolia;
     setOnchainKitConfig({ chain });
     expect(() => getRPCUrl()).toThrow(
-      'RPC URL Unset: You can use the Coinbase Developer Platform RPC by providing an API key in `setOnchainKitConfig`: https://portal.cdp.coinbase.com/products/templates',
+      'API Key Unset: You can use the Coinbase Developer Platform RPC by providing an API key in `OnchainKitProvider` or by manually calling `setOnchainKitConfig`: https://portal.cdp.coinbase.com/products/onchainkit',
     );
   });
 

--- a/src/network/getRPCUrl.test.ts
+++ b/src/network/getRPCUrl.test.ts
@@ -7,7 +7,7 @@ describe('OnchainKitConfig RPC URL', () => {
     const chain = baseSepolia;
     setOnchainKitConfig({ chain });
     expect(() => getRPCUrl()).toThrow(
-      'RPC URL Unset: You can use the Coinbase Developer Platform RPC by providing an API key in `setOnchainKitConfig`: https://portal.cdp.coinbase.com/products/templates',
+      'API Key Unset: You can use the Coinbase Developer Platform RPC by providing an API key in `OnchainKitProvider` or by manually calling `setOnchainKitConfig`: https://portal.cdp.coinbase.com/products/onchainkit',
     );
   });
 

--- a/src/network/getRPCUrl.ts
+++ b/src/network/getRPCUrl.ts
@@ -1,4 +1,4 @@
-import { ONCHAIN_KIT_CONFIG } from '../OnchainKitConfig';
+import { ONCHAIN_KIT_CONFIG } from "../OnchainKitConfig";
 
 /**
  * Access the RPC URL for OnchainKit.
@@ -7,11 +7,11 @@ import { ONCHAIN_KIT_CONFIG } from '../OnchainKitConfig';
 export const getRPCUrl = () => {
   if (!ONCHAIN_KIT_CONFIG.rpcUrl && !ONCHAIN_KIT_CONFIG.apiKey) {
     throw new Error(
-      'RPC URL Unset: You can use the Coinbase Developer Platform RPC by providing an API key in `setOnchainKitConfig`: https://portal.cdp.coinbase.com/products/templates',
+      'API Key Unset: You can use the Coinbase Developer Platform RPC by providing an API key in `OnchainKitProvider` or by manually calling `setOnchainKitConfig`: https://portal.cdp.coinbase.com/products/onchainkit'
     );
   }
   return (
     ONCHAIN_KIT_CONFIG.rpcUrl ||
-    `https://api.developer.coinbase.com/rpc/v1/${ONCHAIN_KIT_CONFIG.chain.name.replace(' ', '-').toLowerCase()}/${ONCHAIN_KIT_CONFIG.apiKey}`
+    `https://api.developer.coinbase.com/rpc/v1/${ONCHAIN_KIT_CONFIG.chain.name.replace(" ", "-").toLowerCase()}/${ONCHAIN_KIT_CONFIG.apiKey}`
   );
 };

--- a/src/network/getRPCUrl.ts
+++ b/src/network/getRPCUrl.ts
@@ -1,4 +1,4 @@
-import { ONCHAIN_KIT_CONFIG } from "../OnchainKitConfig";
+import { ONCHAIN_KIT_CONFIG } from '../OnchainKitConfig';
 
 /**
  * Access the RPC URL for OnchainKit.
@@ -7,7 +7,7 @@ import { ONCHAIN_KIT_CONFIG } from "../OnchainKitConfig";
 export const getRPCUrl = () => {
   if (!ONCHAIN_KIT_CONFIG.rpcUrl && !ONCHAIN_KIT_CONFIG.apiKey) {
     throw new Error(
-      'API Key Unset: You can use the Coinbase Developer Platform RPC by providing an API key in `OnchainKitProvider` or by manually calling `setOnchainKitConfig`: https://portal.cdp.coinbase.com/products/onchainkit'
+      'API Key Unset: You can use the Coinbase Developer Platform RPC by providing an API key in `OnchainKitProvider` or by manually calling `setOnchainKitConfig`: https://portal.cdp.coinbase.com/products/onchainkit',
     );
   }
   return (

--- a/src/network/getRPCUrl.ts
+++ b/src/network/getRPCUrl.ts
@@ -12,6 +12,6 @@ export const getRPCUrl = () => {
   }
   return (
     ONCHAIN_KIT_CONFIG.rpcUrl ||
-    `https://api.developer.coinbase.com/rpc/v1/${ONCHAIN_KIT_CONFIG.chain.name.replace(" ", "-").toLowerCase()}/${ONCHAIN_KIT_CONFIG.apiKey}`
+    `https://api.developer.coinbase.com/rpc/v1/${ONCHAIN_KIT_CONFIG.chain.name.replace(' ', '-').toLowerCase()}/${ONCHAIN_KIT_CONFIG.apiKey}`
   );
 };


### PR DESCRIPTION
**What changed? Why?**
- direct users to `products/onchainkit` in the CDP Portal instead

**Notes to reviewers**

**How has it been tested?**
