### PR TITLE
docs: Update code block styling

### DIFF
--- a/.changeset/six-poets-pull.md
+++ b/.changeset/six-poets-pull.md
@@ -4,3 +4,4 @@
 
 -**chore**: Fix TransactionGasFee test. By @cpcramer #830
 -**chore**: Landing page UI fixes. By @cpcramer #833
+-**docs**: Update Code snippet UI. By @cpcramer #836

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -496,10 +496,5 @@ setFilteredTokens(filteredTokens);
     <p className="leading-7 text-sm text-gray-400 px-0 pt-16">
       This project is licensed under the [MIT License](https://github.com/coinbase/onchainkit/blob/main/LICENSE.md) · [Terms of Service](https://www.coinbase.com/legal/cloud/terms-of-service).
     </p>
-    <p className="leading-7 text-sm text-gray-400 px-0 pt-4">
-      <a href="https://www.coinbase.com/legal/cloud/terms-of-service" target="_blank" rel="noopener noreferrer">
-        Terms of Service
-      </a>
-    </p>
   </footer>
 </main>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -50,14 +50,16 @@ import WalletComponents from '../components/WalletComponents';
   <div className="mx-auto max-w-2xl">
     <div className="md:text-center flex flex-col gap-8 pt-[100px] pb-16">
       <h1 className="text-center text-6xl md:text-9xl font-medium no-underline dark:text-white tracking-[-0.1rem]">OnchainKit</h1>
-      <div className="text-center text-xl md:text-3xl dark:text-white">
-        <p className="leading-7 md:leading-none">
+      <div className="landing-page-hero text-center text-xl md:text-3xl dark:text-white">
+        <p>
           Build your onchain apps with ready-to-use React components and Typescript utilities.
         </p>
       </div>
     </div>
-    <div className="flex flex-col md:flex-row space-between items-center gap-6 w-full">
-      <div id="home-install" className="h-full grow">
+    <div className="flex flex-col items-center gap-6 w-full">
+      <div id="home-install" className="h-full w-9/12">
+
+{/* TODO: override background grey to match other components */}
 :::code-group
 
 ```bash [npm]
@@ -78,12 +80,11 @@ bun add @coinbase/onchainkit
 
 :::
 
-      </div>
-      <a href="/getting-started" className="font-sans justify-self-end border rounded-xl border-solid border border-indigo-400 text-indigo-400 px-4 py-3 font-bold">
+    </div>
+      <a href="/getting-started" className="font-sans border rounded-xl border-solid border-indigo-400 text-indigo-400 px-4 py-3 font-bold mt-4">
         View docs
       </a>
     </div>
-
   </div>
 </div>
 <div className="flex flex-col md:flex-row justify-between items-center md:mb-[64px] mx-auto max-w-[1225px] z-10 pt-[100px]">
@@ -493,10 +494,10 @@ setFilteredTokens(filteredTokens);
         </ul>
       </div>
     </div>
-    <p className="leading-7 text-xl text-gray-400 px-0 pt-16">
-      This project is licensed under the MIT License - see the [LICENSE.md](https://github.com/coinbase/onchainkit/blob/main/LICENSE.md) file for details.
+    <p className="leading-7 text-sm text-gray-400 px-0 pt-16">
+      This project is licensed under the [MIT License](https://github.com/coinbase/onchainkit/blob/main/LICENSE.md) · [Terms of Service](https://www.coinbase.com/legal/cloud/terms-of-service).
     </p>
-    <p className="leading-7 text-xl text-gray-400 px-0 pt-4">
+    <p className="leading-7 text-sm text-gray-400 px-0 pt-4">
       <a href="https://www.coinbase.com/legal/cloud/terms-of-service" target="_blank" rel="noopener noreferrer">
         Terms of Service
       </a>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -455,7 +455,7 @@ setFilteredTokens(filteredTokens);
     <div className="flex flex-col md:flex-row md:items-end justify-between">
       <div className="flex flex-col justify-between xl:flex-row xl:space-x-[25px]">
         <div className="pt-[20px] xl:pt-[40px]">
-          <h2 className="text-4xl md:text-9xl text-center md:text-left font-medium tracking-[-0.1rem]">OnchainKit</h2>
+          <h2 className="dark:text-white text-4xl md:text-9xl text-center md:text-left font-medium tracking-[-0.1rem]">OnchainKit</h2>
           <p className="leading-7 text-xl text-gray-400 px-0 py-6 max-w-[500px] md:text-left text-center">
             Build your onchain apps with ready-to-use React components and Typescript utilities.
           </p>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -59,7 +59,6 @@ import WalletComponents from '../components/WalletComponents';
     <div className="flex flex-col items-center gap-6 w-full">
       <div id="home-install" className="h-full w-9/12">
 
-{/* TODO: override background grey to match other components */}
 :::code-group
 
 ```bash [npm]

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -23,7 +23,9 @@
 .vocs_Tabs_content,
 .vocs_CodeBlock,
 .vocs_CodeTitle,
-.vocs_Pre_wrapper {
+.vocs_Pre_wrapper,
+.vocs_Heading::before,
+.vocs_Code {
   background-color: #1F2937 !important;
 }
 

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -17,7 +17,6 @@
   }
 }
 
-/* Set background color and basic styling for all components */
 .vocs_CodeGroup,
 .vocs_Tabs_list,
 .vocs_Tabs_trigger,
@@ -50,7 +49,6 @@
   transition: color 0.3s;
 }
 
-/* Code block styling */
 .vocs_Pre_wrapper pre {
   background-color: transparent !important;
 }

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -17,6 +17,39 @@
   }
 }
 
+/* Set background color and basic styling for all components */
+.vocs_CodeGroup,
+.vocs_Tabs_list,
+.vocs_Tabs_trigger,
+.vocs_Tabs_content,
+.vocs_CodeBlock,
+.vocs_CodeTitle,
+.vocs_Pre_wrapper {
+  background-color: #1F2937 !important;
+}
+
+.vocs_CodeGroup {
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.vocs_Tabs_list {
+  padding: 8px 8px 0;
+}
+
+.vocs_Tabs_trigger {
+  color: #F9FAFB;
+  padding: 8px 16px;
+  border: none;
+  cursor: pointer;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  transition: color 0.3s;
+}
+
 #home-install .vocs_CodeGroup {
   display: flex;
   height: 100%;
@@ -31,49 +64,9 @@
   font-size: 14px;
 }
 
-/* Set background color for all components */
-.vocs_CodeGroup,
-.vocs_Tabs_list,
-.vocs_Tabs_trigger,
-.vocs_Tabs_content,
-.vocs_CodeBlock,
-.vocs_CodeTitle,
-.vocs_Pre_wrapper {
-  background-color: #1F2937 !important;
-}
-
-/* Overall container styling */
-.vocs_CodeGroup {
-  border-radius: 8px;
-  overflow: hidden;
-}
-
-/* Tab list container */
-.vocs_Tabs_list {
-  padding: 8px 8px 0;
-}
-
-/* Individual tab button styling */
-.vocs_Tabs_trigger {
-  color: #B0B0B0;
-  padding: 8px 16px;
-  border: none;
-  cursor: pointer;
-  border-top-left-radius: 4px;
-  border-top-right-radius: 4px;
-  transition: color 0.3s;
-}
-
-/* Active tab button styling */
-.vocs_Tabs_trigger[data-state="active"] {
-  color: #FFFFFF;
-  font-weight: bold;
-}
-
 /* Code block styling */
 .vocs_Pre_wrapper pre {
   background-color: transparent !important;
-  color: inherit !important;
 }
 
 @media (max-width: 768px) {

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -50,6 +50,11 @@
   transition: color 0.3s;
 }
 
+/* Code block styling */
+.vocs_Pre_wrapper pre {
+  background-color: transparent !important;
+}
+
 #home-install .vocs_CodeGroup {
   display: flex;
   height: 100%;
@@ -62,11 +67,6 @@
 
 #home-install .vocs_Code {
   font-size: 14px;
-}
-
-/* Code block styling */
-.vocs_Pre_wrapper pre {
-  background-color: transparent !important;
 }
 
 @media (max-width: 768px) {
@@ -118,10 +118,6 @@
   display: none;
 }
 
-.landing-page-hero .vocs_Paragraph {
-  line-height: 1.5;
-}
-
 .dark .css-main-container {
   background-color: #111827;
 }
@@ -135,6 +131,10 @@
 }
 .dark .css-alternate-container {
   background-color: #030713;
+}
+
+.landing-page-hero .vocs_Paragraph {
+  line-height: 1.5;
 }
 
 .landing-page .vocs_Header,

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -31,6 +31,51 @@
   font-size: 14px;
 }
 
+/* Set background color for all components */
+.vocs_CodeGroup,
+.vocs_Tabs_list,
+.vocs_Tabs_trigger,
+.vocs_Tabs_content,
+.vocs_CodeBlock,
+.vocs_CodeTitle,
+.vocs_Pre_wrapper {
+  background-color: #1F2937 !important;
+}
+
+/* Overall container styling */
+.vocs_CodeGroup {
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+/* Tab list container */
+.vocs_Tabs_list {
+  padding: 8px 8px 0;
+}
+
+/* Individual tab button styling */
+.vocs_Tabs_trigger {
+  color: #B0B0B0;
+  padding: 8px 16px;
+  border: none;
+  cursor: pointer;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+  transition: color 0.3s;
+}
+
+/* Active tab button styling */
+.vocs_Tabs_trigger[data-state="active"] {
+  color: #FFFFFF;
+  font-weight: bold;
+}
+
+/* Code block styling */
+.vocs_Pre_wrapper pre {
+  background-color: transparent !important;
+  color: inherit !important;
+}
+
 @media (max-width: 768px) {
   .vocs_CodeBlock {
     margin-left: auto;
@@ -78,6 +123,10 @@
 
 .vocs_Content:has(#blobs) + .vocs_Footer {
   display: none;
+}
+
+.landing-page-hero .vocs_Paragraph {
+  line-height: 1.5;
 }
 
 .dark .css-main-container {


### PR DESCRIPTION
**What changed? Why?**
**Update styling for our documentation code block snippets - most notably we are overriding the background color to match the rest of the docs.** 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="765" alt="Screenshot 2024-07-18 at 2 24 34 PM" src="https://github.com/user-attachments/assets/f458ada2-78d7-4e5e-b2fc-9cdd9e022b54">
   </td>
    <td>
<img width="703" alt="Screenshot 2024-07-18 at 2 24 52 PM" src="https://github.com/user-attachments/assets/d43ea4e3-11cb-4e4d-a768-57a74fd7b937">

   </td>
  </tr>
</table>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="657" alt="Screenshot 2024-07-18 at 2 38 08 PM" src="https://github.com/user-attachments/assets/20835533-66d9-4483-8db0-e2ae541f61cc">
   </td>
    <td>
<img width="612" alt="Screenshot 2024-07-18 at 2 38 38 PM" src="https://github.com/user-attachments/assets/fe2f956d-63ef-4b53-97a2-dd6f6a63a1d9">

   </td>
  </tr>
</table>


**Update `MIT License` and `Terms of Service` in the landing page footer.** 
- Make text smaller. 
- Update language.
- Update format to be inline. 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="1056" alt="Screenshot 2024-07-18 at 3 10 35 PM" src="https://github.com/user-attachments/assets/a7e7bc42-a3c9-43bf-be05-55f81758471a">


   </td>
    <td>
<img width="1050" alt="Screenshot 2024-07-18 at 3 10 04 PM" src="https://github.com/user-attachments/assets/3e3471bd-2eaf-49e2-97b4-a3340138f166">


   </td>
  </tr>
</table>

**Update Landing Page "hero" to have less inline spacing.** 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="771" alt="Screenshot 2024-07-18 at 2 26 28 PM" src="https://github.com/user-attachments/assets/ed0525c5-0e5b-4504-af0d-4fb18d9634ae">
   </td>
    <td>
<img width="757" alt="Screenshot 2024-07-18 at 2 26 48 PM" src="https://github.com/user-attachments/assets/7c78ffce-064a-452e-8b2a-a670041c0e0a">
   </td>
  </tr>
</table>

**Update the footer OnchainKit text to match the header OnchainKit text.**

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="682" alt="Screenshot 2024-07-18 at 2 27 19 PM" src="https://github.com/user-attachments/assets/f24fdc17-6090-4d93-befb-9d420c2f16bc">
   </td>
    <td>
<img width="705" alt="Screenshot 2024-07-18 at 2 27 27 PM" src="https://github.com/user-attachments/assets/dfe8895f-82a7-4bb6-81d3-63dca5d37db5">
   </td>
  </tr>
</table>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="891" alt="Screenshot 2024-07-18 at 2 59 47 PM" src="https://github.com/user-attachments/assets/dc503739-f262-474c-bff6-e5c351997e79">

   </td>
    <td>
<img width="704" alt="Screenshot 2024-07-18 at 3 00 00 PM" src="https://github.com/user-attachments/assets/8a8785ef-7eba-4d58-be2b-29403d0cf43b">

   </td>
  </tr>
</table>

**Notes to reviewers**

**How has it been tested?**
