### PR TITLE
chore: add Storybook workflow doc

### DIFF
--- a/site/docs/pages/guides/contribution.mdx
+++ b/site/docs/pages/guides/contribution.mdx
@@ -65,6 +65,18 @@ onchainkit
 
 ## Workflows
 
+### Storybook
+
+Storybook is a frontend workshop for building UI components and pages in isolation. It helps you develop and share hard-to-reach states and edge cases without needing to run your whole app.
+
+To develop and test your components in Storybook, run the following command:
+
+```bash
+yarn storybook:dev
+
+# In a browser, navigate to http://localhost:6006/
+```
+
 ### Testing
 
 Write and update existing unit tests. You can watch file changes and rerun tests automatically like this:


### PR DESCRIPTION
**What changed? Why?**
Added docs for storybook workflow

<img width="600" alt="Screenshot 2024-07-15 at 9 02 42 PM" src="https://github.com/user-attachments/assets/7dbcb3a4-9c1f-443d-8b5b-41132c207245">

**How has it been tested?**
`cd site && yarn dev`