### PR TITLE
chore: Return the sliced address when no ENS name is found

### DIFF
--- a/.changeset/lazy-shoes-work.md
+++ b/.changeset/lazy-shoes-work.md
@@ -4,3 +4,4 @@
 
 - **feat**: polish `Transaction` component. By @abcrane123 #831 #835
 - **chore**: fix TransactionGasFee test. By @cpcramer #830
+- **chore**: Fix Name component to return the sliced address when no ENS name is found. By @cpcramer #842

--- a/src/identity/components/Name.test.tsx
+++ b/src/identity/components/Name.test.tsx
@@ -159,7 +159,7 @@ describe('Name', () => {
     expect(screen.getByText(testName)).toBeInTheDocument();
   });
 
-  it('returns null when ENS name is not available', () => {
+  it('displays sliced address when ENS name is not available', () => {
     (useIdentityContext as vi.Mock).mockReturnValue({
       schemaId: '0x123',
     });
@@ -167,8 +167,9 @@ describe('Name', () => {
       data: null,
       isLoading: false,
     });
-    const { container } = render(<Name address={testNameComponentAddress} />);
-    expect(container.firstChild).toBeNull();
+    (getSlicedAddress as vi.Mock).mockReturnValue('0xName...ess');
+    render(<Name address={testNameComponentAddress} />);
+    expect(screen.getByText('0xName...ess')).toBeInTheDocument();
   });
 
   it('displays empty when ens still fetching', () => {

--- a/src/identity/components/Name.tsx
+++ b/src/identity/components/Name.tsx
@@ -1,10 +1,11 @@
 import { Children, useMemo } from 'react';
+import { Badge } from './Badge';
+import { cn, text } from '../../styles/theme';
+import { DisplayBadge } from './DisplayBadge';
+import { getSlicedAddress } from '../getSlicedAddress';
 import { useIdentityContext } from './IdentityProvider';
 import { useName } from '../hooks/useName';
 import type { NameReact } from '../types';
-import { Badge } from './Badge';
-import { DisplayBadge } from './DisplayBadge';
-import { cn, text } from '../../styles/theme';
 
 /**
  * Name is a React component that renders the user name from an Ethereum address.
@@ -41,10 +42,6 @@ export function Name({
     return <span className={className} />;
   }
 
-  if (!name) {
-    return null;
-  }
-
   return (
     <div className="flex items-center gap-1">
       <span
@@ -52,7 +49,7 @@ export function Name({
         className={cn(text.headline, className)}
         {...props}
       >
-        {name}
+        {name || getSlicedAddress(accountAddress)}
       </span>
       {badge && <DisplayBadge address={accountAddress}>{badge}</DisplayBadge>}
     </div>


### PR DESCRIPTION
**What changed? Why?**
Fix `Name` component to return the sliced address when no ENS name is found.

**Notes to reviewers**

**How has it been tested?**
<img width="724" alt="Screenshot 2024-07-19 at 2 19 22 PM" src="https://github.com/user-attachments/assets/78ce8338-47c5-4e95-953d-8f2f8d82ab6b">

