### PR TITLE
docs: Add Terms of Service

### DIFF
--- a/.changeset/forty-carpets-double.md
+++ b/.changeset/forty-carpets-double.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
--**docs**: Add Terms of Service. By @cpcramer #000
+-**docs**: Add Terms of Service. By @cpcramer #806

--- a/.changeset/forty-carpets-double.md
+++ b/.changeset/forty-carpets-double.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**docs**: Add Terms of Service. By @cpcramer #000

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -491,5 +491,10 @@ setFilteredTokens(filteredTokens);
     <p className="leading-7 text-xl text-gray-400 px-0 pt-16">
       This project is licensed under the MIT License - see the [LICENSE.md](https://github.com/coinbase/onchainkit/blob/main/LICENSE.md) file for details.
     </p>
+    <p className="leading-7 text-xl text-gray-400 px-0 pt-4">
+      <a href="https://docs.base.org/docs/terms-of-service" target="_blank" rel="noopener noreferrer">
+        Terms of Service
+      </a>
+    </p>
   </footer>
 </main>


### PR DESCRIPTION
**What changed? Why?**
Add Terms of Service to the landing page footer.
- The link points towards the Base docs Terms of Service - https://docs.base.org/docs/terms-of-service/

**Notes to reviewers**

**How has it been tested?**

<img width="1581" alt="Screenshot 2024-07-15 at 10 40 44 AM" src="https://github.com/user-attachments/assets/233b2b5a-366e-4321-9b5a-162baa7e554d">
