### PR TITLE
fix: handle edge case in `toReadableAmount`

### DIFF
--- a/src/swap/utils/toReadableAmount.test.ts
+++ b/src/swap/utils/toReadableAmount.test.ts
@@ -13,6 +13,7 @@ describe('toReadableAmount', () => {
   it('handles decimals correctly', () => {
     expect(toReadableAmount('1500000000000000000', 18)).toBe('1.5');
     expect(toReadableAmount('100000', 6)).toBe('0.1');
+    expect(toReadableAmount('1.500001', 6)).toBe('1500001');
   });
 
   it('handles very small numbers', () => {
@@ -34,4 +35,5 @@ describe('toReadableAmount', () => {
       '1000000000000000000',
     );
   });
+  
 });

--- a/src/swap/utils/toReadableAmount.ts
+++ b/src/swap/utils/toReadableAmount.ts
@@ -1,4 +1,16 @@
 export function toReadableAmount(amount: string, decimals: number): string {
+  // Remove any leading/trailing whitespace
+  amount = amount.trim();
+
+  // Check if the amount contains a decimal point
+  if (amount.includes('.')) {
+    const [wholePart, fractionalPart] = amount.split('.');
+    const paddedFractionalPart = fractionalPart.padEnd(decimals, '0');
+    const combinedAmount = wholePart + paddedFractionalPart;
+    return combinedAmount.replace(/^0+/, '') || '0'; // Remove leading zeros, but keep at least one digit
+  }
+
+  // If no decimal point, proceed with the original logic
   const bigIntAmount = BigInt(amount);
   const divisor = 10n ** BigInt(decimals);
   const wholePart = (bigIntAmount / divisor).toString();


### PR DESCRIPTION
**What changed? Why?**
- handle edge case with an amount with a decimal (not convertable to native `BigInt`)

**Notes to reviewers**

**How has it been tested?**
