### PR TITLE
docs: Fix button and link colors in light mode

### DIFF
--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -9,8 +9,8 @@ showOutline: false
 
 import { base } from 'viem/chains';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
-import { Address, Avatar, Badge, EthBalance, Name, Identity } from '@coinbase/onchainkit/identity';
-import { Swap, SwapAmountInput, SwapButton, SwapMessage, SwapToggleButton } from '@coinbase/onchainkit/swap';
+import { Address, Avatar, Badge, EthBalance, Name, Identity } from './src/identity';
+import { Swap, SwapAmountInput, SwapButton, SwapMessage, SwapToggleButton } from './src/swap';
 import { color } from '@coinbase/onchainkit/theme';
 import {
   ConnectWallet,
@@ -19,7 +19,7 @@ import {
   WalletDropdownBaseName,
   WalletDropdownLink,
   WalletDropdownDisconnect,
-} from '@coinbase/onchainkit/wallet';
+} from './src/wallet';
 import App from '../components/App';
 import NavigationList from '../components/landing/NavigationList';
 import SwapWrapper from '../components/SwapWrapper';
@@ -33,7 +33,7 @@ import {
   TransactionStatus,
   TransactionStatusAction,
   TransactionStatusLabel,
-} from '@coinbase/onchainkit/transaction';
+} from './src/transaction';
 
 <div id="blobs">
   <div
@@ -100,7 +100,7 @@ bun add @coinbase/onchainkit
 :::
 
     </div>
-      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 px-4 py-3 font-bold mt-4">
+      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 px-4 py-3 font-bold mt-4">
         View docs
       </a>
     </div>
@@ -127,7 +127,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
     </p>
-    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Identity
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -175,7 +175,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Create or connect your wallet with [Connect Wallet](/wallet/wallet), powered by [Smart Wallet](https://www.smartwallet.dev/why).
     </p>
-    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Wallet
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -243,7 +243,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Search [Tokens](/token/types#token) using [getTokens](/token/get-tokens) and display them with [TokenSearch](/token/token-search), [TokenChip](/token/token-chip), and [TokenRow](/token/token-row).
     </p>
-    <a href="/token/token-chip" title="Start with Tokens Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/token/token-chip" title="Start with Tokens Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Tokens
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -298,7 +298,7 @@ setFilteredTokens(filteredTokens);
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
     </p>
-    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Swap
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px] md:pt-[20px]">
@@ -372,7 +372,7 @@ setFilteredTokens(filteredTokens);
   <p className="text-base md:text-base pb-[24px] md:text-left text-center">
     Trigger onchain operations and sponsor them with [Paymaster](https://www.coinbase.com/developer-platform/products/paymaster).
   </p>
-  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
     Start with Transaction
   </a>
   <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -452,7 +452,7 @@ setFilteredTokens(filteredTokens);
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).
     </p>
-    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Frame
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px]">
@@ -507,7 +507,7 @@ setFilteredTokens(filteredTokens);
     <aside className="mx-auto md:mx-0">
       <a
         href="https://www.figma.com/community/file/1370194397345450683/onchainkit"
-        className="flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
+        className="flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -554,7 +554,7 @@ setFilteredTokens(filteredTokens);
           <p className="leading-7 text-xl text-gray-400 px-0 py-6 max-w-[500px] md:text-left text-center">
             Build your onchain apps with ready-to-use React components and Typescript utilities.
           </p>
-          <a href="/getting-started" title="Get started with OnchainKit" className="alternate-button mx-auto md:mx-0 flex justify-center items-center bg-indigo-600 text-[white] font-bold leading-6 px-4 py-3 rounded-xl w-[180px]">
+          <a href="/getting-started" title="Get started with OnchainKit" className="alternate-button mx-auto md:mx-0 flex justify-center items-center bg-indigo-600 hover:bg-indigo-700 text-[white] dark:bg-indigo-400 dark:text-black dark:hover:bg-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl w-[180px]">
             Get started
           </a>
         </div>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -9,8 +9,8 @@ showOutline: false
 
 import { base } from 'viem/chains';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
-import { Address, Avatar, Badge, EthBalance, Name, Identity } from '@coinbase/onchainkit/identity';
-import { Swap, SwapAmountInput, SwapButton, SwapMessage, SwapToggleButton } from '@coinbase/onchainkit/swap';
+import { Address, Avatar, Badge, EthBalance, Name, Identity } from './src/identity';
+import { Swap, SwapAmountInput, SwapButton, SwapMessage, SwapToggleButton } from './src/swap';
 import { color } from '@coinbase/onchainkit/theme';
 import {
   ConnectWallet,
@@ -19,7 +19,7 @@ import {
   WalletDropdownBaseName,
   WalletDropdownLink,
   WalletDropdownDisconnect,
-} from '@coinbase/onchainkit/wallet';
+} from './src/wallet';
 import App from '../components/App';
 import NavigationList from '../components/landing/NavigationList';
 import SwapWrapper from '../components/SwapWrapper';
@@ -33,7 +33,7 @@ import {
   TransactionStatus,
   TransactionStatusAction,
   TransactionStatusLabel,
-} from '@coinbase/onchainkit/transaction';
+} from './src/transaction';
 
 <div id="blobs">
   <div
@@ -100,7 +100,7 @@ bun add @coinbase/onchainkit
 :::
 
     </div>
-      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 px-4 py-3 font-bold mt-4">
+      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 px-4 py-3 font-bold mt-4">
         View docs
       </a>
     </div>
@@ -127,7 +127,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
     </p>
-    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Identity
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -175,7 +175,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Create or connect your wallet with [Connect Wallet](/wallet/wallet), powered by [Smart Wallet](https://www.smartwallet.dev/why).
     </p>
-    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Wallet
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -243,7 +243,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Search [Tokens](/token/types#token) using [getTokens](/token/get-tokens) and display them with [TokenSearch](/token/token-search), [TokenChip](/token/token-chip), and [TokenRow](/token/token-row).
     </p>
-    <a href="/token/token-chip" title="Start with Tokens Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/token/token-chip" title="Start with Tokens Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Tokens
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -298,7 +298,7 @@ setFilteredTokens(filteredTokens);
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
     </p>
-    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Swap
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px] md:pt-[20px]">
@@ -372,7 +372,7 @@ setFilteredTokens(filteredTokens);
   <p className="text-base md:text-base pb-[24px] md:text-left text-center">
     Trigger onchain operations and sponsor them with [Paymaster](https://www.coinbase.com/developer-platform/products/paymaster).
   </p>
-  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
     Start with Transaction
   </a>
   <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -452,7 +452,7 @@ setFilteredTokens(filteredTokens);
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).
     </p>
-    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Frame
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px]">
@@ -507,7 +507,7 @@ setFilteredTokens(filteredTokens);
     <aside className="mx-auto md:mx-0">
       <a
         href="https://www.figma.com/community/file/1370194397345450683/onchainkit"
-        className="flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
+        className="flex justify-center items-center border border-indigo-600 text-indigo-600 dark:border-indigo-400 dark:text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -100,7 +100,7 @@ bun add @coinbase/onchainkit
 :::
 
     </div>
-      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-400 text-indigo-400 px-4 py-3 font-bold mt-4">
+      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 px-4 py-3 font-bold mt-4">
         View docs
       </a>
     </div>
@@ -127,7 +127,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
     </p>
-    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Identity
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -175,7 +175,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Create or connect your wallet with [Connect Wallet](/wallet/wallet), powered by [Smart Wallet](https://www.smartwallet.dev/why).
     </p>
-    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Wallet
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -243,7 +243,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Search [Tokens](/token/types#token) using [getTokens](/token/get-tokens) and display them with [TokenSearch](/token/token-search), [TokenChip](/token/token-chip), and [TokenRow](/token/token-row).
     </p>
-    <a href="/token/token-chip" title="Start with Tokens Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/token/token-chip" title="Start with Tokens Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Tokens
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -298,7 +298,7 @@ setFilteredTokens(filteredTokens);
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
     </p>
-    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Swap
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px] md:pt-[20px]">
@@ -372,7 +372,7 @@ setFilteredTokens(filteredTokens);
   <p className="text-base md:text-base pb-[24px] md:text-left text-center">
     Trigger onchain operations and sponsor them with [Paymaster](https://www.coinbase.com/developer-platform/products/paymaster).
   </p>
-  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
     Start with Transaction
   </a>
   <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -452,7 +452,7 @@ setFilteredTokens(filteredTokens);
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).
     </p>
-    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Frame
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px]">
@@ -494,9 +494,6 @@ setFilteredTokens(filteredTokens);
   </aside>
 </section>
 
-
-
-
 {' '}
 
 <section className="css-alternate-container w-full flex flex-col items-center py-24">
@@ -510,7 +507,7 @@ setFilteredTokens(filteredTokens);
     <aside className="mx-auto md:mx-0">
       <a
         href="https://www.figma.com/community/file/1370194397345450683/onchainkit"
-        className="flex justify-center items-center border border-indigo-400 text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
+        className="flex justify-center items-center border border-indigo-600 dark:border-indigo-400 text-indigo-600 dark-text-indigo-400 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -520,7 +517,6 @@ setFilteredTokens(filteredTokens);
   </div>
 </section>
 
-
 {' '}
 
 <section className="css-alternate-container w-full flex items-center justify-center">
@@ -528,7 +524,6 @@ setFilteredTokens(filteredTokens);
     <img alt="OnchainKit figma" src="/assets/onchain-figma.png" width="auto" />
   </aside>
 </section>
-
 
 {' '}
 
@@ -550,9 +545,7 @@ setFilteredTokens(filteredTokens);
 
 {' '}
 
-
 <hr className="my-8 md:my-20" />
-
   <footer className="landing-footer flex flex-col justify-center space-y-[25px] max-w-screen-xl w-full pb-[30px]">
     <div className="flex flex-col md:flex-row md:items-end justify-between">
       <div className="flex flex-col justify-between xl:flex-row xl:space-x-[25px]">

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -9,8 +9,8 @@ showOutline: false
 
 import { base } from 'viem/chains';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
-import { Address, Avatar, Badge, EthBalance, Name, Identity } from './src/identity';
-import { Swap, SwapAmountInput, SwapButton, SwapMessage, SwapToggleButton } from './src/swap';
+import { Address, Avatar, Badge, EthBalance, Name, Identity } from '@coinbase/onchainkit/identity';
+import { Swap, SwapAmountInput, SwapButton, SwapMessage, SwapToggleButton } from '@coinbase/onchainkit/swap';
 import { color } from '@coinbase/onchainkit/theme';
 import {
   ConnectWallet,
@@ -19,7 +19,7 @@ import {
   WalletDropdownBaseName,
   WalletDropdownLink,
   WalletDropdownDisconnect,
-} from './src/wallet';
+} from '@coinbase/onchainkit/wallet';
 import App from '../components/App';
 import NavigationList from '../components/landing/NavigationList';
 import SwapWrapper from '../components/SwapWrapper';
@@ -33,7 +33,7 @@ import {
   TransactionStatus,
   TransactionStatusAction,
   TransactionStatusLabel,
-} from './src/transaction';
+} from '@coinbase/onchainkit/transaction';
 
 <div id="blobs">
   <div


### PR DESCRIPTION
**What changed? Why?**

https://linear.app/coinbase/issue/BOE-300/light-mode-button-and-link-colors-should-be-indigo-600-not-indigo-400

https://linear.app/coinbase/issue/BOE-301/add-hover-state-to-all-the-buttons

1. **Fix button and link colors in light mode:** 
 - Our button and link border and text colors were not updating when switching from dark to light mode. 

- Dark mode remains the same. 

2. **Update all start with and view docs buttons to highlight when hovered**

3. **Fix Get started** button light and dark mode styling. Also adding hover styling.

Light mode button and links are now indigo-600 rather than indigo-400.:
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="1407" alt="Screenshot 2024-08-17 at 7 02 50 PM" src="https://github.com/user-attachments/assets/390cef6d-98b0-417f-9c24-aed307232e4f">

</td>
    <td>

<img width="1090" alt="Screenshot 2024-08-17 at 7 02 58 PM" src="https://github.com/user-attachments/assets/44288766-0ac7-4af3-a6eb-c00e9d5e9a4f">

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
