### PR TITLE
feat: Add disable swap button functionality

### DIFF
--- a/.changeset/serious-flies-tie.md
+++ b/.changeset/serious-flies-tie.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+feat: add optional disable prop to SwapButton. by: @abcrane123 #604

--- a/.changeset/serious-flies-tie.md
+++ b/.changeset/serious-flies-tie.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-feat: add optional disable prop to SwapButton. by: @abcrane123 #604
+feat: add optional disable prop to SwapButton by: @abcrane123 #604

--- a/.changeset/serious-flies-tie.md
+++ b/.changeset/serious-flies-tie.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-feat: add optional disable prop to SwapButton by: @abcrane123 #604
+- **feat**: add optional disable prop to SwapButton by: @abcrane123 #604

--- a/site/docs/pages/swap/swap.mdx
+++ b/site/docs/pages/swap/swap.mdx
@@ -72,6 +72,9 @@ export default function SwapComponents() {
     });
   }, [sendTransaction]);
 
+  // Disable SwapButton if additional checks required
+  const isDisabled = false;
+
   return ({ address ? (
     <Swap address={address}> // [!code focus]
       <SwapAmountInput // [!code focus]
@@ -85,7 +88,7 @@ export default function SwapComponents() {
         token={USDCToken} // [!code focus]
         type="to" // [!code focus]
       /> // [!code focus]
-      <SwapButton onSubmit={onSubmit} /> // [!code focus]
+      <SwapButton onSubmit={onSubmit} disabled={isDisabled} /> // [!code focus]
       <SwapMessage /> // [!code focus]
     </Swap> // [!code focus]
   ) : (
@@ -103,4 +106,4 @@ export default function SwapComponents() {
 - [`SwapReact`](/swap/types#swapreact)
 - [`SwapAmountInput`](/swap/types#swapamountinput)
 - [`SwapToggleButton`](/swap/types#swaptogglebutton)
-- [`SwapButton`](/swap/types#swapbutton)
+- [`SwapButtonReact`](/swap/types#swapbuttonreact)

--- a/site/docs/pages/swap/types.mdx
+++ b/site/docs/pages/swap/types.mdx
@@ -67,7 +67,7 @@ type SwapAmountInputReact = {
 type SwapButtonReact = {
   disabled?: boolean; // Disables swap button 
   onError?: (error: SwapError) => void; // Callback when error occurs
-  onSubmit?: (swapTransaction: BuildSwapTransaction) => void; Callback to submit Swap
+  onSubmit?: (swapTransaction: BuildSwapTransaction) => void; // Callback to submit Swap
 };
 ```
 

--- a/site/docs/pages/swap/types.mdx
+++ b/site/docs/pages/swap/types.mdx
@@ -61,6 +61,16 @@ type SwapAmountInputReact = {
 };
 ```
 
+## `SwapButtonReact`
+
+```ts
+type SwapButtonReact = {
+  disabled?: boolean; // Disables swap button 
+  onError?: (error: SwapError) => void; // Callback when error occurs
+  onSubmit?: (swapTransaction: BuildSwapTransaction) => void; Callback to submit Swap
+};
+```
+
 ## `SwapError`
 
 ```ts

--- a/src/swap/components/SwapButton.tsx
+++ b/src/swap/components/SwapButton.tsx
@@ -6,7 +6,7 @@ import { buildSwapTransaction } from '../core/buildSwapTransaction';
 import { cn } from '../../utils/cn';
 import { isSwapError } from '../core/isSwapError';
 
-export function SwapButton({ onSubmit }: SwapButtonReact) {
+export function SwapButton({ disabled, onSubmit }: SwapButtonReact) {
   const { address, fromAmount, fromToken, toToken, setError } =
     useSwapContext();
 
@@ -36,9 +36,10 @@ export function SwapButton({ onSubmit }: SwapButtonReact) {
       className={cn(
         'w-full rounded-xl bg-indigo-600',
         'mt-4 px-4 py-3 font-medium text-base text-white leading-6',
+        disabled ? 'opacity-[0.38]' : '',
       )}
       onClick={handleSubmit}
-      disabled={!fromAmount || !fromToken || !toToken}
+      disabled={!fromAmount || !fromToken || !toToken || disabled}
     >
       <TextHeadline color="white">Swap</TextHeadline>
     </button>

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -105,7 +105,7 @@ export type SwapAPIResponse = {
  */
 export type SwapButtonReact = {
   disabled?: boolean; // Disables swap button
-  onError?: (error: SwapError) => void; //
+  onError?: (error: SwapError) => void;
   onSubmit?: (swapTransaction: BuildSwapTransaction) => void;
 };
 

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -104,7 +104,8 @@ export type SwapAPIResponse = {
  * Note: exported as public Type
  */
 export type SwapButtonReact = {
-  onError?: (error: SwapError) => void;
+  disabled?: boolean; // Disables swap button
+  onError?: (error: SwapError) => void; //
   onSubmit?: (swapTransaction: BuildSwapTransaction) => void;
 };
 


### PR DESCRIPTION
**What changed? Why?**
- add optional `disabled` prop to `SwapButton` so users can control whether or not swap is swappable

![Screenshot 2024-06-17 at 1 18 12 PM](https://github.com/coinbase/onchainkit/assets/170486079/ac15ba99-f135-4f60-b0df-f047c5dcd90a)

![Screenshot 2024-06-17 at 1 21 48 PM](https://github.com/coinbase/onchainkit/assets/170486079/90273eac-667f-4ae5-970f-8fa5fe1dc133)


**Notes to reviewers**

**How has it been tested?**
locally