### PR TITLE
docs: Add isSliced option to Address and remove slice logic from Name

### DIFF
--- a/.changeset/famous-readers-matter.md
+++ b/.changeset/famous-readers-matter.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-- **docs**: Add isSliced option to the Address component. This allows this component to render the full users address when set to false. Remove the isSliced field from the Name component and update the component to return null if the ENS name is not found for the given address. By @cpcramer #733
+- **docs**: Add isSliced option to the Address component. This allows this component to render the full users address when set to false. Remove the isSliced field from the Name component and update the component to return null if the ENS name is not found for the given address. Update onchainkit dependency to version 0.24.3. By @cpcramer #733

--- a/.changeset/famous-readers-matter.md
+++ b/.changeset/famous-readers-matter.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-- **docs**: Add isSliced option to the Address component. This allows this component to render the full users address when set to false. Remove the isSliced field from the Name component and update the component to return null if the ENS name is not found for the given address. Update onchainkit dependency to version 0.24.3. By @cpcramer #733
+- **docs**: Add isSliced option to the Address component. This allows this component to render the full users address when set to false. Remove the isSliced field from the Name component and update the component to return null if the ENS name is not found for the given address. Update onchainkit dependency to version 0.24.3. Add sub sections to the Address and Name pages. By @cpcramer #733

--- a/.changeset/famous-readers-matter.md
+++ b/.changeset/famous-readers-matter.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-- **docs**: Add isSliced option to the Name and Address component. This allows these components to render the full users address when set to false. By @cpcramer #733
+- **docs**: Add isSliced option to the Address component. This allows this component to render the full users address when set to false. Remove the isSliced field from the Name component and update the component to return null if the ENS name is not found for the given address. By @cpcramer #733

--- a/.changeset/famous-readers-matter.md
+++ b/.changeset/famous-readers-matter.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **docs**: Add isSliced option to the Name and Address component. This allows these components to render the full users address when set to false. By @cpcramer #733

--- a/site/docs/pages/identity/address.mdx
+++ b/site/docs/pages/identity/address.mdx
@@ -19,6 +19,8 @@ import { Address } from '@coinbase/onchainkit/identity';
   <Address className="bg-gray-300 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
 </App>
 
+### Display full address
+
 Set `isSliced` to false, to display the full address:
 
 ```tsx
@@ -30,7 +32,9 @@ import { Address } from '@coinbase/onchainkit/identity';
   <Address className="bg-gray-300 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" isSliced={false}/>
 </App>
 
-Override styles via `className` prop:
+### Override styles
+
+You can override component styles using `className`.
 
 ```tsx
 import { Address } from '@coinbase/onchainkit/identity';

--- a/site/docs/pages/identity/address.mdx
+++ b/site/docs/pages/identity/address.mdx
@@ -16,7 +16,18 @@ import { Address } from '@coinbase/onchainkit/identity';
 ```
 
 <App>
-  <Address  address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
+  <Address className="bg-gray-300 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
+</App>
+
+Set `isSliced` to false, to display the full address:
+
+```tsx
+import { Address } from '@coinbase/onchainkit/identity';
+<Address address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" isSliced={false}/> // [!code focus]
+```
+
+<App>
+  <Address className="bg-gray-300 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" isSliced={false}/>
 </App>
 
 Override styles via `className` prop:
@@ -24,13 +35,13 @@ Override styles via `className` prop:
 ```tsx
 import { Address } from '@coinbase/onchainkit/identity';
 <Address
-  className="bg-white px-2 py-1" // [!code focus]
+  className="bg-emerald-400 px-2 py-1 rounded" // [!code focus]
   address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"
 />
 ```
 
 <App>
-  <Address className="bg-white px-2 py-1" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
+  <Address className="bg-emerald-400 px-2 py-1" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"/>
 </App>
 
 ## Props

--- a/site/docs/pages/identity/name.mdx
+++ b/site/docs/pages/identity/name.mdx
@@ -18,7 +18,9 @@ import { Name } from '@coinbase/onchainkit/identity';
   <Name className='bg-gray-300 rounded' address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"/>
 </App>
 
-Override styles via `className` prop:
+### Override styles
+
+You can override component styles using `className`.
 
 ```tsx
 import { Name } from '@coinbase/onchainkit/identity';
@@ -32,16 +34,7 @@ import { Name } from '@coinbase/onchainkit/identity';
   <Name className="bg-emerald-400 px-2 py-1 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
 </App>
 
-Address without an ENS name, and it defaults to his sliced address:
-
-```tsx
-import { Name } from '@coinbase/onchainkit/identity';
-<Name address="0x1234567890abcdef1234567890abcdef12345678" /> // [!code focus]
-```
-
-<App>
-  <Name className='bg-gray-300 rounded' address="0x435233231234567890abcdef1234567890abcdef12345678"/>
-</App>
+### Add attestation badge
 
 Show attestation on ENV name with [`Badge`](/identity/badge) component.
 

--- a/site/docs/pages/identity/name.mdx
+++ b/site/docs/pages/identity/name.mdx
@@ -15,7 +15,7 @@ import { Name } from '@coinbase/onchainkit/identity';
 ```
 
 <App>
-  <Name address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
+  <Name className='bg-gray-300 rounded' address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"/>
 </App>
 
 Override styles via `className` prop:
@@ -23,13 +23,13 @@ Override styles via `className` prop:
 ```tsx
 import { Name } from '@coinbase/onchainkit/identity';
 <Name
-  className="bg-default"// [!code focus]
+  className="bg-emerald-400"// [!code focus]
   address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"
 />
 ```
 
 <App>
-  <Name className="bg-default px-2 py-1" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
+  <Name className="bg-emerald-400 px-2 py-1 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
 </App>
 
 Address without an ENS name, and it defaults to his sliced address:
@@ -40,7 +40,18 @@ import { Name } from '@coinbase/onchainkit/identity';
 ```
 
 <App>
-  <Name address="0x1234567890abcdef1234567890abcdef12345678" />
+  <Name className='bg-gray-300 rounded' address="0x435233231234567890abcdef1234567890abcdef12345678" />
+</App>
+
+Set `isSliced` to false, to display the full address if the ENS name is not found:
+
+```tsx
+import { Name } from '@coinbase/onchainkit/identity';
+<Name address="0x1234567890abcdef1234567890abcdef12345678" isSliced={false}/> // [!code focus]
+```
+
+<App>
+  <Name className='bg-gray-300 rounded' address="0x435233231234567890abcdef1234567890abcdef12345678" isSliced={false}/>
 </App>
 
 Show attestation on ENV name with [`Badge`](/identity/badge) component.
@@ -66,7 +77,7 @@ import { Badge, Name, Identity } from '@coinbase/onchainkit/identity'; // [!code
     address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9"
     className="bg-transparent"
   >
-    <Name >
+    <Name className='bg-gray-300 rounded'>
       <Badge />
     </Name>
   </Identity>

--- a/site/docs/pages/identity/name.mdx
+++ b/site/docs/pages/identity/name.mdx
@@ -40,18 +40,7 @@ import { Name } from '@coinbase/onchainkit/identity';
 ```
 
 <App>
-  <Name className='bg-gray-300 rounded' address="0x435233231234567890abcdef1234567890abcdef12345678" />
-</App>
-
-Set `isSliced` to false, to display the full address if the ENS name is not found:
-
-```tsx
-import { Name } from '@coinbase/onchainkit/identity';
-<Name address="0x1234567890abcdef1234567890abcdef12345678" isSliced={false}/> // [!code focus]
-```
-
-<App>
-  <Name className='bg-gray-300 rounded' address="0x435233231234567890abcdef1234567890abcdef12345678" isSliced={false}/>
+  <Name className='bg-gray-300 rounded' address="0x435233231234567890abcdef1234567890abcdef12345678"/>
 </App>
 
 Show attestation on ENV name with [`Badge`](/identity/badge) component.

--- a/site/docs/pages/identity/types.mdx
+++ b/site/docs/pages/identity/types.mdx
@@ -121,7 +121,6 @@ type IdentityReact = {
 export type NameReact = {
   address?: Address | null; // Ethereum address to be displayed.
   className?: string; // Optional className override for top span element.
-  isSliced?: boolean; // Determines if the address should be sliced when no ENS name is available.
   children?: ReactNode; // Optional attestation by passing Badge component as its children
 } & HTMLAttributes<HTMLSpanElement>; // Optional additional span attributes to apply to the name.
 ```

--- a/site/docs/pages/identity/types.mdx
+++ b/site/docs/pages/identity/types.mdx
@@ -121,7 +121,7 @@ type IdentityReact = {
 export type NameReact = {
   address?: Address | null; // Ethereum address to be displayed.
   className?: string; // Optional className override for top span element.
-  sliced?: boolean; // Determines if the address should be sliced when no ENS name is available.
+  isSliced?: boolean; // Determines if the address should be sliced when no ENS name is available.
   children?: ReactNode; // Optional attestation by passing Badge component as its children
 } & HTMLAttributes<HTMLSpanElement>; // Optional additional span attributes to apply to the name.
 ```

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
     "preview": "vocs preview"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "0.24.1",
+    "@coinbase/onchainkit": "0.24.3",
     "@types/react": "latest",
     "@vercel/edge": "^1.1.1",
     "permissionless": "^0.1.29",

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -338,9 +338,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:0.24.1":
-  version: 0.24.1
-  resolution: "@coinbase/onchainkit@npm:0.24.1"
+"@coinbase/onchainkit@npm:0.24.3":
+  version: 0.24.3
+  resolution: "@coinbase/onchainkit@npm:0.24.3"
   dependencies:
     "@tanstack/react-query": "npm:^5"
     clsx: "npm:^2.1.1"
@@ -354,7 +354,7 @@ __metadata:
     "@xmtp/frames-validator": ^0.6.0
     react: ^18
     react-dom: ^18
-  checksum: bbe3e6f2af5120468a8bbfff9d6720f06b0e6383e39f32f1c9a76119ee22fb28f858c6f0b8efa04145869f986f95aa61a274025ecf845599cb97c0e11be629a1
+  checksum: f81c4b588a170fc9bccc3d367d67f8ce5c19d57252f82edf2b6ffb8b2a82d1447454c629df45fcae851d40b43bea561d59dfad4f7d4a5204f581d010a9462f3a
   languageName: node
   linkType: hard
 
@@ -7826,7 +7826,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "onchainkit@workspace:."
   dependencies:
-    "@coinbase/onchainkit": "npm:0.24.1"
+    "@coinbase/onchainkit": "npm:0.24.3"
     "@types/react": "npm:latest"
     "@vercel/edge": "npm:^1.1.1"
     permissionless: "npm:^0.1.29"


### PR DESCRIPTION
**What changed? Why?**
Tracking issue: https://github.com/coinbase/onchainkit/issues/732

| Part | Description | Status |
|---|----|---|
| 1 | [[Part 1] feat: Add isSliced option to Address and remove slice logic from Name](https://github.com/coinbase/onchainkit/pull/747) | ✅  |
| 2 | [[Part 2] docs: Add isSliced option to Address and remove slice logic from Name](https://github.com/coinbase/onchainkit/pull/733) | _In Progress_|

Add the `isSliced` option to the `Address` component. This allows the component to render the full users address when set to false. 

Update the `Name` component to remove slice logic and return null if the ENS name is not found.

- Add documentation examples to show the `false` case for the Address component. 
- Update displayed examples on the Name and Address docs page to make them easier to read in dark mode.
- Add sub sections to the Name and Address pages.


**Notes to reviewers**

**How has it been tested?**
`Address` page:
<img width="383" alt="Screenshot 2024-07-09 at 3 42 09 PM" src="https://github.com/coinbase/onchainkit/assets/39774249/4a6e28b7-4df7-4f92-b2d9-0977d2532360">


`Name` page:
<img width="380" alt="Screenshot 2024-07-09 at 3 40 45 PM" src="https://github.com/coinbase/onchainkit/assets/39774249/c965b998-aeb3-403a-b4be-81ec3f2f7f84">

`Added sub sections to Address and Name`
<img width="136" alt="Screenshot 2024-07-09 at 3 42 28 PM" src="https://github.com/coinbase/onchainkit/assets/39774249/3b081618-260d-42da-abb7-91bcc787323e">

Improved Name example visibility:
`Before`
<img width="567" alt="Screenshot 2024-06-28 at 2 02 16 PM" src="https://github.com/coinbase/onchainkit/assets/39774249/9935994f-f340-4722-b77c-b0b13ea7c633">


`After`
<img width="101" alt="Screenshot 2024-07-09 at 3 41 33 PM" src="https://github.com/coinbase/onchainkit/assets/39774249/c271ebdb-9a9c-4368-b19d-cb68ad1cd2ad">


Improved Address example visibility:
`Before`
<img width="590" alt="Screenshot 2024-06-28 at 2 04 39 PM" src="https://github.com/coinbase/onchainkit/assets/39774249/0ab8a0af-344f-4293-82c1-3fc9799bc72f">

`After`
<img width="390" alt="Screenshot 2024-07-09 at 3 41 47 PM" src="https://github.com/coinbase/onchainkit/assets/39774249/13bf1238-baf7-46a0-a9fb-fef2d24e061f">


