### PR TITLE
Feat: Add chain to useName

### DIFF
--- a/.changeset/late-keys-deny.md
+++ b/.changeset/late-keys-deny.md
@@ -1,5 +1,5 @@
 ---
-"@coinbase/onchainkit": minor
+"@coinbase/onchainkit": patch
 ---
-
-Improve getName to support custom chain
+- **feat**: Add added `chain` option to `useName`, this will help add ENS support for L2 chains. By @kirkas #781
+- **fix**: Modify `getName` to return a rejected promise instead of an error. By @kirkas #781

--- a/.changeset/late-keys-deny.md
+++ b/.changeset/late-keys-deny.md
@@ -1,5 +1,7 @@
 ---
 "@coinbase/onchainkit": patch
 ---
-- **feat**: Add added `chain` option to `useName`, this will help add ENS support for L2 chains. By @kirkas #781
-- **fix**: Modify `getName` to return a rejected promise instead of an error. By @kirkas #781
+- **feat**: Added `chain` option to `useName` component for L2 chain name resolution support. By @kirkas #781
+- **feat**: Added `chain` option to `<Name>` component for L2 chain name resolution support. By @kirkas #781
+- **fix**: Modified `getName` to return a rejected promise instead of an error. By @kirkas #781
+- **fix**: Disabled `retry` in `getNewReactQueryTestProvider` to run tests faster and avoid timeouts. By @kirkas #781

--- a/.changeset/late-keys-deny.md
+++ b/.changeset/late-keys-deny.md
@@ -1,7 +1,7 @@
 ---
 "@coinbase/onchainkit": patch
 ---
-- **feat**: Added `chain` option to `useName` component for L2 chain name resolution support. By @kirkas #781
+- **feat**: Added `chain` option to `useName` function for L2 chain name resolution support. By @kirkas #781
 - **feat**: Added `chain` option to `<Name>` component for L2 chain name resolution support. By @kirkas #781
 - **fix**: Modified `getName` to return a rejected promise instead of an error. By @kirkas #781
 - **fix**: Disabled `retry` in `getNewReactQueryTestProvider` to run tests faster and avoid timeouts. By @kirkas #781

--- a/.changeset/late-keys-deny.md
+++ b/.changeset/late-keys-deny.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+Improve getName to support custom chain

--- a/.changeset/two-pigs-itch.md
+++ b/.changeset/two-pigs-itch.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+add chain props to useName

--- a/.changeset/two-pigs-itch.md
+++ b/.changeset/two-pigs-itch.md
@@ -1,5 +1,0 @@
----
-"@coinbase/onchainkit": minor
----
-
-add chain props to useName

--- a/src/identity/components/Name.stories.tsx
+++ b/src/identity/components/Name.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Name } from './Name';
+import { baseSepolia, optimism } from 'viem/chains';
 
 const meta = {
   title: 'Identity/Name',
@@ -31,5 +32,19 @@ export const Sliced: Story = {
   args: {
     address: '0x1234567891234567881234567891234567891234',
     sliced: true,
+  },
+};
+
+export const BaseSepolia: Story = {
+  args: {
+    address: '0x8c8F1a1e1bFdb15E7ed562efc84e5A588E68aD73',
+    chain: baseSepolia,
+  },
+};
+
+export const UnsupportedChain: Story = {
+  args: {
+    address: '0x8c8F1a1e1bFdb15E7ed562efc84e5A588E68aD73',
+    chain: optimism,
   },
 };

--- a/src/identity/components/Name.test.tsx
+++ b/src/identity/components/Name.test.tsx
@@ -11,6 +11,7 @@ import { useAttestations } from '../hooks/useAttestations';
 import { Name } from './Name';
 import { Badge } from './Badge';
 import { useIdentityContext } from './IdentityProvider';
+import { baseSepolia } from 'viem/chains';
 
 const silenceError = () => {
   const consoleErrorMock = vi
@@ -69,6 +70,18 @@ describe('OnchainAddress', () => {
       isLoading: false,
     });
     render(<Name address={testAddress} />);
+    expect(screen.getByText(testName)).toBeInTheDocument();
+  });
+
+  it('displays custom chain ENS name when available', () => {
+    (useIdentityContext as vi.Mock).mockReturnValue({
+      schemaId: '0x123',
+    });
+    (useName as vi.Mock).mockReturnValue({
+      data: testName,
+      isLoading: false,
+    });
+    render(<Name address={testAddress} chain={baseSepolia} />);
     expect(screen.getByText(testName)).toBeInTheDocument();
   });
 

--- a/src/identity/components/Name.tsx
+++ b/src/identity/components/Name.tsx
@@ -13,6 +13,7 @@ export function Name({
   address = null,
   className,
   children,
+  chain,
   ...props
 }: NameReact) {
   const { address: contextAddress } = useIdentityContext();
@@ -26,6 +27,7 @@ export function Name({
 
   const { data: name, isLoading } = useName({
     address: accountAddress,
+    chain,
   });
 
   const badge = useMemo(() => {

--- a/src/identity/core/getName.test.tsx
+++ b/src/identity/core/getName.test.tsx
@@ -100,7 +100,7 @@ describe('getName', () => {
   it('should throw an error on unsupported chain', async () => {
     await expect(
       getName({ address: walletAddress, chain: optimism }),
-    ).rejects.toThrow(
+    ).rejects.toBe(
       'ChainId not supported, name resolution is only supported on Ethereum and Base.',
     );
   });

--- a/src/identity/core/getName.ts
+++ b/src/identity/core/getName.ts
@@ -22,7 +22,7 @@ export const getName = async ({
   const chainSupportsUniversalResolver = chainIsEthereum || chainIsBase;
 
   if (!chainSupportsUniversalResolver) {
-    throw Error(
+    return Promise.reject(
       'ChainId not supported, name resolution is only supported on Ethereum and Base.',
     );
   }

--- a/src/identity/hooks/getNewReactQueryTestProvider.tsx
+++ b/src/identity/hooks/getNewReactQueryTestProvider.tsx
@@ -3,9 +3,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 /**
  * This is a unit testing helper function to create a new React Query Test Provider.
  * It is important to get a new instance each time to prevent cached results from the previous test
+ * Note: React-query recommends turning off retries for tests, in order to avoid timeout
+ * https://tanstack.com/query/v4/docs/framework/react/guides/testing#turn-off-retries
  */
 export const getNewReactQueryTestProvider = () => {
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
   function ReactQueryTestProvider({ children }: { children: React.ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/src/identity/hooks/useName.test.tsx
+++ b/src/identity/hooks/useName.test.tsx
@@ -9,7 +9,6 @@ import { getNewReactQueryTestProvider } from './getNewReactQueryTestProvider';
 import { describe, beforeEach, it, expect, vi, type Mock } from 'vitest';
 import { base, optimism } from 'viem/chains';
 
-
 vi.mock('../../network/client');
 vi.mock('../../network/getChainPublicClient', () => ({
   ...vi.importActual('../../network/getChainPublicClient'),
@@ -20,7 +19,6 @@ describe('useName', () => {
   const mockGetEnsName = publicClient.getEnsName as Mock;
   const mockReadContract = publicClient.readContract as Mock;
   const testAddress = '0x123';
-
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -81,7 +79,7 @@ describe('useName', () => {
     });
   });
 
-  it('returns undefined unsupported chain ', async () => {
+  it('returns error for unsupported chain ', async () => {
     // Use the renderHook function to create a test harness for the useName hook
     const { result } = renderHook(
       () => useName({ address: testAddress, chain: optimism }),
@@ -94,6 +92,11 @@ describe('useName', () => {
     await waitFor(() => {
       // Check that the ENS name and loading state are correct
       expect(result.current.data).toBe(undefined);
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(result.current.error).toBe(
+        'ChainId not supported, name resolution is only supported on Ethereum and Base.',
+      );
     });
   });
 });

--- a/src/identity/hooks/useName.test.tsx
+++ b/src/identity/hooks/useName.test.tsx
@@ -7,6 +7,8 @@ import { useName } from './useName';
 import { publicClient } from '../../network/client';
 import { getNewReactQueryTestProvider } from './getNewReactQueryTestProvider';
 import { describe, beforeEach, it, expect, vi, type Mock } from 'vitest';
+import { base, optimism } from 'viem/chains';
+
 
 vi.mock('../../network/client');
 vi.mock('../../network/getChainPublicClient', () => ({
@@ -16,13 +18,15 @@ vi.mock('../../network/getChainPublicClient', () => ({
 
 describe('useName', () => {
   const mockGetEnsName = publicClient.getEnsName as Mock;
+  const mockReadContract = publicClient.readContract as Mock;
+  const testAddress = '0x123';
+
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('returns the correct ENS name and loading state', async () => {
-    const testAddress = '0x123';
     const testEnsName = 'test.ens';
 
     // Mock the getEnsName method of the publicClient
@@ -42,8 +46,6 @@ describe('useName', () => {
   });
 
   it('returns the loading state true while still fetching from ens action', async () => {
-    const testAddress = '0x123';
-
     // Use the renderHook function to create a test harness for the useName hook
     const { result } = renderHook(() => useName({ address: testAddress }), {
       wrapper: getNewReactQueryTestProvider(),
@@ -54,6 +56,44 @@ describe('useName', () => {
       // Check that the ENS name and loading state are correct
       expect(result.current.data).toBe(undefined);
       expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  it('returns the correct ENS name and loading state for custom chain ', async () => {
+    const testEnsName = 'test.customchain.eth';
+
+    // Mock the getEnsName method of the publicClient
+    mockReadContract.mockResolvedValue(testEnsName);
+
+    // Use the renderHook function to create a test harness for the useName hook
+    const { result } = renderHook(
+      () => useName({ address: testAddress, chain: base }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    // Wait for the hook to finish fetching the ENS name
+    await waitFor(() => {
+      // Check that the ENS name and loading state are correct
+      expect(result.current.data).toBe(testEnsName);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('returns undefined unsupported chain ', async () => {
+    // Use the renderHook function to create a test harness for the useName hook
+    const { result } = renderHook(
+      () => useName({ address: testAddress, chain: optimism }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    // Wait for the hook to finish fetching the ENS name
+    await waitFor(() => {
+      // Check that the ENS name and loading state are correct
+      expect(result.current.data).toBe(undefined);
     });
   });
 });

--- a/src/identity/hooks/useName.ts
+++ b/src/identity/hooks/useName.ts
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
-import type { Address } from 'viem';
 import { getName } from '../core/getName';
+import type { Address, Chain } from 'viem';
 import type { GetNameReturnType } from '../types';
 
 type UseNameOptions = {
   address: Address; // The Ethereum address for which the ENS name is to be fetched.
+  chain?: Chain;
 };
 
 // Additional query options, including `enabled` and `cacheTime`
@@ -20,7 +21,7 @@ type UseNameQueryOptions = {
  *  - `{UseQueryResult}`: The rest of useQuery return values. including isLoading, isError, error, isFetching, refetch, etc.
  */
 export const useName = (
-  { address }: UseNameOptions,
+  { address, chain }: UseNameOptions,
   queryOptions?: UseNameQueryOptions,
 ) => {
   const { enabled = true, cacheTime } = queryOptions ?? {};
@@ -28,7 +29,7 @@ export const useName = (
   return useQuery<GetNameReturnType>({
     queryKey: ['useName', ensActionKey],
     queryFn: async () => {
-      return await getName({ address });
+      return await getName({ address, chain });
     },
     gcTime: cacheTime,
     enabled,

--- a/src/identity/hooks/useName.ts
+++ b/src/identity/hooks/useName.ts
@@ -1,6 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getName } from '../core/getName';
-import type { GetNameReturnType, UseNameOptions, UseNameQueryOptions } from '../types';
+import type {
+  GetNameReturnType,
+  UseNameOptions,
+  UseNameQueryOptions,
+} from '../types';
 
 /**
  * It leverages the `@tanstack/react-query` hook for fetching and optionally caching the ENS name

--- a/src/identity/hooks/useName.ts
+++ b/src/identity/hooks/useName.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getName } from '../core/getName';
 import type { Address, Chain } from 'viem';
 import type { GetNameReturnType } from '../types';
+import type { QueryOptions } from '@tanstack/react-query';
 
 type UseNameOptions = {
   address: Address; // The Ethereum address for which the ENS name is to be fetched.

--- a/src/identity/hooks/useName.ts
+++ b/src/identity/hooks/useName.ts
@@ -1,19 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { getName } from '../core/getName';
-import type { Address, Chain } from 'viem';
-import type { GetNameReturnType } from '../types';
-import type { QueryOptions } from '@tanstack/react-query';
-
-type UseNameOptions = {
-  address: Address; // The Ethereum address for which the ENS name is to be fetched.
-  chain?: Chain;
-};
-
-// Additional query options, including `enabled` and `cacheTime`
-type UseNameQueryOptions = {
-  enabled?: boolean; // Whether the query should be enabled. Defaults to true.
-  cacheTime?: number; // Cache time in milliseconds.
-};
+import type { GetNameReturnType, UseNameOptions, UseNameQueryOptions } from '../types';
 
 /**
  * It leverages the `@tanstack/react-query` hook for fetching and optionally caching the ENS name

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -161,7 +161,6 @@ export type NameReact = {
   address?: Address | null; // Ethereum address to be displayed.
   children?: ReactNode; // Optional attestation by passing Badge component as its children
   className?: string; // Optional className override for top span element.
-  chain?: Chain; // Optional chain for domain resolution
 } & HTMLAttributes<HTMLSpanElement>; // Optional additional span attributes to apply to the name.
 
 /**

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -161,6 +161,7 @@ export type NameReact = {
   address?: Address | null; // Ethereum address to be displayed.
   children?: ReactNode; // Optional attestation by passing Badge component as its children
   className?: string; // Optional className override for top span element.
+  chain?: Chain; // Optional chain for domain resolution
 } & HTMLAttributes<HTMLSpanElement>; // Optional additional span attributes to apply to the name.
 
 /**

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -120,6 +120,23 @@ export type GetNameReturnType = string | null;
 /**
  * Note: exported as public Type
  */
+export type UseNameOptions = {
+  address: Address; // The Ethereum address for which the ENS name is to be fetched.
+  chain?: Chain; // Optional chain for domain resolution
+};
+
+/**
+ * Note: exported as public Type
+ * Additional query options, including `enabled` and `cacheTime`
+ */
+export type UseNameQueryOptions = {
+  enabled?: boolean; // Whether the query should be enabled. Defaults to true.
+  cacheTime?: number; // Cache time in milliseconds.
+};
+
+/**
+ * Note: exported as public Type
+ */
 export type IdentityContextType = {
   address: Address; // The Ethereum address to fetch the avatar and name for.
   schemaId?: Address | null; // The Ethereum address of the schema to use for EAS attestation.

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -144,6 +144,7 @@ export type NameReact = {
   address?: Address | null; // Ethereum address to be displayed.
   children?: ReactNode; // Optional attestation by passing Badge component as its children
   className?: string; // Optional className override for top span element.
+  chain?: Chain; // Optional chain for domain resolution
 } & HTMLAttributes<HTMLSpanElement>; // Optional additional span attributes to apply to the name.
 
 /**


### PR DESCRIPTION
**What changed? Why?**
- **feat**: Added `chain` option to `useName` function for L2 chain name resolution support. 
- **feat**: Added `chain` option to `<Name>` component for L2 chain name resolution support.
- **fix**: Modified `getName` to return a rejected promise instead of an error. 
- **fix**: Disabled `retry` in `getNewReactQueryTestProvider` to run tests faster and avoid timeouts. 

**How has it been tested?**
- locally with 100% passing
- 100% test coverage
- In storybook

<img width="789" alt="image" src="https://github.com/user-attachments/assets/a9cf2709-9572-4e55-a149-1dfb7b8a4861">
