### PR TITLE
docs: Fix Swap override styles example

### DIFF
--- a/site/docs/pages/swap/swap.mdx
+++ b/site/docs/pages/swap/swap.mdx
@@ -301,24 +301,22 @@ You can override component styles using `className`.
 ```tsx
 // omitted for brevity
 
-<Swap address={address} className='bg-gray-200'> // [!code focus]
+<Swap address={address}>
   <SwapAmountInput
     label="Sell"
     swappableTokens={swappableTokens}
     token={swappableTokens[1]}
     type="from"
-    className='bg-white' // [!code focus]
   />
-  <SwapToggleButton className='border-red-600 bg-white'/> // [!code focus]
+  <SwapToggleButton className='border-[#EA580C]'/> // [!code focus]
   <SwapAmountInput
     label="Buy"
     swappableTokens={swappableTokens}
     token={swappableTokens[2]}
     type="to"
-    className='bg-white' // [!code focus]
   />
-  <SwapButton className='bg-red-600'/> // [!code focus]
-  <SwapMessage className='text-red-600'/> // [!code focus]
+  <SwapButton className='bg-[#EA580C]'/> // [!code focus]
+  <SwapMessage />
 </Swap>
 ```
 
@@ -327,24 +325,22 @@ You can override component styles using `className`.
     {({ address, swappableTokens }) => {
       if (address) {
         return (
-          <Swap address={address} className='bg-gray-200'>
+          <Swap address={address} >
             <SwapAmountInput
               label="Sell"
               swappableTokens={swappableTokens}
               token={swappableTokens[1]}
               type="from"
-              className='bg-white'
             />
-            <SwapToggleButton className='border-red-600 bg-white'/>
+            <SwapToggleButton className='border-[#EA580C]' />
             <SwapAmountInput
               label="Buy"
               swappableTokens={swappableTokens}
               token={swappableTokens[2]}
               type="to"
-              className='bg-white'
             />
-            <SwapButton className='bg-red-600' disabled />
-            <SwapMessage className='text-red-600'/>
+            <SwapButton className='bg-[#EA580C]' disabled />
+            <SwapMessage/>
           </Swap>
         )
       }


### PR DESCRIPTION
**What changed? Why?**
This example broke after we updated how we implement light mode / dark mode. 

This fixes that render and also updates our showcase styling to match our figma docs. 

<img width="494" alt="Screenshot 2024-08-15 at 10 39 08 AM" src="https://github.com/user-attachments/assets/52d1cdc0-43d7-41fb-a063-74e8aecc3bfb">

<img width="499" alt="Screenshot 2024-08-15 at 10 39 18 AM" src="https://github.com/user-attachments/assets/c2855fe7-69f7-493f-8d5c-2f31ad9cb0ba">

**Notes to reviewers**

**How has it been tested?**
