### PR TITLE
feat: Add EOA account support to Transaction Component

### DIFF
--- a/.changeset/young-pets-buy.md
+++ b/.changeset/young-pets-buy.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+-**feat**: Add EOA account support to Transaction Component. By @cpcramer #866

--- a/src/transaction/components/TransactionProvider.test.tsx
+++ b/src/transaction/components/TransactionProvider.test.tsx
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react';
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { TransactionContextType } from '../types';
+import {
+  TransactionProvider,
+  useTransactionContext,
+} from './TransactionProvider';
+
+vi.mock('../hooks/useWriteContracts', () => ({
+  useWriteContracts: vi.fn(() => ({ status: 'idle', writeContracts: vi.fn() })),
+}));
+
+vi.mock('../hooks/useWriteContract', () => ({
+  useWriteContract: vi.fn(() => ({
+    status: 'idle',
+    writeContract: vi.fn(),
+    data: null,
+  })),
+}));
+
+vi.mock('../hooks/useCallsStatus', () => ({
+  useCallsStatus: vi.fn(() => ({ transactionHash: null })),
+}));
+
+vi.mock('../../internal/hooks/useValue', () => ({
+  useValue: vi.fn((value) => value),
+}));
+
+describe('TransactionProvider', () => {
+  it('should provide the transaction context to its children', () => {
+    let providedContext: TransactionContextType | undefined;
+
+    const TestComponent: React.FC = () => {
+      const context = useTransactionContext();
+      providedContext = context;
+      return null;
+    };
+
+    render(
+      <TransactionProvider address="0x123" contracts={[]} onError={() => {}}>
+        <TestComponent />
+      </TransactionProvider>,
+    );
+
+    expect(providedContext).toBeDefined();
+    if (providedContext) {
+      expect(providedContext.address).toBe('0x123');
+      expect(providedContext.contracts).toEqual([]);
+      expect(providedContext.isLoading).toBe(false);
+      expect(providedContext.status).toBe('idle');
+      expect(providedContext.transactionHash).toBeNull();
+      expect(typeof providedContext.onSubmit).toBe('function');
+      expect(typeof providedContext.setErrorMessage).toBe('function');
+      expect(typeof providedContext.setIsToastVisible).toBe('function');
+      expect(typeof providedContext.setTransactionId).toBe('function');
+    }
+  });
+});

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -55,6 +55,8 @@ export function TransactionProvider({
   const { transactionHash } = useCallsStatus({ onError, transactionId });
 
   const fallbackToWriteContract = useCallback(async () => {
+    // EOAs don't support batching, so we process contracts individually.
+    // This gracefully handles accidental batching attempts with EOAs.
     for (const contract of contracts) {
       try {
         await writeContract(contract);
@@ -72,6 +74,8 @@ export function TransactionProvider({
         contracts,
       });
 
+      // EOA accounts always fail on writeContracts, returning undefined.
+      // Fallback to writeContract, which works for EOAs.
       if (result === undefined) {
         await fallbackToWriteContract();
       }

--- a/src/transaction/hooks/useWriteContract.ts
+++ b/src/transaction/hooks/useWriteContract.ts
@@ -12,6 +12,11 @@ type UseWriteContractParams = {
 const uncaughtErrorCode = 'UNCAUGHT_WRITE_TRANSACTIONS_ERROR';
 const errorCode = 'WRITE_TRANSACTIONS_ERROR';
 
+/**
+ * Wagmi hook for single contract transactions.
+ * Supports both EOAs and Smart Wallets.
+ * Does not support transaction batching or paymasters.
+ */
 export function useWriteContract({
   onError,
   setErrorMessage,

--- a/src/transaction/hooks/useWriteContract.ts
+++ b/src/transaction/hooks/useWriteContract.ts
@@ -1,32 +1,26 @@
 import type { TransactionExecutionError } from 'viem';
-import { useWriteContracts as useWriteContractsWagmi } from 'wagmi/experimental';
+import { useWriteContract as useWriteContractWagmi } from 'wagmi';
 import type { TransactionError } from '../types';
+import { genericErrorMessage } from './useWriteContracts';
 
-type UseWriteContractsParams = {
+type UseWriteContractParams = {
   onError?: (e: TransactionError) => void;
   setErrorMessage: (error: string) => void;
   setTransactionId: (id: string) => void;
 };
 
-export const genericErrorMessage = 'Something went wrong. Please try again.';
 const uncaughtErrorCode = 'UNCAUGHT_WRITE_TRANSACTIONS_ERROR';
 const errorCode = 'WRITE_TRANSACTIONS_ERROR';
-const eoaErrorMesssage = 'this request method is not supported';
 
-export function useWriteContracts({
+export function useWriteContract({
   onError,
   setErrorMessage,
   setTransactionId,
-}: UseWriteContractsParams) {
+}: UseWriteContractParams) {
   try {
-    const { status, writeContracts } = useWriteContractsWagmi({
+    const { status, writeContract, data } = useWriteContractWagmi({
       mutation: {
         onError: (e) => {
-          // Ignore EOA-specific error to fallback to writeContract
-          if (e.message.includes(eoaErrorMesssage)) {
-            return;
-          }
-
           if (
             (e as TransactionExecutionError)?.cause?.name ===
             'UserRejectedRequestError'
@@ -42,10 +36,10 @@ export function useWriteContracts({
         },
       },
     });
-    return { status, writeContracts };
+    return { status, writeContract, data };
   } catch (err) {
     onError?.({ code: uncaughtErrorCode, error: JSON.stringify(err) });
     setErrorMessage(genericErrorMessage);
-    return { status: 'error', writeContracts: () => {} };
+    return { status: 'error', writeContract: () => {} };
   }
 }

--- a/src/transaction/hooks/useWriteContracts.ts
+++ b/src/transaction/hooks/useWriteContracts.ts
@@ -13,6 +13,12 @@ const uncaughtErrorCode = 'UNCAUGHT_WRITE_TRANSACTIONS_ERROR';
 const errorCode = 'WRITE_TRANSACTIONS_ERROR';
 const eoaErrorMesssage = 'this request method is not supported';
 
+/**
+ * useWriteContracts: Experimental Wagmi hook for batching transactions.
+ * Supports Smart Wallets.
+ * Does not support batch operations and capabilities such as paymasters.
+ * Does not support EOAs.
+ */
 export function useWriteContracts({
   onError,
   setErrorMessage,

--- a/src/transaction/hooks/useWriteContracts.ts
+++ b/src/transaction/hooks/useWriteContracts.ts
@@ -16,7 +16,7 @@ const eoaErrorMesssage = 'this request method is not supported';
 /**
  * useWriteContracts: Experimental Wagmi hook for batching transactions.
  * Supports Smart Wallets.
- * Does not support batch operations and capabilities such as paymasters.
+ * Supports batch operations and capabilities such as paymasters.
  * Does not support EOAs.
  */
 export function useWriteContracts({


### PR DESCRIPTION
**What changed? Why?**
Add `EOA` account support to the `Transaction Component`. 
- Add `useWriteContract` wrapper.
- To support both `Smart Wallets` and `EOA` wallets we are defaulting to use `writeContracts` first, and then if that fails with an `EOA` specific error then we fallback to use `writeContract` and iterate through the list of contracts that were intended to be batched.
- Add basic functionality test for the Transaction Provider

<img width="592" alt="Screenshot 2024-07-23 at 6 44 08 PM" src="https://github.com/user-attachments/assets/a67e62e7-2ee3-460d-b6a5-fe91235ee2e6">


**Notes to reviewers**

**How has it been tested?**
Basic functionality unit test :
<img width="878" alt="Screenshot 2024-07-23 at 10 34 14 PM" src="https://github.com/user-attachments/assets/ff59c488-3a76-4cc9-aa6e-b7ffab5171d1">


Tested locally on BaseSepolia. 

EOA Transaction landed onchain https://sepolia.basescan.org/tx/0x950f41d5bc0fe191b3a019d4c00f2ee295c1fb0a77f5a99d2db54334d5c3a300