### PR TITLE
chore: Add tests for useWriteContract and useWriteContracts wrapper

### DIFF
--- a/.changeset/brave-lobsters-begin.md
+++ b/.changeset/brave-lobsters-begin.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**chore**: Add tests for useWriteContract and useWriteContracts. By @cpcramer #884

--- a/src/transaction/hooks/useWriteContract.test.ts
+++ b/src/transaction/hooks/useWriteContract.test.ts
@@ -1,0 +1,126 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWriteContract as useWriteContractWagmi } from 'wagmi';
+import { useWriteContract } from './useWriteContract';
+
+vi.mock('wagmi', () => ({
+  useWriteContract: vi.fn(),
+}));
+
+describe('useWriteContract', () => {
+  const mockSetErrorMessage = vi.fn();
+  const mockSetTransactionId = vi.fn();
+  const mockOnError = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should return wagmi hook data when successful', () => {
+    const mockWriteContract = vi.fn();
+    const mockData = 'mockTransactionData';
+    (useWriteContractWagmi as any).mockReturnValue({
+      status: 'idle',
+      writeContract: mockWriteContract,
+      data: mockData,
+    });
+
+    const { result } = renderHook(() =>
+      useWriteContract({
+        setErrorMessage: mockSetErrorMessage,
+        setTransactionId: mockSetTransactionId,
+        onError: mockOnError,
+      }),
+    );
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.writeContract).toBe(mockWriteContract);
+    expect(result.current.data).toBe(mockData);
+  });
+
+  it('should handle generic error', () => {
+    const genericError = new Error('Something went wrong. Please try again.');
+
+    let onErrorCallback: ((error: any) => void) | undefined;
+
+    (useWriteContractWagmi as any).mockImplementation(({ mutation }) => {
+      onErrorCallback = mutation.onError;
+      return {
+        writeContract: vi.fn(),
+        data: null,
+      };
+    });
+
+    renderHook(() =>
+      useWriteContract({
+        setErrorMessage: mockSetErrorMessage,
+        setTransactionId: mockSetTransactionId,
+        onError: mockOnError,
+      }),
+    );
+
+    expect(onErrorCallback).toBeDefined();
+    onErrorCallback?.(genericError);
+
+    expect(mockSetErrorMessage).toHaveBeenCalledWith(
+      'Something went wrong. Please try again.',
+    );
+    expect(mockOnError).toHaveBeenCalledWith({
+      code: 'WRITE_TRANSACTIONS_ERROR',
+      error: 'Generic error',
+    });
+  });
+
+  it('should handle successful transaction', () => {
+    const transactionId = '0x123';
+
+    let onSuccessCallback: ((id: string) => void) | undefined;
+
+    (useWriteContractWagmi as any).mockImplementation(({ mutation }) => {
+      onSuccessCallback = mutation.onSuccess;
+      return {
+        writeContract: vi.fn(),
+        data: transactionId,
+      };
+    });
+
+    renderHook(() =>
+      useWriteContract({
+        setErrorMessage: mockSetErrorMessage,
+        setTransactionId: mockSetTransactionId,
+        onError: mockOnError,
+      }),
+    );
+
+    expect(onSuccessCallback).toBeDefined();
+    onSuccessCallback?.(transactionId);
+
+    expect(mockSetTransactionId).toHaveBeenCalledWith(transactionId);
+  });
+
+  it('should handle uncaught errors', () => {
+    const uncaughtError = new Error('Uncaught error');
+
+    (useWriteContractWagmi as any).mockImplementation(() => {
+      throw uncaughtError;
+    });
+
+    const { result } = renderHook(() =>
+      useWriteContract({
+        setErrorMessage: mockSetErrorMessage,
+        setTransactionId: mockSetTransactionId,
+        onError: mockOnError,
+      }),
+    );
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.writeContract).toBeInstanceOf(Function);
+    expect(mockSetErrorMessage).toHaveBeenCalledWith(
+      'Something went wrong. Please try again.',
+    );
+    expect(mockOnError).toHaveBeenCalledWith({
+      code: 'UNCAUGHT_WRITE_TRANSACTIONS_ERROR',
+      error: JSON.stringify(uncaughtError),
+    });
+  });
+});

--- a/src/transaction/hooks/useWriteContracts.test.ts
+++ b/src/transaction/hooks/useWriteContracts.test.ts
@@ -1,0 +1,136 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWriteContracts as useWriteContractsWagmi } from 'wagmi/experimental';
+import { useWriteContracts } from './useWriteContracts';
+
+vi.mock('wagmi/experimental', () => ({
+  useWriteContracts: vi.fn(),
+}));
+
+type UseWriteContractsConfig = {
+  mutation: {
+    onError: (error: Error) => void;
+    onSuccess: (id: string) => void;
+  };
+};
+
+describe('useWriteContracts', () => {
+  const mockSetErrorMessage = vi.fn();
+  const mockSetTransactionId = vi.fn();
+  const mockOnError = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should return wagmi hook data when successful', () => {
+    const mockWriteContracts = vi.fn();
+    (useWriteContractsWagmi as ReturnType<typeof vi.fn>).mockReturnValue({
+      status: 'idle',
+      writeContracts: mockWriteContracts,
+    });
+
+    const { result } = renderHook(() =>
+      useWriteContracts({
+        setErrorMessage: mockSetErrorMessage,
+        setTransactionId: mockSetTransactionId,
+        onError: mockOnError,
+      }),
+    );
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.writeContracts).toBe(mockWriteContracts);
+  });
+
+  it('should handle generic error', () => {
+    const genericError = new Error('Something went wrong. Please try again.');
+
+    let onErrorCallback: ((error: Error) => void) | undefined;
+
+    (useWriteContractsWagmi as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ mutation }: UseWriteContractsConfig) => {
+        onErrorCallback = mutation.onError;
+        return {
+          writeContracts: vi.fn(),
+          status: 'error',
+        };
+      },
+    );
+
+    renderHook(() =>
+      useWriteContracts({
+        setErrorMessage: mockSetErrorMessage,
+        setTransactionId: mockSetTransactionId,
+        onError: mockOnError,
+      }),
+    );
+
+    expect(onErrorCallback).toBeDefined();
+    onErrorCallback?.(genericError);
+
+    expect(mockSetErrorMessage).toHaveBeenCalledWith(
+      'Something went wrong. Please try again.',
+    );
+    expect(mockOnError).toHaveBeenCalledWith({
+      code: 'WRITE_TRANSACTIONS_ERROR',
+      error: 'Something went wrong. Please try again.',
+    });
+  });
+
+  it('should handle successful transaction', () => {
+    const transactionId = '0x123';
+
+    let onSuccessCallback: ((id: string) => void) | undefined;
+
+    (useWriteContractsWagmi as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ mutation }: UseWriteContractsConfig) => {
+        onSuccessCallback = mutation.onSuccess;
+        return {
+          writeContracts: vi.fn(),
+          status: 'success',
+        };
+      },
+    );
+
+    renderHook(() =>
+      useWriteContracts({
+        setErrorMessage: mockSetErrorMessage,
+        setTransactionId: mockSetTransactionId,
+        onError: mockOnError,
+      }),
+    );
+
+    expect(onSuccessCallback).toBeDefined();
+    onSuccessCallback?.(transactionId);
+
+    expect(mockSetTransactionId).toHaveBeenCalledWith(transactionId);
+  });
+
+  it('should handle uncaught errors', () => {
+    const uncaughtError = new Error('Uncaught error');
+
+    (useWriteContractsWagmi as ReturnType<typeof vi.fn>).mockImplementation(
+      () => {
+        throw uncaughtError;
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useWriteContracts({
+        setErrorMessage: mockSetErrorMessage,
+        setTransactionId: mockSetTransactionId,
+        onError: mockOnError,
+      }),
+    );
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.writeContracts).toBeInstanceOf(Function);
+    expect(mockSetErrorMessage).toHaveBeenCalledWith(
+      'Something went wrong. Please try again.',
+    );
+    expect(mockOnError).toHaveBeenCalledWith({
+      code: 'UNCAUGHT_WRITE_TRANSACTIONS_ERROR',
+      error: JSON.stringify(uncaughtError),
+    });
+  });
+});


### PR DESCRIPTION
**What changed? Why?**
Add tests for `useWriteContract` and `useWriteContracts`. This is part of the initiative to increase `TransactionComponent` test coverage before the launch. 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="774" alt="Screenshot 2024-07-24 at 2 27 14 PM" src="https://github.com/user-attachments/assets/7eccc75c-345e-4373-88cd-61244a04c7b0">

   </td>
    <td>
<img width="805" alt="Screenshot 2024-07-24 at 2 25 10 PM" src="https://github.com/user-attachments/assets/ae598ce0-3be8-4ad1-b291-b5283c542f79">

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
