### PR TITLE
chore: Update sliced address display

### DIFF
--- a/.changeset/modern-cameras-reflect.md
+++ b/.changeset/modern-cameras-reflect.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
--**chore**: Update sliced address to display the first and last 4 characters. By @cpcramer #000
+-**chore**: Update sliced address to display the first and last 4 characters. By @cpcramer #847

--- a/.changeset/modern-cameras-reflect.md
+++ b/.changeset/modern-cameras-reflect.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**chore**: Update sliced address to display the first and last 4 characters. By @cpcramer #000

--- a/site/docs/pages/wallet/wallet.mdx
+++ b/site/docs/pages/wallet/wallet.mdx
@@ -9,7 +9,7 @@ import {
   WalletDropdown,
   WalletDropdownLink,
   WalletDropdownDisconnect,
-} from '@coinbase/onchainkit/wallet';
+} from '../../../../src/wallet';
 import {
   Address,
   Avatar,
@@ -17,7 +17,7 @@ import {
   Badge,
   Identity,
   EthBalance,
-} from '@coinbase/onchainkit/identity';
+} from '../../../../src/identity';
 import { color } from '@coinbase/onchainkit/theme';
 import AppWithRK from '../../components/AppWithRK';
 import WalletComponents from '../../components/WalletComponents';

--- a/site/docs/pages/wallet/wallet.mdx
+++ b/site/docs/pages/wallet/wallet.mdx
@@ -9,7 +9,7 @@ import {
   WalletDropdown,
   WalletDropdownLink,
   WalletDropdownDisconnect,
-} from '../../../../src/wallet';
+} from '@coinbase/onchainkit/wallet';
 import {
   Address,
   Avatar,
@@ -17,7 +17,7 @@ import {
   Badge,
   Identity,
   EthBalance,
-} from '../../../../src/identity';
+} from '@coinbase/onchainkit/identity';
 import { color } from '@coinbase/onchainkit/theme';
 import AppWithRK from '../../components/AppWithRK';
 import WalletComponents from '../../components/WalletComponents';

--- a/src/identity/utils/getSlicedAddress.test.ts
+++ b/src/identity/utils/getSlicedAddress.test.ts
@@ -5,6 +5,6 @@ describe('getSlicedAddress', () => {
     const address = getSlicedAddress(
       '0x1234567890123456789012345678901234567890',
     );
-    expect(address).toEqual('0x123...7890');
+    expect(address).toEqual('0x1234...7890');
   });
 });

--- a/src/identity/utils/getSlicedAddress.ts
+++ b/src/identity/utils/getSlicedAddress.ts
@@ -4,5 +4,5 @@ import type { Address } from 'viem';
  * Returns the first 5 and last 4 characters of an address.
  */
 export const getSlicedAddress = (address: Address) => {
-  return `${address.slice(0, 5)}...${address.slice(-4)}`;
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
 };

--- a/src/identity/utils/getSlicedAddress.ts
+++ b/src/identity/utils/getSlicedAddress.ts
@@ -1,7 +1,7 @@
 import type { Address } from 'viem';
 
 /**
- * Returns the first 5 and last 4 characters of an address.
+ * Returns the first 6 and last 4 characters of an address.
  */
 export const getSlicedAddress = (address: Address) => {
   return `${address.slice(0, 6)}...${address.slice(-4)}`;


### PR DESCRIPTION
**What changed? Why?**
Update the number of characters that a sliced address displays to show 4 characters before and after the ellipsis. 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="393" alt="Screenshot 2024-07-20 at 2 43 28 PM" src="https://github.com/user-attachments/assets/ed99b431-b286-42f4-9eb8-06468cd11c8f">

   </td>
    <td>

<img width="362" alt="Screenshot 2024-07-20 at 2 44 03 PM" src="https://github.com/user-attachments/assets/e3db1c92-a1be-402e-b3ed-5cdb37f5f93a">

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
