### PR TITLE
fix: move viem and wagmi to peer dependencies

### DIFF
--- a/.changeset/nine-goats-battle.md
+++ b/.changeset/nine-goats-battle.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix**: move viem and wagmi to peer dependencies. By @kyhyco #701

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "peerDependencies": {
     "@xmtp/frames-validator": "^0.6.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "viem": "^2",
+    "wagmi": "^2"
   },
   "dependencies": {
     "@tanstack/react-query": "^5",
@@ -30,9 +32,7 @@
     "graphql": "^14 || ^15 || ^16",
     "graphql-request": "^6.1.0",
     "permissionless": "^0.1.29",
-    "tailwind-merge": "^2.3.0",
-    "viem": "^2.13.8",
-    "wagmi": "^2.9.11"
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.8.0",


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
