### PR TITLE
Feat: Add ENSIP-19 support to getName

### DIFF
--- a/.changeset/four-cups-shave.md
+++ b/.changeset/four-cups-shave.md
@@ -1,0 +1,8 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+**feat**: Add `convertChainIdToCoinType` function to convert a chainId to a coinTypeHex for ENSIP-19 reverse resolution. By @kirkas #891
+**fix**: Modify `convertReverseNodeToBytes` to use `convertChainIdToCoinType` instead of hardcoded resolver address. By @kirkas #891
+**fix**: Modify `useName` to return a type `BaseName` for extra type safety. By @kirkas #891
+**feat**: Add more storybook scenarios for `<Name>`. By @kirkas #891

--- a/src/identity/components/Name.stories.tsx
+++ b/src/identity/components/Name.stories.tsx
@@ -37,7 +37,15 @@ export const Sliced: Story = {
 
 export const BaseSepolia: Story = {
   args: {
-    address: '0x8c8F1a1e1bFdb15E7ed562efc84e5A588E68aD73',
+    address: '0xe5546B2Bd78408DB7908F86251e7f694CF6397b9',
+    chain: baseSepolia,
+  },
+};
+
+// This should default to ENS domain
+export const BaseSepoliaWithoutDomain: Story = {
+  args: {
+    address: '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1',
     chain: baseSepolia,
   },
 };

--- a/src/identity/constants.ts
+++ b/src/identity/constants.ts
@@ -1,10 +1,7 @@
 import { base, baseSepolia } from 'viem/chains';
 import type { ResolverAddressesByChainIdMap } from './types';
 
-export const ADDRESS_REVERSE_NODE =
-  '0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2';
-
 export const RESOLVER_ADDRESSES_BY_CHAIN_ID: ResolverAddressesByChainIdMap = {
-  [baseSepolia.id]: '0x8d2D30cdE6c46BC81824d0732cE8395c58da3939',
+  [baseSepolia.id]: '0x6533C94869D28fAA8dF77cc63f9e2b2D6Cf77eBA',
   [base.id]: '0x', // TODO: Update when live
 };

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -116,7 +116,22 @@ export type GetName = {
 /**
  * Note: exported as public Type
  */
-export type GetNameReturnType = string | null;
+export type BaseMainnetName = `${string}.base.eth`;
+
+/**
+ * Note: exported as public Type
+ */
+export type BaseSepoliaName = `${string}.basetest.eth`;
+
+/**
+ * Note: exported as public Type
+ */
+export type BaseName = BaseMainnetName | BaseSepoliaName;
+
+/**
+ * Note: exported as public Type
+ */
+export type GetNameReturnType = string | BaseName | null;
 
 /**
  * Note: exported as public Type

--- a/src/identity/utils/convertChainIdToCoinType.test.ts
+++ b/src/identity/utils/convertChainIdToCoinType.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { arbitrum, base, mainnet, optimism } from 'viem/chains';
+import { convertChainIdToCoinType } from './convertChainIdToCoinType';
+
+describe('convertChainIdToCoinType', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // We test the chain listed on ENSIP-19 documentation https://docs.ens.domains/ensip/19#examples-of-valid-l2-reverse-resolution
+
+  it('should return correct cointype for mainnet', async () => {
+    const coinType = convertChainIdToCoinType(mainnet.id);
+    expect(coinType).toBe('addr');
+  });
+
+  it('should return correct cointype for arbitrum', async () => {
+    const coinType = convertChainIdToCoinType(arbitrum.id);
+    expect(coinType).toBe('8000A4B1');
+  });
+
+  it('should return correct cointype for optimism', async () => {
+    const coinType = convertChainIdToCoinType(optimism.id);
+    expect(coinType).toBe('8000000A');
+  });
+
+  it('should return correct cointype for base', async () => {
+    const coinType = convertChainIdToCoinType(base.id);
+    expect(coinType).toBe('80002105');
+  });
+});

--- a/src/identity/utils/convertChainIdToCoinType.ts
+++ b/src/identity/utils/convertChainIdToCoinType.ts
@@ -1,0 +1,14 @@
+import { mainnet } from 'viem/chains';
+
+/**
+ * Convert an chainId to a coinType hex for reverse chain resolution
+ */
+export const convertChainIdToCoinType = (chainId: number): string => {
+  // L1 resolvers to addr
+  if (chainId === mainnet.id) {
+    return 'addr';
+  }
+
+  const cointype = (0x80000000 | chainId) >>> 0;
+  return cointype.toString(16).toLocaleUpperCase();
+};

--- a/src/identity/utils/convertReverseNodeToBytes.test.ts
+++ b/src/identity/utils/convertReverseNodeToBytes.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 
+import { base } from 'viem/chains';
 import { convertReverseNodeToBytes } from './convertReverseNodeToBytes';
 
 describe('convertReverseNodeToBytes', () => {
@@ -12,9 +13,10 @@ describe('convertReverseNodeToBytes', () => {
   it('should return correct resolver data', async () => {
     const reversedAddress = convertReverseNodeToBytes(
       '0x8c8F1a1e1bFdb15E7ed562efc84e5A588E68aD73',
+      base.id,
     );
     expect(reversedAddress).toBe(
-      '0x6139cf12ddf8f0552eba843e6452ccbb64d5b033ce908f8fb939e4287ece0e68',
+      '0xcd18b9f82b690bdf732816fe0b9796635191f97e59bcebbef4eba6e05a39da05',
     );
   });
 });

--- a/src/identity/utils/convertReverseNodeToBytes.ts
+++ b/src/identity/utils/convertReverseNodeToBytes.ts
@@ -1,15 +1,22 @@
-import { encodePacked, keccak256 } from 'viem';
+import { encodePacked, keccak256, namehash } from 'viem';
 import type { Address } from 'viem';
-import { ADDRESS_REVERSE_NODE } from '../constants';
+import { convertChainIdToCoinType } from './convertChainIdToCoinType';
 
 /**
  * Convert an address to a reverse node for ENS resolution
  */
-export const convertReverseNodeToBytes = (address: Address) => {
+export const convertReverseNodeToBytes = (
+  address: Address,
+  chainId: number,
+) => {
   const addressFormatted = address.toLocaleLowerCase() as Address;
   const addressNode = keccak256(addressFormatted.substring(2) as Address);
+  const chainCoinType = convertChainIdToCoinType(chainId);
+  const baseReverseNode = namehash(
+    `${chainCoinType.toLocaleUpperCase()}.reverse`,
+  );
   const addressReverseNode = keccak256(
-    encodePacked(['bytes32', 'bytes32'], [ADDRESS_REVERSE_NODE, addressNode]),
+    encodePacked(['bytes32', 'bytes32'], [baseReverseNode, addressNode]),
   );
   return addressReverseNode;
 };

--- a/src/identity/utils/getName.ts
+++ b/src/identity/utils/getName.ts
@@ -1,10 +1,10 @@
-import { mainnet } from 'viem/chains';
+import { base, mainnet } from 'viem/chains';
 import { isBase } from '../../isBase';
 import { isEthereum } from '../../isEthereum';
 import { getChainPublicClient } from '../../network/getChainPublicClient';
 import L2ResolverAbi from '../abis/L2ResolverAbi';
 import { RESOLVER_ADDRESSES_BY_CHAIN_ID } from '../constants';
-import type { GetName, GetNameReturnType } from '../types';
+import type { BaseName, GetName, GetNameReturnType } from '../types';
 import { convertReverseNodeToBytes } from './convertReverseNodeToBytes';
 
 /**
@@ -30,7 +30,7 @@ export const getName = async ({
   let client = getChainPublicClient(chain);
 
   if (chainIsBase) {
-    const addressReverseNode = convertReverseNodeToBytes(address);
+    const addressReverseNode = convertReverseNodeToBytes(address, base.id);
     try {
       const baseName = await client.readContract({
         abi: L2ResolverAbi,
@@ -39,7 +39,7 @@ export const getName = async ({
         args: [addressReverseNode],
       });
       if (baseName) {
-        return baseName;
+        return baseName as BaseName;
       }
     } catch (_error) {
       // This is a best effort attempt, so we don't need to do anything here.


### PR DESCRIPTION
**What changed? Why?**
**feat**: Add `convertChainIdToCoinType` function to convert a chainId to a coinTypeHex for ENSIP-19 reverse resolution.
**fix**: Modify `convertReverseNodeToBytes` to use `convertChainIdToCoinType` instead of hardcoded resolver address.
**fix**: Modify `useName` to return a type `BaseName` for extra type safety. 
**feat**: Add more storybook scenarios for `<Name>`.
