### PR TITLE
add min height/width and object fit cover to avatar

### DIFF
--- a/.changeset/afraid-tips-whisper.md
+++ b/.changeset/afraid-tips-whisper.md
@@ -1,0 +1,4 @@
+---
+"@coinbase/onchainkit": minor
+---
+**fix**: Modify `Avatar` component to handle images with varying height/width ratio. By @kirkas #1058

--- a/src/identity/components/Avatar.stories.tsx
+++ b/src/identity/components/Avatar.stories.tsx
@@ -73,7 +73,7 @@ export const WithBadge: Story = {
 
 export const Base: Story = {
   args: {
-    address: '0xFd3d8ffE248173B710b4e24a7E75ac4424853503',
+    address: '0x8c8F1a1e1bFdb15E7ed562efc84e5A588E68aD73',
     chain: base,
   },
 };

--- a/src/identity/components/Avatar.tsx
+++ b/src/identity/components/Avatar.tsx
@@ -74,6 +74,7 @@ export function Avatar({
         {/* biome-ignore lint: alt gets assigned */}
         {displayAvatarImg ? (
           <img
+            className='min-w-full min-h-full object-cover'
             data-testid="ockAvatar_Image"
             loading="lazy"
             width="100%"

--- a/src/identity/components/Avatar.tsx
+++ b/src/identity/components/Avatar.tsx
@@ -74,7 +74,7 @@ export function Avatar({
         {/* biome-ignore lint: alt gets assigned */}
         {displayAvatarImg ? (
           <img
-            className='min-w-full min-h-full object-cover'
+            className="min-h-full min-w-full object-cover"
             data-testid="ockAvatar_Image"
             loading="lazy"
             width="100%"


### PR DESCRIPTION
### Changes
**fix**: Modify `Avatar` component to handle images with varying height/width ratio.

### Before

<img width="187" alt="image" src="https://github.com/user-attachments/assets/92b0cfbe-0ffe-446d-886d-89e167c1042f">


### After
<img width="167" alt="image" src="https://github.com/user-attachments/assets/221555df-a751-4566-b75b-9381516635a2">
