### PR TITLE
chore: Remove coinbase wallet provider fields

### DIFF
--- a/.changeset/breezy-news-reflect.md
+++ b/.changeset/breezy-news-reflect.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **chore**: Remove unsupported fields from the Coinbase Wallet Provider. appChainIds and options. By @cpcramer #717

--- a/site/docs/components/App.tsx
+++ b/site/docs/components/App.tsx
@@ -16,11 +16,7 @@ const wagmiConfig = createConfig({
   chains: [base],
   connectors: [
     coinbaseWallet({
-      appChainIds: [base.id],
       appName: 'onchainkit',
-      options: {
-        chainId: base.id,
-      },
     }),
   ],
   ssr: true,

--- a/site/docs/pages/wallet/introduction.mdx
+++ b/site/docs/pages/wallet/introduction.mdx
@@ -59,7 +59,6 @@ const wagmiConfig = createConfig({
   chains: [baseSepolia],
   connectors: [
     coinbaseWallet({
-      appChainIds: [baseSepolia.id],
       appName: 'onchainkit',
     }),
   ],


### PR DESCRIPTION
**What changed? Why?**
Removing the following unsupported fields from the Coinbase Wallet Provider:
- `appChainIds`
- `options`

**Notes to reviewers**

**How has it been tested?**
