### PR TITLE
chore: Increase Wallet dropdown SVG sizes to 18x18

### DIFF
--- a/.changeset/many-ravens-cry.md
+++ b/.changeset/many-ravens-cry.md
@@ -4,3 +4,4 @@
 
 -**chore**: Add testing to Transaction Toast. By @cpcramer #1023
 -**chore**: Add Connect Wallet tests and refactor to use Vitest. By @cpcramer #1036
+-**chore**: Increase Wallet dropdown png size to 18x18. By @cpcramer #1041

--- a/src/wallet/components/WalletDropdownBaseName.tsx
+++ b/src/wallet/components/WalletDropdownBaseName.tsx
@@ -38,7 +38,7 @@ export function WalletDropdownBaseName({
       target="_blank"
       rel="noopener noreferrer"
     >
-      <div className="-translate-y-1/2 absolute top-1/2 left-4 flex h-4 w-4 items-center justify-center">
+      <div className="-translate-y-1/2 absolute top-1/2 left-4 flex h-[1.125rem] w-[1.125rem] items-center justify-center">
         {baseNameSvg}
       </div>
       <div className="flex w-full items-center pl-6">

--- a/src/wallet/components/WalletDropdownDisconnect.tsx
+++ b/src/wallet/components/WalletDropdownDisconnect.tsx
@@ -24,7 +24,7 @@ export function WalletDropdownDisconnect({
       )}
       onClick={handleDisconnect}
     >
-      <div className="-translate-y-1/2 absolute top-1/2 left-4 flex h-4 w-4 items-center justify-center">
+      <div className="-translate-y-1/2 absolute top-1/2 left-4 flex h-[1.125rem] w-[1.125rem] items-center justify-center">
         {disconnectSvg}
       </div>
       <span className={cn(dsText.body, 'pl-6')}>{text}</span>

--- a/src/wallet/components/WalletDropdownLink.tsx
+++ b/src/wallet/components/WalletDropdownLink.tsx
@@ -35,7 +35,7 @@ export function WalletDropdownLink({
       target={target}
       rel={rel}
     >
-      <div className="-translate-y-1/2 absolute top-1/2 left-4 flex h-4 w-4 items-center justify-center">
+      <div className="-translate-y-1/2 absolute top-1/2 left-4 flex h-[1.125rem] w-[1.125rem]  items-center justify-center">
         {iconSvg}
       </div>
       <span className={cn(text.body, 'pl-6')}>{children}</span>

--- a/src/wallet/components/WalletDropdownLink.tsx
+++ b/src/wallet/components/WalletDropdownLink.tsx
@@ -35,7 +35,7 @@ export function WalletDropdownLink({
       target={target}
       rel={rel}
     >
-      <div className="-translate-y-1/2 absolute top-1/2 left-4 flex h-[1.125rem] w-[1.125rem]  items-center justify-center">
+      <div className="-translate-y-1/2 absolute top-1/2 left-4 flex h-[1.125rem] w-[1.125rem] items-center justify-center">
         {iconSvg}
       </div>
       <span className={cn(text.body, 'pl-6')}>{children}</span>


### PR DESCRIPTION
**What changed? Why?**
Increase our wallet logo sizes from 16x16 to 18x18. 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="263" alt="Screenshot 2024-08-12 at 5 06 38 PM" src="https://github.com/user-attachments/assets/622e2164-a9c0-4fb8-a626-6b3924a58a82">


</td>
    <td>

<img width="279" alt="Screenshot 2024-08-12 at 5 06 23 PM" src="https://github.com/user-attachments/assets/f92e4630-36a6-4320-831c-8e43034c215e">

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
