### PR TITLE
docs: Add Wrap Your App with OnchainProviders section

### DIFF
--- a/.changeset/strong-icons-pump.md
+++ b/.changeset/strong-icons-pump.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **docs**: Add Wrap Your App with OnchainProviders section in the Getting Started guide. By @cpcramer #111

--- a/.changeset/strong-icons-pump.md
+++ b/.changeset/strong-icons-pump.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-- **docs**: Add Wrap Your App with OnchainProviders section in the Getting Started guide. By @cpcramer #111
+- **docs**: Add Wrap Your App with OnchainProviders section in the Getting Started guide. By @cpcramer #777

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -157,11 +157,13 @@ export const wagmiConfig = createConfig({
   },
 });
 ```
-
 :::
+
 ### Wrap Your App with OnchainProviders
 
 Wrap your app with the `OnchainProviders` component to enable OnchainKit components and utilities.
+
+:::code-group
 
 ```tsx [layout.tsx]
 import { OnchainProviders } from './OnchainProviders' // [!code focus]
@@ -174,6 +176,38 @@ export default function RootLayout({ children }) {
   )
 }  
 ```
+
+```tsx [OnchainProviders.tsx]
+'use client';
+import { ReactNode } from 'react';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { base } from 'viem/chains';
+import { WagmiProvider } from 'wagmi';
+import { wagmiConfig } from './wagmi';
+
+type Props = { children: ReactNode };
+
+const queryClient = new QueryClient();
+
+function OnchainProviders({ children }: Props) { // [!code focus]
+  return (
+    <WagmiProvider config={wagmiConfig}>
+      <QueryClientProvider client={queryClient}>
+        <OnchainKitProvider
+          apiKey={process.env.PUBLIC_ONCHAINKIT_API_KEY}
+          chain={base}
+        >
+          {children}
+        </OnchainKitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+} // [!code focus]
+
+export default OnchainProviders; // [!code focus]
+```
+:::
 
 ### Style your components
 

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -159,6 +159,21 @@ export const wagmiConfig = createConfig({
 ```
 
 :::
+### Wrap Your App with OnchainProviders
+
+Wrap your app with the `OnchainProviders` component to enable OnchainKit components and utilities.
+
+```tsx [layout.tsx]
+import { OnchainProviders } from './OnchainProviders' // [!code focus]
+
+export default function RootLayout({ children }) {
+  return (
+    <OnchainProviders> // [!code focus]
+      { children }
+    </OnchainProviders> // [!code focus]
+  )
+}  
+```
 
 ### Style your components
 


### PR DESCRIPTION
**What changed? Why?**
Add `Wrap Your App with OnchainProviders` section in the getting started guide. 

This is a follow up from my dogfooding feedback [here](https://coinbase.slack.com/archives/C06NZU31P4N/p1719185284498779) - _"It wasn't clear that I had to wrap my root component in the OnchainProviders - I had to reference the Wagmi docs to remember this step."_

**Notes to reviewers**

**How has it been tested?**
<img width="553" alt="Screenshot 2024-07-11 at 11 31 11 AM" src="https://github.com/coinbase/onchainkit/assets/39774249/a4572689-ca73-4cf1-b5f1-e204b45c4588">


<img width="548" alt="Screenshot 2024-07-11 at 11 31 22 AM" src="https://github.com/coinbase/onchainkit/assets/39774249/c8b90ea1-ac40-4789-b0e6-24336f97acc1">
