### PR TITLE
chore: Adjust dark mode styles

### DIFF
--- a/site/docs/components/TransactionWrapper.tsx
+++ b/site/docs/components/TransactionWrapper.tsx
@@ -52,7 +52,7 @@ export default function TransactionWrapper({
 
   return (
     <main className='flex flex-col'>
-      <div className='flex max-w-[450px] items-center rounded-lg bg-white p-4 justify-center'>
+      <div className='flex max-w-[450px] items-center rounded-lg p-4 justify-center'>
         {children({ address, contracts, onError, onSuccess })}
       </div>
     </main>

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { closeSvg } from '../../internal/svg/closeSvg';
-import { cn } from '../../styles/theme';
+import { background, cn } from '../../styles/theme';
 import type { TransactionToastReact } from '../types';
 import { useTransactionContext } from './TransactionProvider';
 
@@ -67,8 +67,9 @@ export function TransactionToast({
   return (
     <div
       className={cn(
+        background.default,
         'flex animate-enter items-center justify-between rounded-lg',
-        'bg-gray-100 p-2 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.12)]',
+        'p-2 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.12)]',
         '-translate-x-2/4 fixed z-20',
         positionClass,
         className,


### PR DESCRIPTION
**What changed? Why?**
- remove txn background on docs
- fix dark mode txn toast styling
<img width="776" alt="Screenshot 2024-08-08 at 7 59 18 PM" src="https://github.com/user-attachments/assets/41570eb7-b603-4d7e-a3f1-9854e0e78c02">


<img width="768" alt="Screenshot 2024-08-08 at 7 59 25 PM" src="https://github.com/user-attachments/assets/5f3a5b54-046d-4e09-ab0b-8627ca02fe92">



**Notes to reviewers**

**How has it been tested?**
