### PR TITLE
feat: Add transaction toast components

### DIFF
--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -1,8 +1,60 @@
 import App from '../../components/App';
 import { Avatar, Name } from '@coinbase/onchainkit/identity';
+import { Transaction } from '../../../../src/transaction/components/Transaction';
+import { TransactionGasFee } from '../../../../src/transaction/components/TransactionGasFee';
+import { TransactionGasFeeLabel } from '../../../../src/transaction/components/TransactionGasFeeLabel';
+import { TransactionGasFeeEstimate } from '../../../../src/transaction/components/TransactionGasFeeEstimate';
+import { TransactionGasFeeSponsoredBy } from '../../../../src/transaction/components/TransactionGasFeeSponsoredBy';
+import { TransactionButton } from '../../../../src/transaction/components/TransactionButton';
+import { TransactionStatus } from '../../../../src/transaction/components/TransactionStatus';
+import { TransactionStatusLabel } from '../../../../src/transaction/components/TransactionStatusLabel';
+import { TransactionStatusAction } from '../../../../src/transaction/components/TransactionStatusAction';
+import { TransactionToast } from '../../../../src/transaction/components/TransactionToast';
+import { TransactionToastAction } from '../../../../src/transaction/components/TransactionToastAction';
+import { TransactionToastIcon } from '../../../../src/transaction/components/TransactionToastIcon';
+import { TransactionToastLabel } from '../../../../src/transaction/components/TransactionToastLabel';
+import TransactionWrapper from '../../components/TransactionWrapper';
+import { Wallet, ConnectWallet } from '../../../../src/wallet';
 
 # `<Transaction />`
 
 :::warning
 Component is actively in development. Stay tuned for upcoming releases.
 :::
+
+<App>
+  <TransactionWrapper>
+    {({ address, contracts }) => {
+      if (address) {
+        return (
+          <Transaction address={address} contracts={contracts}>
+            <TransactionButton />
+            <TransactionGasFee>
+              <TransactionGasFeeLabel />
+              <TransactionGasFeeEstimate />
+              <TransactionGasFeeSponsoredBy />
+            </TransactionGasFee>
+            <TransactionStatus>
+              <TransactionStatusLabel />
+              <TransactionStatusAction />
+            </TransactionStatus>
+            <TransactionToast>
+              <TransactionToastIcon />
+              <TransactionToastLabel />
+              <TransactionToastAction />
+            </TransactionToast>
+          </Transaction>
+        )
+      } else {
+        return (
+          <Wallet>
+            <ConnectWallet>
+              <Avatar className="h-6 w-6" />
+              <Name />
+            </ConnectWallet>
+          </Wallet>
+        )
+      }
+    }}
+  </TransactionWrapper>
+</App>

--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -1,60 +1,6 @@
-import App from '../../components/App';
-import { Avatar, Name } from '@coinbase/onchainkit/identity';
-import { Transaction } from '../../../../src/transaction/components/Transaction';
-import { TransactionGasFee } from '../../../../src/transaction/components/TransactionGasFee';
-import { TransactionGasFeeLabel } from '../../../../src/transaction/components/TransactionGasFeeLabel';
-import { TransactionGasFeeEstimate } from '../../../../src/transaction/components/TransactionGasFeeEstimate';
-import { TransactionGasFeeSponsor } from '../../../../src/transaction/components/TransactionGasFeeSponsor';
-import { TransactionButton } from '../../../../src/transaction/components/TransactionButton';
-import { TransactionStatus } from '../../../../src/transaction/components/TransactionStatus';
-import { TransactionStatusLabel } from '../../../../src/transaction/components/TransactionStatusLabel';
-import { TransactionStatusAction } from '../../../../src/transaction/components/TransactionStatusAction';
-import { TransactionToast } from '../../../../src/transaction/components/TransactionToast';
-import { TransactionToastAction } from '../../../../src/transaction/components/TransactionToastAction';
-import { TransactionToastIcon } from '../../../../src/transaction/components/TransactionToastIcon';
-import { TransactionToastLabel } from '../../../../src/transaction/components/TransactionToastLabel';
-import TransactionWrapper from '../../components/TransactionWrapper';
-import { Wallet, ConnectWallet } from '../../../../src/wallet';
-
 # `<Transaction />`
 
 :::warning
 Component is actively in development. Stay tuned for upcoming releases.
 :::
 
-<App>
-  <TransactionWrapper>
-    {({ address, contracts }) => {
-      if (address) {
-        return (
-          <Transaction address={address} contracts={contracts}>
-            <TransactionButton />
-            <TransactionGasFee>
-              <TransactionGasFeeLabel />
-              <TransactionGasFeeEstimate />
-              <TransactionGasFeeSponsor />
-            </TransactionGasFee>
-            <TransactionStatus>
-              <TransactionStatusLabel />
-              <TransactionStatusAction />
-            </TransactionStatus>
-            <TransactionToast>
-              <TransactionToastIcon />
-              <TransactionToastLabel />
-              <TransactionToastAction />
-            </TransactionToast>
-          </Transaction>
-        )
-      } else {
-        return (
-          <Wallet>
-            <ConnectWallet>
-              <Avatar className="h-6 w-6" />
-              <Name />
-            </ConnectWallet>
-          </Wallet>
-        )
-      }
-    }}
-  </TransactionWrapper>
-</App>

--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -4,7 +4,7 @@ import { Transaction } from '../../../../src/transaction/components/Transaction'
 import { TransactionGasFee } from '../../../../src/transaction/components/TransactionGasFee';
 import { TransactionGasFeeLabel } from '../../../../src/transaction/components/TransactionGasFeeLabel';
 import { TransactionGasFeeEstimate } from '../../../../src/transaction/components/TransactionGasFeeEstimate';
-import { TransactionGasFeeSponsoredBy } from '../../../../src/transaction/components/TransactionGasFeeSponsoredBy';
+import { TransactionGasFeeSponsor } from '../../../../src/transaction/components/TransactionGasFeeSponsor';
 import { TransactionButton } from '../../../../src/transaction/components/TransactionButton';
 import { TransactionStatus } from '../../../../src/transaction/components/TransactionStatus';
 import { TransactionStatusLabel } from '../../../../src/transaction/components/TransactionStatusLabel';
@@ -32,7 +32,7 @@ Component is actively in development. Stay tuned for upcoming releases.
             <TransactionGasFee>
               <TransactionGasFeeLabel />
               <TransactionGasFeeEstimate />
-              <TransactionGasFeeSponsoredBy />
+              <TransactionGasFeeSponsor />
             </TransactionGasFee>
             <TransactionStatus>
               <TransactionStatusLabel />

--- a/src/internal/loading/Spinner.tsx
+++ b/src/internal/loading/Spinner.tsx
@@ -1,6 +1,10 @@
 import { cn } from '../../styles/theme';
 
-export function Spinner() {
+type SpinnerReact = {
+  className?: string;
+};
+
+export function Spinner({ className }: SpinnerReact) {
   return (
     <div
       className="flex h-full items-center justify-center"
@@ -10,6 +14,7 @@ export function Spinner() {
         className={cn(
           'animate-spin border-2 border-gray-200 border-t-3',
           'rounded-full border-t-blue-500 px-2.5 py-2.5',
+          className,
         )}
       />
     </div>

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -54,7 +54,7 @@ export function TransactionProvider({
       console.log({ err });
       setErrorMessage('Something went wrong');
     }
-  }, [contracts, writeContracts, setIsToastVisible, setErrorMessage]);
+  }, [contracts, writeContracts]);
 
   useEffect(() => {
     // TODO: replace with gas estimation call

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -35,6 +35,7 @@ export function TransactionProvider({
   const [errorMessage, setErrorMessage] = useState('');
   const [transactionId, setTransactionId] = useState('');
   const [gasFee, setGasFee] = useState('');
+  const [isToastVisible, setIsToastVisible] = useState(false);
 
   const { status, writeContracts } = useWriteContracts({
     setErrorMessage,
@@ -44,13 +45,16 @@ export function TransactionProvider({
   const handleSubmit = useCallback(async () => {
     try {
       setErrorMessage('');
+      setIsToastVisible(true);
       await writeContracts({
         contracts,
       });
     } catch (err) {
+      // TODO: handle error better
       console.log({ err });
+      setErrorMessage('Something went wrong');
     }
-  }, [contracts, writeContracts]);
+  }, [contracts, writeContracts, setIsToastVisible, setErrorMessage]);
 
   useEffect(() => {
     // TODO: replace with gas estimation call
@@ -64,10 +68,13 @@ export function TransactionProvider({
     errorMessage,
     gasFee,
     isLoading: status === 'pending',
+    isToastVisible,
     onSubmit: handleSubmit,
     setErrorMessage,
-    transactionId,
+    setIsToastVisible,
     setTransactionId,
+    status,
+    transactionId,
   });
 
   return (

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+import { cn } from '../../styles/theme';
+import { useTransactionContext } from './TransactionProvider';
+import type { TransactionToastReact } from '../types';
+
+const closeSVG = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M2.14921 1L1 2.1492L6.8508 8L1 13.8508L2.1492 15L8 9.1492L13.8508 15L15 13.8508L9.14921 8L15 2.1492L13.8508 1L8 6.8508L2.14921 1Z"
+      fill="#030712"
+    />
+  </svg>
+);
+
+export function TransactionToast({
+  children,
+  className,
+}: TransactionToastReact) {
+  const { isToastVisible, setIsToastVisible } = useTransactionContext();
+
+  const closeToast = useCallback(() => {
+    setIsToastVisible(false);
+  }, [setIsToastVisible]);
+
+  if (!isToastVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between rounded-lg',
+        'p-2 bg-gray-100 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.12)]',
+        'fixed -translate-x-2/4 left-2/4 bottom-5',
+        className,
+      )}
+    >
+      <div className="flex items-center p-2 gap-4">{children}</div>
+      <button className="p-2" onClick={closeToast} type="button">
+        {closeSVG}
+      </button>
+    </div>
+  );
+}

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -11,6 +11,7 @@ const closeSVG = (
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
+    <title>Close SVG</title>
     <path
       d="M2.14921 1L1 2.1492L6.8508 8L1 13.8508L2.1492 15L8 9.1492L13.8508 15L15 13.8508L9.14921 8L15 2.1492L13.8508 1L8 6.8508L2.14921 1Z"
       fill="#030712"
@@ -36,12 +37,12 @@ export function TransactionToast({
     <div
       className={cn(
         'flex items-center justify-between rounded-lg',
-        'p-2 bg-gray-100 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.12)]',
-        'fixed -translate-x-2/4 left-2/4 bottom-5',
+        'bg-gray-100 p-2 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.12)]',
+        '-translate-x-2/4 fixed bottom-5 left-2/4',
         className,
       )}
     >
-      <div className="flex items-center p-2 gap-4">{children}</div>
+      <div className="flex items-center gap-4 p-2">{children}</div>
       <button className="p-2" onClick={closeToast} type="button">
         {closeSVG}
       </button>

--- a/src/transaction/components/TransactionToastAction.tsx
+++ b/src/transaction/components/TransactionToastAction.tsx
@@ -1,0 +1,11 @@
+import { cn, text } from '../../styles/theme';
+import { useGetTransactionToast } from '../core/useGetTransactionToast';
+import type { TransactionToastActionReact } from '../types';
+
+export function TransactionToastAction({
+  className,
+}: TransactionToastActionReact) {
+  const { actionElement } = useGetTransactionToast();
+
+  return <div className={cn(text.label1, className)}>{actionElement}</div>;
+}

--- a/src/transaction/components/TransactionToastIcon.tsx
+++ b/src/transaction/components/TransactionToastIcon.tsx
@@ -1,4 +1,4 @@
-import { cn, color, text } from '../../styles/theme';
+import { cn, text } from '../../styles/theme';
 import { useGetTransactionToast } from '../core/useGetTransactionToast';
 import type { TransactionToastIconReact } from '../types';
 

--- a/src/transaction/components/TransactionToastIcon.tsx
+++ b/src/transaction/components/TransactionToastIcon.tsx
@@ -1,0 +1,8 @@
+import { cn, color, text } from '../../styles/theme';
+import { useGetTransactionToast } from '../core/useGetTransactionToast';
+import type { TransactionToastIconReact } from '../types';
+
+export function TransactionToastIcon({ className }: TransactionToastIconReact) {
+  const { icon } = useGetTransactionToast();
+  return <div className={cn(text.label2, className)}>{icon}</div>;
+}

--- a/src/transaction/components/TransactionToastLabel.tsx
+++ b/src/transaction/components/TransactionToastLabel.tsx
@@ -1,0 +1,14 @@
+import { cn, color, text } from '../../styles/theme';
+import { useGetTransactionToast } from '../core/useGetTransactionToast';
+import type { TransactionToastLabelReact } from '../types';
+
+export function TransactionToastLabel({
+  className,
+}: TransactionToastLabelReact) {
+  const { label } = useGetTransactionToast();
+  return (
+    <div className={cn(text.label1, className)}>
+      <p className={color.foreground}>{label}</p>
+    </div>
+  );
+}

--- a/src/transaction/core/useGetTransactionToast.tsx
+++ b/src/transaction/core/useGetTransactionToast.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react';
+import { useTransactionContext } from '../components/TransactionProvider';
+import { cn, color, text } from '../../styles/theme';
+import { useOnchainKit } from '../../useOnchainKit';
+import { getChainExplorer } from './getChainExplorer';
+import { Spinner } from '../../internal/loading/Spinner';
+import type { ReactNode } from 'react';
+
+const successSVG = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M8 0C3.58 0 0 3.58 0 8C0 12.42 3.58 16 8 16C12.42 16 16 12.42 16 8C16 3.58 12.42 0 8 0ZM6.72667 11.5333L3.73333 8.54L4.67333 7.6L6.72667 9.65333L11.44 4.94L12.38 5.88L6.72667 11.5333Z"
+      fill="#65A30D"
+    />
+  </svg>
+);
+
+const errorSVG = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58171 12.4183 0 8 0C3.58172 0 0 3.58171 0 8C0 12.4183 3.58172 16 8 16ZM11.7576 5.0909L8.84853 8L11.7576 10.9091L10.9091 11.7576L8 8.84851L5.09093 11.7576L4.2424 10.9091L7.15147 8L4.2424 5.0909L5.09093 4.24239L8 7.15145L10.9091 4.24239L11.7576 5.0909Z"
+      fill="#E11D48"
+    />
+  </svg>
+);
+
+export function useGetTransactionToast() {
+  const { errorMessage, onSubmit, status, transactionId } =
+    useTransactionContext();
+  const { chain } = useOnchainKit();
+
+  return useMemo(() => {
+    const chainExplorer = getChainExplorer(chain.id);
+
+    let actionElement: ReactNode = null;
+    let label: string = '';
+    let icon: ReactNode = null;
+
+    if (status === 'pending') {
+      actionElement = (
+        <a href="">
+          <span className={cn(text.label1, color.primary)}>
+            View block explorer
+          </span>
+        </a>
+      );
+      icon = <Spinner className="px-1.5 py-1.5" />;
+      label = 'Transaction in progress';
+    }
+    if (transactionId) {
+      actionElement = (
+        <a
+          href={`${chainExplorer}/tx/${transactionId}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span className={cn(text.label1, color.primary)}>
+            View transaction
+          </span>
+        </a>
+      );
+      icon = successSVG;
+      label = 'Successful';
+    }
+    if (status === 'error') {
+      actionElement = (
+        <button type="button" onClick={onSubmit}>
+          <span className={cn(text.label1, color.primary)}>Try again</span>
+        </button>
+      );
+      icon = errorSVG;
+      label = 'Something went wrong';
+    }
+
+    return { actionElement, icon, label };
+  }, [chain, errorMessage, status, transactionId]);
+}

--- a/src/transaction/core/useGetTransactionToast.tsx
+++ b/src/transaction/core/useGetTransactionToast.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useTransactionContext } from '../components/TransactionProvider';
 import { cn, color, text } from '../../styles/theme';
 import { useOnchainKit } from '../../useOnchainKit';
-import { getChainExplorer } from './getChainExplorer';
+import { getChainExplorer } from '../../network/getChainExplorer';
 import { Spinner } from '../../internal/loading/Spinner';
 import type { ReactNode } from 'react';
 

--- a/src/transaction/core/useGetTransactionToast.tsx
+++ b/src/transaction/core/useGetTransactionToast.tsx
@@ -14,6 +14,7 @@ const successSVG = (
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
+    <title>Success SVG</title>
     <path
       d="M8 0C3.58 0 0 3.58 0 8C0 12.42 3.58 16 8 16C12.42 16 16 12.42 16 8C16 3.58 12.42 0 8 0ZM6.72667 11.5333L3.73333 8.54L4.67333 7.6L6.72667 9.65333L11.44 4.94L12.38 5.88L6.72667 11.5333Z"
       fill="#65A30D"
@@ -29,6 +30,7 @@ const errorSVG = (
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
+    <title>Error SVG</title>
     <path
       d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58171 12.4183 0 8 0C3.58172 0 0 3.58171 0 8C0 12.4183 3.58172 16 8 16ZM11.7576 5.0909L8.84853 8L11.7576 10.9091L10.9091 11.7576L8 8.84851L5.09093 11.7576L4.2424 10.9091L7.15147 8L4.2424 5.0909L5.09093 4.24239L8 7.15145L10.9091 4.24239L11.7576 5.0909Z"
       fill="#E11D48"
@@ -37,20 +39,20 @@ const errorSVG = (
 );
 
 export function useGetTransactionToast() {
-  const { errorMessage, onSubmit, status, transactionId } =
-    useTransactionContext();
+  const { onSubmit, status, transactionId } = useTransactionContext();
   const { chain } = useOnchainKit();
 
   return useMemo(() => {
     const chainExplorer = getChainExplorer(chain.id);
 
     let actionElement: ReactNode = null;
-    let label: string = '';
+    let label = '';
     let icon: ReactNode = null;
 
     if (status === 'pending') {
       actionElement = (
-        <a href="">
+        // TODO: update with correct url
+        <a href={chainExplorer}>
           <span className={cn(text.label1, color.primary)}>
             View block explorer
           </span>
@@ -85,5 +87,5 @@ export function useGetTransactionToast() {
     }
 
     return { actionElement, icon, label };
-  }, [chain, errorMessage, status, transactionId]);
+  }, [chain, onSubmit, status, transactionId]);
 }

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -30,10 +30,13 @@ export type TransactionContextType = {
   error?: TransactionErrorState;
   errorMessage?: string;
   isLoading: boolean;
+  isToastVisible: boolean;
   gasFee?: string;
   onSubmit: () => void;
   setErrorMessage: (error: string) => void;
+  setIsToastVisible: (isVisible: boolean) => void;
   setTransactionId: (id: string) => void;
+  status?: string;
   transactionId?: string;
 };
 
@@ -96,5 +99,22 @@ export type TransactionStatusActionReact = {
 };
 
 export type TransactionStatusLabelReact = {
+  className?: string;
+};
+
+export type TransactionToastActionReact = {
+  className?: string;
+};
+
+export type TransactionToastIconReact = {
+  className?: string;
+};
+
+export type TransactionToastLabelReact = {
+  className?: string;
+};
+
+export type TransactionToastReact = {
+  children: ReactNode;
   className?: string;
 };


### PR DESCRIPTION
**What changed? Why?**
- add transaction toast components

<img width="333" alt="Screenshot 2024-07-16 at 8 39 21 PM" src="https://github.com/user-attachments/assets/80d31946-f740-46f3-9329-304ea5ebd147">

<img width="443" alt="Screenshot 2024-07-16 at 8 39 07 PM" src="https://github.com/user-attachments/assets/260c93bd-b15b-49bc-91e6-5d6d097dcb05">

<img width="367" alt="Screenshot 2024-07-16 at 8 38 19 PM" src="https://github.com/user-attachments/assets/1614df7b-9e1e-4ad7-b8ed-8c0a608e9bc3">

**Notes to reviewers**

**How has it been tested?**
