### PR TITLE
Feat: getName: Default to ENS name when custom chain name is not available

### DIFF
--- a/.changeset/tame-suns-rule.md
+++ b/.changeset/tame-suns-rule.md
@@ -1,0 +1,4 @@
+---
+"@coinbase/onchainkit": patch
+---
+- **fix**: Modified `getName` to default to ENS name when custom chain name is not available. By @kirkas #792

--- a/src/identity/core/getName.test.tsx
+++ b/src/identity/core/getName.test.tsx
@@ -92,6 +92,17 @@ describe('getName', () => {
   it('should return null if user is not registered', async () => {
     const expectedEnsName = null;
     mockReadContract.mockResolvedValue(expectedEnsName);
+    mockGetEnsName.mockResolvedValue(expectedEnsName);
+    const name = await getName({ address: walletAddress, chain: base });
+    expect(name).toBe(expectedEnsName);
+    expect(getChainPublicClient).toHaveBeenCalledWith(base);
+  });
+
+  it('should default to ENS name if custom chain name is not registered', async () => {
+    const expectedBaseName = null;
+    const expectedEnsName = 'registered.eth';
+    mockReadContract.mockResolvedValue(expectedBaseName);
+    mockGetEnsName.mockResolvedValue(expectedEnsName);
     const name = await getName({ address: walletAddress, chain: base });
     expect(name).toBe(expectedEnsName);
     expect(getChainPublicClient).toHaveBeenCalledWith(base);

--- a/src/identity/core/getName.ts
+++ b/src/identity/core/getName.ts
@@ -39,11 +39,11 @@ export const getName = async ({
     });
 
     if (baseName) {
-      return baseName
-    } else {
-      // Default to mainnet
-      client = getChainPublicClient(mainnet)
+      return baseName;
     }
+
+    // Default to mainnet
+    client = getChainPublicClient(mainnet);
   }
 
   // ENS username

--- a/src/identity/core/getName.ts
+++ b/src/identity/core/getName.ts
@@ -27,7 +27,7 @@ export const getName = async ({
     );
   }
 
-  const client = getChainPublicClient(chain);
+  let client = getChainPublicClient(chain);
 
   if (chainIsBase) {
     const addressReverseNode = convertReverseNodeToBytes(address);
@@ -38,7 +38,12 @@ export const getName = async ({
       args: [addressReverseNode],
     });
 
-    if (baseName) return baseName;
+    if (baseName) {
+      return baseName
+    } else {
+      // Default to mainnet
+      client = getChainPublicClient(mainnet)
+    }
   }
 
   // ENS username

--- a/src/identity/core/getName.ts
+++ b/src/identity/core/getName.ts
@@ -31,14 +31,14 @@ export const getName = async ({
 
   if (chainIsBase) {
     const addressReverseNode = convertReverseNodeToBytes(address);
-
-    const baseEnsName = await client.readContract({
+    const baseName = await client.readContract({
       abi: L2ResolverAbi,
       address: RESOLVER_ADDRESSES_BY_CHAIN_ID[chain.id],
       functionName: 'name',
       args: [addressReverseNode],
     });
-    return baseEnsName ?? null;
+
+    if (baseName) return baseName;
   }
 
   // ENS username

--- a/src/identity/hooks/useName.test.tsx
+++ b/src/identity/hooks/useName.test.tsx
@@ -79,6 +79,30 @@ describe('useName', () => {
     });
   });
 
+  it('default to ENS name if custom chain name is not registered', async () => {
+    const testCustomChainEnsName = undefined;
+    const testEnsName = 'ethereum.eth';
+
+    // Mock the getEnsName method of the publicClient
+    mockReadContract.mockResolvedValue(testCustomChainEnsName);
+    mockGetEnsName.mockResolvedValue(testEnsName);
+
+    // Use the renderHook function to create a test harness for the useName hook
+    const { result } = renderHook(
+      () => useName({ address: testAddress, chain: base }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    // Wait for the hook to finish fetching the ENS name
+    await waitFor(() => {
+      // Check that the ENS name and loading state are correct
+      expect(result.current.data).toBe(testEnsName);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
   it('returns error for unsupported chain ', async () => {
     // Use the renderHook function to create a test harness for the useName hook
     const { result } = renderHook(


### PR DESCRIPTION
**What changed? Why?**
- **fix**: Modified `getName` to default to ENS name when custom chain name is not available.

**How has it been tested?**
Add tests, 100% coverage