### PR TITLE
Update txn success handler to pass multiple receipts for multiple contracts (EOA)

### DIFF
--- a/site/docs/pages/transaction/types.mdx
+++ b/site/docs/pages/transaction/types.mdx
@@ -54,7 +54,7 @@ type TransactionProviderReact = {
   children: ReactNode; // The child components to be rendered within the provider component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters provided to the child components.
   onError?: (e: TransactionError) => void; // An optional callback function that handles errors within the provider.
-  onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes transaction hash
+  onSuccess?: (response: TransactionReceipt | TransactionReceipt[]) => void; // An optional callback function that exposes transaction hash
 };
 ```
 
@@ -67,16 +67,7 @@ type TransactionReact = {
   className?: string; // An optional CSS class name for styling the component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters for the transaction.
   onError?: (e: TransactionError) => void; // An optional callback function that handles transaction errors.
-  onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes transaction hash
-};
-```
-
-## `TransactionResponse`
-
-```ts
-type TransactionResponse = {
-  transactionHash: string; // Proof that a transaction was validated and added to the blockchain
-  receipt: TransactionReceipt; // The receipt of the transaction
+  onSuccess?: (response: TransactionReceipt | TransactionReceipt[]) => void; // An optional callback function that exposes transaction hash
 };
 ```
 

--- a/site/docs/pages/transaction/types.mdx
+++ b/site/docs/pages/transaction/types.mdx
@@ -54,7 +54,7 @@ type TransactionProviderReact = {
   children: ReactNode; // The child components to be rendered within the provider component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters provided to the child components.
   onError?: (e: TransactionError) => void; // An optional callback function that handles errors within the provider.
-  onSuccess?: (response: TransactionReceipt | TransactionReceipt[]) => void; // An optional callback function that exposes transaction hash
+  onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes the transaction receipts
 };
 ```
 
@@ -67,8 +67,17 @@ type TransactionReact = {
   className?: string; // An optional CSS class name for styling the component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters for the transaction.
   onError?: (e: TransactionError) => void; // An optional callback function that handles transaction errors.
-  onSuccess?: (response: TransactionReceipt | TransactionReceipt[]) => void; // An optional callback function that exposes transaction hash
+  onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes the transaction receipts
 };
+```
+
+## `TransactionResponse`
+
+```ts
+type TransactionResponse = {
+  transactionReceipts: TransactionReceipt[];
+};
+
 ```
 
 ## `TransactionSponsorReact`

--- a/src/swap/components/Swap.test.tsx
+++ b/src/swap/components/Swap.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import { Swap } from './Swap';
+
+vi.mock('./SwapProvider', () => ({
+  SwapProvider: ({ children }) => (
+    <div data-testid="mock-SwapProvider">{children}</div>
+  ),
+  useSwapContext: vi.fn(),
+}));
+
+describe('Swap Component', () => {
+  it('should render the title correctly', () => {
+    render(<Swap title="Test Swap" />);
+
+    const title = screen.getByTestId('ockSwap_Title');
+    expect(title).toHaveTextContent('Test Swap');
+  });
+
+  it('should pass className to container div', () => {
+    render(<Swap className="custom-class" />);
+
+    const container = screen.getByTestId('ockSwap_Container');
+    expect(container).toHaveClass('custom-class');
+  });
+});

--- a/src/swap/components/SwapToggleButton.test.tsx
+++ b/src/swap/components/SwapToggleButton.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import { useSwapContext } from './SwapProvider';
+import { SwapToggleButton } from './SwapToggleButton';
+
+vi.mock('./SwapProvider', () => ({
+  useSwapContext: vi.fn(),
+}));
+
+describe('SwapToggleButton', () => {
+  it('should call handleToggle when clicked', () => {
+    const handleToggleMock = vi.fn();
+    (useSwapContext as jest.Mock).mockReturnValue({
+      handleToggle: handleToggleMock,
+    });
+
+    render(<SwapToggleButton />);
+
+    const button = screen.getByTestId('SwapTokensButton');
+    fireEvent.click(button);
+
+    expect(handleToggleMock).toHaveBeenCalled();
+  });
+
+  it('should render with correct classes', () => {
+    render(<SwapToggleButton className="custom-class" />);
+
+    const button = screen.getByTestId('SwapTokensButton');
+    expect(button).toHaveClass('custom-class');
+  });
+});

--- a/src/swap/components/SwapToggleButton.test.tsx
+++ b/src/swap/components/SwapToggleButton.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, it, vi } from 'vitest';
 import { useSwapContext } from './SwapProvider';
 import { SwapToggleButton } from './SwapToggleButton';

--- a/src/transaction/components/TransactionProvider.test.tsx
+++ b/src/transaction/components/TransactionProvider.test.tsx
@@ -2,11 +2,9 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   useAccount,
-  useConfig,
   useSwitchChain,
   useWaitForTransactionReceipt,
 } from 'wagmi';
-import { waitForTransactionReceipt } from 'wagmi/actions';
 import { useCallsStatus } from '../hooks/useCallsStatus';
 import { useWriteContract } from '../hooks/useWriteContract';
 import { useWriteContracts } from '../hooks/useWriteContracts';

--- a/src/transaction/components/TransactionProvider.test.tsx
+++ b/src/transaction/components/TransactionProvider.test.tsx
@@ -2,9 +2,11 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   useAccount,
+  useConfig,
   useSwitchChain,
   useWaitForTransactionReceipt,
 } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
 import { useCallsStatus } from '../hooks/useCallsStatus';
 import { useWriteContract } from '../hooks/useWriteContract';
 import { useWriteContracts } from '../hooks/useWriteContracts';
@@ -17,6 +19,8 @@ vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
   useSwitchChain: vi.fn(),
   useWaitForTransactionReceipt: vi.fn(),
+  useConfig: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
 }));
 
 vi.mock('../hooks/useCallsStatus', () => ({

--- a/src/transaction/components/TransactionProvider.test.tsx
+++ b/src/transaction/components/TransactionProvider.test.tsx
@@ -1,19 +1,19 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   useAccount,
   useSwitchChain,
   useWaitForTransactionReceipt,
-} from "wagmi";
-import { useCallsStatus } from "../hooks/useCallsStatus";
-import { useWriteContract } from "../hooks/useWriteContract";
-import { useWriteContracts } from "../hooks/useWriteContracts";
+} from 'wagmi';
+import { useCallsStatus } from '../hooks/useCallsStatus';
+import { useWriteContract } from '../hooks/useWriteContract';
+import { useWriteContracts } from '../hooks/useWriteContracts';
 import {
   TransactionProvider,
   useTransactionContext,
-} from "./TransactionProvider";
+} from './TransactionProvider';
 
-vi.mock("wagmi", () => ({
+vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
   useSwitchChain: vi.fn(),
   useWaitForTransactionReceipt: vi.fn(),
@@ -21,17 +21,17 @@ vi.mock("wagmi", () => ({
   waitForTransactionReceipt: vi.fn(),
 }));
 
-vi.mock("../hooks/useCallsStatus", () => ({
+vi.mock('../hooks/useCallsStatus', () => ({
   useCallsStatus: vi.fn(),
 }));
 
-vi.mock("../hooks/useWriteContract", () => ({
+vi.mock('../hooks/useWriteContract', () => ({
   useWriteContract: vi.fn(),
 }));
 
-vi.mock("../hooks/useWriteContracts", () => ({
+vi.mock('../hooks/useWriteContracts', () => ({
   useWriteContracts: vi.fn(),
-  genericErrorMessage: "Something went wrong. Please try again.",
+  genericErrorMessage: 'Something went wrong. Please try again.',
 }));
 
 const TestComponent = () => {
@@ -46,7 +46,7 @@ const TestComponent = () => {
   );
 };
 
-describe("TransactionProvider", () => {
+describe('TransactionProvider', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({ chainId: 1 });
@@ -55,15 +55,15 @@ describe("TransactionProvider", () => {
     });
     (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
       transactionHash: null,
-      status: "IDLE",
+      status: 'IDLE',
     });
     (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
-      status: "IDLE",
+      status: 'IDLE',
       writeContract: vi.fn(),
       data: null,
     });
     (useWriteContracts as ReturnType<typeof vi.fn>).mockReturnValue({
-      status: "IDLE",
+      status: 'IDLE',
       writeContractsAsync: vi.fn(),
     });
     (useWaitForTransactionReceipt as ReturnType<typeof vi.fn>).mockReturnValue({
@@ -71,20 +71,20 @@ describe("TransactionProvider", () => {
     });
   });
 
-  it("should update context on handleSubmit", async () => {
+  it('should update context on handleSubmit', async () => {
     const writeContractsAsyncMock = vi.fn();
     (useWriteContracts as ReturnType<typeof vi.fn>).mockReturnValue({
-      statusWriteContracts: "IDLE",
+      statusWriteContracts: 'IDLE',
       writeContractsAsync: writeContractsAsyncMock,
     });
 
     render(
       <TransactionProvider address="0x123" contracts={[]} onError={() => {}}>
         <TestComponent />
-      </TransactionProvider>
+      </TransactionProvider>,
     );
 
-    const button = screen.getByText("Submit");
+    const button = screen.getByText('Submit');
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -92,14 +92,14 @@ describe("TransactionProvider", () => {
     });
   });
 
-  it("should call onsuccess when receipt exists", async () => {
+  it('should call onsuccess when receipt exists', async () => {
     const onSuccessMock = vi.fn();
     (useWaitForTransactionReceipt as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: "123",
+      data: '123',
     });
 
     (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
-      transactionHash: "hash",
+      transactionHash: 'hash',
     });
 
     render(
@@ -110,10 +110,10 @@ describe("TransactionProvider", () => {
         onSuccess={onSuccessMock}
       >
         <TestComponent />
-      </TransactionProvider>
+      </TransactionProvider>,
     );
 
-    const button = screen.getByText("Submit");
+    const button = screen.getByText('Submit');
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -121,34 +121,34 @@ describe("TransactionProvider", () => {
     });
   });
 
-  it("should handle errors during submission", async () => {
+  it('should handle errors during submission', async () => {
     const writeContractsAsyncMock = vi
       .fn()
-      .mockRejectedValue(new Error("Test error"));
+      .mockRejectedValue(new Error('Test error'));
     (useWriteContracts as ReturnType<typeof vi.fn>).mockReturnValue({
-      statusWriteContracts: "IDLE",
+      statusWriteContracts: 'IDLE',
       writeContractsAsync: writeContractsAsyncMock,
     });
 
     render(
       <TransactionProvider address="0x123" contracts={[]} onError={() => {}}>
         <TestComponent />
-      </TransactionProvider>
+      </TransactionProvider>,
     );
 
-    const button = screen.getByText("Submit");
+    const button = screen.getByText('Submit');
     fireEvent.click(button);
 
     await waitFor(() => {
-      const testComponent = screen.getByTestId("context-value");
-      const updatedContext = JSON.parse(testComponent.textContent || "{}");
+      const testComponent = screen.getByTestId('context-value');
+      const updatedContext = JSON.parse(testComponent.textContent || '{}');
       expect(updatedContext.errorMessage).toBe(
-        "Something went wrong. Please try again."
+        'Something went wrong. Please try again.',
       );
     });
   });
 
-  it("should switch chains when required", async () => {
+  it('should switch chains when required', async () => {
     const switchChainAsyncMock = vi.fn();
     (useSwitchChain as ReturnType<typeof vi.fn>).mockReturnValue({
       switchChainAsync: switchChainAsyncMock,
@@ -162,10 +162,10 @@ describe("TransactionProvider", () => {
         onError={() => {}}
       >
         <TestComponent />
-      </TransactionProvider>
+      </TransactionProvider>,
     );
 
-    const button = screen.getByText("Submit");
+    const button = screen.getByText('Submit');
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -173,41 +173,41 @@ describe("TransactionProvider", () => {
     });
   });
 
-  it("should display toast on error", async () => {
+  it('should display toast on error', async () => {
     (useWriteContracts as ReturnType<typeof vi.fn>).mockReturnValue({
-      statusWriteContracts: "IDLE",
-      writeContractsAsync: vi.fn().mockRejectedValue(new Error("Test error")),
+      statusWriteContracts: 'IDLE',
+      writeContractsAsync: vi.fn().mockRejectedValue(new Error('Test error')),
     });
 
     render(
       <TransactionProvider address="0x123" contracts={[]} onError={() => {}}>
         <TestComponent />
-      </TransactionProvider>
+      </TransactionProvider>,
     );
 
-    const button = screen.getByText("Submit");
+    const button = screen.getByText('Submit');
     fireEvent.click(button);
 
     await waitFor(() => {
-      const testComponent = screen.getByTestId("context-value");
-      const updatedContext = JSON.parse(testComponent.textContent || "{}");
+      const testComponent = screen.getByTestId('context-value');
+      const updatedContext = JSON.parse(testComponent.textContent || '{}');
       expect(updatedContext.isToastVisible).toBe(true);
     });
   });
 });
 
-describe("useTransactionContext", () => {
-  it("should throw an error when used outside of TransactionProvider", () => {
+describe('useTransactionContext', () => {
+  it('should throw an error when used outside of TransactionProvider', () => {
     const TestComponent = () => {
       useTransactionContext();
       return null;
     };
 
     const consoleError = vi
-      .spyOn(console, "error")
+      .spyOn(console, 'error')
       .mockImplementation(() => {}); // Suppress error logging
     expect(() => render(<TestComponent />)).toThrow(
-      "useTransactionContext must be used within a Transaction component"
+      'useTransactionContext must be used within a Transaction component',
     );
     consoleError.mockRestore();
   });

--- a/src/transaction/components/TransactionProvider.test.tsx
+++ b/src/transaction/components/TransactionProvider.test.tsx
@@ -1,19 +1,19 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useAccount,
   useSwitchChain,
   useWaitForTransactionReceipt,
-} from 'wagmi';
-import { useCallsStatus } from '../hooks/useCallsStatus';
-import { useWriteContract } from '../hooks/useWriteContract';
-import { useWriteContracts } from '../hooks/useWriteContracts';
+} from "wagmi";
+import { useCallsStatus } from "../hooks/useCallsStatus";
+import { useWriteContract } from "../hooks/useWriteContract";
+import { useWriteContracts } from "../hooks/useWriteContracts";
 import {
   TransactionProvider,
   useTransactionContext,
-} from './TransactionProvider';
+} from "./TransactionProvider";
 
-vi.mock('wagmi', () => ({
+vi.mock("wagmi", () => ({
   useAccount: vi.fn(),
   useSwitchChain: vi.fn(),
   useWaitForTransactionReceipt: vi.fn(),
@@ -21,17 +21,17 @@ vi.mock('wagmi', () => ({
   waitForTransactionReceipt: vi.fn(),
 }));
 
-vi.mock('../hooks/useCallsStatus', () => ({
+vi.mock("../hooks/useCallsStatus", () => ({
   useCallsStatus: vi.fn(),
 }));
 
-vi.mock('../hooks/useWriteContract', () => ({
+vi.mock("../hooks/useWriteContract", () => ({
   useWriteContract: vi.fn(),
 }));
 
-vi.mock('../hooks/useWriteContracts', () => ({
+vi.mock("../hooks/useWriteContracts", () => ({
   useWriteContracts: vi.fn(),
-  genericErrorMessage: 'Something went wrong. Please try again.',
+  genericErrorMessage: "Something went wrong. Please try again.",
 }));
 
 const TestComponent = () => {
@@ -46,7 +46,7 @@ const TestComponent = () => {
   );
 };
 
-describe('TransactionProvider', () => {
+describe("TransactionProvider", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({ chainId: 1 });
@@ -55,15 +55,15 @@ describe('TransactionProvider', () => {
     });
     (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
       transactionHash: null,
-      status: 'IDLE',
+      status: "IDLE",
     });
     (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
-      status: 'IDLE',
+      status: "IDLE",
       writeContract: vi.fn(),
       data: null,
     });
     (useWriteContracts as ReturnType<typeof vi.fn>).mockReturnValue({
-      status: 'IDLE',
+      status: "IDLE",
       writeContractsAsync: vi.fn(),
     });
     (useWaitForTransactionReceipt as ReturnType<typeof vi.fn>).mockReturnValue({
@@ -71,20 +71,20 @@ describe('TransactionProvider', () => {
     });
   });
 
-  it('should update context on handleSubmit', async () => {
+  it("should update context on handleSubmit", async () => {
     const writeContractsAsyncMock = vi.fn();
     (useWriteContracts as ReturnType<typeof vi.fn>).mockReturnValue({
-      statusWriteContracts: 'IDLE',
+      statusWriteContracts: "IDLE",
       writeContractsAsync: writeContractsAsyncMock,
     });
 
     render(
       <TransactionProvider address="0x123" contracts={[]} onError={() => {}}>
         <TestComponent />
-      </TransactionProvider>,
+      </TransactionProvider>
     );
 
-    const button = screen.getByText('Submit');
+    const button = screen.getByText("Submit");
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -92,14 +92,14 @@ describe('TransactionProvider', () => {
     });
   });
 
-  it('should call onsuccess when receipt exists', async () => {
+  it("should call onsuccess when receipt exists", async () => {
     const onSuccessMock = vi.fn();
     (useWaitForTransactionReceipt as ReturnType<typeof vi.fn>).mockReturnValue({
-      data: '123',
+      data: "123",
     });
 
     (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
-      transactionHash: 'hash',
+      transactionHash: "hash",
     });
 
     render(
@@ -110,10 +110,10 @@ describe('TransactionProvider', () => {
         onSuccess={onSuccessMock}
       >
         <TestComponent />
-      </TransactionProvider>,
+      </TransactionProvider>
     );
 
-    const button = screen.getByText('Submit');
+    const button = screen.getByText("Submit");
     fireEvent.click(button);
 
     await waitFor(() => {
@@ -121,46 +121,93 @@ describe('TransactionProvider', () => {
     });
   });
 
-  it('should handle errors during submission', async () => {
+  it("should handle errors during submission", async () => {
     const writeContractsAsyncMock = vi
       .fn()
-      .mockRejectedValue(new Error('Test error'));
+      .mockRejectedValue(new Error("Test error"));
     (useWriteContracts as ReturnType<typeof vi.fn>).mockReturnValue({
-      statusWriteContracts: 'IDLE',
+      statusWriteContracts: "IDLE",
       writeContractsAsync: writeContractsAsyncMock,
     });
 
     render(
       <TransactionProvider address="0x123" contracts={[]} onError={() => {}}>
         <TestComponent />
-      </TransactionProvider>,
+      </TransactionProvider>
     );
 
-    const button = screen.getByText('Submit');
+    const button = screen.getByText("Submit");
     fireEvent.click(button);
 
     await waitFor(() => {
-      const testComponent = screen.getByTestId('context-value');
-      const updatedContext = JSON.parse(testComponent.textContent || '{}');
+      const testComponent = screen.getByTestId("context-value");
+      const updatedContext = JSON.parse(testComponent.textContent || "{}");
       expect(updatedContext.errorMessage).toBe(
-        'Something went wrong. Please try again.',
+        "Something went wrong. Please try again."
       );
+    });
+  });
+
+  it("should switch chains when required", async () => {
+    const switchChainAsyncMock = vi.fn();
+    (useSwitchChain as ReturnType<typeof vi.fn>).mockReturnValue({
+      switchChainAsync: switchChainAsyncMock,
+    });
+
+    render(
+      <TransactionProvider
+        address="0x123"
+        chainId={2}
+        contracts={[]}
+        onError={() => {}}
+      >
+        <TestComponent />
+      </TransactionProvider>
+    );
+
+    const button = screen.getByText("Submit");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(switchChainAsyncMock).toHaveBeenCalled();
+    });
+  });
+
+  it("should display toast on error", async () => {
+    (useWriteContracts as ReturnType<typeof vi.fn>).mockReturnValue({
+      statusWriteContracts: "IDLE",
+      writeContractsAsync: vi.fn().mockRejectedValue(new Error("Test error")),
+    });
+
+    render(
+      <TransactionProvider address="0x123" contracts={[]} onError={() => {}}>
+        <TestComponent />
+      </TransactionProvider>
+    );
+
+    const button = screen.getByText("Submit");
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      const testComponent = screen.getByTestId("context-value");
+      const updatedContext = JSON.parse(testComponent.textContent || "{}");
+      expect(updatedContext.isToastVisible).toBe(true);
     });
   });
 });
 
-describe('useTransactionContext', () => {
-  it('should throw an error when used outside of TransactionProvider', () => {
+describe("useTransactionContext", () => {
+  it("should throw an error when used outside of TransactionProvider", () => {
     const TestComponent = () => {
       useTransactionContext();
       return null;
     };
 
     const consoleError = vi
-      .spyOn(console, 'error')
+      .spyOn(console, "error")
       .mockImplementation(() => {}); // Suppress error logging
     expect(() => render(<TestComponent />)).toThrow(
-      'useTransactionContext must be used within a Transaction component',
+      "useTransactionContext must be used within a Transaction component"
     );
     consoleError.mockRestore();
   });

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -189,10 +189,10 @@ export function TransactionProvider({
   }, [chainId, executeContracts, handleSubmitErrors, switchChain]);
 
   useEffect(() => {
-    if (receiptArray?.length > 1) {
-      onSuccess?.(receiptArray);
+    if (receiptArray?.length) {
+      onSuccess?.({ transactionReceipts: receiptArray });
     } else if (receipt) {
-      onSuccess?.(receipt);
+      onSuccess?.({ transactionReceipts: [receipt] });
     }
   }, [onSuccess, receipt, receiptArray]);
 

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -94,7 +94,7 @@ export function TransactionProvider({
         receipts.push(txnReceipt);
       } catch (err) {
         console.error('getTransactionReceiptsError', err);
-        setErrorMessage(genericErrorMessage);
+        setErrorMessage(GENERIC_ERROR_MESSAGE);
       }
     }
     setReceiptArray(receipts);

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -10,7 +10,12 @@ import type {
   TransactionExecutionError,
   TransactionReceipt,
 } from 'viem';
-import { useAccount, useConfig, useSwitchChain, useWaitForTransactionReceipt } from 'wagmi';
+import {
+  useAccount,
+  useConfig,
+  useSwitchChain,
+  useWaitForTransactionReceipt,
+} from 'wagmi';
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import { useValue } from '../../internal/hooks/useValue';
 import {

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -98,13 +98,16 @@ export function TransactionProvider({
       }
     }
     setReceiptArray(receipts);
-  }, [transactionHashArray]);
+  }, [chainId, config, transactionHashArray]);
 
   useEffect(() => {
-    if (transactionHashArray.length === contracts.length && contracts?.length > 1) {
+    if (
+      transactionHashArray.length === contracts.length &&
+      contracts?.length > 1
+    ) {
       getTransactionReceipts();
     }
-  }, [contracts, transactionHashArray]);
+  }, [contracts, getTransactionReceipts, transactionHashArray]);
 
   const fallbackToWriteContract = useCallback(async () => {
     // EOAs don't support batching, so we process contracts individually.

--- a/src/transaction/hooks/useCallsStatus.ts
+++ b/src/transaction/hooks/useCallsStatus.ts
@@ -19,6 +19,7 @@ export function useCallsStatus({
         refetchInterval: (data) => {
           return data.state.data?.status === 'CONFIRMED' ? false : 1000;
         },
+        enabled: !!transactionId,
       },
     });
 

--- a/src/transaction/hooks/useWriteContract.test.ts
+++ b/src/transaction/hooks/useWriteContract.test.ts
@@ -22,7 +22,7 @@ type MockUseWriteContractReturn = {
 
 describe('useWriteContract', () => {
   const mockSetErrorMessage = vi.fn();
-  const mockSetTransactionId = vi.fn();
+  const mockSetTransactionHashArray = vi.fn();
   const mockOnError = vi.fn();
 
   beforeEach(() => {
@@ -41,7 +41,7 @@ describe('useWriteContract', () => {
     const { result } = renderHook(() =>
       useWriteContract({
         setErrorMessage: mockSetErrorMessage,
-        setTransactionId: mockSetTransactionId,
+        setTransactionHashArray: mockSetTransactionHashArray,
         onError: mockOnError,
       }),
     );
@@ -70,7 +70,7 @@ describe('useWriteContract', () => {
     renderHook(() =>
       useWriteContract({
         setErrorMessage: mockSetErrorMessage,
-        setTransactionId: mockSetTransactionId,
+        setTransactionHashArray: mockSetTransactionHashArray,
         onError: mockOnError,
       }),
     );
@@ -106,7 +106,7 @@ describe('useWriteContract', () => {
     renderHook(() =>
       useWriteContract({
         setErrorMessage: mockSetErrorMessage,
-        setTransactionId: mockSetTransactionId,
+        setTransactionHashArray: mockSetTransactionHashArray,
         onError: mockOnError,
       }),
     );
@@ -114,7 +114,7 @@ describe('useWriteContract', () => {
     expect(onSuccessCallback).toBeDefined();
     onSuccessCallback?.(transactionId);
 
-    expect(mockSetTransactionId).toHaveBeenCalledWith(transactionId);
+    expect(mockSetTransactionHashArray).toHaveBeenCalledWith([transactionId]);
   });
 
   it('should handle uncaught errors', () => {
@@ -129,7 +129,7 @@ describe('useWriteContract', () => {
     const { result } = renderHook(() =>
       useWriteContract({
         setErrorMessage: mockSetErrorMessage,
-        setTransactionId: mockSetTransactionId,
+        setTransactionHashArray: mockSetTransactionHashArray,
         onError: mockOnError,
       }),
     );

--- a/src/transaction/hooks/useWriteContract.ts
+++ b/src/transaction/hooks/useWriteContract.ts
@@ -1,4 +1,4 @@
-import type { TransactionExecutionError } from 'viem';
+import type { Address, TransactionExecutionError } from 'viem';
 import { useWriteContract as useWriteContractWagmi } from 'wagmi';
 import {
   GENERIC_ERROR_MESSAGE,
@@ -10,7 +10,8 @@ import type { TransactionError } from '../types';
 type UseWriteContractParams = {
   onError?: (e: TransactionError) => void;
   setErrorMessage: (error: string) => void;
-  setTransactionId: (id: string) => void;
+  setTransactionHashArray: (ids: Address[]) => void;
+  transactionHashArray?: Address[];
 };
 
 /**
@@ -21,7 +22,8 @@ type UseWriteContractParams = {
 export function useWriteContract({
   onError,
   setErrorMessage,
-  setTransactionId,
+  setTransactionHashArray,
+  transactionHashArray,
 }: UseWriteContractParams) {
   try {
     const { status, writeContractAsync, data } = useWriteContractWagmi({
@@ -37,8 +39,10 @@ export function useWriteContract({
           }
           onError?.({ code: WRITE_CONTRACT_ERROR_CODE, error: e.message });
         },
-        onSuccess: (id) => {
-          setTransactionId(id);
+        onSuccess: (hash: Address) => {
+          setTransactionHashArray(
+            transactionHashArray ? transactionHashArray?.concat(hash) : [hash],
+          );
         },
       },
     });

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -62,7 +62,7 @@ export type TransactionProviderReact = {
   children: ReactNode; // The child components to be rendered within the provider component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters provided to the child components.
   onError?: (e: TransactionError) => void; // An optional callback function that handles errors within the provider.
-  onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes transaction hash
+  onSuccess?: (response: TransactionReceipt | TransactionReceipt[]) => void; // An optional callback function that exposes transaction hash
 };
 
 /**
@@ -76,15 +76,7 @@ export type TransactionReact = {
   className?: string; // An optional CSS class name for styling the component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters for the transaction.
   onError?: (e: TransactionError) => void; // An optional callback function that handles transaction errors.
-  onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes transaction hash
-};
-
-/**
- * Note: exported as public Type
- */
-export type TransactionResponse = {
-  transactionHash: string; // Proof that a transaction was validated and added to the blockchain
-  receipt: TransactionReceipt; // The receipt of the transaction
+  onSuccess?: (response: TransactionReceipt | TransactionReceipt[]) => void; // An optional callback function that exposes transaction hash
 };
 
 /**

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -62,7 +62,7 @@ export type TransactionProviderReact = {
   children: ReactNode; // The child components to be rendered within the provider component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters provided to the child components.
   onError?: (e: TransactionError) => void; // An optional callback function that handles errors within the provider.
-  onSuccess?: (response: TransactionReceipt | TransactionReceipt[]) => void; // An optional callback function that exposes transaction hash
+  onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes the transaction receipts
 };
 
 /**
@@ -76,7 +76,14 @@ export type TransactionReact = {
   className?: string; // An optional CSS class name for styling the component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters for the transaction.
   onError?: (e: TransactionError) => void; // An optional callback function that handles transaction errors.
-  onSuccess?: (response: TransactionReceipt | TransactionReceipt[]) => void; // An optional callback function that exposes transaction hash
+  onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes the transaction receipts
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type TransactionResponse = {
+  transactionReceipts: TransactionReceipt[];
 };
 
 /**


### PR DESCRIPTION
**What changed? Why?**
- implement `waitForTransactionReceipt` to handle case where user passes multiple contracts and is using EOA
- this function will be called for each transaction hash so that we can pass multiple receipts in onsuccess handler

**Notes to reviewers**

**How has it been tested?**
