### PR TITLE
chore: Add Identity.tsx unit tests

### DIFF
--- a/.changeset/big-worms-sparkle.md
+++ b/.changeset/big-worms-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**chore**: Add Identity unit tests. By @cpcramer #807

--- a/src/identity/components/Identity.test.tsx
+++ b/src/identity/components/Identity.test.tsx
@@ -160,20 +160,20 @@ describe('Identity Component', () => {
     render(
       <Identity address="0x123456789" hasCopyAddressOnClick={true}>
         <div>Child Component</div>
-      </Identity>
+      </Identity>,
     );
 
     const identityLayout = screen.getByTestId('ockIdentity_container');
     fireEvent.click(identityLayout);
 
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("0x123456789");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('0x123456789');
   });
 
   it('should not call handleCopy when address is not provided', async () => {
     render(
       <Identity address={null} hasCopyAddressOnClick={true}>
         <div>Child Component</div>
-      </Identity>
+      </Identity>,
     );
 
     const identityLayout = screen.getByTestId('ockIdentity_container');
@@ -183,7 +183,9 @@ describe('Identity Component', () => {
   });
 
   it('should log an error and return false when clipboard write fails', async () => {
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
     Object.assign(navigator, {
       clipboard: {
         writeText: vi.fn().mockRejectedValue(new Error('Failed to copy')),
@@ -193,15 +195,18 @@ describe('Identity Component', () => {
     render(
       <Identity address="0x123456789" hasCopyAddressOnClick={true}>
         <div>Child Component</div>
-      </Identity>
+      </Identity>,
     );
 
     const identityLayout = screen.getByTestId('ockIdentity_container');
     fireEvent.click(identityLayout);
 
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("0x123456789");
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('0x123456789');
     await waitFor(() => {
-      expect(consoleErrorSpy).toHaveBeenCalledWith('Failed to copy: ', expect.any(Error));
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to copy: ',
+        expect.any(Error),
+      );
     });
   });
 });

--- a/src/identity/components/Identity.test.tsx
+++ b/src/identity/components/Identity.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Avatar } from './Avatar';
 import { Name } from './Name';
 import { Identity } from './Identity';


### PR DESCRIPTION
**What changed? Why?**
Add `Identity.tsx` unit tests to improve test coverage from 73% to 100%. Adding coverage to the `handleCopy` function.

**Notes to reviewers**

**How has it been tested?**

**Old:**

<img width="715" alt="Screenshot 2024-07-15 at 2 25 41 PM" src="https://github.com/user-attachments/assets/bdbda4a1-0a0c-4934-8f55-0c2267c4425a">

<img width="767" alt="Screenshot 2024-07-15 at 2 25 16 PM" src="https://github.com/user-attachments/assets/3cc5ef7f-4cd3-42e6-b48c-abbec69a4123">


**New:**

<img width="714" alt="Screenshot 2024-07-15 at 2 24 06 PM" src="https://github.com/user-attachments/assets/e2381e43-6c40-4060-9200-2e75735b872f">

<img width="740" alt="Screenshot 2024-07-15 at 2 23 51 PM" src="https://github.com/user-attachments/assets/c4c76714-9e03-4b38-8e54-25936da096f4">

<img width="455" alt="Screenshot 2024-07-15 at 2 22 28 PM" src="https://github.com/user-attachments/assets/e1fdf8c8-a9df-4a34-a116-c2ad36697c2b">

