### PR TITLE
feat: Implement WalletDropdownBaseName Sub-Component 

### DIFF
--- a/.changeset/afraid-dogs-vanish.md
+++ b/.changeset/afraid-dogs-vanish.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**feat**: Implement WalletDropdownBaseName Sub-Component. By @cpcramer #913

--- a/src/internal/svg/baseNameSvg.tsx
+++ b/src/internal/svg/baseNameSvg.tsx
@@ -1,0 +1,22 @@
+export const baseNameSvg = (
+  <svg
+    data-testid="ockbaseNameSvg"
+    role="img"
+    aria-label="ock-base-name"
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    className="h-full w-full"
+  >
+    <path
+      d="M11.75 3.75C11.75 5.82107 10.0711 7.5 8 7.5C5.92893 7.5 4.25 5.82107 4.25 3.75C4.25 1.67893 5.92893 0 8 0C10.0711 0 11.75 1.67893 11.75 3.75Z"
+      fill="#0A0B0D"
+    />
+    <path
+      d="M10.99 8.01001C12.21 8.04001 13.3 8.80001 13.73 9.95001L16 16H0L2.27 9.95001C2.7 8.80001 3.79 8.03001 5.01 8.01001C5.05 8.04001 6.37 9.00001 8 9.00001C9.63 9.00001 10.95 8.04001 10.99 8.01001Z"
+      fill="#0A0B0D"
+    />
+  </svg>
+);

--- a/src/wallet/components/WalletDropdownBaseName.test.tsx
+++ b/src/wallet/components/WalletDropdownBaseName.test.tsx
@@ -1,0 +1,86 @@
+import type { UseQueryResult } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { GetAccountReturnType } from '@wagmi/core';
+import { describe, expect, it, vi } from 'vitest';
+import { useAccount } from 'wagmi';
+import { useName } from '../../identity/hooks/useName';
+import { WalletDropdownBaseName } from './WalletDropdownBaseName';
+
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+}));
+
+vi.mock('../../identity/hooks/useName', () => ({
+  useName: vi.fn(),
+}));
+
+describe('WalletDropdownBaseName', () => {
+  it('should render "Claim a Basename" when no basename', () => {
+    (useAccount as vi.Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+      address: '0x1234' as `0x${string}`,
+      isConnected: true,
+    });
+    (
+      useName as vi.Mock<[], Partial<UseQueryResult<string | null, Error>>>
+    ).mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<WalletDropdownBaseName />);
+    expect(screen.getByText('Claim a Basename')).toBeInTheDocument();
+    expect(screen.getByText('NEW')).toBeInTheDocument();
+  });
+
+  it('should render "Go to profile" when basename exists', () => {
+    (useAccount as vi.Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+      address: '0x1234' as `0x${string}`,
+      isConnected: true,
+    });
+    (
+      useName as vi.Mock<[], Partial<UseQueryResult<string | null, Error>>>
+    ).mockReturnValue({
+      data: 'test.base',
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<WalletDropdownBaseName />);
+    expect(screen.getByText('Go to profile')).toBeInTheDocument();
+    expect(screen.queryByText('NEW')).not.toBeInTheDocument();
+  });
+
+  it('should render Spinner when loading', () => {
+    (useAccount as vi.Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+      address: '0x1234' as `0x${string}`,
+      isConnected: true,
+    });
+    (
+      useName as vi.Mock<[], Partial<UseQueryResult<string | null, Error>>>
+    ).mockReturnValue({
+      data: null,
+      isLoading: true,
+      isError: false,
+      error: null,
+    });
+
+    render(<WalletDropdownBaseName />);
+    expect(screen.getByTestId('ockSpinner')).toBeInTheDocument();
+    expect(screen.queryByText('Claim a Basename')).not.toBeInTheDocument();
+    expect(screen.queryByText('Go to profile')).not.toBeInTheDocument();
+    expect(screen.queryByText('NEW')).not.toBeInTheDocument();
+  });
+
+  it('should return null if there is no address', () => {
+    (useAccount as vi.Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+      address: undefined,
+      isConnected: false,
+    });
+
+    const { container } = render(<WalletDropdownBaseName />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/wallet/components/WalletDropdownBaseName.tsx
+++ b/src/wallet/components/WalletDropdownBaseName.tsx
@@ -1,0 +1,66 @@
+import { base } from 'viem/chains';
+import { useAccount } from 'wagmi';
+import { useName } from '../../identity/hooks/useName';
+import { Spinner } from '../../internal/components/Spinner';
+import { baseNameSvg } from '../../internal/svg/baseNameSvg';
+import { cn, pressable, text } from '../../styles/theme';
+import type { WalletDropdownBaseNameReact } from '../types';
+
+export function WalletDropdownBaseName({
+  className,
+}: WalletDropdownBaseNameReact) {
+  const { address } = useAccount();
+
+  if (!address) {
+    return null;
+  }
+
+  const { data: baseName, isLoading } = useName({
+    address,
+    chain: base,
+  });
+
+  let hasBaseUserName = false;
+
+  if (baseName) {
+    hasBaseUserName = true;
+  }
+
+  const title = hasBaseUserName ? 'Go to profile' : 'Claim a Basename';
+  const href = hasBaseUserName
+    ? `https://www.base.org/name/${baseName}`
+    : 'https://www.base.org/names';
+
+  return (
+    <a
+      className={cn(
+        pressable.default,
+        'flex items-center px-4 py-2',
+        className,
+      )}
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {baseNameSvg && <div className="mr-2 h-5 w-5">{baseNameSvg}</div>}
+      <div className="flex items-center">
+        {isLoading ? (
+          <Spinner />
+        ) : (
+          <>
+            <span className={cn(text.body, 'shrink-0')}>{title}</span>
+            {!hasBaseUserName && (
+              <span
+                className={cn(
+                  'ml-2 rounded-full bg-[#E0E7FF] px-2 text-center font-bold font-inter text-[#4F46E5] text-[0.6875rem] uppercase leading-6',
+                )}
+              >
+                NEW
+              </span>
+            )}
+          </>
+        )}
+      </div>
+    </a>
+  );
+}

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -2,6 +2,7 @@
 export { ConnectWallet } from './components/ConnectWallet';
 export { Wallet } from './components/Wallet';
 export { WalletDropdown } from './components/WalletDropdown';
+export { WalletDropdownBaseName } from './components/WalletDropdownBaseName';
 export { WalletDropdownDisconnect } from './components/WalletDropdownDisconnect';
 export { WalletDropdownLink } from './components/WalletDropdownLink';
 export { isValidAAEntrypoint } from './utils/isValidAAEntrypoint';

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -75,6 +75,13 @@ export type WalletReact = {
 /**
  * Note: exported as public Type
  */
+export type WalletDropdownBaseNameReact = {
+  className?: string; // Optional className override for the element
+};
+
+/**
+ * Note: exported as public Type
+ */
 export type WalletDropdownReact = {
   children: React.ReactNode;
   className?: string; // Optional className override for top div element


### PR DESCRIPTION
**What changed? Why?**

Add the Base Name tab to the Wallet Component. When a user has a Base Name, this tab will direct them to their Base Name profile page. If a user does not have a Base Name, this tab will direct them to a page where they can create one!

- Add `WalletDropdownBaseName` component
- Add BaseName SVG
- Add `WalletDropdownBaseName` tests

| Part | Description | Status |
|---|----|---|
| 1 | [feat: Implement WalletDropdownBaseName Sub-Component #913](https://github.com/coinbase/onchainkit/pull/913) | _In Progress_|
| 2 | [docs: Implement WalletDropdownBaseName Sub-Component #916](https://github.com/coinbase/onchainkit/pull/916) | _In Progress_|

Video recording:
[Wallet Components & Utilities · OnchainKit - 27 July 2024 - Watch Video](https://www.loom.com/share/0a38993d78864be8a27d6d688f52f857)

<img width="240" alt="Screenshot 2024-07-27 at 1 11 57 PM" src="https://github.com/user-attachments/assets/8d7bb4b8-e1c7-4b9d-8127-3b5ef023bf91">

<img width="255" alt="Screenshot 2024-07-27 at 1 11 38 PM" src="https://github.com/user-attachments/assets/0a2b6f81-2a79-4790-9dea-ae407083eefb">


**Notes to reviewers**

**How has it been tested?**
