### PR TITLE
chore: export `TransactionResponse` type

### DIFF
--- a/.changeset/cool-moons-bake.md
+++ b/.changeset/cool-moons-bake.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix**: Export TransactionResponse type. By @abcrane123 #1007

--- a/site/docs/pages/transaction/types.mdx
+++ b/site/docs/pages/transaction/types.mdx
@@ -40,7 +40,7 @@ type TransactionReact = {
 
 ```ts
 type TransactionResponse = {
-  transactionReceipts: TransactionReceipt[];
+  transactionReceipts: TransactionReceipt[]; // An array containing the transaction receipts
 };
 ```
 

--- a/src/transaction/index.ts
+++ b/src/transaction/index.ts
@@ -13,6 +13,7 @@ export type {
   TransactionButtonReact,
   TransactionError,
   TransactionReact,
+  TransactionResponse,
   TransactionSponsorReact,
   TransactionStatusReact,
   TransactionStatusActionReact,


### PR DESCRIPTION
**What changed? Why?**
- export missing type

**Notes to reviewers**

**How has it been tested?**
