### PR TITLE
Fix: Update type documentation for custom chain name resolution

### DIFF
--- a/.changeset/flat-readers-reflect.md
+++ b/.changeset/flat-readers-reflect.md
@@ -1,0 +1,4 @@
+---
+"@coinbase/onchainkit": patch
+---
+- **fix**: Update type documentation for `useName`, `getName`, `<Name>` & `<Identity/>`. By @kirkas #804

--- a/site/docs/pages/identity/types.mdx
+++ b/site/docs/pages/identity/types.mdx
@@ -86,6 +86,7 @@ type GetAvatarReturnType = string | null;
 ```ts
 type GetName = {
   address: Address;
+  chain?: Chain;
 };
 ```
 
@@ -108,19 +109,22 @@ type IdentityContextType = {
 
 ```ts
 type IdentityReact = {
-  address: Address; // The Ethereum address to fetch the avatar and name for.
+  address?: Address; // The Ethereum address to fetch the avatar and name for.
+  chain?: Chain; // Optional chain for domain resolution
   children: ReactNode;
   className?: string; // Optional className override for top div element.
   schemaId?: Address | null; // The Ethereum address of the schema to use for EAS attestation.
+  hasCopyAddressOnClick?: boolean;
 };
 ```
 
 ## `NameReact`
 
 ```ts
-export type NameReact = {
+type NameReact = {
   address?: Address | null; // Ethereum address to be displayed.
-  className?: string; // Optional className override for top span element.
   children?: ReactNode; // Optional attestation by passing Badge component as its children
+  chain?: Chain; // Optional chain for domain resolution
+  className?: string; // Optional className override for top span element.
 } & HTMLAttributes<HTMLSpanElement>; // Optional additional span attributes to apply to the name.
 ```

--- a/site/docs/pages/identity/use-name.mdx
+++ b/site/docs/pages/identity/use-name.mdx
@@ -19,7 +19,8 @@ const { data: name, isLoading } = useName({ address: '0x1234' });
 
 ```ts
 type UseNameOptions = {
-  address: `0x${string}`;
+  address: Address; // The Ethereum address for which the ENS name is to be fetched.
+  chain?: Chain; // Optional chain for domain resolution
 };
 
 type UseNameQueryOptions = {


### PR DESCRIPTION
**What changed? Why?**
- **fix**: Update type documentation for `useName`, `getName`, `<Name>` & `<Identity/>`


