### PR TITLE
chore: Fix hover state for all components

### DIFF
--- a/.changeset/dry-ligers-end.md
+++ b/.changeset/dry-ligers-end.md
@@ -3,3 +3,5 @@
 ---
 
 - **feat**: added `transactionIdle` and `transactionPending` to `lifeCycleStatus` in the Transaction experience. By @zizzamia #1088
+-**chore**: Update Playground title and Github link. By @cpcramer #1081
+-**chore**: Fix how our defined pressable classes were accessing the hover state variable. Update the TransactionButton and WalletDropdown to use our pre-existing pressable classes. By @cpcramer #1092

--- a/.changeset/dry-ligers-end.md
+++ b/.changeset/dry-ligers-end.md
@@ -3,5 +3,4 @@
 ---
 
 - **feat**: added `transactionIdle` and `transactionPending` to `lifeCycleStatus` in the Transaction experience. By @zizzamia #1088
--**chore**: Update Playground title and Github link. By @cpcramer #1081
 -**chore**: Fix how our defined pressable classes were accessing the hover state variable. Update the TransactionButton and WalletDropdown to use our pre-existing pressable classes. By @cpcramer #1092

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -24,7 +24,7 @@ export const pressable = {
   inverse:
     'cursor-pointer bg-ock-inverse active:bg-ock-inverse-active hover:bg-ock-inverse-hover',
   primary:
-    'cursor-pointer bg-ock-primary active:bg-ock-primary-active hover:bg-ock-primary-hover',
+    'cursor-pointer bg-ock-primary active:bg-ock-primary-active hover:bg-[var(--bg-ock-primary-hover)]',
   secondary:
     'cursor-pointer bg-ock-secondary active:bg-ock-secondary-active hover:bg-ock-secondary-hover',
   shadow: 'shadow-ock-default',

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -18,15 +18,15 @@ export const text = {
 
 export const pressable = {
   default:
-    'cursor-pointer bg-ock-default active:bg-ock-default-active hover:bg-ock-default-hover',
+    'cursor-pointer bg-ock-default active:bg-ock-default-active hover:bg-[var(--bg-ock-default-hover)]',
   alternate:
-    'cursor-pointer bg-ock-alternate active:bg-ock-alternate-active hover:bg-ock-alternate-hover',
+    'cursor-pointer bg-ock-alternate active:bg-ock-alternate-active hover:[var(--bg-ock-alternate-hover)]',
   inverse:
-    'cursor-pointer bg-ock-inverse active:bg-ock-inverse-active hover:bg-ock-inverse-hover',
+    'cursor-pointer bg-ock-inverse active:bg-ock-inverse-active hover:bg-[var(--bg-ock-inverse-hover)]',
   primary:
     'cursor-pointer bg-ock-primary active:bg-ock-primary-active hover:bg-[var(--bg-ock-primary-hover)]',
   secondary:
-    'cursor-pointer bg-ock-secondary active:bg-ock-secondary-active hover:bg-ock-secondary-hover',
+    'cursor-pointer bg-ock-secondary active:bg-ock-secondary-active hover:bg-[var(--bg-ock-secondary-hover)]',
   shadow: 'shadow-ock-default',
   disabled: 'opacity-[0.38]',
 } as const;

--- a/src/transaction/components/TransactionButton.tsx
+++ b/src/transaction/components/TransactionButton.tsx
@@ -86,7 +86,7 @@ export function TransactionButton({
   return (
     <button
       className={cn(
-        pressable.primary,
+        background.primary,
         'w-full rounded-xl',
         'mt-4 px-4 py-3 font-medium text-base text-white leading-6',
         isDisabled && pressable.disabled,

--- a/src/transaction/components/TransactionButton.tsx
+++ b/src/transaction/components/TransactionButton.tsx
@@ -86,7 +86,7 @@ export function TransactionButton({
   return (
     <button
       className={cn(
-        background.primary,
+        pressable.primary,
         'w-full rounded-xl',
         'mt-4 px-4 py-3 font-medium text-base text-white leading-6',
         isDisabled && pressable.disabled,

--- a/src/transaction/components/TransactionButton.tsx
+++ b/src/transaction/components/TransactionButton.tsx
@@ -3,7 +3,7 @@ import { useChainId } from 'wagmi';
 import { useShowCallsStatus } from 'wagmi/experimental';
 import { Spinner } from '../../internal/components/Spinner';
 import { getChainExplorer } from '../../network/getChainExplorer';
-import { background, cn, color, pressable, text } from '../../styles/theme';
+import { cn, color, pressable, text } from '../../styles/theme';
 import type { TransactionButtonReact } from '../types';
 import { isSpinnerDisplayed } from '../utils/isSpinnerDisplayed';
 import { useTransactionContext } from './TransactionProvider';
@@ -86,7 +86,7 @@ export function TransactionButton({
   return (
     <button
       className={cn(
-        background.primary,
+        pressable.primary,
         'w-full rounded-xl',
         'mt-4 px-4 py-3 font-medium text-base text-white leading-6',
         isDisabled && pressable.disabled,

--- a/src/wallet/components/WalletDropdown.tsx
+++ b/src/wallet/components/WalletDropdown.tsx
@@ -1,7 +1,7 @@
 import { Children, cloneElement, isValidElement, useMemo } from 'react';
 import { useAccount } from 'wagmi';
 import { Identity } from '../../identity/components/Identity';
-import { background, cn } from '../../styles/theme';
+import { pressable, cn } from '../../styles/theme';
 import { useBreakpoints } from '../../useBreakpoints';
 import type { WalletDropdownReact } from '../types';
 import { WalletBottomSheet } from './WalletBottomSheet';
@@ -37,7 +37,7 @@ export function WalletDropdown({ children, className }: WalletDropdownReact) {
   return (
     <div
       className={cn(
-        background.default,
+        pressable.default,
         'absolute right-0 z-10 mt-1 flex w-max min-w-[250px] flex-col overflow-hidden rounded-xl pb-2',
         className,
       )}

--- a/src/wallet/components/WalletDropdown.tsx
+++ b/src/wallet/components/WalletDropdown.tsx
@@ -1,7 +1,7 @@
 import { Children, cloneElement, isValidElement, useMemo } from 'react';
 import { useAccount } from 'wagmi';
 import { Identity } from '../../identity/components/Identity';
-import { pressable, cn } from '../../styles/theme';
+import { cn, pressable } from '../../styles/theme';
 import { useBreakpoints } from '../../useBreakpoints';
 import type { WalletDropdownReact } from '../types';
 import { WalletBottomSheet } from './WalletBottomSheet';


### PR DESCRIPTION
**What changed? Why?**
Fix hover state styling for all components and update specific buttons

Issue:
- Our themed CSS class variables were not correctly applying the custom hover styles.
- As a result, none of the components were displaying our intended default hover styling.

Fix:
1. In theme.ts: Corrected how we access the hover state variable.
2. For TransactionButton and WalletDropdown:
   - Implemented the 'pressable' class.
   - This maintains their current styling while also enabling the use of our defined state classes (including hover).

Outcome:
- All components now correctly display the default hover styling.
- TransactionButton and WalletDropdown have consistent styling with added state-based effects.

[Watch the video walkthrough to see the tested behavior](https://www.loom.com/share/82aeac2b82744924b40eb8262f9edb01?sid=86caa2d3-998b-449c-8279-fb9ec0261f7b)



**Notes to reviewers**

**How has it been tested?**
Confirmed for the Connect Wallet button and Transaction button in light and dark modes. 
