### PR TITLE
docs: Fix Transaction Wrapper item alignment

### DIFF
--- a/site/docs/components/TransactionWrapper.tsx
+++ b/site/docs/components/TransactionWrapper.tsx
@@ -52,7 +52,7 @@ export default function TransactionWrapper({
 
   return (
     <main className='flex flex-col'>
-      <div className='flex max-w-[450px] items-center rounded-lg bg-white p-4'>
+      <div className='flex max-w-[450px] items-center rounded-lg bg-white p-4 justify-center'>
         {children({ address, contracts, onError, onSuccess })}
       </div>
     </main>


### PR DESCRIPTION
**What changed? Why?**

justify-center is aligning items along the main axis (horizontally in this case).


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="751" alt="Screenshot 2024-08-06 at 2 28 58 PM" src="https://github.com/user-attachments/assets/4481e636-3c55-427a-a176-886714de7298">


</td>
    <td>
<img width="761" alt="Screenshot 2024-08-06 at 2 28 31 PM" src="https://github.com/user-attachments/assets/3e807fbd-db32-4d11-a77b-1b0049487f8e">


   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
