### PR TITLE
docs: Improve landing page button hover visibility

### DIFF
--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -100,7 +100,7 @@ bun add @coinbase/onchainkit
 :::
 
     </div>
-      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 px-4 py-3 font-bold mt-4">
+      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 px-4 py-3 font-bold mt-4">
         View docs
       </a>
     </div>
@@ -127,7 +127,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Create or connect your wallet with [Connect Wallet](/wallet/wallet), powered by [Smart Wallet](https://www.smartwallet.dev/why).
     </p>
-    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Wallet
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -193,7 +193,7 @@ bun add @coinbase/onchainkit
   <p className="text-base md:text-base pb-[24px] md:text-left text-center">
     Trigger onchain operations and sponsor them with [Paymaster](https://www.coinbase.com/developer-platform/products/paymaster).
   </p>
-  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
     Start with Transaction
   </a>
   <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -273,7 +273,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
     </p>
-    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Swap
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px] md:pt-[20px]">
@@ -347,7 +347,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
     </p>
-    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Identity
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -396,7 +396,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).
     </p>
-    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Frame
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px]">
@@ -451,7 +451,7 @@ bun add @coinbase/onchainkit
     <aside className="mx-auto md:mx-0">
       <a
         href="https://www.figma.com/community/file/1370194397345450683/onchainkit"
-        className="flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
+        className="flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
         target="_blank"
         rel="noopener noreferrer"
       >

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -100,7 +100,7 @@ bun add @coinbase/onchainkit
 :::
 
     </div>
-      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 px-4 py-3 font-bold mt-4">
+      <a href="/getting-started" title="View OnchainKit docs" className="font-sans border rounded-xl border-solid border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 px-4 py-3 font-bold mt-4">
         View docs
       </a>
     </div>
@@ -127,7 +127,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Create or connect your wallet with [Connect Wallet](/wallet/wallet), powered by [Smart Wallet](https://www.smartwallet.dev/why).
     </p>
-    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Wallet
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -193,7 +193,7 @@ bun add @coinbase/onchainkit
   <p className="text-base md:text-base pb-[24px] md:text-left text-center">
     Trigger onchain operations and sponsor them with [Paymaster](https://www.coinbase.com/developer-platform/products/paymaster).
   </p>
-  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+  <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
     Start with Transaction
   </a>
   <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -273,7 +273,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
     </p>
-    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Swap
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px] md:pt-[20px]">
@@ -347,7 +347,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
     </p>
-    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Identity
     </a>
     <div className="flex grow md:flex-row pt-[44px] flex-col">
@@ -396,7 +396,7 @@ bun add @coinbase/onchainkit
     <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).
     </p>
-    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
+    <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
       Start with Frame
     </a>
     <div className="flex grow flex-col items-center md:flex-row pt-[44px]">
@@ -451,7 +451,7 @@ bun add @coinbase/onchainkit
     <aside className="mx-auto md:mx-0">
       <a
         href="https://www.figma.com/community/file/1370194397345450683/onchainkit"
-        className="flex justify-center items-center border border-indigo-600 text-indigo-600 hover:border-indigo-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
+        className="flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-100 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[180px]"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
**What changed? Why?**
Hover on buttons were difficult to see, especially on light mode. 

Adding `hover:bg-gray-200` to light mode and `dark:hover:bg-gray-700` to dark mode. 

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="145" alt="Screenshot 2024-08-19 at 10 25 41 AM" src="https://github.com/user-attachments/assets/1434239a-4bae-4d1e-895a-a28a01a3bf36">

</td>
    <td>

<img width="156" alt="Screenshot 2024-08-19 at 10 25 15 AM" src="https://github.com/user-attachments/assets/ef357afb-e1e7-450c-8abf-6b028f1220af">

   </td>
  </tr>
</table>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="181" alt="Screenshot 2024-08-19 at 11 13 33 AM" src="https://github.com/user-attachments/assets/8a59fae7-eba1-4432-8d10-7f207dfa4bb5">


</td>
    <td>

<img width="145" alt="Screenshot 2024-08-19 at 11 13 09 AM" src="https://github.com/user-attachments/assets/faae7942-de8a-4c26-b77b-5c5acbd3cb2a">

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
