### PR TITLE
docs: Fix Identity Badge page

### DIFF
--- a/.changeset/stale-spies-refuse.md
+++ b/.changeset/stale-spies-refuse.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**docs**: Fix Identity Badge page. By @cpcramer #918

--- a/site/docs/components/App.tsx
+++ b/site/docs/components/App.tsx
@@ -1,6 +1,6 @@
 'use client';
-// import { OnchainKitProvider } from '@coinbase/onchainkit';
-import { OnchainKitProvider } from '../pages/src/OnchainKitProvider';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+// import { OnchainKitProvider } from '../pages/src/OnchainKitProvider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { http, WagmiProvider, createConfig } from 'wagmi';

--- a/site/docs/components/App.tsx
+++ b/site/docs/components/App.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { OnchainKitProvider } from '@coinbase/onchainkit';
-// import { OnchainKitProvider } from '../pages/src/OnchainKitProvider';
+// import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { OnchainKitProvider } from '../pages/src/OnchainKitProvider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import { http, WagmiProvider, createConfig } from 'wagmi';

--- a/site/docs/pages/identity/badge.mdx
+++ b/site/docs/pages/identity/badge.mdx
@@ -1,5 +1,5 @@
 import { base } from 'viem/chains';
-import { Avatar, Badge, Name, Identity } from '../src/identity';
+import { Avatar, Badge, Name, Identity } from '@coinbase/onchainkit/identity';
 import App from '../../components/App';
 
 # `<Badge />`

--- a/site/docs/pages/identity/badge.mdx
+++ b/site/docs/pages/identity/badge.mdx
@@ -1,10 +1,10 @@
 import { base } from 'viem/chains';
-import { Avatar, Badge, Name, Identity } from '@coinbase/onchainkit/identity';
+import { Avatar, Badge, Name, Identity } from '../src/identity';
 import App from '../../components/App';
 
 # `<Badge />`
 
-Use `Badge` component along with [`Avatar`](/identity/avatar) or [`Name`](/identity/name) components to display user attestation atteached to their account
+Use `Badge` component along with [`Avatar`](/identity/avatar) or [`Name`](/identity/name) components to display user attestations attached to their account
 
 ## Usage
 
@@ -37,11 +37,11 @@ Badge with custom colors:
 
 ```tsx
 import { Badge } from '@coinbase/onchainkit/identity';
-<Badge backgroundColor="#7DA1F8" borderColor="white" /> // [!code focus]
+<Badge className="bg-blue-400 border-[white]"/> // [!code focus]
 ```
 
 <App>
-  <Badge backgroundColor="#7DA1F8" borderColor="white" tickerColor="#FDFDFD" />
+  <Badge className="bg-blue-400 border-[white]"/>
 </App>
 
 ## Props

--- a/site/docs/pages/identity/badge.mdx
+++ b/site/docs/pages/identity/badge.mdx
@@ -37,11 +37,11 @@ Badge with custom colors:
 
 ```tsx
 import { Badge } from '@coinbase/onchainkit/identity';
-<Badge className="bg-blue-400 border-[white]"/> // [!code focus]
+<Badge className="bg-blue-400 border-white"/> // [!code focus]
 ```
 
 <App>
-  <Badge className="bg-blue-400 border-[white]"/>
+  <Badge className="bg-blue-400 border-white"/>
 </App>
 
 ## Props


### PR DESCRIPTION
**What changed? Why?**
Fix Identity Badge documentation page. The badge component example for custom styling was not behaving as expected. Updating to use the className override. 

Fix grammar. 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="716" alt="Screenshot 2024-07-27 at 4 18 25 PM" src="https://github.com/user-attachments/assets/b27c72ad-c286-4720-bc5f-42ae13523988">

   </td>
    <td>
<img width="647" alt="Screenshot 2024-07-27 at 4 18 48 PM" src="https://github.com/user-attachments/assets/e41e8839-1533-4849-b92b-adfa9e4e4472">

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
