### PR TITLE
docs: Update Name and Address code snippets and component examples

### DIFF
--- a/.changeset/ninety-rats-applaud.md
+++ b/.changeset/ninety-rats-applaud.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
--**docs**: Update Name and Address docs code snippet and displayed component to fully match - removed some hidden styling for readablility to maximize authenticity. By @cpcramer
+- **docs**: Update `Name` and `Address` docs code snippet and displayed component to fully match - removed some hidden styling for readablility to maximize authenticity. By @cpcramer #770

--- a/.changeset/ninety-rats-applaud.md
+++ b/.changeset/ninety-rats-applaud.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**docs**: Update Name and Address docs code snippet and displayed component to fully match - removed some hidden styling for readablility to maximize authenticity. By @cpcramer

--- a/site/docs/pages/identity/address.mdx
+++ b/site/docs/pages/identity/address.mdx
@@ -16,7 +16,7 @@ import { Address } from '@coinbase/onchainkit/identity';
 ```
 
 <App>
-  <Address className="bg-gray-300 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
+  <Address address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" />
 </App>
 
 ### Display full address
@@ -29,7 +29,7 @@ import { Address } from '@coinbase/onchainkit/identity';
 ```
 
 <App>
-  <Address className="bg-gray-300 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" isSliced={false}/>
+  <Address address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" isSliced={false}/>
 </App>
 
 ### Override styles
@@ -45,7 +45,7 @@ import { Address } from '@coinbase/onchainkit/identity';
 ```
 
 <App>
-  <Address className="bg-emerald-400 px-2 py-1" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"/>
+  <Address className="bg-emerald-400 px-2 py-1 rounded" address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"/>
 </App>
 
 ## Props

--- a/site/docs/pages/identity/name.mdx
+++ b/site/docs/pages/identity/name.mdx
@@ -15,7 +15,7 @@ import { Name } from '@coinbase/onchainkit/identity';
 ```
 
 <App>
-  <Name className='bg-gray-300 rounded' address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"/>
+  <Name address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"/>
 </App>
 
 ### Override styles
@@ -25,7 +25,7 @@ You can override component styles using `className`.
 ```tsx
 import { Name } from '@coinbase/onchainkit/identity';
 <Name
-  className="bg-emerald-400"// [!code focus]
+  className="bg-emerald-400 px-2 py-1 rounded"// [!code focus]
   address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1"
 />
 ```
@@ -59,7 +59,7 @@ import { Badge, Name, Identity } from '@coinbase/onchainkit/identity'; // [!code
     address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9"
     className="bg-transparent"
   >
-    <Name className='bg-gray-300 rounded'>
+    <Name>
       <Badge />
     </Name>
   </Identity>


### PR DESCRIPTION
**What changed? Why?**
Update the Name and Address code snippets and component examples so that they match. The intention is to maximize the parity between the code snippets in the documentation and the displayed components.

- Remove some hidden component styling that was intended to improve readability - we want to maximize for authenticity. 
- 
**Notes to reviewers**

**How has it been tested?**
<img width="579" alt="Screenshot 2024-07-10 at 9 29 24 AM" src="https://github.com/coinbase/onchainkit/assets/39774249/0e5b2290-533a-42d6-b283-dc88ee765591">

<img width="596" alt="Screenshot 2024-07-10 at 9 29 35 AM" src="https://github.com/coinbase/onchainkit/assets/39774249/964a59ea-68f0-4b50-9605-ce81c09c1502">
