### PR TITLE
docs: Swap introduction page

### DIFF
--- a/.changeset/nice-fireants-rescue.md
+++ b/.changeset/nice-fireants-rescue.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**docs**: Add Swap introduction page. By @cpcramer #788

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -230,5 +230,5 @@ Get started with ready-to-use onchain components.
 - [**`Identity`**](/identity/introduction) - Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
 - [**`Wallet`**](/wallet/wallet) - Create or connect your wallet with [Connect Wallet](/wallet/wallet).
 - [**`Tokens`**](/token/introduction) - Search [Tokens](/token/types#token) using [getTokens](/token/get-tokens) and display them with [TokenSearch](/token/token-search), [TokenChip](/token/token-chip), and [TokenRow](/token/token-row).
-- [**`Swap`**](/swap/swap) - Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
+- [**`Swap`**](/swap/introduction) - Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
 - [**`Frame`**](/frame/frame-metadata) - Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -276,7 +276,7 @@ setFilteredTokens(filteredTokens);
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
     </p>
-    <a href="/swap/swap" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]">
+    <a href="/swap/introduction" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]">
       Start with Swap
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px] md:pt-[20px]">

--- a/site/docs/pages/swap/introduction.mdx
+++ b/site/docs/pages/swap/introduction.mdx
@@ -2,11 +2,12 @@
 title: Swap components & utilities · OnchainKit
 description: Introduction to Swap components & utilities
 ---
+
 import App from '../../components/App';
+import SwapWrapper from '../../components/SwapWrapper';
 import { Avatar, Name } from '@coinbase/onchainkit/identity';
 import { Swap, SwapAmountInput, SwapButton, SwapMessage, SwapToggleButton } from '@coinbase/onchainkit/swap';
-import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
-import SwapWrapper from '../../components/SwapWrapper';
+import { ConnectWallet, Wallet } from '@coinbase/onchainkit/wallet';
 
 # Introduction to Swap components & utilities
 
@@ -18,9 +19,9 @@ The available components are:
 
 - `<Swap />` - Set the user's address and error handling.
 - `<SwapAmountInput />` - Set the [Token](/token/types#token) to swap and specify the input type (`from` or `to`).
-- `<SwapToggleButton />` - Optional component to toggle between input types.
-- `<SwapMessage />` - Optional component that displays a message related to the swap operation's current state.
 - `<SwapButton />` - Set the onSubmit and onError callbacks.
+- `<SwapMessage />` - Optional component that displays a message related to the swap operation's current state.
+- `<SwapToggleButton />` - Optional component to toggle between input types.
 
 ```tsx
 <Swap address={address}> // [!code focus]
@@ -82,8 +83,8 @@ The available components are:
 
 The available utilities are:
 
-- [`getSwapQuote`](/swap/get-swap-quote): Get a quote for a swap between two Tokens.
 - [`buildSwapTransaction`](/swap/build-swap-transaction): Get an unsigned transaction for a swap between two Tokens.
+- [`getSwapQuote`](/swap/get-swap-quote): Get a quote for a swap between two Tokens.
 
 ## Required providers
 

--- a/site/docs/pages/swap/introduction.mdx
+++ b/site/docs/pages/swap/introduction.mdx
@@ -1,0 +1,109 @@
+---
+title: Swap components & utilities · OnchainKit
+description: Introduction to Swap components & utilities
+---
+import App from '../../components/App';
+import { Avatar, Name } from '@coinbase/onchainkit/identity';
+import { Swap, SwapAmountInput, SwapButton, SwapMessage, SwapToggleButton } from '@coinbase/onchainkit/swap';
+import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
+import SwapWrapper from '../../components/SwapWrapper';
+
+# Introduction to Swap components & utilities
+
+OnchainKit provides TypeScript utilities and React components to help you build applications to execute Token swaps.
+
+## Components
+
+The available components are:
+
+- `<Swap />` - Set the user's address and error handling.
+- `<SwapAmountInput />` - Set the [Token](/token/types#token) to swap and specify the input type (`from` or `to`).
+- `<SwapToggleButton />` - Optional component to toggle between input types.
+- `<SwapMessage />` - Optional component that displays a message related to the swap operation's current state.
+- `<SwapButton />` - Set the onSubmit and onError callbacks.
+
+```tsx
+<Swap address={address}> // [!code focus]
+  <SwapAmountInput // [!code focus]
+    label="Sell" // [!code focus]
+    swappableTokens={swappableTokens} // [!code focus]
+    token={ETHToken} // [!code focus]
+    type="from" // [!code focus]
+  /> // [!code focus]
+  <SwapToggleButton /> // [!code focus]
+  <SwapAmountInput // [!code focus]
+    label="Buy" // [!code focus]
+    swappableTokens={swappableTokens} // [!code focus]
+    token={USDCToken} // [!code focus]
+    type="to" // [!code focus]
+  /> // [!code focus]
+  <SwapButton onSubmit={onSubmit} /> // [!code focus]
+  <SwapMessage /> // [!code focus]
+</Swap> // [!code focus]
+```
+      
+<App>
+  <SwapWrapper>
+    {({ address, swappableTokens }) => {
+      if (address) {
+        return (
+          <Swap address={address}>
+            <SwapAmountInput
+              label="Sell"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[1]}
+              type="from"
+            />
+            <SwapToggleButton />
+            <SwapAmountInput
+              label="Buy"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[2]}
+              type="to"
+            />
+            <SwapButton />
+            <SwapMessage />
+          </Swap>
+        )
+      }
+      return <>
+        <Wallet>
+          <ConnectWallet>
+            <Avatar className="h-6 w-6" />
+            <Name />
+          </ConnectWallet>
+        </Wallet>
+      </>;
+    }}
+  </SwapWrapper>
+</App>
+
+## Utilities
+
+The available utilities are:
+
+- [`getSwapQuote`](/swap/get-swap-quote): Get a quote for a swap between two Tokens.
+- [`buildSwapTransaction`](/swap/build-swap-transaction): Get an unsigned transaction for a swap between two Tokens.
+
+## Required providers
+
+If you are using any of the provided components, you will need to install and configure `@tanstack/react-query` and wrap your app in `<QueryClientProvider>`.
+
+```tsx
+import { Avatar } from '@coinbase/onchainkit/identity';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Create a client
+const queryClient = new QueryClient();
+
+function App() {
+  return (
+    // Provide the client to your App
+    <QueryClientProvider client={queryClient}>
+      <Avatar address="0x1234567890abcdef1234567890abcdef12345678" />
+    </QueryClientProvider>
+  );
+}
+```
+
+See [Tanstack Query documentation](https://tanstack.com/query/v5/docs/framework/react/quick-start) for more info.

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -153,6 +153,7 @@ export const sidebar = [
   {
     text: 'Swap',
     items: [
+      { text: 'Introduction', link: '/swap/introduction' },
       {
         text: 'Components',
         items: [
@@ -181,7 +182,7 @@ export const sidebar = [
         link: '/swap/types',
       },
     ],
-    link: '/swap/swap',
+    link: '/swap/introduction',
   },
   {
     text: 'Token',


### PR DESCRIPTION
**What changed? Why?**
Add Swap introduction page 

We want to ensure that all of the components in the sidebar in docs are formatted appropriately with an "introduction" page like "Identity" and "Token" components. This updates the Swap component to be consistent with the other formats. 

**Notes to reviewers**

**How has it been tested?**
<img width="416" alt="Screenshot 2024-07-12 at 11 45 27 AM" src="https://github.com/user-attachments/assets/4f66a6ec-dfbb-4dac-b380-0fd7729e4a7c">
