### PR TITLE
feat: add `use client` directives to swap components

### DIFF
--- a/.changeset/three-bottles-kiss.md
+++ b/.changeset/three-bottles-kiss.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+feat: add `use client` directives to swap components

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Children, useCallback, useMemo, useState } from 'react';
 import { SwapAmountInput } from './SwapAmountInput';
 import { SwapButton } from './SwapButton';

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback, useEffect, useMemo } from 'react';
 
 import { useSwapContext } from '../context';

--- a/src/swap/components/SwapButton.tsx
+++ b/src/swap/components/SwapButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback } from 'react';
 import { useSwapContext } from '../context';
 import { buildSwapTransaction } from '../core/buildSwapTransaction';

--- a/src/swap/components/SwapMessage.tsx
+++ b/src/swap/components/SwapMessage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useSwapContext } from '../context';
 import { text } from '../../styles/theme';
 import { getSwapMessage } from '../core/getSwapMessage';

--- a/src/swap/components/SwapToggleButton.tsx
+++ b/src/swap/components/SwapToggleButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn, pressable } from '../../styles/theme';
 import { useSwapContext } from '../context';
 


### PR DESCRIPTION
This PR adds `use client` directives to components intended to be run only on the client such as:
- contexts
- buttons
- inputs
- those using `useState`
- ...

This way it would be easier to integrate to projects that use server components