### PR TITLE
docs: Remove code group border

### DIFF
--- a/.changeset/six-poets-pull.md
+++ b/.changeset/six-poets-pull.md
@@ -5,3 +5,4 @@
 -**chore**: Fix TransactionGasFee test. By @cpcramer #830
 -**chore**: Landing page UI fixes. By @cpcramer #833
 -**docs**: Update Code snippet UI. By @cpcramer #836
+-**docs**: Remove code group border. By @cpcramer #837

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -57,7 +57,7 @@ import WalletComponents from '../components/WalletComponents';
       </div>
     </div>
     <div className="flex flex-col items-center gap-6 w-full">
-      <div id="home-install" className="h-full w-9/12">
+      <div id="home-install" className="h-full w-10/12">
 
 :::code-group
 

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -19,7 +19,6 @@
 
 .vocs_CodeGroup,
 .vocs_Tabs_list,
-.vocs_Tabs_trigger,
 .vocs_Tabs_content,
 .vocs_CodeBlock,
 .vocs_CodeTitle,
@@ -27,6 +26,11 @@
 .vocs_Heading::before,
 .vocs_Code {
   background-color: #1F2937 !important;
+  border-color: #1F2937 !important;
+}
+
+.vocs_Tabs_trigger {
+  background-color: #1F2937;
 }
 
 .vocs_CodeGroup {


### PR DESCRIPTION
**What changed? Why?**
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="763" alt="Screenshot 2024-07-18 at 5 31 13 PM" src="https://github.com/user-attachments/assets/7aed4431-3725-4663-b66f-b1f131a79187">

   </td>
    <td>

<img width="882" alt="Screenshot 2024-07-18 at 5 31 30 PM" src="https://github.com/user-attachments/assets/1f40257f-4fa5-4a38-a222-4505835f283b">

   </td>
  </tr>
</table>

Increase installation width to not cut off on mobile.
<img width="330" alt="Screenshot 2024-07-18 at 5 36 02 PM" src="https://github.com/user-attachments/assets/f4b5c925-1f42-44b4-860c-68a2ee0ce284">


**Notes to reviewers**

**How has it been tested?**
