### PR TITLE
chore: Block onchainkit.xyz/temp-demo 

### DIFF
--- a/site/docs/pages/temp-demo.mdx
+++ b/site/docs/pages/temp-demo.mdx
@@ -1,7 +1,0 @@
-
-<div className="flex justify-center p-4">
-  <div className="text-center">
-    <h1 className="text-3xl md:text-4xl">Temp Demo Page</h1>
-    <p className="text-lg md:text-xl">Temporary demo page to test geo blocking restrictions.</p>
-  </div>
-</div>

--- a/site/docs/pages/temp-demo.mdx
+++ b/site/docs/pages/temp-demo.mdx
@@ -1,0 +1,7 @@
+
+<div className="flex justify-center p-4">
+  <div className="text-center">
+    <h1 className="text-3xl md:text-4xl">Temp Demo Page</h1>
+    <p className="text-lg md:text-xl">Temporary demo page to test geo blocking restrictions.</p>
+  </div>
+</div>

--- a/site/middleware.ts
+++ b/site/middleware.ts
@@ -14,7 +14,7 @@ const BLOCKED_COUNTRIES = [
 ];
 
 export const config = {
-  matcher: ['/temp-demo'],
+  matcher: ['/'],
 };
 
 export default function middleware(request: Request) {

--- a/site/middleware.ts
+++ b/site/middleware.ts
@@ -3,6 +3,7 @@ import { geolocation, next } from '@vercel/edge';
 // List of blocked countries (ISO 3166-1 alpha-2 country codes)
 // North Korea (KP), Iran (IR), Syria (SY), Cuba (CU), Crimea (UA-43), Luhansk (UA-09), Donetsk (UA-14)
 const BLOCKED_COUNTRIES = [
+  'US',
   'KP',
   'IR',
   'SY',
@@ -14,7 +15,7 @@ const BLOCKED_COUNTRIES = [
 ];
 
 export const config = {
-  matcher: ['/'],
+  matcher: ['/temp-demo'],
 };
 
 export default function middleware(request: Request) {


### PR DESCRIPTION
**What changed? Why?**
Temporarily block onchainkit.xyz/temp-demo in the US to ensure that our geo blocking is working. 

**Notes to reviewers**

**How has it been tested?**
