### PR TITLE
feat: `v2` Swap API

### DIFF
--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -10,6 +10,7 @@ import { SwapToggleButton } from './SwapToggleButton';
 // istanbul ignore next
 export function Swap({
   address,
+  aggregator = true,
   children,
   title = 'Swap',
   className,
@@ -31,7 +32,7 @@ export function Swap({
   }, [children]);
 
   return (
-    <SwapProvider address={address}>
+    <SwapProvider address={address} aggregator={aggregator}>
       <div
         className={cn(
           background.default,

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -10,7 +10,7 @@ import { SwapToggleButton } from './SwapToggleButton';
 // istanbul ignore next
 export function Swap({
   address,
-  aggregator = true,
+  experimental = new Map<string, boolean>(),
   children,
   title = 'Swap',
   className,
@@ -32,7 +32,10 @@ export function Swap({
   }, [children]);
 
   return (
-    <SwapProvider address={address} aggregator={aggregator}>
+    <SwapProvider
+      address={address}
+      useAggregator={experimental.get('useAggregators') || true}
+    >
       <div
         className={cn(
           background.default,

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -10,7 +10,7 @@ import { SwapToggleButton } from './SwapToggleButton';
 // istanbul ignore next
 export function Swap({
   address,
-  experimental = new Map<string, boolean>(),
+  experimental = { useAggregator: true },
   children,
   title = 'Swap',
   className,
@@ -32,10 +32,7 @@ export function Swap({
   }, [children]);
 
   return (
-    <SwapProvider
-      address={address}
-      useAggregator={experimental.get('useAggregators') || true}
-    >
+    <SwapProvider address={address} useAggregator={experimental?.useAggregator}>
       <div
         className={cn(
           background.default,

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -32,7 +32,7 @@ export function Swap({
   }, [children]);
 
   return (
-    <SwapProvider address={address} useAggregator={experimental?.useAggregator}>
+    <SwapProvider address={address} experimental={experimental}>
       <div
         className={cn(
           background.default,

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -35,10 +35,12 @@ export function useSwapContext() {
 
 export function SwapProvider({
   address,
+  aggregator,
   children,
 }: {
-  children: React.ReactNode;
   address: Address;
+  aggregator: boolean;
+  children: React.ReactNode;
 }) {
   const [loading, setLoading] = useState(false);
   const [isTransactionPending, setPendingTransaction] = useState(false);
@@ -99,6 +101,7 @@ export function SwapProvider({
 
       try {
         const response = await getSwapQuote({
+          aggregator,
           from: source.token,
           to: destination.token,
           amount,
@@ -141,6 +144,7 @@ export function SwapProvider({
 
       try {
         const response = await buildSwapTransaction({
+          aggregator,
           amount: from.amount,
           fromAddress: address,
           from: from.token,

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -126,7 +126,7 @@ export function SwapProvider({
         destination.setLoading(false);
       }
     },
-    [from, to, handleError],
+    [aggregator, from, to, handleError],
   );
 
   const handleSubmit = useCallback(
@@ -188,6 +188,7 @@ export function SwapProvider({
     },
     [
       address,
+      aggregator,
       config,
       handleError,
       from.amount,

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -36,12 +36,17 @@ export function useSwapContext() {
 export function SwapProvider({
   address,
   children,
-  useAggregator,
+  experimental,
 }: {
   address: Address;
   children: React.ReactNode;
-  useAggregator: boolean;
+  experimental: {
+    useAggregator: boolean; // Whether to use a DEX aggregator. (default: true)
+  };
 }) {
+  // Feature flags
+  const { useAggregator } = experimental;
+
   const [loading, setLoading] = useState(false);
   const [isTransactionPending, setPendingTransaction] = useState(false);
 

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -35,12 +35,12 @@ export function useSwapContext() {
 
 export function SwapProvider({
   address,
-  aggregator,
   children,
+  useAggregator,
 }: {
   address: Address;
-  aggregator: boolean;
   children: React.ReactNode;
+  useAggregator: boolean;
 }) {
   const [loading, setLoading] = useState(false);
   const [isTransactionPending, setPendingTransaction] = useState(false);
@@ -101,11 +101,11 @@ export function SwapProvider({
 
       try {
         const response = await getSwapQuote({
-          aggregator,
-          from: source.token,
-          to: destination.token,
           amount,
           amountReference: 'from',
+          from: source.token,
+          to: destination.token,
+          useAggregator,
         });
         // If request resolves to error response set the quoteError
         // property of error state to the SwapError response */
@@ -126,7 +126,7 @@ export function SwapProvider({
         destination.setLoading(false);
       }
     },
-    [aggregator, from, to, handleError],
+    [from, to, useAggregator, handleError],
   );
 
   const handleSubmit = useCallback(
@@ -144,11 +144,11 @@ export function SwapProvider({
 
       try {
         const response = await buildSwapTransaction({
-          aggregator,
           amount: from.amount,
           fromAddress: address,
           from: from.token,
           to: to.token,
+          useAggregator,
         });
 
         if (isSwapError(response)) {
@@ -188,13 +188,13 @@ export function SwapProvider({
     },
     [
       address,
-      aggregator,
       config,
       handleError,
       from.amount,
       from.token,
       sendTransactionAsync,
       to.token,
+      useAggregator,
     ],
   );
 

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -56,12 +56,12 @@ export type GetSwapAPIParams = GetQuoteAPIParams & {
  * Note: exported as public Type
  */
 export type GetSwapQuoteParams = {
-  aggregator: boolean; // Whether to use a DEX aggregator
   amount: string; // The amount to be swapped
   amountReference?: string; // The reference amount for the swap
   from: Token; // The source token for the swap
   isAmountInDecimals?: boolean; // Whether the amount is in decimals
   to: Token; // The destination token for the swap
+  useAggregator: boolean; // Whether to use a DEX aggregator
 };
 
 /**
@@ -135,14 +135,14 @@ export type SwapContextType = {
   isTransactionPending: boolean;
   handleSubmit: (
     onError?: (error: SwapError) => void,
-    onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>,
+    onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>
   ) => void;
   handleToggle: () => void;
   handleAmountChange: (
     t: 'from' | 'to',
     amount: string,
     st?: Token,
-    dt?: Token,
+    dt?: Token
   ) => void;
 };
 
@@ -197,9 +197,9 @@ export type SwapParams = {
  */
 export type SwapReact = {
   address: Address; // Connected address from connector.
-  aggregator?: boolean; // Optional boolean to enable/disable aggregator.
   children: ReactNode;
   className?: string; // Optional className override for top div element.
+  experimental?: Map<string, boolean>; // Experimental features
   title?: string; // Title for the Swap component. (default: "Swap")
 };
 

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -45,6 +45,7 @@ export type GetQuoteAPIParams = {
   to: AddressOrETH | ''; // The destination address or 'ETH' for Ethereum
   amount: string; // The amount to be swapped
   amountReference?: string; // The reference amount for the swap
+  v2Enabled?: boolean; // Whether to use V2 of the API (default: false)
 };
 
 export type GetSwapAPIParams = GetQuoteAPIParams & {
@@ -57,6 +58,7 @@ export type GetSwapAPIParams = GetQuoteAPIParams & {
 export type GetSwapQuoteParams = {
   from: Token; // The source token for the swap
   to: Token; // The destination token for the swap
+  aggregator: boolean; // Whether to use a DEX aggregator
   amount: string; // The amount to be swapped
   amountReference?: string; // The reference amount for the swap
   isAmountInDecimals?: boolean; // Whether the amount is in decimals
@@ -195,6 +197,7 @@ export type SwapParams = {
  */
 export type SwapReact = {
   address: Address; // Connected address from connector.
+  aggregator?: boolean; // Optional boolean to enable/disable aggregator.
   children: ReactNode;
   className?: string; // Optional className override for top div element.
   title?: string; // Title for the Swap component. (default: "Swap")

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -135,14 +135,14 @@ export type SwapContextType = {
   isTransactionPending: boolean;
   handleSubmit: (
     onError?: (error: SwapError) => void,
-    onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>
+    onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>,
   ) => void;
   handleToggle: () => void;
   handleAmountChange: (
     t: 'from' | 'to',
     amount: string,
     st?: Token,
-    dt?: Token
+    dt?: Token,
   ) => void;
 };
 

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -41,10 +41,10 @@ export type GetAPIParamsForToken =
   | BuildSwapTransactionParams;
 
 export type GetQuoteAPIParams = {
-  from: AddressOrETH | ''; // The source address or 'ETH' for Ethereum
-  to: AddressOrETH | ''; // The destination address or 'ETH' for Ethereum
   amount: string; // The amount to be swapped
   amountReference?: string; // The reference amount for the swap
+  from: AddressOrETH | ''; // The source address or 'ETH' for Ethereum
+  to: AddressOrETH | ''; // The destination address or 'ETH' for Ethereum
   v2Enabled?: boolean; // Whether to use V2 of the API (default: false)
 };
 
@@ -56,12 +56,12 @@ export type GetSwapAPIParams = GetQuoteAPIParams & {
  * Note: exported as public Type
  */
 export type GetSwapQuoteParams = {
-  from: Token; // The source token for the swap
-  to: Token; // The destination token for the swap
   aggregator: boolean; // Whether to use a DEX aggregator
   amount: string; // The amount to be swapped
   amountReference?: string; // The reference amount for the swap
+  from: Token; // The source token for the swap
   isAmountInDecimals?: boolean; // Whether the amount is in decimals
+  to: Token; // The destination token for the swap
 };
 
 /**

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -199,7 +199,9 @@ export type SwapReact = {
   address: Address; // Connected address from connector.
   children: ReactNode;
   className?: string; // Optional className override for top div element.
-  experimental?: Map<string, boolean>; // Experimental features
+  experimental?: {
+    useAggregator: boolean; // Whether to use a DEX aggregator. (default: true)
+  };
   title?: string; // Title for the Swap component. (default: "Swap")
 };
 

--- a/src/swap/utils/buildSwapTransaction.test.ts
+++ b/src/swap/utils/buildSwapTransaction.test.ts
@@ -142,6 +142,112 @@ describe('buildSwapTransaction', () => {
     ]);
   });
 
+  it('should return a swap with useAggregator=false', async () => {
+    const mockParams = {
+      useAggregator: false,
+      fromAddress: testFromAddress as `0x${string}`,
+      amountReference: testAmountReference,
+      from: ETH,
+      to: DEGEN,
+      amount: testAmount,
+    };
+    const mockApiParams = {
+      v2Enabled: true,
+      ...getAPIParamsForToken(mockParams),
+    };
+
+    const mockResponse = {
+      id: 1,
+      jsonrpc: '2.0',
+      result: {
+        tx: {
+          data: '0x0000000000000',
+          gas: '463613',
+          gasPrice: '2106527',
+          from: '0xaeE5834a78a30F6762407F6F8c3A2090054b0086',
+          to: '0xdef1c0ded9bec7f1a1670819833240f027b25eff',
+          value: '100000000000000',
+        },
+        quote: {
+          from: {
+            address: '',
+            chainId: 8453,
+            decimals: 18,
+            image:
+              'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+            name: 'ETH',
+            symbol: 'ETH',
+          },
+          to: {
+            address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+            chainId: 8453,
+            decimals: 18,
+            image:
+              'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
+            name: 'DEGEN',
+            symbol: 'DEGEN',
+          },
+          fromAmount: '100000000000000',
+          toAmount: '19395353519910973703',
+          amountReference: 'from',
+          priceImpact: '0.94',
+          chainId: 8453,
+          highPriceImpact: false,
+          slippage: '3',
+          warning: undefined,
+        },
+        fee: {
+          baseAsset: {
+            name: 'DEGEN',
+            address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+            currencyCode: 'DEGEN',
+            decimals: 18,
+            imageURL:
+              'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
+            blockchain: 'eth',
+            aggregators: [Array],
+            swappable: true,
+            unverified: false,
+            chainId: 8453,
+          },
+          percentage: '1',
+          amount: '195912661817282562',
+        },
+        approveTx: undefined,
+        chainId: '8453',
+      },
+    };
+
+    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+
+    const trade = mockResponse.result;
+    const expectedResponse = {
+      approveTransaction: trade.approveTx
+        ? getSwapTransaction(trade.approveTx, trade.chainId)
+        : undefined,
+      fee: trade.fee,
+      quote: trade.quote,
+      transaction: getSwapTransaction(trade.tx, trade.chainId),
+      warning: trade.quote.warning,
+    };
+
+    const quote = (await buildSwapTransaction(
+      mockParams,
+    )) as BuildSwapTransaction;
+
+    expect(quote.approveTransaction).toEqual(
+      expectedResponse.approveTransaction,
+    );
+    expect(quote.transaction).toEqual(expectedResponse.transaction);
+    expect(quote.fee).toEqual(expectedResponse.fee);
+    expect(quote.warning).toEqual(expectedResponse.warning);
+
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_TRADE, [
+      mockApiParams,
+    ]);
+  });
+
   it('should return a swap with an approve transaction', async () => {
     const mockParams = {
       useAggregator: true,

--- a/src/swap/utils/buildSwapTransaction.test.ts
+++ b/src/swap/utils/buildSwapTransaction.test.ts
@@ -116,9 +116,7 @@ describe('buildSwapTransaction', () => {
 
     const trade = mockResponse.result;
     const expectedResponse = {
-      approveTransaction: trade.approveTx
-        ? getSwapTransaction(trade.approveTx, trade.chainId)
-        : undefined,
+      approveTransaction: undefined,
       fee: trade.fee,
       quote: trade.quote,
       transaction: getSwapTransaction(trade.tx, trade.chainId),
@@ -222,9 +220,7 @@ describe('buildSwapTransaction', () => {
 
     const trade = mockResponse.result;
     const expectedResponse = {
-      approveTransaction: trade.approveTx
-        ? getSwapTransaction(trade.approveTx, trade.chainId)
-        : undefined,
+      approveTransaction: undefined,
       fee: trade.fee,
       quote: trade.quote,
       transaction: getSwapTransaction(trade.tx, trade.chainId),
@@ -332,9 +328,7 @@ describe('buildSwapTransaction', () => {
 
     const trade = mockResponse.result;
     const expectedResponse = {
-      approveTransaction: trade.approveTx
-        ? getSwapTransaction(trade.approveTx, trade.chainId)
-        : undefined,
+      approveTransaction: getSwapTransaction(trade.approveTx, trade.chainId),
       fee: trade.fee,
       quote: trade.quote,
       transaction: getSwapTransaction(trade.tx, trade.chainId),

--- a/src/swap/utils/buildSwapTransaction.test.ts
+++ b/src/swap/utils/buildSwapTransaction.test.ts
@@ -41,7 +41,7 @@ describe('buildSwapTransaction', () => {
 
   it('should return a swap', async () => {
     const mockParams = {
-      aggregator: true,
+      useAggregator: true,
       fromAddress: testFromAddress as `0x${string}`,
       amountReference: testAmountReference,
       from: ETH,
@@ -144,7 +144,7 @@ describe('buildSwapTransaction', () => {
 
   it('should return a swap with an approve transaction', async () => {
     const mockParams = {
-      aggregator: true,
+      useAggregator: true,
       fromAddress: testFromAddress as `0x${string}`,
       amountReference: testAmountReference,
       from: DEGEN,
@@ -254,7 +254,7 @@ describe('buildSwapTransaction', () => {
 
   it('should return an error if sendRequest fails', async () => {
     const mockParams = {
-      aggregator: true,
+      useAggregator: true,
       fromAddress: testFromAddress as `0x${string}`,
       amountReference: testAmountReference,
       from: ETH,
@@ -282,7 +282,7 @@ describe('buildSwapTransaction', () => {
 
   it('should return an error object from buildSwapTransaction', async () => {
     const mockParams = {
-      aggregator: true,
+      useAggregator: true,
       fromAddress: testFromAddress as `0x${string}`,
       amountReference: testAmountReference,
       from: ETH,

--- a/src/swap/utils/buildSwapTransaction.test.ts
+++ b/src/swap/utils/buildSwapTransaction.test.ts
@@ -41,6 +41,7 @@ describe('buildSwapTransaction', () => {
 
   it('should return a swap', async () => {
     const mockParams = {
+      aggregator: true,
       fromAddress: testFromAddress as `0x${string}`,
       amountReference: testAmountReference,
       from: ETH,
@@ -125,11 +126,11 @@ describe('buildSwapTransaction', () => {
     };
 
     const quote = (await buildSwapTransaction(
-      mockParams,
+      mockParams
     )) as BuildSwapTransaction;
 
     expect(quote.approveTransaction).toEqual(
-      expectedResponse.approveTransaction,
+      expectedResponse.approveTransaction
     );
     expect(quote.transaction).toEqual(expectedResponse.transaction);
     expect(quote.fee).toEqual(expectedResponse.fee);
@@ -143,6 +144,7 @@ describe('buildSwapTransaction', () => {
 
   it('should return a swap with an approve transaction', async () => {
     const mockParams = {
+      aggregator: true,
       fromAddress: testFromAddress as `0x${string}`,
       amountReference: testAmountReference,
       from: DEGEN,
@@ -234,11 +236,11 @@ describe('buildSwapTransaction', () => {
     };
 
     const quote = (await buildSwapTransaction(
-      mockParams,
+      mockParams
     )) as BuildSwapTransaction;
 
     expect(quote.approveTransaction).toEqual(
-      expectedResponse.approveTransaction,
+      expectedResponse.approveTransaction
     );
     expect(quote.transaction).toEqual(expectedResponse.transaction);
     expect(quote.fee).toEqual(expectedResponse.fee);
@@ -252,6 +254,7 @@ describe('buildSwapTransaction', () => {
 
   it('should return an error if sendRequest fails', async () => {
     const mockParams = {
+      aggregator: true,
       fromAddress: testFromAddress as `0x${string}`,
       amountReference: testAmountReference,
       from: ETH,
@@ -261,7 +264,7 @@ describe('buildSwapTransaction', () => {
     const mockApiParams = getAPIParamsForToken(mockParams);
 
     const mockError = new Error(
-      'buildSwapTransaction: Error: Failed to send request',
+      'buildSwapTransaction: Error: Failed to send request'
     );
     (sendRequest as vi.Mock).mockRejectedValue(mockError);
 
@@ -279,6 +282,7 @@ describe('buildSwapTransaction', () => {
 
   it('should return an error object from buildSwapTransaction', async () => {
     const mockParams = {
+      aggregator: true,
       fromAddress: testFromAddress as `0x${string}`,
       amountReference: testAmountReference,
       from: ETH,

--- a/src/swap/utils/buildSwapTransaction.test.ts
+++ b/src/swap/utils/buildSwapTransaction.test.ts
@@ -126,11 +126,11 @@ describe('buildSwapTransaction', () => {
     };
 
     const quote = (await buildSwapTransaction(
-      mockParams
+      mockParams,
     )) as BuildSwapTransaction;
 
     expect(quote.approveTransaction).toEqual(
-      expectedResponse.approveTransaction
+      expectedResponse.approveTransaction,
     );
     expect(quote.transaction).toEqual(expectedResponse.transaction);
     expect(quote.fee).toEqual(expectedResponse.fee);
@@ -236,11 +236,11 @@ describe('buildSwapTransaction', () => {
     };
 
     const quote = (await buildSwapTransaction(
-      mockParams
+      mockParams,
     )) as BuildSwapTransaction;
 
     expect(quote.approveTransaction).toEqual(
-      expectedResponse.approveTransaction
+      expectedResponse.approveTransaction,
     );
     expect(quote.transaction).toEqual(expectedResponse.transaction);
     expect(quote.fee).toEqual(expectedResponse.fee);
@@ -264,7 +264,7 @@ describe('buildSwapTransaction', () => {
     const mockApiParams = getAPIParamsForToken(mockParams);
 
     const mockError = new Error(
-      'buildSwapTransaction: Error: Failed to send request'
+      'buildSwapTransaction: Error: Failed to send request',
     );
     (sendRequest as vi.Mock).mockRejectedValue(mockError);
 

--- a/src/swap/utils/buildSwapTransaction.ts
+++ b/src/swap/utils/buildSwapTransaction.ts
@@ -25,7 +25,7 @@ export async function buildSwapTransaction(
 
   let apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
 
-  if (!params.aggregator) {
+  if (!params.useAggregator) {
     apiParams = {
       v2Enabled: true,
       ...apiParams,

--- a/src/swap/utils/buildSwapTransaction.ts
+++ b/src/swap/utils/buildSwapTransaction.ts
@@ -15,7 +15,7 @@ import { getSwapTransaction } from './getSwapTransaction';
  * Retrieves an unsigned transaction for a swap from Token A to Token B.
  */
 export async function buildSwapTransaction(
-  params: BuildSwapTransactionParams
+  params: BuildSwapTransactionParams,
 ): Promise<BuildSwapTransactionResponse> {
   // Default parameters
   const defaultParams = {
@@ -35,7 +35,7 @@ export async function buildSwapTransaction(
   try {
     const res = await sendRequest<SwapAPIParams, SwapAPIResponse>(
       CDP_GET_SWAP_TRADE,
-      [apiParams]
+      [apiParams],
     );
     if (res.error) {
       return {

--- a/src/swap/utils/buildSwapTransaction.ts
+++ b/src/swap/utils/buildSwapTransaction.ts
@@ -23,7 +23,14 @@ export async function buildSwapTransaction(
     isAmountInDecimals: false,
   };
 
-  const apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
+  var apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
+
+  if (!params.aggregator) {
+    apiParams = {
+      v2Enabled: true,
+      ...apiParams,
+    };
+  }
 
   try {
     const res = await sendRequest<SwapAPIParams, SwapAPIResponse>(

--- a/src/swap/utils/buildSwapTransaction.ts
+++ b/src/swap/utils/buildSwapTransaction.ts
@@ -15,7 +15,7 @@ import { getSwapTransaction } from './getSwapTransaction';
  * Retrieves an unsigned transaction for a swap from Token A to Token B.
  */
 export async function buildSwapTransaction(
-  params: BuildSwapTransactionParams,
+  params: BuildSwapTransactionParams
 ): Promise<BuildSwapTransactionResponse> {
   // Default parameters
   const defaultParams = {
@@ -23,7 +23,7 @@ export async function buildSwapTransaction(
     isAmountInDecimals: false,
   };
 
-  var apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
+  let apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
 
   if (!params.aggregator) {
     apiParams = {
@@ -35,7 +35,7 @@ export async function buildSwapTransaction(
   try {
     const res = await sendRequest<SwapAPIParams, SwapAPIResponse>(
       CDP_GET_SWAP_TRADE,
-      [apiParams],
+      [apiParams]
     );
     if (res.error) {
       return {

--- a/src/swap/utils/getSwapQuote.test.ts
+++ b/src/swap/utils/getSwapQuote.test.ts
@@ -90,6 +90,63 @@ describe('getSwapQuote', () => {
     ]);
   });
 
+  it('should return a quote for a swap with useAggregator=false', async () => {
+    const mockParams = {
+      useAggregator: false,
+      amountReference: testAmountReference,
+      from: ETH,
+      to: DEGEN,
+      amount: testAmount,
+    };
+    const mockApiParams = {
+      v2Enabled: true,
+      ...getAPIParamsForToken(mockParams),
+    };
+
+    const mockResponse = {
+      id: 1,
+      jsonrpc: '2.0',
+      result: {
+        from: {
+          address: '',
+          chainId: 8453,
+          decimals: 18,
+          image:
+            'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+          name: 'ETH',
+          symbol: 'ETH',
+        },
+        to: {
+          address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+          chainId: 8453,
+          decimals: 18,
+          image:
+            'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
+          name: 'DEGEN',
+          symbol: 'DEGEN',
+        },
+        fromAmount: '100000000000000000',
+        toAmount: '16732157880511600003860',
+        amountReference: 'from',
+        priceImpact: '0.07',
+        chainId: 8453,
+        hasHighPriceImpact: false,
+        slippage: '3',
+      },
+    };
+
+    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+
+    const quote = await getSwapQuote(mockParams);
+
+    expect(quote).toEqual(mockResponse.result);
+
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
+      mockApiParams,
+    ]);
+  });
+
   it('should return an error if sendRequest fails', async () => {
     const mockParams = {
       useAggregator: true,

--- a/src/swap/utils/getSwapQuote.test.ts
+++ b/src/swap/utils/getSwapQuote.test.ts
@@ -38,6 +38,7 @@ describe('getSwapQuote', () => {
 
   it('should return a quote for a swap', async () => {
     const mockParams = {
+      aggregator: true,
       amountReference: testAmountReference,
       from: ETH,
       to: DEGEN,
@@ -91,6 +92,7 @@ describe('getSwapQuote', () => {
 
   it('should return an error if sendRequest fails', async () => {
     const mockParams = {
+      aggregator: true,
       amountReference: testAmountReference,
       from: ETH,
       to: DEGEN,
@@ -115,6 +117,7 @@ describe('getSwapQuote', () => {
 
   it('should return an error object from getSwapQuote', async () => {
     const mockParams = {
+      aggregator: true,
       amountReference: testAmountReference,
       from: ETH,
       to: DEGEN,

--- a/src/swap/utils/getSwapQuote.test.ts
+++ b/src/swap/utils/getSwapQuote.test.ts
@@ -38,7 +38,7 @@ describe('getSwapQuote', () => {
 
   it('should return a quote for a swap', async () => {
     const mockParams = {
-      aggregator: true,
+      useAggregator: true,
       amountReference: testAmountReference,
       from: ETH,
       to: DEGEN,
@@ -92,7 +92,7 @@ describe('getSwapQuote', () => {
 
   it('should return an error if sendRequest fails', async () => {
     const mockParams = {
-      aggregator: true,
+      useAggregator: true,
       amountReference: testAmountReference,
       from: ETH,
       to: DEGEN,
@@ -117,7 +117,7 @@ describe('getSwapQuote', () => {
 
   it('should return an error object from getSwapQuote', async () => {
     const mockParams = {
-      aggregator: true,
+      useAggregator: true,
       amountReference: testAmountReference,
       from: ETH,
       to: DEGEN,

--- a/src/swap/utils/getSwapQuote.ts
+++ b/src/swap/utils/getSwapQuote.ts
@@ -21,7 +21,14 @@ export async function getSwapQuote(
     amountReference: 'from',
     isAmountInDecimals: false,
   };
-  const apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
+  var apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
+
+  if (!params.aggregator) {
+    apiParams = {
+      v2Enabled: true,
+      ...apiParams,
+    };
+  }
 
   try {
     const res = await sendRequest<SwapAPIParams, SwapQuote>(

--- a/src/swap/utils/getSwapQuote.ts
+++ b/src/swap/utils/getSwapQuote.ts
@@ -14,14 +14,14 @@ import { getSwapErrorCode } from './getSwapErrorCode';
  * Retrieves a quote for a swap from Token A to Token B.
  */
 export async function getSwapQuote(
-  params: GetSwapQuoteParams,
+  params: GetSwapQuoteParams
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {
     amountReference: 'from',
     isAmountInDecimals: false,
   };
-  var apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
+  let apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
 
   if (!params.aggregator) {
     apiParams = {
@@ -33,7 +33,7 @@ export async function getSwapQuote(
   try {
     const res = await sendRequest<SwapAPIParams, SwapQuote>(
       CDP_GET_SWAP_QUOTE,
-      [apiParams],
+      [apiParams]
     );
     if (res.error) {
       return {

--- a/src/swap/utils/getSwapQuote.ts
+++ b/src/swap/utils/getSwapQuote.ts
@@ -23,7 +23,7 @@ export async function getSwapQuote(
   };
   let apiParams = getAPIParamsForToken({ ...defaultParams, ...params });
 
-  if (!params.aggregator) {
+  if (!params.useAggregator) {
     apiParams = {
       v2Enabled: true,
       ...apiParams,

--- a/src/swap/utils/getSwapQuote.ts
+++ b/src/swap/utils/getSwapQuote.ts
@@ -14,7 +14,7 @@ import { getSwapErrorCode } from './getSwapErrorCode';
  * Retrieves a quote for a swap from Token A to Token B.
  */
 export async function getSwapQuote(
-  params: GetSwapQuoteParams
+  params: GetSwapQuoteParams,
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {
@@ -33,7 +33,7 @@ export async function getSwapQuote(
   try {
     const res = await sendRequest<SwapAPIParams, SwapQuote>(
       CDP_GET_SWAP_QUOTE,
-      [apiParams]
+      [apiParams],
     );
     if (res.error) {
       return {


### PR DESCRIPTION
**What changed? Why?**
- add `aggregators` prop to `<Swap/>` to control `V1` or `V2` API
- this will add the `v2Enabled` parameter in the request body, our API will route these to a beta implementation for serving quotes/trades directly from Uniswap V3

`V1` API does not index pools with under <= $10,000 of liquidity, `V2` API will make a direct call to the `UniswapRouter` contract

**Notes to reviewers**
`slippage` for the `V2` API is hardcoded to 1000 bps (10%) - Tina is aligned for the initial launch and we'll fast-follow to add configurability to the UI

usage
```javascript
<Swap address={address} experimental={{ useAggregator: false }}>
          ...
</Swap>
```

**How has it been tested?**
See Slack for demo
