### PR TITLE
chore: Ignore SVG files during testing

### DIFF
--- a/.changeset/moody-deers-occur.md
+++ b/.changeset/moody-deers-occur.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**chore**: Ignore SVG files during testing. By @cpcramer #808

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         'node_modules/**',
         'onchainkit/esm/**',
         'site/**',
+        '**/*Svg.tsx',
       ],
       reportOnFailure: true,
       thresholds: {


### PR DESCRIPTION
**What changed? Why?**
Update test coverage report to ignore our static SVG files such as `disconnectSvg.tsx` and `walletSvg.tsx`. This cleans up our test coverage report and gives us a more accurate depiction of our test coverage. 

**Notes to reviewers**

**How has it been tested?**
**Before:**
<img width="731" alt="Screenshot 2024-07-15 at 2 52 57 PM" src="https://github.com/user-attachments/assets/524aeda6-d40a-4f24-a21d-259400529b91">

<img width="833" alt="Screenshot 2024-07-15 at 2 52 43 PM" src="https://github.com/user-attachments/assets/dda7b728-668e-423c-939c-1d89e431b6b3">

**After:** 
<img width="729" alt="Screenshot 2024-07-15 at 2 50 37 PM" src="https://github.com/user-attachments/assets/31b51015-bcd0-4129-97fe-c4bd288b5891">
