### PR TITLE
docs: Add Next Steps to the Getting Started page

### DIFF
--- a/.changeset/sweet-drinks-impress.md
+++ b/.changeset/sweet-drinks-impress.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **docs**: Add Next Steps section to the Getting Started page. By @cpcramer #782

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -222,3 +222,13 @@ import '@coinbase/onchainkit/styles.css';
 For `tailwindcss` users, follow the [Tailwindcss Integration Guide](/guides/tailwind).
 
 ::::
+
+### Next Steps
+
+Get started with ready-to-use onchain components.
+
+- [**`Identity`**](/identity/introduction) - Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
+- [**`Wallet`**](/wallet/wallet) - Create or connect your wallet with [Connect Wallet](/wallet/wallet).
+- [**`Tokens`**](/token/introduction) - Search [Tokens](/token/types#token) using [getTokens](/token/get-tokens) and display them with [TokenSearch](/token/token-search), [TokenChip](/token/token-chip), and [TokenRow](/token/token-row).
+- [**`Swap`**](/swap/swap) - Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
+- [**`Frame`**](/frame/frame-metadata) - Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).


### PR DESCRIPTION
**What changed? Why?**
Add links to ready-to-use onchain components: `Identity`, `Wallet`, `Tokens`, `Swap`, `Frame`.

This is a follow up from my dogfooding feedback here - _"Completing the guide doesn't result in anything working; it transitions into the docs starting with components then utilities. This feels disjointed and incomplete."_

Added a "Next Steps" section at the bottom of the `Getting Started` guide to provide direction to developers after completing the `Getting Started` guide.

I initially aimed for rendering something locally when the developer completed the Getting Started page, similar to create-react-app or Wagmi. This idea is better suited for a future "Quick Start" guide - which can work in addition to a `Getting Started` page.` Getting Started` is for when developers want to integrate `OnchainKit` into their existing application, and `Quick Start` is for those who just want to play around with `OnchainKit` and start rendering components as soon as possible.


**Notes to reviewers**

**How has it been tested?**
<img width="749" alt="Screenshot 2024-07-11 at 4 17 06 PM" src="https://github.com/user-attachments/assets/d558bf3a-5f32-416d-95e9-a8becd1beddd">
