### PR TITLE
Fix: Fix the usename hook to use chain.id  in the query key to avoid overlap between chains

### DIFF
--- a/.changeset/brown-moose-doubt.md
+++ b/.changeset/brown-moose-doubt.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": minor
 ---
 
-**fix**: fix `useName` hook to use `chain.id` in the query key to avoid overlap between chains. By @kirkas #867
+**fix**: fix `useName` hook to use `chain.id` in the query key to avoid overlap between chains. By @kirkas #869

--- a/.changeset/brown-moose-doubt.md
+++ b/.changeset/brown-moose-doubt.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+**fix**: fix `useName` hook to use `chain.id` in the query key to avoid overlap between chains. By @kirkas #867

--- a/src/identity/components/Avatar.test.tsx
+++ b/src/identity/components/Avatar.test.tsx
@@ -1,4 +1,4 @@
-import { base } from 'viem/chains';
+import { base, baseSepolia, optimism } from 'viem/chains';
 import { vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -208,6 +208,39 @@ describe('Avatar Component', () => {
 
     expect(useNameMock).toHaveBeenCalledWith({
       address: testAvatarComponentAddress,
+    });
+  });
+
+  it('use identity context chain if provided', () => {
+    useIdentityContextMock.mockReturnValue({
+      chain: optimism,
+      address: testIdentityProviderAddress,
+    });
+
+    render(<Avatar />);
+
+    expect(useNameMock).toHaveBeenCalledWith({
+      address: testIdentityProviderAddress,
+      chain: optimism,
+    });
+  });
+
+  it('use component chain over identity context if both are provided', () => {
+    useIdentityContextMock.mockReturnValue({
+      chain: optimism,
+      address: testIdentityProviderAddress,
+    });
+
+    useNameMock.mockReturnValue({
+      data: 'ens_name',
+      isLoading: false,
+    });
+
+    render(<Avatar chain={baseSepolia} />);
+
+    expect(useNameMock).toHaveBeenCalledWith({
+      address: testIdentityProviderAddress,
+      chain: baseSepolia,
     });
   });
 });

--- a/src/identity/components/Avatar.tsx
+++ b/src/identity/components/Avatar.tsx
@@ -16,14 +16,19 @@ import { defaultLoadingSVG } from './defaultLoadingSVG';
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component
 export function Avatar({
   address = null,
+  chain,
   className,
   defaultComponent,
   loadingComponent,
   children,
   ...props
 }: AvatarReact) {
-  const { address: contextAddress } = useIdentityContext();
-  if (!contextAddress && !address) {
+  const { address: contextAddress, chain: contextChain } = useIdentityContext();
+
+  const accountAddress = address ?? contextAddress;
+  const accountChain = chain ?? contextChain;
+
+  if (!accountAddress) {
     throw new Error(
       'Avatar: an Ethereum address must be provided to the Identity or Avatar component.',
     );
@@ -32,7 +37,9 @@ export function Avatar({
   // The component first attempts to retrieve the ENS name and avatar for the given Ethereum address.
   const { data: name, isLoading: isLoadingName } = useName({
     address: address ?? contextAddress,
+    chain: accountChain,
   });
+
   const { data: avatar, isLoading: isLoadingAvatar } = useAvatar(
     { ensName: name ?? '' },
     { enabled: !!name },

--- a/src/identity/hooks/useName.ts
+++ b/src/identity/hooks/useName.ts
@@ -17,7 +17,8 @@ export const useName = (
   queryOptions?: UseNameQueryOptions,
 ) => {
   const { enabled = true, cacheTime } = queryOptions ?? {};
-  const ensActionKey = `ens-name-${address}`;
+  const chainActionKey = chain ? chain.id : 'default-chain';
+  const ensActionKey = `ens-name-${address}-${chainActionKey}`;
   return useQuery<GetNameReturnType>({
     queryKey: ['useName', ensActionKey],
     queryFn: async () => {

--- a/src/identity/hooks/useName.ts
+++ b/src/identity/hooks/useName.ts
@@ -5,6 +5,7 @@ import type {
   UseNameQueryOptions,
 } from '../types';
 import { getName } from '../utils/getName';
+import { mainnet } from 'viem/chains';
 
 /**
  * It leverages the `@tanstack/react-query` hook for fetching and optionally caching the ENS name
@@ -13,12 +14,11 @@ import { getName } from '../utils/getName';
  *  - `{UseQueryResult}`: The rest of useQuery return values. including isLoading, isError, error, isFetching, refetch, etc.
  */
 export const useName = (
-  { address, chain }: UseNameOptions,
+  { address, chain = mainnet }: UseNameOptions,
   queryOptions?: UseNameQueryOptions,
 ) => {
   const { enabled = true, cacheTime } = queryOptions ?? {};
-  const chainActionKey = chain ? chain.id : 'default-chain';
-  const ensActionKey = `ens-name-${address}-${chainActionKey}`;
+  const ensActionKey = `ens-name-${address}-${chain.id}`;
   return useQuery<GetNameReturnType>({
     queryKey: ['useName', ensActionKey],
     queryFn: async () => {

--- a/src/identity/hooks/useName.ts
+++ b/src/identity/hooks/useName.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
+import { mainnet } from 'viem/chains';
 import type {
   GetNameReturnType,
   UseNameOptions,
   UseNameQueryOptions,
 } from '../types';
 import { getName } from '../utils/getName';
-import { mainnet } from 'viem/chains';
 
 /**
  * It leverages the `@tanstack/react-query` hook for fetching and optionally caching the ENS name

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -39,6 +39,7 @@ export type Attestation = {
  */
 export type AvatarReact = {
   address?: Address | null; // The Ethereum address to fetch the avatar for.
+  chain?: Chain; // Optional chain for domain resolution
   className?: string; // Optional className override for top div element.
   loadingComponent?: JSX.Element; // Optional custom component to display while the avatar data is loading.
   defaultComponent?: JSX.Element; // Optional custom component to display when no ENS name or avatar is available.


### PR DESCRIPTION
**What changed? Why?**

**fix**: fix `useName` hook to use `chain.id` in the query key to avoid overlap between chains

