### PR TITLE
Feat: add chain to IdentityProvider and Identity

### DIFF
--- a/.changeset/many-readers-prove.md
+++ b/.changeset/many-readers-prove.md
@@ -1,6 +1,0 @@
----
-"@coinbase/onchainkit": patch
----
-- **feat**: Added `chain` option to `<IdentityProvider>` for L2 chain name resolution support. By @kirkas #785
-- **feat**: Added `chain` option to `<Identity>` component for L2 chain name resolution support. By @kirkas #785
-- **fix**: Update `<Name>` rely on the `<IdentityProvider>` if present. By @kirkas #785

--- a/.changeset/many-readers-prove.md
+++ b/.changeset/many-readers-prove.md
@@ -1,0 +1,6 @@
+---
+"@coinbase/onchainkit": patch
+---
+- **feat**: Added `chain` option to `<IdentityProvider>` for L2 chain name resolution support. By @kirkas #785
+- **feat**: Added `chain` option to `<Identity>` component for L2 chain name resolution support. By @kirkas #785
+- **fix**: Update `<Name>` rely on the `<IdentityProvider>` if present. By @kirkas #785

--- a/.changeset/old-beds-yawn.md
+++ b/.changeset/old-beds-yawn.md
@@ -1,0 +1,7 @@
+---
+"@coinbase/onchainkit": patch
+---
+- **feat**: Added `chain` option to `<IdentityProvider>` for L2 chain name resolution support. By @kirkas #781
+- **feat**: Added `chain` option to `<Identity>` component for L2 chain name resolution support. By @kirkas #781
+- **fix**: Modify `<Name>` to prioritize its own address/chain props over the provider's. By @kirkas #781
+- **fix**: Modify `<Address>`, `<Avatar>`, `<EthBalance>` to prioritize its own address prop over the provider's. By @kirkas #781

--- a/.changeset/old-beds-yawn.md
+++ b/.changeset/old-beds-yawn.md
@@ -4,4 +4,4 @@
 - **feat**: Added `chain` option to `<IdentityProvider>` for L2 chain name resolution support. By @kirkas #781
 - **feat**: Added `chain` option to `<Identity>` component for L2 chain name resolution support. By @kirkas #781
 - **fix**: Modify `<Name>` to prioritize its own address/chain props over the provider's. By @kirkas #781
-- **fix**: Modify `<Address>`, `<Avatar>`, `<EthBalance>` to prioritize its own address prop over the provider's. By @kirkas #781
+- **fix**: Modify `<Address>`, `<Avatar>`, `<EthBalance>` & `<DisplayBadge>` to prioritize its own address prop over the provider's. By @kirkas #781

--- a/src/identity/components/Address.test.tsx
+++ b/src/identity/components/Address.test.tsx
@@ -34,7 +34,9 @@ const mockGetSlicedAddress = (addr: string) =>
   `${addr.slice(0, 5)}...${addr.slice(-4)}`;
 
 describe('Address component', () => {
-  const mockAddress = '0x1234567890abcdef1234567890abcdef12345678';
+  const testIdentityProviderAddress = '0xIdentityAddress';
+  const testAddressComponentAddress =
+    '0x1234567890abcdef1234567890abcdef12345678';
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -52,42 +54,68 @@ describe('Address component', () => {
   });
 
   it('renders the sliced address when address supplied to Identity', () => {
-    useIdentityContextMock.mockReturnValue({ address: mockAddress });
+    useIdentityContextMock.mockReturnValue({
+      address: testAddressComponentAddress,
+    });
     (getSlicedAddress as vi.Mock).mockReturnValue(
-      mockGetSlicedAddress(mockAddress),
+      mockGetSlicedAddress(testAddressComponentAddress),
     );
 
     const { getByText } = render(<Address />);
-    expect(getByText(mockGetSlicedAddress(mockAddress))).toBeInTheDocument();
+    expect(
+      getByText(mockGetSlicedAddress(testAddressComponentAddress)),
+    ).toBeInTheDocument();
   });
 
   it('renders the sliced address when address supplied to Identity', () => {
     useIdentityContextMock.mockReturnValue({});
     (getSlicedAddress as vi.Mock).mockReturnValue(
-      mockGetSlicedAddress(mockAddress),
+      mockGetSlicedAddress(testAddressComponentAddress),
     );
 
-    const { getByText } = render(<Address address={mockAddress} />);
-    expect(getByText(mockGetSlicedAddress(mockAddress))).toBeInTheDocument();
+    const { getByText } = render(
+      <Address address={testAddressComponentAddress} />,
+    );
+    expect(
+      getByText(mockGetSlicedAddress(testAddressComponentAddress)),
+    ).toBeInTheDocument();
   });
 
   it('displays sliced address when ENS name is not available and isSliced is set to true', () => {
     useIdentityContextMock.mockReturnValue({});
     (getSlicedAddress as vi.Mock).mockReturnValue(
-      mockGetSlicedAddress(mockAddress),
+      mockGetSlicedAddress(testAddressComponentAddress),
     );
 
-    render(<Address address={mockAddress} isSliced={true} />);
+    render(<Address address={testAddressComponentAddress} isSliced={true} />);
     expect(
-      screen.getByText(mockGetSlicedAddress(mockAddress)),
+      screen.getByText(mockGetSlicedAddress(testAddressComponentAddress)),
     ).toBeInTheDocument();
-    expect(getSlicedAddress).toHaveBeenCalledWith(mockAddress);
+    expect(getSlicedAddress).toHaveBeenCalledWith(testAddressComponentAddress);
   });
 
   it('displays full address when isSliced is false and ENS name is not available', () => {
     useIdentityContextMock.mockReturnValue({});
-    render(<Address address={mockAddress} isSliced={false} />);
-    expect(screen.getByText(mockAddress)).toBeInTheDocument();
+    render(<Address address={testAddressComponentAddress} isSliced={false} />);
+    expect(screen.getByText(testAddressComponentAddress)).toBeInTheDocument();
+    expect(getSlicedAddress).not.toHaveBeenCalled();
+  });
+
+  it('use identity context address if provided', () => {
+    useIdentityContextMock.mockReturnValue({
+      address: testIdentityProviderAddress,
+    });
+    render(<Address isSliced={false} />);
+    expect(screen.getByText(testIdentityProviderAddress)).toBeInTheDocument();
+    expect(getSlicedAddress).not.toHaveBeenCalled();
+  });
+
+  it('use component address over identity context if both are provided', () => {
+    useIdentityContextMock.mockReturnValue({
+      address: testIdentityProviderAddress,
+    });
+    render(<Address address={testAddressComponentAddress} isSliced={false} />);
+    expect(screen.getByText(testAddressComponentAddress)).toBeInTheDocument();
     expect(getSlicedAddress).not.toHaveBeenCalled();
   });
 });

--- a/src/identity/components/Address.tsx
+++ b/src/identity/components/Address.tsx
@@ -15,7 +15,7 @@ export function Address({
     );
   }
 
-  const accountAddress = contextAddress ?? address;
+  const accountAddress = address ?? contextAddress;
 
   return (
     <span data-testid="ockAddress" className={cn(text.label2, className)}>

--- a/src/identity/components/Avatar.tsx
+++ b/src/identity/components/Avatar.tsx
@@ -30,7 +30,7 @@ export function Avatar({
 
   // The component first attempts to retrieve the ENS name and avatar for the given Ethereum address.
   const { data: name, isLoading: isLoadingName } = useName({
-    address: contextAddress ?? address,
+    address: address ?? contextAddress,
   });
   const { data: avatar, isLoading: isLoadingAvatar } = useAvatar(
     { ensName: name ?? '' },
@@ -80,7 +80,7 @@ export function Avatar({
         )}
       </div>
       {badge && (
-        <DisplayBadge address={contextAddress ?? address}>
+        <DisplayBadge address={address ?? contextAddress}>
           <div
             data-testid="ockAvatar_BadgeContainer"
             className="-bottom-0.5 -right-0.5 absolute flex h-[15px] w-[15px] items-center justify-center rounded-full bg-transparent"

--- a/src/identity/components/DisplayBadge.test.tsx
+++ b/src/identity/components/DisplayBadge.test.tsx
@@ -10,6 +10,10 @@ import { useOnchainKit } from '../../useOnchainKit';
 import { useAttestations } from '../hooks/useAttestations';
 import { useIdentityContext } from './IdentityProvider';
 
+function mock<T>(func: T) {
+  return func as vi.Mock;
+}
+
 vi.mock('../../useOnchainKit', () => ({
   useOnchainKit: vi.fn(),
 }));
@@ -20,21 +24,28 @@ vi.mock('./IdentityProvider', () => ({
   useIdentityContext: vi.fn(),
 }));
 
+const useIdentityContextMock = mock(useIdentityContext);
+const useOnchainKitMock = mock(useOnchainKit);
+const useAttestationsMock = mock(useAttestations);
+
 describe('DisplayBadge', () => {
+  const testIdentityProviderAddress = '0xIdentityAddress';
+  const testDisplayBadgeComponentAddress = '0xDisplayBadgeAddress';
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should throw an error if neither contextSchemaId nor schemaId is provided', () => {
-    (useOnchainKit as vi.Mock).mockReturnValue({
+    useOnchainKitMock.mockReturnValue({
       chain: 'test-chain',
       schemaId: null,
     });
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    useIdentityContextMock.mockReturnValue({
       schemaId: null,
-      address: '0x123',
+      address: testIdentityProviderAddress,
     });
-    (useAttestations as vi.Mock).mockReturnValue([]);
+    useAttestationsMock.mockReturnValue([]);
 
     expect(() =>
       render(
@@ -48,15 +59,15 @@ describe('DisplayBadge', () => {
   });
 
   it('should return null if attestations are empty', () => {
-    (useOnchainKit as vi.Mock).mockReturnValue({
+    useOnchainKitMock.mockReturnValue({
       chain: 'test-chain',
       schemaId: 'test-schema-id',
     });
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    useIdentityContextMock.mockReturnValue({
       schemaId: null,
-      address: '0x123',
+      address: testIdentityProviderAddress,
     });
-    (useAttestations as vi.Mock).mockReturnValue([]);
+    useAttestationsMock.mockReturnValue([]);
 
     const { container } = render(
       <DisplayBadge>
@@ -67,15 +78,15 @@ describe('DisplayBadge', () => {
   });
 
   it('should render children if attestations are not empty', () => {
-    (useOnchainKit as vi.Mock).mockReturnValue({
+    useOnchainKitMock.mockReturnValue({
       chain: 'test-chain',
       schemaId: 'test-schema-id',
     });
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    useIdentityContextMock.mockReturnValue({
       schemaId: null,
-      address: '0x123',
+      address: testIdentityProviderAddress,
     });
-    (useAttestations as vi.Mock).mockReturnValue(['attestation1']);
+    useAttestationsMock.mockReturnValue(['attestation1']);
 
     render(
       <DisplayBadge>
@@ -83,5 +94,41 @@ describe('DisplayBadge', () => {
       </DisplayBadge>,
     );
     expect(screen.getByTestId('ockBadge')).toBeInTheDocument();
+  });
+
+  it('use identity context address if provided', () => {
+    useIdentityContextMock.mockReturnValue({
+      address: testIdentityProviderAddress,
+    });
+
+    render(
+      <DisplayBadge>
+        <Badge />
+      </DisplayBadge>,
+    );
+
+    expect(useAttestations).toHaveBeenCalledWith({
+      address: testIdentityProviderAddress,
+      chain: 'test-chain',
+      schemaId: 'test-schema-id',
+    });
+  });
+
+  it('use component address over identity context if both are provided', () => {
+    useIdentityContextMock.mockReturnValue({
+      address: testIdentityProviderAddress,
+    });
+
+    render(
+      <DisplayBadge address={testDisplayBadgeComponentAddress}>
+        <Badge />
+      </DisplayBadge>,
+    );
+
+    expect(useAttestations).toHaveBeenCalledWith({
+      address: testDisplayBadgeComponentAddress,
+      chain: 'test-chain',
+      schemaId: 'test-schema-id',
+    });
   });
 });

--- a/src/identity/components/DisplayBadge.tsx
+++ b/src/identity/components/DisplayBadge.tsx
@@ -19,7 +19,7 @@ export function DisplayBadge({ children, address }: DisplayBadgeReact) {
     );
   }
   const attestations = useAttestations({
-    address: contextAddress ?? address,
+    address: address ?? contextAddress,
     chain: chain,
     schemaId: contextSchemaId ?? schemaId,
   });

--- a/src/identity/components/EthBalance.test.tsx
+++ b/src/identity/components/EthBalance.test.tsx
@@ -37,6 +37,8 @@ const useIdentityContextMock = mock(useIdentityContext);
 const useGetETHBalanceMock = mock(useGetETHBalance);
 
 describe('EthBalance', () => {
+  const testIdentityProviderAddress = '0xIdentityAddress';
+  const testEthBalanceComponentAddress = '0xEthBalanceComponentAddress';
   it('should throw an error if no address is provided', () => {
     useIdentityContextMock.mockReturnValue({ address: null });
 
@@ -50,7 +52,6 @@ describe('EthBalance', () => {
   });
 
   it('should display the balance if provided', () => {
-    const address = '0x1234567890abcdef';
     const balance = 1.23456789;
     useIdentityContextMock.mockReturnValue({ address: null });
     useGetETHBalanceMock.mockReturnValue({
@@ -59,13 +60,17 @@ describe('EthBalance', () => {
     });
     (getRoundedAmount as vi.Mock).mockReturnValue('1.2346');
 
-    render(<EthBalance address={address} className="custom-class" />);
+    render(
+      <EthBalance
+        address={testEthBalanceComponentAddress}
+        className="custom-class"
+      />,
+    );
 
     expect(screen.getByText('1.2346 ETH')).toBeInTheDocument();
   });
 
   it('should return null if balance is undefined or there is an error', () => {
-    const address = '0x1234567890abcdef';
     useIdentityContextMock.mockReturnValue({ address: null });
     useGetETHBalanceMock.mockReturnValue({
       convertedBalance: undefined,
@@ -73,8 +78,52 @@ describe('EthBalance', () => {
     });
 
     const { container } = render(
-      <EthBalance address={address} className="custom-class" />,
+      <EthBalance
+        address={testEthBalanceComponentAddress}
+        className="custom-class"
+      />,
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it('use identity context address if provided', () => {
+    const balance = 1.23456789;
+    useIdentityContextMock.mockReturnValue({
+      address: testIdentityProviderAddress,
+    });
+    useGetETHBalanceMock.mockReturnValue({
+      convertedBalance: balance,
+      error: null,
+    });
+    (getRoundedAmount as vi.Mock).mockReturnValue('1.2346');
+
+    render(<EthBalance className="custom-class" />);
+
+    expect(useGetETHBalanceMock).toHaveBeenCalledWith(
+      testIdentityProviderAddress,
+    );
+  });
+
+  it('use component address over identity context if both are provided', () => {
+    const balance = 1.23456789;
+    useIdentityContextMock.mockReturnValue({
+      address: testIdentityProviderAddress,
+    });
+    useGetETHBalanceMock.mockReturnValue({
+      convertedBalance: balance,
+      error: null,
+    });
+    (getRoundedAmount as vi.Mock).mockReturnValue('1.2346');
+
+    render(
+      <EthBalance
+        className="custom-class"
+        address={testEthBalanceComponentAddress}
+      />,
+    );
+
+    expect(useGetETHBalanceMock).toHaveBeenCalledWith(
+      testEthBalanceComponentAddress,
+    );
   });
 });

--- a/src/identity/components/EthBalance.tsx
+++ b/src/identity/components/EthBalance.tsx
@@ -12,7 +12,7 @@ export function EthBalance({ address, className }: EthBalanceReact) {
   }
 
   const { convertedBalance: balance, error } = useGetETHBalance(
-    contextAddress ?? address,
+    address ?? contextAddress,
   );
 
   if (!balance || error) {

--- a/src/identity/components/Identity.tsx
+++ b/src/identity/components/Identity.tsx
@@ -2,6 +2,7 @@ import type { IdentityReact } from '../types';
 import { IdentityProvider } from './IdentityProvider';
 import { IdentityLayout } from './IdentityLayout';
 import { useCallback } from 'react';
+import { useOnchainKit } from '../../useOnchainKit';
 
 export function Identity({
   address,
@@ -9,8 +10,13 @@ export function Identity({
   className,
   schemaId,
   hasCopyAddressOnClick = false,
+  chain,
 }: IdentityReact) {
   // istanbul ignore next
+  const { chain: contextChain } = useOnchainKit();
+
+  const accountChain = contextChain || chain;
+
   const handleCopy = useCallback(async () => {
     if (!address) return false;
 
@@ -27,7 +33,11 @@ export function Identity({
   const onClick = hasCopyAddressOnClick ? handleCopy : undefined;
 
   return (
-    <IdentityProvider address={address} schemaId={schemaId}>
+    <IdentityProvider
+      address={address}
+      schemaId={schemaId}
+      chain={accountChain}
+    >
       <IdentityLayout className={className} onClick={onClick}>
         {children}
       </IdentityLayout>

--- a/src/identity/components/IdentityProvider.test.tsx
+++ b/src/identity/components/IdentityProvider.test.tsx
@@ -4,23 +4,26 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { render, renderHook } from '@testing-library/react';
-import type { Address } from 'viem';
+import type { Address, Chain } from 'viem';
 import { IdentityProvider, useIdentityContext } from './IdentityProvider';
+import { baseSepolia } from 'viem/chains';
 
 describe('IdentityProvider', () => {
   it('provides context values from props', () => {
     const address: Address = '0x1234567890abcdef1234567890abcdef12345678';
     const schemaId: Address = '0xabcdefabcdefabcdefabcdefabcdefabcdef';
+    const chain: Chain = baseSepolia;
 
     const { result } = renderHook(() => useIdentityContext(), {
       wrapper: ({ children }) => (
-        <IdentityProvider address={address} schemaId={schemaId}>
+        <IdentityProvider address={address} schemaId={schemaId} chain={chain}>
           {children}
         </IdentityProvider>
       ),
     });
     expect(result.current.address).toEqual(address);
     expect(result.current.schemaId).toEqual(schemaId);
+    expect(result.current.chain.id).toEqual(chain.id);
   });
 
   it('should return default context when no props are passed', () => {
@@ -35,5 +38,6 @@ describe('IdentityProvider', () => {
     });
     expect(result.current.address).toEqual('');
     expect(result.current.schemaId).toEqual(undefined);
+    expect(result.current.chain.id).toEqual(84532); // defaults to base
   });
 });

--- a/src/identity/components/IdentityProvider.test.tsx
+++ b/src/identity/components/IdentityProvider.test.tsx
@@ -6,7 +6,8 @@ import '@testing-library/jest-dom';
 import { render, renderHook } from '@testing-library/react';
 import type { Address, Chain } from 'viem';
 import { IdentityProvider, useIdentityContext } from './IdentityProvider';
-import { baseSepolia } from 'viem/chains';
+import { baseSepolia, optimism, sepolia } from 'viem/chains';
+import { OnchainKitProvider } from '../../OnchainKitProvider';
 
 describe('IdentityProvider', () => {
   it('provides context values from props', () => {
@@ -27,17 +28,37 @@ describe('IdentityProvider', () => {
   });
 
   it('should return default context when no props are passed', () => {
-    render(
-      <IdentityProvider>
-        <div />
-      </IdentityProvider>,
-    );
-
     const { result } = renderHook(() => useIdentityContext(), {
       wrapper: IdentityProvider,
     });
     expect(result.current.address).toEqual('');
     expect(result.current.schemaId).toEqual(undefined);
     expect(result.current.chain.id).toEqual(84532); // defaults to base
+  });
+
+  it('use onchainkit context chain if provided', () => {
+    const { result } = renderHook(() => useIdentityContext(), {
+      wrapper: ({ children }) => (
+        <OnchainKitProvider chain={optimism}>
+          <IdentityProvider>{children}</IdentityProvider>
+        </OnchainKitProvider>
+      ),
+    });
+    expect(result.current.address).toEqual('');
+    expect(result.current.schemaId).toEqual(undefined);
+    expect(result.current.chain.id).toEqual(optimism.id);
+  });
+
+  it('use identity context chain over onchainkit context if both are provided', () => {
+    const { result } = renderHook(() => useIdentityContext(), {
+      wrapper: ({ children }) => (
+        <OnchainKitProvider chain={optimism}>
+          <IdentityProvider chain={sepolia}>{children}</IdentityProvider>
+        </OnchainKitProvider>
+      ),
+    });
+    expect(result.current.address).toEqual('');
+    expect(result.current.schemaId).toEqual(undefined);
+    expect(result.current.chain.id).toEqual(sepolia.id);
   });
 });

--- a/src/identity/components/IdentityProvider.tsx
+++ b/src/identity/components/IdentityProvider.tsx
@@ -24,9 +24,9 @@ export function IdentityProvider(props: IdentityProvider) {
   const { chain: contextChain } = useOnchainKit();
   const value = useValue({
     address,
+    chain: props.chain ?? contextChain,
     schemaId: props.schemaId,
     setAddress,
-    chain: props.chain || contextChain,
   });
 
   return (

--- a/src/identity/components/IdentityProvider.tsx
+++ b/src/identity/components/IdentityProvider.tsx
@@ -1,7 +1,8 @@
 import { type ReactNode, useState, createContext, useContext } from 'react';
-import type { Address } from 'viem';
+import type { Address, Chain } from 'viem';
 import { useValue } from '../../internal/hooks/useValue';
 import type { IdentityContextType } from '../types';
+import { useOnchainKit } from '../../useOnchainKit';
 
 const emptyContext = {} as IdentityContextType;
 
@@ -15,15 +16,17 @@ type IdentityProvider = {
   address?: Address;
   children: ReactNode;
   schemaId?: Address | null;
+  chain?: Chain;
 };
 
 export function IdentityProvider(props: IdentityProvider) {
   const [address, setAddress] = useState(props.address ?? ('' as Address));
-
+  const { chain: contextChain } = useOnchainKit();
   const value = useValue({
     address,
     schemaId: props.schemaId,
     setAddress,
+    chain: props.chain || contextChain,
   });
 
   return (

--- a/src/identity/components/IdentityProvider.tsx
+++ b/src/identity/components/IdentityProvider.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useState, createContext, useContext } from 'react';
 import type { Address, Chain } from 'viem';
 import { useValue } from '../../internal/hooks/useValue';
-import type { IdentityContextType } from '../types';
+import type { IdentityContextType, IdentityProviderReact } from '../types';
 import { useOnchainKit } from '../../useOnchainKit';
 
 const emptyContext = {} as IdentityContextType;
@@ -12,14 +12,7 @@ export function useIdentityContext() {
   return useContext(IdentityContext);
 }
 
-type IdentityProvider = {
-  address?: Address;
-  children: ReactNode;
-  schemaId?: Address | null;
-  chain?: Chain;
-};
-
-export function IdentityProvider(props: IdentityProvider) {
+export function IdentityProvider(props: IdentityProviderReact) {
   const [address, setAddress] = useState(props.address ?? ('' as Address));
   const { chain: contextChain } = useOnchainKit();
   const value = useValue({

--- a/src/identity/components/Name.tsx
+++ b/src/identity/components/Name.tsx
@@ -23,8 +23,8 @@ export function Name({
     );
   }
 
-  const accountAddress = contextAddress ?? address;
-  const accountChain = contextChain ?? chain;
+  const accountAddress = address ?? contextAddress;
+  const accountChain = chain ?? contextChain;
 
   const { data: name, isLoading } = useName({
     address: accountAddress,

--- a/src/identity/components/Name.tsx
+++ b/src/identity/components/Name.tsx
@@ -16,7 +16,7 @@ export function Name({
   chain,
   ...props
 }: NameReact) {
-  const { address: contextAddress } = useIdentityContext();
+  const { address: contextAddress, chain: contextChain } = useIdentityContext();
   if (!contextAddress && !address) {
     throw new Error(
       'Name: an Ethereum address must be provided to the Identity or Name component.',
@@ -24,10 +24,11 @@ export function Name({
   }
 
   const accountAddress = contextAddress ?? address;
+  const accountChain = contextChain ?? chain;
 
   const { data: name, isLoading } = useName({
     address: accountAddress,
-    chain,
+    chain: accountChain,
   });
 
   const badge = useMemo(() => {

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -130,6 +130,16 @@ export type IdentityContextType = {
 /**
  * Note: exported as public Type
  */
+export type IdentityProviderReact = {
+  address?: Address;
+  children: ReactNode;
+  schemaId?: Address | null;
+  chain?: Chain;
+};
+
+/**
+ * Note: exported as public Type
+ */
 export type IdentityReact = {
   address?: Address; // The Ethereum address to fetch the avatar and name for.
   chain?: Chain; // Optional chain for domain resolution

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -124,6 +124,7 @@ export type IdentityContextType = {
   address: Address; // The Ethereum address to fetch the avatar and name for.
   schemaId?: Address | null; // The Ethereum address of the schema to use for EAS attestation.
   setAddress: Dispatch<SetStateAction<Address>>;
+  chain?: Chain; // Optional chain for domain resolution
 };
 
 /**
@@ -132,6 +133,7 @@ export type IdentityContextType = {
 export type IdentityReact = {
   address?: Address; // The Ethereum address to fetch the avatar and name for.
   children: ReactNode;
+  chain?: Chain; // Optional chain for domain resolution
   className?: string; // Optional className override for top div element.
   schemaId?: Address | null; // The Ethereum address of the schema to use for EAS attestation.
   hasCopyAddressOnClick?: boolean;

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -122,9 +122,9 @@ export type GetNameReturnType = string | null;
  */
 export type IdentityContextType = {
   address: Address; // The Ethereum address to fetch the avatar and name for.
+  chain?: Chain; // Optional chain for domain resolution
   schemaId?: Address | null; // The Ethereum address of the schema to use for EAS attestation.
   setAddress: Dispatch<SetStateAction<Address>>;
-  chain?: Chain; // Optional chain for domain resolution
 };
 
 /**
@@ -132,8 +132,8 @@ export type IdentityContextType = {
  */
 export type IdentityReact = {
   address?: Address; // The Ethereum address to fetch the avatar and name for.
-  children: ReactNode;
   chain?: Chain; // Optional chain for domain resolution
+  children: ReactNode;
   className?: string; // Optional className override for top div element.
   schemaId?: Address | null; // The Ethereum address of the schema to use for EAS attestation.
   hasCopyAddressOnClick?: boolean;
@@ -145,8 +145,8 @@ export type IdentityReact = {
 export type NameReact = {
   address?: Address | null; // Ethereum address to be displayed.
   children?: ReactNode; // Optional attestation by passing Badge component as its children
-  className?: string; // Optional className override for top span element.
   chain?: Chain; // Optional chain for domain resolution
+  className?: string; // Optional className override for top span element.
 } & HTMLAttributes<HTMLSpanElement>; // Optional additional span attributes to apply to the name.
 
 /**


### PR DESCRIPTION
**What changed? Why?**

- **feat**: Added `chain` option to `<IdentityProvider>` for L2 chain name resolution support.
- **feat**: Added `chain` option to `<Identity>` component for L2 chain name resolution support.
- **fix**: Modify `<Name>` to prioritize its own address/chain props over the provider's. 
- **fix**: Modify `<Address>`, `<Avatar>`, `<EthBalance>` to prioritize its own address prop over the provider's. 

**Notes to reviewers**

**How has it been tested?**
Locally 100% test passing / coverage