### PR TITLE
chore: Update Swap component docs

### DIFF
--- a/.changeset/friendly-ants-peel.md
+++ b/.changeset/friendly-ants-peel.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **chore**: Update Swap component docs. Update wagmi import from sendTransaction to useSendTransaction. Add EthToken and USDCToken parameters. By @cpcramer #694

--- a/site/docs/pages/swap/swap.mdx
+++ b/site/docs/pages/swap/swap.mdx
@@ -48,7 +48,7 @@ export default function SwapComponents() {
   const { sendTransaction } = useSendTransaction();
 
   const ETHToken: Token = {     
-    address: "0x4200000000000000000000000000000000000006",
+    address: "",
     chainId: 8453,
     decimals: 18,
     name: "Ethereum",

--- a/site/docs/pages/swap/swap.mdx
+++ b/site/docs/pages/swap/swap.mdx
@@ -36,7 +36,7 @@ import { // [!code focus]
   SwapToggleButton, // [!code focus]
   SwapButton, // [!code focus]
 } from '@coinbase/onchainkit/swap'; // [!code focus]
-import { useAccount, sendTransaction } from 'wagmi';
+import { useAccount, useSendTransaction } from 'wagmi';
 import type { // [!code focus]
   BuildSwapTransaction, // [!code focus]
   SwapError, // [!code focus]
@@ -47,9 +47,21 @@ export default function SwapComponents() {
   const { address } = useAccount();
   const { sendTransaction } = useSendTransaction();
 
-  const ETHToken: Token = { ... };
+  const ETHToken: Token = {     
+    address: "0x4200000000000000000000000000000000000006",
+    chainId: 8453,
+    decimals: 18,
+    name: "Ethereum",
+    symbol: "ETH", 
+    };
 
-  const USDCToken: Token = { ... };
+  const USDCToken: Token = { 
+    address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    chainId: 8453,
+    decimals: 6,
+    name: "USDC",
+    symbol: "USDC",
+   };
 
   const swappableTokens: Token[] = [ ... ];
 


### PR DESCRIPTION
**What changed? Why?**
Update wagmi import from `sendTransaction` to `useSendTransaction`. 
<img width="546" alt="Screenshot 2024-06-24 at 11 56 31 AM" src="https://github.com/coinbase/onchainkit/assets/39774249/6848edd7-1457-483a-96d6-27479433b7c6">

Add `EthToken` and `USDCToken` parameters to make it easier for the developer to copy and paste code to get started.
<img width="706" alt="Screenshot 2024-06-24 at 11 57 29 AM" src="https://github.com/coinbase/onchainkit/assets/39774249/1c756861-f90c-49b6-82b6-402c12a3b268">
**Notes to reviewers**


**How has it been tested?**
