### PR TITLE
feat: BaseSepolia Network Switcher 

### DIFF
--- a/site/docs/components/switchNetworkBaseSepolia.tsx
+++ b/site/docs/components/switchNetworkBaseSepolia.tsx
@@ -2,38 +2,38 @@ import { useSwitchChain, useAccount } from "wagmi";
 import { baseSepolia } from "wagmi/chains";
 import { useState, ReactNode } from "react";
 
-type SwitchTargetBaseSepoliaProps = {
+type SwitchNetworkBaseSepoliaProps = {
   children: (props: {
     isLoading: boolean;
-    SwitchTargetBaseSepolia: () => Promise<void>;
+    SwitchNetworkBaseSepolia: () => Promise<void>;
   }) => ReactNode;
 };
 
-export default function SwitchTargetBaseSepolia({
+export default function SwitchNetworkBaseSepolia({
   children,
-}: SwitchTargetBaseSepoliaProps) {
+}: SwitchNetworkBaseSepoliaProps) {
   const { switchChain } = useSwitchChain();
-  const { chain } = useAccount();
+  const { chain, isConnected } = useAccount();
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleSwitchTargetBaseSepolia = async () => {
+  const handleSwitchNetworkBaseSepolia = async () => {
     setIsLoading(true);
     try {
       await switchChain({ chainId: baseSepolia.id });
     } catch (error) {
-      console.error("switchTargetBaseSepolia:", error);
+      console.error("switchNetworkBaseSepolia:", error);
     } finally {
       setIsLoading(false);
     }
   };
 
-  // Don't render anything if already on Base Sepolia
-  if (chain?.id === baseSepolia.id) {
+  // Don't render anything if the wallet is not connected or already on Base Sepolia
+  if (!isConnected || chain?.id === baseSepolia.id) {
     return null;
   }
 
   return children({
     isLoading,
-    SwitchTargetBaseSepolia: handleSwitchTargetBaseSepolia,
+    SwitchNetworkBaseSepolia: handleSwitchNetworkBaseSepolia,
   });
 }

--- a/site/docs/components/switchTargetBaseSepolia.tsx
+++ b/site/docs/components/switchTargetBaseSepolia.tsx
@@ -1,0 +1,39 @@
+import { useSwitchChain, useAccount } from "wagmi";
+import { baseSepolia } from "wagmi/chains";
+import { useState, ReactNode } from "react";
+
+type SwitchTargetBaseSepoliaProps = {
+  children: (props: {
+    isLoading: boolean;
+    SwitchTargetBaseSepolia: () => Promise<void>;
+  }) => ReactNode;
+};
+
+export default function SwitchTargetBaseSepolia({
+  children,
+}: SwitchTargetBaseSepoliaProps) {
+  const { switchChain } = useSwitchChain();
+  const { chain } = useAccount();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSwitchTargetBaseSepolia = async () => {
+    setIsLoading(true);
+    try {
+      await switchChain({ chainId: baseSepolia.id });
+    } catch (error) {
+      console.error("switchTargetBaseSepolia:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Don't render anything if already on Base Sepolia
+  if (chain?.id === baseSepolia.id) {
+    return null;
+  }
+
+  return children({
+    isLoading,
+    SwitchTargetBaseSepolia: handleSwitchTargetBaseSepolia,
+  });
+}

--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -1,12 +1,12 @@
-import { Avatar, Name } from '@coinbase/onchainkit/identity';
+import { Avatar, Name } from '../src/identity';
 import {
   Transaction,
   TransactionButton,
   TransactionStatus,
   TransactionStatusLabel,
   TransactionStatusAction
-} from '@coinbase/onchainkit/transaction';
-import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
+} from '../src/transaction';
+import { Wallet, ConnectWallet } from '../src/wallet';
 import AppWithBaseSepolia from '../../components/AppWithBaseSepolia';
 import TransactionWrapper from '../../components/TransactionWrapper';
 import SwitchNetworkBaseSepolia from '../../components/switchNetworkBaseSepolia';

--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -9,7 +9,7 @@ import {
 import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
 import AppWithBaseSepolia from '../../components/AppWithBaseSepolia';
 import TransactionWrapper from '../../components/TransactionWrapper';
-import SwitchTargetBaseSepolia from '../../components/switchTargetBaseSepolia';
+import SwitchNetworkBaseSepolia from '../../components/switchNetworkBaseSepolia';
 
 # `<Transaction />`
 
@@ -77,11 +77,11 @@ export default function TransactionComponents() {
 }
 ```
 <AppWithBaseSepolia>
-  <SwitchTargetBaseSepolia>
-    {({ isLoading, SwitchTargetBaseSepolia }) => (
+  <SwitchNetworkBaseSepolia>
+    {({ isLoading, SwitchNetworkBaseSepolia }) => (
       <div className="flex max-w-[450px] items-center rounded-lg bg-white p-1">
         <button 
-          onClick={SwitchTargetBaseSepolia} 
+          onClick={SwitchNetworkBaseSepolia} 
           disabled={isLoading}
           className="w-full bg-white text-black text-sm font-semibold py-1 px-2 rounded-lg shadow-sm hover:bg-gray-50 transition-colors"
         >
@@ -89,7 +89,7 @@ export default function TransactionComponents() {
         </button>
       </div>
     )}    
-  </SwitchTargetBaseSepolia>
+  </SwitchNetworkBaseSepolia>
 </AppWithBaseSepolia>
 
 <AppWithBaseSepolia>

--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -1,6 +1,6 @@
 import { Avatar, Name } from '@coinbase/onchainkit/identity';
-import { 
-  Transaction, 
+import {
+  Transaction,
   TransactionButton,
   TransactionStatus,
   TransactionStatusLabel,
@@ -9,6 +9,7 @@ import {
 import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
 import AppWithBaseSepolia from '../../components/AppWithBaseSepolia';
 import TransactionWrapper from '../../components/TransactionWrapper';
+import SwitchTargetBaseSepolia from '../../components/switchTargetBaseSepolia';
 
 # `<Transaction />`
 
@@ -75,6 +76,21 @@ export default function TransactionComponents() {
   );
 }
 ```
+<AppWithBaseSepolia>
+  <SwitchTargetBaseSepolia>
+    {({ isLoading, SwitchTargetBaseSepolia }) => (
+      <div className="flex max-w-[450px] items-center rounded-lg bg-white p-1">
+        <button 
+          onClick={SwitchTargetBaseSepolia} 
+          disabled={isLoading}
+          className="w-full bg-white text-black text-sm font-semibold py-1 px-2 rounded-lg shadow-sm hover:bg-gray-50 transition-colors"
+        >
+          {isLoading ? 'Switching...' : 'Switch to Base Sepolia'}
+        </button>
+      </div>
+    )}    
+  </SwitchTargetBaseSepolia>
+</AppWithBaseSepolia>
 
 <AppWithBaseSepolia>
   <TransactionWrapper>


### PR DESCRIPTION
**What changed? Why?**
Add `"Switch to Base Sepolia"` button above the Transaction Button in `/transaction/transaction` 
- The button will only display if the users EOA wallet is connect and if they are not on Base Sepolia. 

This is needed because as of today the Transaction Button will error if an EOA account user is on any network other than `Base Sepolia`.

We will eventually use this component throughout OnchainKit.xyz - potentially as a nav bar drop down or prompted in the wallet popup. 



<img width="1161" alt="Screenshot 2024-07-24 at 5 15 09 PM" src="https://github.com/user-attachments/assets/cf6af2bf-621c-4d97-a376-9e9e420e013c">

[BOE-85](https://linear.app/coinbase/issue/BOE-85/add-network-switching-functionality-to-onchainkitxyz-that-default-to)
**Notes to reviewers**

**How has it been tested?**
