### PR TITLE
chore: Add tests for SwapAmountInput

### DIFF
--- a/.changeset/ten-swans-trade.md
+++ b/.changeset/ten-swans-trade.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**chore**: Add tests for SwapAmountInput. By @cpcramer. #987


### PR DESCRIPTION
**What changed? Why?**
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="644" alt="Screenshot 2024-08-06 at 1 12 38 PM" src="https://github.com/user-attachments/assets/98a4eaea-a422-4bd7-b9ca-93fc70c271f4">


</td>
    <td>

<img width="586" alt="Screenshot 2024-08-06 at 1 10 09 PM" src="https://github.com/user-attachments/assets/84ec403b-bb45-44fe-9161-20a1098e467b">

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
