### PR TITLE
docs: Display badge component on landing page

### DIFF
--- a/.changeset/unlucky-falcons-thank.md
+++ b/.changeset/unlucky-falcons-thank.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**docs**: Display badge component check mark on landing page' By @cpcramer #924

--- a/site/docs/pages/identity/badge.mdx
+++ b/site/docs/pages/identity/badge.mdx
@@ -20,9 +20,9 @@ import { Badge } from '@coinbase/onchainkit/identity';
 
 ```css [css]
 .badge {
-  background: white;
+  background: #4F46E5;
   path {
-    fill: blue;
+    fill: #F9FAFB;
   }
 }
 ```

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -120,7 +120,7 @@ bun add @coinbase/onchainkit
   className="rounded-xl"
 >
   <Avatar>
-    <Badge />
+    <Badge className="badge"/>
   </Avatar>
   <Name />
   <Address />
@@ -136,7 +136,7 @@ bun add @coinbase/onchainkit
           className="rounded-xl"
         >
           <Avatar>
-            <Badge />
+            <Badge className="badge"/>
           </Avatar>
           <Name />
           <Address />
@@ -170,7 +170,7 @@ bun add @coinbase/onchainkit
     <Identity className="px-4 pt-3 pb-2" hasCopyAddressOnClick>
       <Avatar />
       <Name>
-        <Badge />
+        <Badge className="badge"/>
       </Name>
       <Address />
       <EthBalance />
@@ -194,7 +194,7 @@ bun add @coinbase/onchainkit
       <Identity className="px-4 pt-3 pb-2" hasCopyAddressOnClick>
         <Avatar />
         <Name>
-          <Badge />
+          <Badge className="badge"/>
         </Name>
         <Address className={color.foregroundMuted} />
         <EthBalance />


### PR DESCRIPTION
**What changed? Why?**
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="198" alt="Screenshot 2024-07-29 at 9 02 18 AM" src="https://github.com/user-attachments/assets/55d3a10d-151b-4a6b-b594-1718a884958e">


</td>
    <td>

<img width="261" alt="Screenshot 2024-07-29 at 9 01 45 AM" src="https://github.com/user-attachments/assets/2901d797-bfd9-4a5c-94e6-9af9f4bbf897">

   </td>
  </tr>
</table>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="295" alt="Screenshot 2024-07-29 at 9 02 26 AM" src="https://github.com/user-attachments/assets/2db0b95e-b484-44ed-a033-5005f43b0e84">

</td>
    <td>
<img width="382" alt="Screenshot 2024-07-29 at 9 01 54 AM" src="https://github.com/user-attachments/assets/8f35d048-1288-455a-8d19-55e7be55b421">


   </td>
  </tr>
</table>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="753" alt="Screenshot 2024-07-29 at 9 02 08 AM" src="https://github.com/user-attachments/assets/d83e6b31-83c1-4c30-b3c5-5fbae558a904">


</td>
    <td>

<img width="912" alt="Screenshot 2024-07-29 at 9 01 35 AM" src="https://github.com/user-attachments/assets/76eccc33-814e-4deb-bd64-c6b5cf2f89ef">

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
