### PR TITLE
chore: Update Playground title and Github link 

### DIFF
--- a/.changeset/dry-ligers-end.md
+++ b/.changeset/dry-ligers-end.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**chore**: Update Playground title and Github link. By @cpcramer #1081

--- a/playground/nextjs-app-router/app/layout.tsx
+++ b/playground/nextjs-app-router/app/layout.tsx
@@ -7,7 +7,7 @@ import '@coinbase/onchainkit/styles.css';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'OnchainKit Demo',
+  title: 'OnchainKit Playground',
 };
 
 export default function RootLayout({

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -22,7 +22,7 @@ function Demo() {
   return (
     <>
       <div className="hidden min-w-120 w-1/4 flex-col border-r bg-background p-6 sm:flex">
-        <div className="mb-12 text-lg font-semibold">OnchainKit Demo</div>
+        <div className="mb-12 text-lg font-semibold">OnchainKit Playground</div>
         <form className="grid gap-8">
           <ActiveComponent />
           <WalletType />

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -32,8 +32,9 @@ function Demo() {
         <a
           target="_blank"
           className="hover:underline text-sm absolute bottom-6 left-6"
-          href="https://github.com/ilikesymmetry/onchainkit-demo"
+          href="https://github.com/coinbase/onchainkit/tree/main/playground"
           rel="noreferrer"
+          title="View OnchainKit Playground on GitHub"
         >
           View Github
         </a>


### PR DESCRIPTION
**What changed? Why?**
Update playground title from `OnchainKit Demo` to `OnchainKit Playground`.
<img width="295" alt="Screenshot 2024-08-16 at 9 48 39 AM" src="https://github.com/user-attachments/assets/4197e555-4831-457b-821f-c1f861c4cf17">

Update Github link to point to https://github.com/coinbase/onchainkit/tree/main/playground

**Notes to reviewers**

**How has it been tested?**
