### PR TITLE
feat: add `onStart` hook to `SwapButton`

### DIFF
--- a/.changeset/seven-peas-brush.md
+++ b/.changeset/seven-peas-brush.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+**feat**: add `onStart` hook to `SwapButton` by @0xAlec #914

--- a/src/swap/components/SwapButton.tsx
+++ b/src/swap/components/SwapButton.tsx
@@ -7,6 +7,7 @@ export function SwapButton({
   className,
   disabled = false,
   onError,
+  onStart,
   onSuccess,
 }: SwapButtonReact) {
   const { to, from, loading, isTransactionPending, handleSubmit } =
@@ -34,7 +35,7 @@ export function SwapButton({
         text.headline,
         className,
       )}
-      onClick={() => handleSubmit(onError, onSuccess)}
+      onClick={() => handleSubmit(onError, onStart, onSuccess)}
       disabled={isDisabled}
       data-testid="ockSwapButton_Button"
     >

--- a/src/swap/components/SwapButton.tsx
+++ b/src/swap/components/SwapButton.tsx
@@ -7,8 +7,8 @@ export function SwapButton({
   className,
   disabled = false,
   onError,
+  onStart,
   onSuccess,
-  onStatus,
 }: SwapButtonReact) {
   const { to, from, loading, isTransactionPending, handleSubmit } =
     useSwapContext();
@@ -35,7 +35,7 @@ export function SwapButton({
         text.headline,
         className,
       )}
-      onClick={() => handleSubmit(onError, onSuccess, onStatus)}
+      onClick={() => handleSubmit(onError, onStart, onSuccess)}
       disabled={isDisabled}
       data-testid="ockSwapButton_Button"
     >

--- a/src/swap/components/SwapButton.tsx
+++ b/src/swap/components/SwapButton.tsx
@@ -7,8 +7,8 @@ export function SwapButton({
   className,
   disabled = false,
   onError,
-  onStart,
   onSuccess,
+  onStatus,
 }: SwapButtonReact) {
   const { to, from, loading, isTransactionPending, handleSubmit } =
     useSwapContext();
@@ -35,7 +35,7 @@ export function SwapButton({
         text.headline,
         className,
       )}
-      onClick={() => handleSubmit(onError, onStart, onSuccess)}
+      onClick={() => handleSubmit(onError, onSuccess, onStatus)}
       disabled={isDisabled}
       data-testid="ockSwapButton_Button"
     >

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -11,7 +11,12 @@ import { formatTokenAmount } from '../../internal/utils/formatTokenAmount';
 import type { Token } from '../../token';
 import { USER_REJECTED_ERROR_CODE } from '../constants';
 import { useFromTo } from '../hooks/useFromTo';
-import type { SwapContextType, SwapError, SwapErrorState } from '../types';
+import type {
+  SwapContextType,
+  SwapError,
+  SwapErrorState,
+  SwapHooks,
+} from '../types';
 import { buildSwapTransaction } from '../utils/buildSwapTransaction';
 import { getSwapQuote } from '../utils/getSwapQuote';
 import { isSwapError } from '../utils/isSwapError';
@@ -140,8 +145,8 @@ export function SwapProvider({
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component
     async function handleSubmit(
       onError?: (error: SwapError) => void,
-      onStart?: (txHash: string) => void | Promise<void>,
       onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>,
+      onStatus?: SwapHooks,
     ) {
       if (!address || !from.token || !to.token || !from.amount) {
         return;
@@ -170,8 +175,8 @@ export function SwapProvider({
           setPendingTransaction,
           setLoading,
           sendTransactionAsync,
-          onStart,
           onSuccess,
+          onStatus,
         });
 
         // TODO: refresh balances
@@ -190,6 +195,7 @@ export function SwapProvider({
           });
         } else {
           onError?.(e as SwapError);
+          onStatus?.onError?.(e as SwapError);
           handleError({ swapError: e as SwapError });
         }
       } finally {

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -11,12 +11,7 @@ import { formatTokenAmount } from '../../internal/utils/formatTokenAmount';
 import type { Token } from '../../token';
 import { USER_REJECTED_ERROR_CODE } from '../constants';
 import { useFromTo } from '../hooks/useFromTo';
-import type {
-  SwapContextType,
-  SwapError,
-  SwapErrorState,
-  SwapHooks,
-} from '../types';
+import type { SwapContextType, SwapError, SwapErrorState } from '../types';
 import { buildSwapTransaction } from '../utils/buildSwapTransaction';
 import { getSwapQuote } from '../utils/getSwapQuote';
 import { isSwapError } from '../utils/isSwapError';
@@ -145,8 +140,8 @@ export function SwapProvider({
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component
     async function handleSubmit(
       onError?: (error: SwapError) => void,
+      onStart?: (txHash: string) => void | Promise<void>,
       onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>,
-      onStatus?: SwapHooks,
     ) {
       if (!address || !from.token || !to.token || !from.amount) {
         return;
@@ -175,8 +170,8 @@ export function SwapProvider({
           setPendingTransaction,
           setLoading,
           sendTransactionAsync,
+          onStart,
           onSuccess,
-          onStatus,
         });
 
         // TODO: refresh balances
@@ -195,7 +190,6 @@ export function SwapProvider({
           });
         } else {
           onError?.(e as SwapError);
-          onStatus?.onError?.(e as SwapError);
           handleError({ swapError: e as SwapError });
         }
       } finally {

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -140,6 +140,7 @@ export function SwapProvider({
     // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component
     async function handleSubmit(
       onError?: (error: SwapError) => void,
+      onStart?: (txHash: string) => void | Promise<void>,
       onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>,
     ) {
       if (!address || !from.token || !to.token || !from.amount) {
@@ -169,6 +170,7 @@ export function SwapProvider({
           setPendingTransaction,
           setLoading,
           sendTransactionAsync,
+          onStart,
           onSuccess,
         });
 

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -126,6 +126,7 @@ export type SwapButtonReact = {
   className?: string; // Optional className override for top div element.
   disabled?: boolean; // Disables swap button
   onError?: (error: SwapError) => void; // Callback function for error
+  onStart?: (txHash: string) => void | Promise<void>; // Callback function for start
   onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>; // Callback function for success
 };
 

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -138,6 +138,7 @@ export type SwapContextType = {
   isTransactionPending: boolean;
   handleSubmit: (
     onError?: (error: SwapError) => void,
+    onStart?: (txHash: string) => void | Promise<void>,
     onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>,
   ) => void;
   handleToggle: () => void;

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -126,8 +126,8 @@ export type SwapButtonReact = {
   className?: string; // Optional className override for top div element.
   disabled?: boolean; // Disables swap button
   onError?: (error: SwapError) => void; // Callback function for error
-  onStart?: (txHash: string) => void | Promise<void>; // Callback function for start
   onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>; // Callback function for success
+  onStatus?: SwapHooks; // Callback functions for error, start, and success
 };
 
 export type SwapContextType = {
@@ -138,8 +138,8 @@ export type SwapContextType = {
   isTransactionPending: boolean;
   handleSubmit: (
     onError?: (error: SwapError) => void,
-    onStart?: (txHash: string) => void | Promise<void>,
     onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>,
+    onStatus?: SwapHooks,
   ) => void;
   handleToggle: () => void;
   handleAmountChange: (
@@ -156,6 +156,12 @@ export type SwapContextType = {
 export type SwapError = {
   code: string; // The error code
   error: string; // The error message
+};
+
+export type SwapHooks = {
+  onError?: (error: SwapError) => void; // Callback function for error
+  onStart?: (txHash: string) => void | Promise<void>; // Callback function for start
+  onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>; // Callback function for success
 };
 
 export type SwapErrorState = {

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -126,8 +126,8 @@ export type SwapButtonReact = {
   className?: string; // Optional className override for top div element.
   disabled?: boolean; // Disables swap button
   onError?: (error: SwapError) => void; // Callback function for error
+  onStart?: (txHash: string) => void | Promise<void>; // Callback function for start
   onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>; // Callback function for success
-  onStatus?: SwapHooks; // Callback functions for error, start, and success
 };
 
 export type SwapContextType = {
@@ -138,8 +138,8 @@ export type SwapContextType = {
   isTransactionPending: boolean;
   handleSubmit: (
     onError?: (error: SwapError) => void,
+    onStart?: (txHash: string) => void | Promise<void>,
     onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>,
-    onStatus?: SwapHooks,
   ) => void;
   handleToggle: () => void;
   handleAmountChange: (
@@ -156,12 +156,6 @@ export type SwapContextType = {
 export type SwapError = {
   code: string; // The error code
   error: string; // The error message
-};
-
-export type SwapHooks = {
-  onError?: (error: SwapError) => void; // Callback function for error
-  onStart?: (txHash: string) => void | Promise<void>; // Callback function for start
-  onSuccess?: (txReceipt: TransactionReceipt) => void | Promise<void>; // Callback function for success
 };
 
 export type SwapErrorState = {

--- a/src/swap/utils/processSwapTransaction.test.ts
+++ b/src/swap/utils/processSwapTransaction.test.ts
@@ -23,11 +23,11 @@ describe('processSwapTransaction', () => {
     .mockResolvedValueOnce('txHash');
   const onSuccess = vi.fn();
   const onStart = vi.fn();
-  const onSuccessAsync = vi.fn().mockImplementation(async (txHash: string) => {
+  const onSuccessAsync = vi.fn().mockImplementation(async (_txHash: string) => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
 
-  const onStartAsync = vi.fn().mockImplementation(async (txHash: string) => {
+  const onStartAsync = vi.fn().mockImplementation(async (_txHash: string) => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
 

--- a/src/swap/utils/processSwapTransaction.test.ts
+++ b/src/swap/utils/processSwapTransaction.test.ts
@@ -13,8 +13,23 @@ vi.mock('wagmi/actions', () => ({
 describe('processSwapTransaction', () => {
   const setPendingTransaction = vi.fn();
   const setLoading = vi.fn();
-  const sendTransactionAsync = vi.fn().mockResolvedValue('approveTxHash');
+  const sendTransactionAsync = vi
+    .fn()
+    .mockResolvedValueOnce('approveTxHash')
+    .mockResolvedValueOnce('txHash');
+  const sendTransactionAsync2 = vi
+    .fn()
+    .mockResolvedValueOnce('approveTxHash')
+    .mockResolvedValueOnce('txHash');
   const onSuccess = vi.fn();
+  const onStart = vi.fn();
+  const onSuccessAsync = vi.fn().mockImplementation(async (txHash: string) => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  const onStartAsync = vi.fn().mockImplementation(async (txHash: string) => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -101,6 +116,7 @@ describe('processSwapTransaction', () => {
       setLoading,
       sendTransactionAsync,
       onSuccess,
+      onStart,
     });
 
     expect(setPendingTransaction).toHaveBeenCalledTimes(4);
@@ -113,6 +129,9 @@ describe('processSwapTransaction', () => {
     expect(setLoading).toHaveBeenCalledWith(true);
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(onSuccess).toHaveBeenCalledWith({});
+    expect(onStart).toHaveBeenCalledTimes(2);
+    expect(onStart).toHaveBeenNthCalledWith(1, 'approveTxHash');
+    expect(onStart).toHaveBeenNthCalledWith(2, 'txHash');
   });
 
   it('should make the swap for non-ERC-20 tokens', async () => {
@@ -190,6 +209,7 @@ describe('processSwapTransaction', () => {
       setLoading,
       sendTransactionAsync,
       onSuccess,
+      onStart,
     });
 
     expect(setPendingTransaction).toHaveBeenCalledTimes(2);
@@ -200,5 +220,104 @@ describe('processSwapTransaction', () => {
     expect(setLoading).toHaveBeenCalledWith(true);
     expect(onSuccess).toHaveBeenCalledTimes(1);
     expect(onSuccess).toHaveBeenCalledWith({});
+  });
+
+  it('should successfully call relevant async lifecycle hooks', async () => {
+    const swapTransaction: BuildSwapTransaction = {
+      transaction: {
+        to: '0x123',
+        value: 0n,
+        data: '0x',
+        chainId: 8453,
+        gas: 0n,
+      },
+      approveTransaction: {
+        to: '0x456',
+        value: 0n,
+        data: '0x123',
+        chainId: 8453,
+        gas: 0n,
+      },
+      quote: {
+        from: {
+          address: '',
+          chainId: 8453,
+          decimals: 18,
+          image:
+            'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+          name: 'ETH',
+          symbol: 'ETH',
+        },
+        to: {
+          address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+          chainId: 8453,
+          decimals: 18,
+          image:
+            'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
+          name: 'DEGEN',
+          symbol: 'DEGEN',
+        },
+        fromAmount: '100000000000000',
+        toAmount: '19395353519910973703',
+        amountReference: 'from',
+        priceImpact: '0.94',
+        hasHighPriceImpact: false,
+        slippage: '3',
+        warning: undefined,
+      },
+      fee: {
+        baseAsset: {
+          name: 'DEGEN',
+          address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+          symbol: 'DEGEN',
+          decimals: 18,
+          image:
+            'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
+          chainId: 8453,
+        },
+        percentage: '1',
+        amount: '195912661817282562',
+      },
+    };
+    const config = createConfig({
+      chains: [mainnet, sepolia],
+      connectors: [
+        mock({
+          accounts: [
+            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+            '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+          ],
+        }),
+      ],
+      transports: {
+        [mainnet.id]: http(),
+        [sepolia.id]: http(),
+      },
+    });
+
+    await processSwapTransaction({
+      swapTransaction,
+      config,
+      setPendingTransaction,
+      setLoading,
+      sendTransactionAsync: sendTransactionAsync2,
+      onSuccess: onSuccessAsync,
+      onStart: onStartAsync,
+    });
+
+    expect(setPendingTransaction).toHaveBeenCalledTimes(4);
+    expect(setPendingTransaction).toHaveBeenCalledWith(true);
+    expect(setPendingTransaction).toHaveBeenCalledWith(false);
+    expect(sendTransactionAsync2).toHaveBeenCalledTimes(2);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+
+    expect(setLoading).toHaveBeenCalledTimes(1);
+    expect(setLoading).toHaveBeenCalledWith(true);
+    expect(onSuccessAsync).toHaveBeenCalledTimes(1);
+    expect(onSuccessAsync).toHaveBeenCalledWith({});
+    expect(onStartAsync).toHaveBeenCalledTimes(2);
+    expect(onStartAsync).toHaveBeenNthCalledWith(1, 'approveTxHash');
+    expect(onStartAsync).toHaveBeenNthCalledWith(2, 'txHash');
   });
 });

--- a/src/swap/utils/processSwapTransaction.test.ts
+++ b/src/swap/utils/processSwapTransaction.test.ts
@@ -115,8 +115,10 @@ describe('processSwapTransaction', () => {
       setPendingTransaction,
       setLoading,
       sendTransactionAsync,
-      onSuccess,
-      onStart,
+      onStatus: {
+        onStart,
+        onSuccess,
+      },
     });
 
     expect(setPendingTransaction).toHaveBeenCalledTimes(4);
@@ -208,8 +210,10 @@ describe('processSwapTransaction', () => {
       setPendingTransaction,
       setLoading,
       sendTransactionAsync,
-      onSuccess,
-      onStart,
+      onStatus: {
+        onStart,
+        onSuccess,
+      },
     });
 
     expect(setPendingTransaction).toHaveBeenCalledTimes(2);
@@ -302,8 +306,10 @@ describe('processSwapTransaction', () => {
       setPendingTransaction,
       setLoading,
       sendTransactionAsync: sendTransactionAsync2,
-      onSuccess: onSuccessAsync,
-      onStart: onStartAsync,
+      onStatus: {
+        onStart: onStartAsync,
+        onSuccess: onSuccessAsync,
+      },
     });
 
     expect(setPendingTransaction).toHaveBeenCalledTimes(4);
@@ -319,5 +325,100 @@ describe('processSwapTransaction', () => {
     expect(onStartAsync).toHaveBeenCalledTimes(2);
     expect(onStartAsync).toHaveBeenNthCalledWith(1, 'approveTxHash');
     expect(onStartAsync).toHaveBeenNthCalledWith(2, 'txHash');
+  });
+
+  it('should successfully call legacy lifecycle hooks', async () => {
+    const swapTransaction: BuildSwapTransaction = {
+      transaction: {
+        to: '0x123',
+        value: 0n,
+        data: '0x',
+        chainId: 8453,
+        gas: 0n,
+      },
+      approveTransaction: {
+        to: '0x456',
+        value: 0n,
+        data: '0x123',
+        chainId: 8453,
+        gas: 0n,
+      },
+      quote: {
+        from: {
+          address: '',
+          chainId: 8453,
+          decimals: 18,
+          image:
+            'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+          name: 'ETH',
+          symbol: 'ETH',
+        },
+        to: {
+          address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+          chainId: 8453,
+          decimals: 18,
+          image:
+            'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
+          name: 'DEGEN',
+          symbol: 'DEGEN',
+        },
+        fromAmount: '100000000000000',
+        toAmount: '19395353519910973703',
+        amountReference: 'from',
+        priceImpact: '0.94',
+        hasHighPriceImpact: false,
+        slippage: '3',
+        warning: undefined,
+      },
+      fee: {
+        baseAsset: {
+          name: 'DEGEN',
+          address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+          symbol: 'DEGEN',
+          decimals: 18,
+          image:
+            'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
+          chainId: 8453,
+        },
+        percentage: '1',
+        amount: '195912661817282562',
+      },
+    };
+    const config = createConfig({
+      chains: [mainnet, sepolia],
+      connectors: [
+        mock({
+          accounts: [
+            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+            '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+            '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+          ],
+        }),
+      ],
+      transports: {
+        [mainnet.id]: http(),
+        [sepolia.id]: http(),
+      },
+    });
+
+    await processSwapTransaction({
+      swapTransaction,
+      config,
+      setPendingTransaction,
+      setLoading,
+      sendTransactionAsync: sendTransactionAsync2,
+      onSuccess,
+    });
+
+    expect(setPendingTransaction).toHaveBeenCalledTimes(4);
+    expect(setPendingTransaction).toHaveBeenCalledWith(true);
+    expect(setPendingTransaction).toHaveBeenCalledWith(false);
+    expect(sendTransactionAsync2).toHaveBeenCalledTimes(2);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+
+    expect(setLoading).toHaveBeenCalledTimes(1);
+    expect(setLoading).toHaveBeenCalledWith(true);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith({});
   });
 });

--- a/src/swap/utils/processSwapTransaction.test.ts
+++ b/src/swap/utils/processSwapTransaction.test.ts
@@ -115,10 +115,8 @@ describe('processSwapTransaction', () => {
       setPendingTransaction,
       setLoading,
       sendTransactionAsync,
-      onStatus: {
-        onStart,
-        onSuccess,
-      },
+      onSuccess,
+      onStart,
     });
 
     expect(setPendingTransaction).toHaveBeenCalledTimes(4);
@@ -210,10 +208,8 @@ describe('processSwapTransaction', () => {
       setPendingTransaction,
       setLoading,
       sendTransactionAsync,
-      onStatus: {
-        onStart,
-        onSuccess,
-      },
+      onSuccess,
+      onStart,
     });
 
     expect(setPendingTransaction).toHaveBeenCalledTimes(2);
@@ -306,10 +302,8 @@ describe('processSwapTransaction', () => {
       setPendingTransaction,
       setLoading,
       sendTransactionAsync: sendTransactionAsync2,
-      onStatus: {
-        onStart: onStartAsync,
-        onSuccess: onSuccessAsync,
-      },
+      onSuccess: onSuccessAsync,
+      onStart: onStartAsync,
     });
 
     expect(setPendingTransaction).toHaveBeenCalledTimes(4);
@@ -325,100 +319,5 @@ describe('processSwapTransaction', () => {
     expect(onStartAsync).toHaveBeenCalledTimes(2);
     expect(onStartAsync).toHaveBeenNthCalledWith(1, 'approveTxHash');
     expect(onStartAsync).toHaveBeenNthCalledWith(2, 'txHash');
-  });
-
-  it('should successfully call legacy lifecycle hooks', async () => {
-    const swapTransaction: BuildSwapTransaction = {
-      transaction: {
-        to: '0x123',
-        value: 0n,
-        data: '0x',
-        chainId: 8453,
-        gas: 0n,
-      },
-      approveTransaction: {
-        to: '0x456',
-        value: 0n,
-        data: '0x123',
-        chainId: 8453,
-        gas: 0n,
-      },
-      quote: {
-        from: {
-          address: '',
-          chainId: 8453,
-          decimals: 18,
-          image:
-            'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
-          name: 'ETH',
-          symbol: 'ETH',
-        },
-        to: {
-          address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
-          chainId: 8453,
-          decimals: 18,
-          image:
-            'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
-          name: 'DEGEN',
-          symbol: 'DEGEN',
-        },
-        fromAmount: '100000000000000',
-        toAmount: '19395353519910973703',
-        amountReference: 'from',
-        priceImpact: '0.94',
-        hasHighPriceImpact: false,
-        slippage: '3',
-        warning: undefined,
-      },
-      fee: {
-        baseAsset: {
-          name: 'DEGEN',
-          address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
-          symbol: 'DEGEN',
-          decimals: 18,
-          image:
-            'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
-          chainId: 8453,
-        },
-        percentage: '1',
-        amount: '195912661817282562',
-      },
-    };
-    const config = createConfig({
-      chains: [mainnet, sepolia],
-      connectors: [
-        mock({
-          accounts: [
-            '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
-            '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-            '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
-          ],
-        }),
-      ],
-      transports: {
-        [mainnet.id]: http(),
-        [sepolia.id]: http(),
-      },
-    });
-
-    await processSwapTransaction({
-      swapTransaction,
-      config,
-      setPendingTransaction,
-      setLoading,
-      sendTransactionAsync: sendTransactionAsync2,
-      onSuccess,
-    });
-
-    expect(setPendingTransaction).toHaveBeenCalledTimes(4);
-    expect(setPendingTransaction).toHaveBeenCalledWith(true);
-    expect(setPendingTransaction).toHaveBeenCalledWith(false);
-    expect(sendTransactionAsync2).toHaveBeenCalledTimes(2);
-    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
-
-    expect(setLoading).toHaveBeenCalledTimes(1);
-    expect(setLoading).toHaveBeenCalledWith(true);
-    expect(onSuccess).toHaveBeenCalledTimes(1);
-    expect(onSuccess).toHaveBeenCalledWith({});
   });
 });

--- a/src/swap/utils/processSwapTransaction.ts
+++ b/src/swap/utils/processSwapTransaction.ts
@@ -35,10 +35,7 @@ export async function processSwapTransaction({
       value: approveTransaction.value,
       data: approveTransaction.data,
     });
-    const onStartCallback = onStart?.(approveTxHash);
-    if (onStartCallback instanceof Promise) {
-      await onStartCallback;
-    }
+    await Promise.resolve(onStart?.(approveTxHash));
     await waitForTransactionReceipt(config, {
       hash: approveTxHash,
       confirmations: 1,
@@ -53,10 +50,7 @@ export async function processSwapTransaction({
     value: transaction.value,
     data: transaction.data,
   });
-  const onStartCallback = onStart?.(txHash);
-  if (onStartCallback instanceof Promise) {
-    await onStartCallback;
-  }
+  await Promise.resolve(onStart?.(txHash));
 
   setPendingTransaction(false);
 
@@ -68,8 +62,5 @@ export async function processSwapTransaction({
   });
 
   // user callback
-  const onSuccessCallback = onSuccess?.(transactionObject);
-  if (onSuccessCallback instanceof Promise) {
-    await onSuccessCallback;
-  }
+  await Promise.resolve(onSuccess?.(transactionObject));
 }

--- a/src/swap/utils/processSwapTransaction.ts
+++ b/src/swap/utils/processSwapTransaction.ts
@@ -2,7 +2,7 @@ import type { TransactionReceipt } from 'viem';
 import type { Config } from 'wagmi';
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import type { SendTransactionMutateAsync } from 'wagmi/query';
-import type { BuildSwapTransaction, SwapHooks } from '../types';
+import type { BuildSwapTransaction } from '../types';
 
 export async function processSwapTransaction({
   swapTransaction,
@@ -10,20 +10,19 @@ export async function processSwapTransaction({
   setPendingTransaction,
   setLoading,
   sendTransactionAsync,
+  onStart,
   onSuccess,
-  onStatus,
 }: {
   swapTransaction: BuildSwapTransaction;
   config: Config;
   setPendingTransaction: (value: React.SetStateAction<boolean>) => void;
   setLoading: (value: React.SetStateAction<boolean>) => void;
   sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
+  onStart: ((txHash: string) => void | Promise<void>) | undefined;
   onSuccess:
     | ((txReceipt: TransactionReceipt) => void | Promise<void>)
     | undefined;
-  onStatus: SwapHooks | undefined;
 }) {
-  const { onStart, onSuccess: onStatusSuccess } = onStatus ?? {};
   const { transaction, approveTransaction } = swapTransaction;
 
   // for swaps from ERC-20 tokens,
@@ -62,7 +61,6 @@ export async function processSwapTransaction({
     confirmations: 1,
   });
 
-  // user success callbacks
+  // user callback
   await Promise.resolve(onSuccess?.(transactionObject));
-  await Promise.resolve(onStatusSuccess?.(transactionObject));
 }

--- a/src/swap/utils/processSwapTransaction.ts
+++ b/src/swap/utils/processSwapTransaction.ts
@@ -2,7 +2,7 @@ import type { TransactionReceipt } from 'viem';
 import type { Config } from 'wagmi';
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import type { SendTransactionMutateAsync } from 'wagmi/query';
-import type { BuildSwapTransaction } from '../types';
+import type { BuildSwapTransaction, SwapHooks } from '../types';
 
 export async function processSwapTransaction({
   swapTransaction,
@@ -10,19 +10,20 @@ export async function processSwapTransaction({
   setPendingTransaction,
   setLoading,
   sendTransactionAsync,
-  onStart,
   onSuccess,
+  onStatus,
 }: {
   swapTransaction: BuildSwapTransaction;
   config: Config;
   setPendingTransaction: (value: React.SetStateAction<boolean>) => void;
   setLoading: (value: React.SetStateAction<boolean>) => void;
   sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
-  onStart: ((txHash: string) => void | Promise<void>) | undefined;
   onSuccess:
     | ((txReceipt: TransactionReceipt) => void | Promise<void>)
     | undefined;
+  onStatus: SwapHooks | undefined;
 }) {
+  const { onStart, onSuccess: onStatusSuccess } = onStatus ?? {};
   const { transaction, approveTransaction } = swapTransaction;
 
   // for swaps from ERC-20 tokens,
@@ -61,6 +62,7 @@ export async function processSwapTransaction({
     confirmations: 1,
   });
 
-  // user callback
+  // user success callbacks
   await Promise.resolve(onSuccess?.(transactionObject));
+  await Promise.resolve(onStatusSuccess?.(transactionObject));
 }


### PR DESCRIPTION
**What changed? Why?**
add `onStart` hook to `SwapButton`, which will be called with the `txHash` (tx receipt has not been awaited yet). 

for swaps from ERC-20s, the `onStart` hook will be ran twice (one for the approval transaction, one for the actual transaction)

this is to expose more transaction state in order to enable use cases like custom toast messages

**Notes to reviewers**

**How has it been tested?**
locally and in unit tests

```
            <SwapButton
              onStatus={{
                onStart: async (txHash) => {
                  await new Promise((resolve) => setTimeout(resolve, 1000));
                  console.log('async onStart:', txHash);
                },
              }}
            />
```
