### PR TITLE
docs: force doc site to connect to base chain

### DIFF
--- a/.changeset/happy-avocados-matter.md
+++ b/.changeset/happy-avocados-matter.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **docs**: force doc site to connect to base. By @kyhyco #613

--- a/site/docs/components/App.tsx
+++ b/site/docs/components/App.tsx
@@ -18,6 +18,9 @@ const wagmiConfig = createConfig({
     coinbaseWallet({
       appChainIds: [base.id],
       appName: 'onchainkit',
+      options: {
+        chainId: base.id,
+      },
     }),
   ],
   ssr: true,


### PR DESCRIPTION
**What changed? Why?**
- force doc site to connect to base chain

**Notes to reviewers**

**How has it been tested?**
locally