### PR TITLE
chore: typo fix

### DIFF
--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -20,7 +20,7 @@ The `<Transaction />` component is a high-level component that wraps the entire 
 It handles the transaction lifecycle, including gas estimation, fee sponsorship, and status updates.
 
 :::danger
-Component is not ship yet. Stay tuned for upcoming releases.
+Component is not shipped yet. Stay tuned for upcoming releases.
 :::
 
 ```tsx [code]


### PR DESCRIPTION
**What changed? Why?**
Little typo fix on the message that Transaction component is not shipped yet.

**Notes to reviewers**

**How has it been tested?**
Locally 
<img width="737" alt="Screenshot 2024-07-19 at 7 32 02 PM" src="https://github.com/user-attachments/assets/cd7b5a85-2471-4491-aad3-4cc1d048d8b6">

