### PR TITLE
fix: Swap components error handling

### DIFF
--- a/site/docs/components/SwapComponents.tsx
+++ b/site/docs/components/SwapComponents.tsx
@@ -6,7 +6,7 @@ import { useCallback, useState } from 'react';
 //   SwapButton,
 //   SwapMessage,
 //   SwapToggleButton,
-// } from '../../../src/swap';
+// } from '../../../src/swap/index.ts';
 import {
   Swap,
   SwapAmountInput,
@@ -17,10 +17,7 @@ import {
 import { ConnectAccount } from '@coinbase/onchainkit/wallet';
 import { useAccount } from 'wagmi';
 // import { useSendTransaction } from 'wagmi';
-import type {
-  BuildSwapTransaction,
-  SwapError,
-} from '@coinbase/onchainkit/swap';
+import type { BuildSwapTransaction } from '@coinbase/onchainkit/swap';
 import type { Token } from '@coinbase/onchainkit/token';
 
 type PreparedTransaction = {
@@ -93,15 +90,11 @@ export default function SwapComponents() {
     [],
   );
 
-  const onError = useCallback((error: SwapError) => {
-    console.error('SwapError:', error);
-  }, []);
-
   return (
     <main className="flex flex-col">
       <div className="flex items-center space-x-4">
         {address ? (
-          <Swap address={address} onError={onError}>
+          <Swap address={address}>
             <SwapAmountInput
               label="Sell"
               swappableTokens={swappableTokens}
@@ -115,7 +108,7 @@ export default function SwapComponents() {
               token={USDCToken}
               type="to"
             />
-            <SwapButton onError={onError} onSubmit={onSubmit} />
+            <SwapButton onSubmit={onSubmit} />
             <SwapMessage />
           </Swap>
         ) : (

--- a/site/docs/pages/swap/swap.mdx
+++ b/site/docs/pages/swap/swap.mdx
@@ -1,4 +1,3 @@
-{/* import { Swap, SwapAmountInput, SwapButton } from '../../../../src/swap'; */}
 import App from '../../components/App';
 import SwapComponents from '../../components/SwapComponents';
 
@@ -8,7 +7,7 @@ import SwapComponents from '../../components/SwapComponents';
 Component is actively in development. Stay tuned for upcoming releases.
 :::
 
-The `Swap` components provide a comprehensive interface for users to execute [Token](/token/types#token) swaps. 
+The `Swap` components provide a comprehensive interface for users to execute [Token](/token/types#token) swaps.
 
 Before using them, ensure you've completed all [Getting Started steps](/getting-started).
 
@@ -18,7 +17,7 @@ The components are designed to work together. For each component, ensure the fol
 - `<SwapToggleButton />` - Optional component to toggle between input types.
 - `<SwapButton />` - Set the onSubmit and onError callbacks.
 
-The `SwapButton` component prepares a swap transaction but does not submit it to the blockchain. 
+The `SwapButton` component prepares a swap transaction but does not submit it to the blockchain.
 You need to handle the transaction submission and confirmation in your application, as shown in the `onSubmit` code example.
 
 ## Usage
@@ -73,12 +72,8 @@ export default function SwapComponents() {
     });
   }, [sendTransaction]);
 
-  const onError = useCallback((error: SwapError) => {
-    console.error('SwapError:', error);
-  }, []);
-
   return ({ address ? (
-    <Swap address={address} onError={onError}> // [!code focus]
+    <Swap address={address}> // [!code focus]
       <SwapAmountInput // [!code focus]
         label="Sell" // [!code focus]
         token={ETHToken} // [!code focus]
@@ -90,7 +85,7 @@ export default function SwapComponents() {
         token={USDCToken} // [!code focus]
         type="to" // [!code focus]
       /> // [!code focus]
-      <SwapButton onError={onError} onSubmit={onSubmit} /> // [!code focus]
+      <SwapButton onSubmit={onSubmit} /> // [!code focus]
       <SwapMessage /> // [!code focus]
     </Swap> // [!code focus]
   ) : (

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -11,7 +11,7 @@ import { formatTokenAmount } from '../../utils/formatTokenAmount';
 import type { SwapError, SwapReact } from '../types';
 import type { Token } from '../../token';
 
-export function Swap({ address, children, onError }: SwapReact) {
+export function Swap({ address, children }: SwapReact) {
   const [error, setError] = useState<SwapError>();
   const [fromAmount, setFromAmount] = useState('');
   const [fromToken, setFromToken] = useState<Token>();
@@ -33,7 +33,6 @@ export function Swap({ address, children, onError }: SwapReact) {
         });
         if (isSwapError(response)) {
           setError(response);
-          onError?.(response);
           return;
         }
         const formattedAmount = formatTokenAmount(
@@ -43,10 +42,9 @@ export function Swap({ address, children, onError }: SwapReact) {
         setToAmount(formattedAmount);
       } catch (err) {
         setError(err as SwapError);
-        onError?.(err as SwapError);
       }
     },
-    [fromToken, onError, toToken],
+    [fromToken, toToken],
   );
 
   const handleToAmountChange = useCallback(
@@ -64,7 +62,6 @@ export function Swap({ address, children, onError }: SwapReact) {
         });
         if (isSwapError(response)) {
           setError(response);
-          onError?.(response);
           return;
         }
         const formattedAmount = formatTokenAmount(
@@ -74,10 +71,9 @@ export function Swap({ address, children, onError }: SwapReact) {
         setFromAmount(formattedAmount);
       } catch (err) {
         setError(err as SwapError);
-        onError?.(err as SwapError);
       }
     },
-    [fromToken, onError, toToken],
+    [fromToken, toToken],
   );
 
   const handleToggle = useCallback(() => {
@@ -96,6 +92,7 @@ export function Swap({ address, children, onError }: SwapReact) {
       handleFromAmountChange,
       handleToAmountChange,
       handleToggle,
+      setError,
       setFromAmount,
       setFromToken,
       setToToken,

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useContext, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
-import { SwapContext } from '../context';
+import { useSwapContext } from '../context';
 import { TextLabel1, TextLabel2 } from '../../internal/text';
 import { TokenChip, TokenSelectDropdown } from '../../token';
 import { cn } from '../../utils/cn';
@@ -33,7 +33,7 @@ export function SwapAmountInput({
     setToToken,
     toAmount,
     toToken,
-  } = useContext(SwapContext);
+  } = useSwapContext();
 
   const { amount, setAmount, handleAmountChange, setToken, selectedToken } =
     useMemo(() => {

--- a/src/swap/components/SwapButton.tsx
+++ b/src/swap/components/SwapButton.tsx
@@ -1,13 +1,14 @@
+import { useCallback, useContext } from 'react';
 import type { SwapButtonReact, SwapError } from '../types';
 import { SwapContext } from '../context';
 import { TextHeadline } from '../../internal/text';
 import { buildSwapTransaction } from '../core/buildSwapTransaction';
 import { cn } from '../../utils/cn';
 import { isSwapError } from '../core/isSwapError';
-import { useCallback, useContext } from 'react';
 
-export function SwapButton({ onError, onSubmit }: SwapButtonReact) {
-  const { address, fromAmount, fromToken, toToken } = useContext(SwapContext);
+export function SwapButton({ onSubmit }: SwapButtonReact) {
+  const { address, fromAmount, fromToken, toToken, setError } =
+    useContext(SwapContext);
 
   const handleSubmit = useCallback(async () => {
     if (address && fromToken && toToken && fromAmount) {
@@ -19,15 +20,15 @@ export function SwapButton({ onError, onSubmit }: SwapButtonReact) {
           to: toToken,
         });
         if (isSwapError(response)) {
-          onError?.(response);
+          setError(response);
         } else {
           onSubmit?.(response);
         }
       } catch (error) {
-        onError?.(error as SwapError);
+        setError(error as SwapError);
       }
     }
-  }, [address, fromAmount, fromToken, onError, onSubmit, toToken]);
+  }, [address, fromAmount, fromToken, setError, onSubmit, toToken]);
 
   return (
     <button

--- a/src/swap/components/SwapButton.tsx
+++ b/src/swap/components/SwapButton.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import type { SwapButtonReact, SwapError } from '../types';
-import { SwapContext } from '../context';
+import { useSwapContext } from '../context';
 import { TextHeadline } from '../../internal/text';
 import { buildSwapTransaction } from '../core/buildSwapTransaction';
 import { cn } from '../../utils/cn';
@@ -8,7 +8,7 @@ import { isSwapError } from '../core/isSwapError';
 
 export function SwapButton({ onSubmit }: SwapButtonReact) {
   const { address, fromAmount, fromToken, toToken, setError } =
-    useContext(SwapContext);
+    useSwapContext();
 
   const handleSubmit = useCallback(async () => {
     if (address && fromToken && toToken && fromAmount) {

--- a/src/swap/components/SwapMessage.tsx
+++ b/src/swap/components/SwapMessage.tsx
@@ -1,10 +1,10 @@
-import { useContext, useEffect, useState } from 'react';
-import { SwapContext } from '../context';
+import { useEffect, useState } from 'react';
+import { useSwapContext } from '../context';
 import { TextMessage } from '../../internal/text';
 
 export function SwapMessage() {
   const [message, setMessage] = useState<string>('');
-  const { error } = useContext(SwapContext);
+  const { error } = useSwapContext();
   useEffect(() => {
     if (!error) {
       setMessage('');

--- a/src/swap/components/SwapToggleButton.tsx
+++ b/src/swap/components/SwapToggleButton.tsx
@@ -1,5 +1,4 @@
-import { useContext } from 'react';
-import { SwapContext } from '../context';
+import { useSwapContext } from '../context';
 
 const toggleIcon = (
   <svg
@@ -32,7 +31,7 @@ const toggleIcon = (
 );
 
 export function SwapToggleButton() {
-  const { handleToggle } = useContext(SwapContext);
+  const { handleToggle } = useSwapContext();
   return (
     <button
       type="button"

--- a/src/swap/context.ts
+++ b/src/swap/context.ts
@@ -1,6 +1,14 @@
-import { createContext } from 'react';
+import { createContext, useContext } from 'react';
 import type { SwapContextType } from './types';
 
 export const SwapContext = createContext<SwapContextType>(
   {} as SwapContextType,
 );
+
+export function useSwapContext() {
+  const context = useContext(SwapContext);
+  if (context === undefined) {
+    throw new Error('useSwapContext must be used within a Swap component');
+  }
+  return context;
+}

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -113,11 +113,12 @@ export type SwapContextType = {
   error?: SwapError;
   fromAmount: string;
   fromToken?: Token;
+  handleFromAmountChange: (a: string) => void;
+  handleToAmountChange: (a: string) => void;
+  handleToggle: () => void;
+  setError: (e: SwapError) => void;
   setFromAmount: (a: string) => void;
   setFromToken: (t: Token) => void;
-  handleToAmountChange: (a: string) => void;
-  handleFromAmountChange: (a: string) => void;
-  handleToggle: () => void;
   setToAmount: (a: string) => void;
   setToToken: (t: Token) => void;
   toAmount: string;
@@ -152,7 +153,6 @@ export type SwapParams = {
 export type SwapReact = {
   address: Address; // Connected address from connector.
   children: ReactNode;
-  onError?: (error: SwapError) => void;
 };
 
 /**


### PR DESCRIPTION
**What changed? Why?**
- remove `onError` props from Swap components to handle error states internally
- add `useSwapContext` to display error if Swap components are improperly used

**Notes to reviewers**

**How has it been tested?**
locally
