### PR TITLE
chore: Add WalletDropdown Disconnect and Link tests

### DIFF
--- a/.changeset/wet-cougars-pay.md
+++ b/.changeset/wet-cougars-pay.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**chore**: Add WalletDropdown Disconnect and Link tests. By @cpcramer #810

--- a/src/wallet/components/WalletDropdownDisconnect.test.tsx
+++ b/src/wallet/components/WalletDropdownDisconnect.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useConnect, useDisconnect } from 'wagmi';
+import { WalletDropdownDisconnect } from './WalletDropdownDisconnect';
+
+vi.mock('wagmi', () => ({
+  useConnect: vi.fn(),
+  useDisconnect: vi.fn(),
+}));
+
+describe('WalletDropdownDisconnect', () => {
+  const mockDisconnect = vi.fn();
+  const mockConnect = {
+    connectors: [{ id: 'mockConnector' }],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useConnect as vi.Mock).mockReturnValue(mockConnect);
+    (useDisconnect as vi.Mock).mockReturnValue({ disconnect: mockDisconnect });
+  });
+
+  it('renders correctly with default props', () => {
+    render(<WalletDropdownDisconnect />);
+    expect(screen.getByText('Disconnect')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('renders correctly with custom text', () => {
+    render(<WalletDropdownDisconnect text="Log Out" />);
+    expect(screen.getByText('Log Out')).toBeInTheDocument();
+  });
+
+  it('calls disconnect on button click', () => {
+    render(<WalletDropdownDisconnect />);
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(mockDisconnect).toHaveBeenCalledWith({
+      connector: mockConnect.connectors[0],
+    });
+  });
+});

--- a/src/wallet/components/WalletDropdownLink.test.tsx
+++ b/src/wallet/components/WalletDropdownLink.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { WalletDropdownLink } from './WalletDropdownLink';
+
+describe('WalletDropdownLink', () => {
+  it('renders correctly with default props', () => {
+    render(
+      <WalletDropdownLink href="https://example.com">
+        Link Text
+      </WalletDropdownLink>,
+    );
+
+    const linkElement = screen.getByRole('link');
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute('href', 'https://example.com');
+    expect(screen.getByText('Link Text')).toBeInTheDocument();
+  });
+
+  it('renders correctly with icon prop', () => {
+    render(
+      <WalletDropdownLink icon="wallet" href="https://example.com">
+        Link Text
+      </WalletDropdownLink>,
+    );
+
+    const linkElement = screen.getByRole('link');
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute('href', 'https://example.com');
+    expect(screen.getByText('Link Text')).toBeInTheDocument();
+    expect(screen.getByLabelText('ock-wallet-svg')).toBeInTheDocument();
+  });
+
+  it('renders correctly with custom icon element', () => {
+    const customIcon = <svg aria-label="custom-icon" />;
+    render(
+      <WalletDropdownLink icon={customIcon} href="https://example.com">
+        Link Text
+      </WalletDropdownLink>,
+    );
+
+    const linkElement = screen.getByRole('link');
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute('href', 'https://example.com');
+    expect(screen.getByText('Link Text')).toBeInTheDocument();
+    expect(screen.getByLabelText('custom-icon')).toBeInTheDocument();
+  });
+
+  it('renders correctly with target and rel attributes', () => {
+    render(
+      <WalletDropdownLink
+        href="https://example.com"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Link Text
+      </WalletDropdownLink>,
+    );
+
+    const linkElement = screen.getByRole('link');
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute('href', 'https://example.com');
+    expect(linkElement).toHaveAttribute('target', '_blank');
+    expect(linkElement).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(screen.getByText('Link Text')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**What changed? Why?**
Add unit tests for `WalletDropdownDisconnect.tsx` and `WalletDropdownLink.tsx`.

**Notes to reviewers**

**How has it been tested?**
**Before:**
<img width="584" alt="Screenshot 2024-07-15 at 3 43 48 PM" src="https://github.com/user-attachments/assets/cedf6e28-208a-40d1-a80a-7b847d94cf43">


**After:**
<img width="590" alt="Screenshot 2024-07-15 at 3 42 51 PM" src="https://github.com/user-attachments/assets/1a5fb649-9615-4d49-b611-f182a7e58681">
