### PR TITLE
Add basePath to the /playground app

### DIFF
--- a/playground/nextjs-app-router/next.config.mjs
+++ b/playground/nextjs-app-router/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: '/playground',
   typescript: {
     ignoreBuildErrors: true,
   }


### PR DESCRIPTION
**What changed? Why?**
adding a basePath to the /playground app so assets and links are based to /playground. Fixes missing styling.


**Notes to reviewers**

After change:
![Screenshot 2024-08-15 at 3 16 47 PM](https://github.com/user-attachments/assets/26150583-75b5-40fc-bf8c-fa59e7784498)



**How has it been tested?**
Only tested locally by loading the page on http://localhost:3000/playground to see the styles render as expected.