### PR TITLE
docs: Fix Landing Page text color in dark and light mode

### DIFF
--- a/site/docs/components/landing/NavigationList.tsx
+++ b/site/docs/components/landing/NavigationList.tsx
@@ -46,7 +46,7 @@ export default function NavigationList() {
               <div className="h-[70px] w-[70px] rounded-xl bg-gray-800 p-5 group-hover:bg-gray-50">
                 {item.svg}
               </div>
-              <p className="text-center font-normal text-base not-italic leading-6">
+              <p className="text-center font-normal text-base not-italic leading-6 text-gray-950 dark:text-gray-50">
                 {item.label}
               </p>
             </a>

--- a/site/docs/components/landing/NavigationList.tsx
+++ b/site/docs/components/landing/NavigationList.tsx
@@ -46,7 +46,7 @@ export default function NavigationList() {
               <div className="h-[70px] w-[70px] rounded-xl bg-gray-800 p-5 group-hover:bg-gray-50">
                 {item.svg}
               </div>
-              <p className="text-center font-normal text-base not-italic leading-6">
+              <p className="text-center font-normal text-base not-italic leading-6 text-gray-950">
                 {item.label}
               </p>
             </a>

--- a/site/docs/components/landing/NavigationList.tsx
+++ b/site/docs/components/landing/NavigationList.tsx
@@ -46,7 +46,7 @@ export default function NavigationList() {
               <div className="h-[70px] w-[70px] rounded-xl bg-gray-800 p-5 group-hover:bg-gray-50">
                 {item.svg}
               </div>
-              <p className="text-center font-normal text-base not-italic leading-6 text-gray-950 dark:text-gray-50">
+              <p className='text-center font-normal text-base text-gray-950 not-italic leading-6 dark:text-gray-50'>
                 {item.label}
               </p>
             </a>

--- a/site/docs/components/landing/NavigationList.tsx
+++ b/site/docs/components/landing/NavigationList.tsx
@@ -46,7 +46,7 @@ export default function NavigationList() {
               <div className="h-[70px] w-[70px] rounded-xl bg-gray-800 p-5 group-hover:bg-gray-50">
                 {item.svg}
               </div>
-              <p className="text-center font-normal text-base not-italic leading-6 text-gray-950">
+              <p className="text-center font-normal text-base not-italic leading-6">
                 {item.label}
               </p>
             </a>

--- a/site/docs/components/landing/NavigationList.tsx
+++ b/site/docs/components/landing/NavigationList.tsx
@@ -46,7 +46,7 @@ export default function NavigationList() {
               <div className="h-[70px] w-[70px] rounded-xl bg-gray-800 p-5 group-hover:bg-gray-50">
                 {item.svg}
               </div>
-              <p className='text-center font-normal text-base text-gray-950 not-italic leading-6 dark:text-gray-50'>
+              <p className="text-center font-normal text-base text-gray-950 not-italic leading-6 dark:text-gray-50">
                 {item.label}
               </p>
             </a>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -70,7 +70,7 @@ import {
   <div className="mx-auto max-w-2xl">
     <div className="md:text-center flex flex-col gap-8 pt-[100px] pb-16">
       <h1 className="text-center text-6xl md:text-9xl font-medium no-underline text-black dark:text-white tracking-[-0.1rem]">OnchainKit</h1>
-      <div className="landing-page-hero text-center text-xl md:text-3xl text-black dark:text-white">
+      <div className="landing-page-hero text-center text-xl md:text-3xl text-gray-950 dark:text-gray-50">
         <p>
           Build your onchain apps with ready-to-use React components and Typescript utilities.
         </p>
@@ -108,7 +108,7 @@ bun add @coinbase/onchainkit
 </div>
 <div className="flex flex-col md:flex-row justify-between items-center md:mb-[64px] mx-auto max-w-[1225px] z-10 pt-[100px]">
   <div className="flex flex-col gap-4 md:flex-row">
-    <h3 className="py-[15px] md:w-[365px] text-4xl md:text-4xl md:text-left text-center">Ready-to-use onchain components</h3>
+    <h3 className="py-[15px] md:w-[365px] text-4xl md:text-4xl md:text-left text-center text-gray-950 dark:text-gray-50">Ready-to-use onchain components</h3>
   </div>
   <NavigationList />
 </div>
@@ -124,7 +124,7 @@ bun add @coinbase/onchainkit
     </a>
   </main>
   <aside className="pb-6">
-    <p className="text-base md:text-base pb-[24px] md:text-left text-center">
+    <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
       Create or connect your wallet with [Connect Wallet](/wallet/wallet), powered by [Smart Wallet](https://www.smartwallet.dev/why).
     </p>
     <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -186,11 +186,11 @@ bun add @coinbase/onchainkit
 
   <main id="transaction" className="pt-[56px] flex flex-col gap-4 md:flex-row md:text-left text-center">
     <a href="#transaction" title="Transaction Component details">
-      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl">Transaction</h3>
+      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-gray-950 dark:text-gray-50">Transaction</h3>
     </a>
   </main>
   <aside className="pb-6">
-  <p className="text-base md:text-base pb-[24px] md:text-left text-center">
+  <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
     Trigger onchain operations and sponsor them with [Paymaster](https://www.coinbase.com/developer-platform/products/paymaster).
   </p>
   <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -266,11 +266,11 @@ bun add @coinbase/onchainkit
 
   <main id="swap" className="pt-[56px] flex flex-col gap-4 md:flex-row md:text-left text-center">
     <a href="#swap" title="Swap Component details">
-      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl">Swap</h3>
+      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-gray-950 dark:text-gray-50">Swap</h3>
     </a>
   </main>
   <aside className="pb-6">
-    <p className="text-base md:text-base pb-[24px] md:text-left text-center">
+    <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
       Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
     </p>
     <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -340,11 +340,11 @@ bun add @coinbase/onchainkit
 
   <main id="identity" className="flex flex-col gap-4 md:flex-row md:text-left text-center">
     <a href="#identity" title="Identity Component details">
-      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl">Identity</h3>
+      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-gray-950 dark:text-gray-50">Identity</h3>
     </a>
   </main>
   <aside className="pb-6">
-    <p className="text-base md:text-base pb-[24px] md:text-left text-center">
+    <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
       Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
     </p>
     <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -389,11 +389,11 @@ bun add @coinbase/onchainkit
   
   <main id="frame" className="pt-[56px] flex flex-col gap-4 md:flex-row md:text-left text-center">
     <a href="#frame" title="Frame Component details">
-      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl">Frame</h3>
+      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-gray-950 dark:text-gray-50">Frame</h3>
     </a>
   </main>
   <aside className="pb-10">
-    <p className="text-base md:text-base pb-[24px] md:text-left text-center">
+    <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
       Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).
     </p>
     <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -444,9 +444,9 @@ bun add @coinbase/onchainkit
   <div className="w-[1225px] max-w-full flex flex-col justify-between">
     <div className="flex flex-col md:flex-row justify-between items-center pb-[20px]">
       <div>
-        <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-center md:text-left max-w-[250px]">From design to development</h3>
+        <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-center text-gray-950 dark:text-gray-50 md:text-left max-w-[250px]">From design to development</h3>
       </div>
-      <p className="w-[450px] max-w-full text-[#8A919E] text-[28px] font-light leading-9 md:text-[28px] text-center md:text-left">Take ownership over design or collaborate efficiently with designers</p>
+      <p className="w-[450px] max-w-full text-[28px] font-light leading-9 md:text-[28px] text-center text-gray-950 dark:text-gray-50 md:text-left">Take ownership over design or collaborate efficiently with designers</p>
     </div>
     <aside className="mx-auto md:mx-0">
       <a
@@ -473,7 +473,7 @@ bun add @coinbase/onchainkit
 
 <section className="css-alternate-container w-full flex flex-col items-center py-24 gap-[72px]">
   <div>
-    <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl max-w-[525px] text-center">Builders ship faster with OnchainKit</h3>
+    <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl max-w-[525px] text-center text-gray-950 dark:text-gray-50">Builders ship faster with OnchainKit</h3>
   </div>
   <div className="flex flex-col md:flex-row gap-6">
     <div className="max-w-[438px]">
@@ -494,7 +494,7 @@ bun add @coinbase/onchainkit
     <div className="flex flex-col md:flex-row md:items-end justify-between">
       <div className="flex flex-col justify-between xl:flex-row xl:space-x-[25px]">
         <div className="pt-[20px] xl:pt-[40px]">
-          <h2 className="text-black dark:text-white text-4xl md:text-9xl text-center md:text-left font-medium tracking-[-0.1rem]">OnchainKit</h2>
+          <h2 className="text-gray-950 dark:text-white text-4xl md:text-9xl text-center md:text-left font-medium tracking-[-0.1rem]">OnchainKit</h2>
           <p className="leading-7 text-xl text-gray-400 px-0 py-6 max-w-[500px] md:text-left text-center">
             Build your onchain apps with ready-to-use React components and Typescript utilities.
           </p>
@@ -504,7 +504,7 @@ bun add @coinbase/onchainkit
         </div>
       </div>
       <div className="flex flex-col md:flex-row items-center md:space-x-[128px]">
-        <ul className="flex space-x-[28px] py-3 md:py-0">
+        <ul id="home-footer-list" className="flex space-x-[28px] py-3 md:py-0">
           <li>[Docs](/getting-started)</li>
           <li>[Playground](https://onchainkit.xyz/playground)</li>
           <li>[Template](https://github.com/coinbase/onchain-app-template)</li>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -527,7 +527,11 @@ bun add @coinbase/onchainkit
             </svg>
           </a>
           <a href="https://warpcast.com/~/channel/onchainkit" title="View OnchainKit Warpcast page" target="_blank">
-            <img src="/assets/warpcast-logo.png" />
+            <svg width="20" height="18" viewBox="0 0 19 19" xmlns="http://www.w3.org/2000/svg">
+              <g transform="translate(0,19) scale(0.1,-0.1)" fill="#F9FAFB">
+                <path d="M12 178 c-16 -16 -16 -150 0 -166 16 -16 150 -16 166 0 16 16 16 150 0 166 -16 16 -150 16 -166 0z m59 -65 c1 -17 2 -17 6 0 6 22 33 22 34 0 1 -17 2 -17 6 0 2 9 10 17 18 17 10 0 11 -8 3 -40 -11 -43 -22 -50 -36 -24 -8 15 -10 15 -15 0 -11 -27 -24 -18 -35 24 -8 32 -7 40 4 40 8 0 15 -8 15 -17z"/>
+              </g>
+            </svg>
           </a>
         </ul>
       </div>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -527,11 +527,7 @@ bun add @coinbase/onchainkit
             </svg>
           </a>
           <a href="https://warpcast.com/~/channel/onchainkit" title="View OnchainKit Warpcast page" target="_blank">
-            <svg width="20" height="18" viewBox="0 0 19 19" xmlns="http://www.w3.org/2000/svg">
-              <g transform="translate(0,19) scale(0.1,-0.1)" fill="#F9FAFB">
-                <path d="M12 178 c-16 -16 -16 -150 0 -166 16 -16 150 -16 166 0 16 16 16 150 0 166 -16 16 -150 16 -166 0z m59 -65 c1 -17 2 -17 6 0 6 22 33 22 34 0 1 -17 2 -17 6 0 2 9 10 17 18 17 10 0 11 -8 3 -40 -11 -43 -22 -50 -36 -24 -8 15 -10 15 -15 0 -11 -27 -24 -18 -35 24 -8 32 -7 40 4 40 8 0 15 -8 15 -17z"/>
-              </g>
-            </svg>
+            <img src="/assets/warpcast-logo.png" />
           </a>
         </ul>
       </div>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -70,7 +70,7 @@ import {
   <div className="mx-auto max-w-2xl">
     <div className="md:text-center flex flex-col gap-8 pt-[100px] pb-16">
       <h1 className="text-center text-6xl md:text-9xl font-medium no-underline text-black dark:text-white tracking-[-0.1rem]">OnchainKit</h1>
-      <div className="landing-page-hero text-center text-xl md:text-3xl text-gray-950 dark:text-gray-50">
+      <div className="landing-page-hero text-center text-xl md:text-3xl text-black dark:text-white">
         <p>
           Build your onchain apps with ready-to-use React components and Typescript utilities.
         </p>
@@ -108,7 +108,7 @@ bun add @coinbase/onchainkit
 </div>
 <div className="flex flex-col md:flex-row justify-between items-center md:mb-[64px] mx-auto max-w-[1225px] z-10 pt-[100px]">
   <div className="flex flex-col gap-4 md:flex-row">
-    <h3 className="py-[15px] md:w-[365px] text-4xl md:text-4xl md:text-left text-center text-gray-950 dark:text-gray-50">Ready-to-use onchain components</h3>
+    <h3 className="py-[15px] md:w-[365px] text-4xl md:text-4xl md:text-left text-center">Ready-to-use onchain components</h3>
   </div>
   <NavigationList />
 </div>
@@ -124,7 +124,7 @@ bun add @coinbase/onchainkit
     </a>
   </main>
   <aside className="pb-6">
-    <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
+    <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Create or connect your wallet with [Connect Wallet](/wallet/wallet), powered by [Smart Wallet](https://www.smartwallet.dev/why).
     </p>
     <a href="/wallet/wallet" title="Start with Wallet Component" className="mx-auto md:m-0  flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -186,11 +186,11 @@ bun add @coinbase/onchainkit
 
   <main id="transaction" className="pt-[56px] flex flex-col gap-4 md:flex-row md:text-left text-center">
     <a href="#transaction" title="Transaction Component details">
-      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-gray-950 dark:text-gray-50">Transaction</h3>
+      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl">Transaction</h3>
     </a>
   </main>
   <aside className="pb-6">
-  <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
+  <p className="text-base md:text-base pb-[24px] md:text-left text-center">
     Trigger onchain operations and sponsor them with [Paymaster](https://www.coinbase.com/developer-platform/products/paymaster).
   </p>
   <a href="/transaction/transaction" title="Start with Transaction Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -266,11 +266,11 @@ bun add @coinbase/onchainkit
 
   <main id="swap" className="pt-[56px] flex flex-col gap-4 md:flex-row md:text-left text-center">
     <a href="#swap" title="Swap Component details">
-      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-gray-950 dark:text-gray-50">Swap</h3>
+      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl">Swap</h3>
     </a>
   </main>
   <aside className="pb-6">
-    <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
+    <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Swap [Tokens](/token/types#token) using the [Swap](/swap/swap) components.
     </p>
     <a href="/swap/swap" title="Start with Swap Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -340,11 +340,11 @@ bun add @coinbase/onchainkit
 
   <main id="identity" className="flex flex-col gap-4 md:flex-row md:text-left text-center">
     <a href="#identity" title="Identity Component details">
-      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-gray-950 dark:text-gray-50">Identity</h3>
+      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl">Identity</h3>
     </a>
   </main>
   <aside className="pb-6">
-    <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
+    <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Display ENS [avatars](/identity/avatar), Attestation [badges](/identity/badge), ENS [names](/identity/name) and account [addresses](/identity/address).
     </p>
     <a href="/identity/identity" title="Start with Identity Component" className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -389,11 +389,11 @@ bun add @coinbase/onchainkit
   
   <main id="frame" className="pt-[56px] flex flex-col gap-4 md:flex-row md:text-left text-center">
     <a href="#frame" title="Frame Component details">
-      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-gray-950 dark:text-gray-50">Frame</h3>
+      <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl">Frame</h3>
     </a>
   </main>
   <aside className="pb-10">
-    <p className="text-base md:text-base pb-[24px] md:text-left text-center text-gray-950 dark:text-gray-50">
+    <p className="text-base md:text-base pb-[24px] md:text-left text-center">
       Test, build, and ship your Farcaster frames with [FrameMetadata](/frame/frame-metadata).
     </p>
     <a href="/frame/frame-metadata" title="Start with Frame Component"  className="mx-auto md:m-0 flex justify-center items-center border border-indigo-600 text-indigo-600 hover:bg-gray-200 dark:hover:bg-gray-700 dark:border-indigo-400 dark:text-indigo-400 dark:hover:border-indigo-300 font-bold leading-6 px-4 py-3 rounded-xl border-solid w-[210px]">
@@ -444,9 +444,9 @@ bun add @coinbase/onchainkit
   <div className="w-[1225px] max-w-full flex flex-col justify-between">
     <div className="flex flex-col md:flex-row justify-between items-center pb-[20px]">
       <div>
-        <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-center text-gray-950 dark:text-gray-50 md:text-left max-w-[250px]">From design to development</h3>
+        <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl text-center md:text-left max-w-[250px]">From design to development</h3>
       </div>
-      <p className="w-[450px] max-w-full text-[28px] font-light leading-9 md:text-[28px] text-center text-gray-950 dark:text-gray-50 md:text-left">Take ownership over design or collaborate efficiently with designers</p>
+      <p className="w-[450px] max-w-full text-[#8A919E] text-[28px] font-light leading-9 md:text-[28px] text-center md:text-left">Take ownership over design or collaborate efficiently with designers</p>
     </div>
     <aside className="mx-auto md:mx-0">
       <a
@@ -473,7 +473,7 @@ bun add @coinbase/onchainkit
 
 <section className="css-alternate-container w-full flex flex-col items-center py-24 gap-[72px]">
   <div>
-    <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl max-w-[525px] text-center text-gray-950 dark:text-gray-50">Builders ship faster with OnchainKit</h3>
+    <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl max-w-[525px] text-center">Builders ship faster with OnchainKit</h3>
   </div>
   <div className="flex flex-col md:flex-row gap-6">
     <div className="max-w-[438px]">
@@ -494,7 +494,7 @@ bun add @coinbase/onchainkit
     <div className="flex flex-col md:flex-row md:items-end justify-between">
       <div className="flex flex-col justify-between xl:flex-row xl:space-x-[25px]">
         <div className="pt-[20px] xl:pt-[40px]">
-          <h2 className="text-gray-950 dark:text-white text-4xl md:text-9xl text-center md:text-left font-medium tracking-[-0.1rem]">OnchainKit</h2>
+          <h2 className="text-black dark:text-white text-4xl md:text-9xl text-center md:text-left font-medium tracking-[-0.1rem]">OnchainKit</h2>
           <p className="leading-7 text-xl text-gray-400 px-0 py-6 max-w-[500px] md:text-left text-center">
             Build your onchain apps with ready-to-use React components and Typescript utilities.
           </p>
@@ -504,7 +504,7 @@ bun add @coinbase/onchainkit
         </div>
       </div>
       <div className="flex flex-col md:flex-row items-center md:space-x-[128px]">
-        <ul id="home-footer-list" className="flex space-x-[28px] py-3 md:py-0">
+        <ul className="flex space-x-[28px] py-3 md:py-0">
           <li>[Docs](/getting-started)</li>
           <li>[Playground](https://onchainkit.xyz/playground)</li>
           <li>[Template](https://github.com/coinbase/onchain-app-template)</li>

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -504,7 +504,7 @@ bun add @coinbase/onchainkit
         </div>
       </div>
       <div className="flex flex-col md:flex-row items-center md:space-x-[128px]">
-        <ul id="home-footer-list" className="flex space-x-[28px] py-3 md:py-0">
+        <ul className="flex space-x-[28px] py-3 md:py-0">
           <li>[Docs](/getting-started)</li>
           <li>[Playground](https://onchainkit.xyz/playground)</li>
           <li>[Template](https://github.com/coinbase/onchain-app-template)</li>

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -48,14 +48,6 @@
   padding: 8px 8px 0;
 }
 
-.vocs_DesktopTopNav_item.vocs_NavigationMenu_link.vocs_Link.vocs_Link_styleless {
-  color: #030712;
-}
-
-.dark .vocs_DesktopTopNav_item.vocs_NavigationMenu_link.vocs_Link.vocs_Link_styleless {
-  color: #F9FAFB;
-}
-
 .vocs_Tabs_trigger {
   padding: 8px 16px;
   border: none;
@@ -63,23 +55,6 @@
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
   transition: color 0.3s;
-  color: #030712;
-}
-
-#home-footer-list .vocs_Anchor.vocs_Link.vocs_Link_accent_underlined {
-  color: #030712;
-}
-
-.dark #home-footer-list .vocs_Anchor.vocs_Link.vocs_Link_accent_underlined {
-  color: #F9FAFB;
-}
-
-.vocs_NavigationMenu_trigger.vocs_NavigationMenu_link {
-  color: #030712;
-}
-
-.dark .vocs_NavigationMenu_trigger.vocs_NavigationMenu_link {
-  color: #F9FAFB;
 }
 
 .dark .vocs_Pre_wrapper pre {

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -66,11 +66,11 @@
   color: #030712;
 }
 
-#home-footer-list .vocs_Anchor.vocs_Link.vocs_Link_accent_underlined {
+.vocs_Anchor.vocs_Link.vocs_Link_accent_underlined {
   color: #030712;
 }
 
-.dark #home-footer-list .vocs_Anchor.vocs_Link.vocs_Link_accent_underlined {
+.dark .vocs_Anchor.vocs_Link.vocs_Link_accent_underlined {
   color: #F9FAFB;
 }
 

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -48,6 +48,14 @@
   padding: 8px 8px 0;
 }
 
+.vocs_DesktopTopNav_item.vocs_NavigationMenu_link.vocs_Link.vocs_Link_styleless {
+  color: #030712;
+}
+
+.dark .vocs_DesktopTopNav_item.vocs_NavigationMenu_link.vocs_Link.vocs_Link_styleless {
+  color: #F9FAFB;
+}
+
 .vocs_Tabs_trigger {
   padding: 8px 16px;
   border: none;
@@ -55,6 +63,23 @@
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
   transition: color 0.3s;
+  color: #030712;
+}
+
+#home-footer-list .vocs_Anchor.vocs_Link.vocs_Link_accent_underlined {
+  color: #030712;
+}
+
+.dark #home-footer-list .vocs_Anchor.vocs_Link.vocs_Link_accent_underlined {
+  color: #F9FAFB;
+}
+
+.vocs_NavigationMenu_trigger.vocs_NavigationMenu_link {
+  color: #030712;
+}
+
+.dark .vocs_NavigationMenu_trigger.vocs_NavigationMenu_link {
+  color: #F9FAFB;
 }
 
 .dark .vocs_Pre_wrapper pre {

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
     "preview": "vocs preview"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "0.29.2",
+    "@coinbase/onchainkit": "0.29.1",
     "@types/react": "latest",
     "@vercel/edge": "^1.1.1",
     "permissionless": "^0.1.29",

--- a/site/package.json
+++ b/site/package.json
@@ -8,7 +8,7 @@
     "preview": "vocs preview"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "0.29.1",
+    "@coinbase/onchainkit": "0.29.2",
     "@types/react": "latest",
     "@vercel/edge": "^1.1.1",
     "permissionless": "^0.1.29",

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -479,9 +479,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:0.29.2":
-  version: 0.29.2
-  resolution: "@coinbase/onchainkit@npm:0.29.2"
+"@coinbase/onchainkit@npm:0.29.1":
+  version: 0.29.1
+  resolution: "@coinbase/onchainkit@npm:0.29.1"
   dependencies:
     "@rainbow-me/rainbowkit": "npm:^2.1.3"
     "@tanstack/react-query": "npm:^5"
@@ -496,7 +496,7 @@ __metadata:
     "@xmtp/frames-validator": ^0.6.0
     react: ^18
     react-dom: ^18
-  checksum: c45d2c4a81067111a916c32035b254a47510137b4dea0223009b57c233abe0de50c8ddca4cd9d3ed3aa332086abd72d4d80e93dc510ac20e2624fd9e845261c6
+  checksum: 4d5d2b19df71e10369c9c5cef8f5e187e5f051e5758077ba13e8b7ea655a4441183382af8f879a4d74da12340d3604a394419927bd7166fd9433e46b6df3f040
   languageName: node
   linkType: hard
 
@@ -7836,7 +7836,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "onchainkit@workspace:."
   dependencies:
-    "@coinbase/onchainkit": "npm:0.29.2"
+    "@coinbase/onchainkit": "npm:0.29.1"
     "@types/react": "npm:latest"
     "@vercel/edge": "npm:^1.1.1"
     permissionless: "npm:^0.1.29"

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -479,9 +479,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:0.29.1":
-  version: 0.29.1
-  resolution: "@coinbase/onchainkit@npm:0.29.1"
+"@coinbase/onchainkit@npm:0.29.2":
+  version: 0.29.2
+  resolution: "@coinbase/onchainkit@npm:0.29.2"
   dependencies:
     "@rainbow-me/rainbowkit": "npm:^2.1.3"
     "@tanstack/react-query": "npm:^5"
@@ -496,7 +496,7 @@ __metadata:
     "@xmtp/frames-validator": ^0.6.0
     react: ^18
     react-dom: ^18
-  checksum: 4d5d2b19df71e10369c9c5cef8f5e187e5f051e5758077ba13e8b7ea655a4441183382af8f879a4d74da12340d3604a394419927bd7166fd9433e46b6df3f040
+  checksum: c45d2c4a81067111a916c32035b254a47510137b4dea0223009b57c233abe0de50c8ddca4cd9d3ed3aa332086abd72d4d80e93dc510ac20e2624fd9e845261c6
   languageName: node
   linkType: hard
 
@@ -7836,7 +7836,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "onchainkit@workspace:."
   dependencies:
-    "@coinbase/onchainkit": "npm:0.29.1"
+    "@coinbase/onchainkit": "npm:0.29.2"
     "@types/react": "npm:latest"
     "@vercel/edge": "npm:^1.1.1"
     permissionless: "npm:^0.1.29"


### PR DESCRIPTION
**What changed? Why?**
https://linear.app/coinbase/issue/BOE-309/update-the-text-color-to-gray-950

Update the Landing Page light and dark mode text to match the Figma mockups. 


Bump /site `@coinbase/onchainkit` to  `0.29.2`

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="1397" alt="Screenshot 2024-08-19 at 4 26 15 PM" src="https://github.com/user-attachments/assets/b3068063-614e-435a-966c-4dfa07a3443f">

</td>
    <td>
<img width="1385" alt="Screenshot 2024-08-19 at 4 26 00 PM" src="https://github.com/user-attachments/assets/d5260f07-1c1f-4cfa-b813-08dd93b76ff1">

   </td>
  </tr>
</table>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="1385" alt="Screenshot 2024-08-19 at 4 27 00 PM" src="https://github.com/user-attachments/assets/d9c3a6b6-8df6-423e-b386-e8bd4b90518d">


</td>
    <td>
<img width="1365" alt="Screenshot 2024-08-19 at 4 26 52 PM" src="https://github.com/user-attachments/assets/53545978-fd38-44da-9853-574222fae8e4">


   </td>
  </tr>
</table>

**Notes to reviewers**

**How has it been tested?**
