### PR TITLE
chore: Update Wallet disconnect SVG

### DIFF
--- a/.changeset/many-ways-divide.md
+++ b/.changeset/many-ways-divide.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+chore: Update disconnect SVG image. By @cpcramer #1103

--- a/src/internal/svg/disconnectSvg.stories.ts
+++ b/src/internal/svg/disconnectSvg.stories.ts
@@ -1,5 +1,5 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
 import { disconnectSvg } from './disconnectSvg';
 
 const SvgWrapper: React.FC = () =>

--- a/src/internal/svg/disconnectSvg.stories.ts
+++ b/src/internal/svg/disconnectSvg.stories.ts
@@ -1,17 +1,19 @@
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { fn } from '@storybook/test';
 import { disconnectSvg } from './disconnectSvg';
 
+// Wrapper component to display the SVG
+const SvgWrapper: React.FC = () => React.createElement('div', { 
+  style: { width: '100px', height: '100px' } 
+}, disconnectSvg);
+
 const meta = {
-  title: 'Wallet/disconnectSvg',
-  component: disconnectSvg,
+  title: 'Wallet/DisconnectSvg',
+  component: SvgWrapper,
   tags: ['autodocs'],
-  argTypes: {},
-  args: { onClick: fn() },
-} satisfies Meta<typeof disconnectSvg>;
+} satisfies Meta<typeof SvgWrapper>;
 
 export default meta;
-
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {};

--- a/src/internal/svg/disconnectSvg.stories.ts
+++ b/src/internal/svg/disconnectSvg.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { disconnectSvg } from './disconnectSvg';
+
+const meta = {
+  title: 'Wallet/disconnectSvg',
+  component: disconnectSvg,
+  tags: ['autodocs'],
+  argTypes: {},
+  args: { onClick: fn() },
+} satisfies Meta<typeof disconnectSvg>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};

--- a/src/internal/svg/disconnectSvg.stories.ts
+++ b/src/internal/svg/disconnectSvg.stories.ts
@@ -6,7 +6,7 @@ const SvgWrapper: React.FC = () =>
   React.createElement(
     'div',
     {
-      style: { width: '100%', height: '100%', viewBox: '0 0 24 24' },
+      style: { width: '100%', height: '100%', viewBox: '0 0 16 20' },
     },
     disconnectSvg,
   );

--- a/src/internal/svg/disconnectSvg.stories.ts
+++ b/src/internal/svg/disconnectSvg.stories.ts
@@ -2,12 +2,11 @@ import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { disconnectSvg } from './disconnectSvg';
 
-// Wrapper component to display the SVG
 const SvgWrapper: React.FC = () =>
   React.createElement(
     'div',
     {
-      style: { width: '100px', height: '100px' },
+      style: { width: '100px', height: '100px', viewBox: '0 0 24 24' },
     },
     disconnectSvg,
   );

--- a/src/internal/svg/disconnectSvg.stories.ts
+++ b/src/internal/svg/disconnectSvg.stories.ts
@@ -6,7 +6,7 @@ const SvgWrapper: React.FC = () =>
   React.createElement(
     'div',
     {
-      style: { width: '100px', height: '100px', viewBox: '0 0 24 24' },
+      style: { width: '100%', height: '100%', viewBox: '0 0 24 24' },
     },
     disconnectSvg,
   );

--- a/src/internal/svg/disconnectSvg.stories.ts
+++ b/src/internal/svg/disconnectSvg.stories.ts
@@ -3,9 +3,14 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { disconnectSvg } from './disconnectSvg';
 
 // Wrapper component to display the SVG
-const SvgWrapper: React.FC = () => React.createElement('div', { 
-  style: { width: '100px', height: '100px' } 
-}, disconnectSvg);
+const SvgWrapper: React.FC = () =>
+  React.createElement(
+    'div',
+    {
+      style: { width: '100px', height: '100px' },
+    },
+    disconnectSvg,
+  );
 
 const meta = {
   title: 'Wallet/DisconnectSvg',

--- a/src/internal/svg/disconnectSvg.tsx
+++ b/src/internal/svg/disconnectSvg.tsx
@@ -1,4 +1,4 @@
-import { fill } from '../../styles/theme';
+import { fill } from "../../styles/theme";
 
 export const disconnectSvg = (
   <svg
@@ -6,16 +6,16 @@ export const disconnectSvg = (
     aria-label="ock-disconnectSvg"
     width="100%"
     height="100%"
-    viewBox="0 0 20 20"
+    viewBox="0 0 16 20"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
   >
     <path
-      d="M10.9735 2.69696L10.9735 4.52272L5.49622 4.52272L5.49622 15.4773L10.9735 15.4773L10.9735 17.303L3.67046 17.303L3.67046 2.69696L10.9735 2.69696Z"
+      d="M11.0668 0.91803L11.0668 2.93852L2.02049 2.93852L2.02049 15.0615L11.0668 15.0615L11.0668 17.082L-7.06549e-07 17.082L0 0.918029L11.0668 0.91803Z"
       className={fill.defaultReverse}
     />
     <path
-      d="M13.4614 13.5207L16.7804 10.0235L13.4783 6.34848L12.1202 7.56872L13.4931 9.09667L7.32216 9.09667L7.32216 10.9224L13.4102 10.9224L12.1371 12.2639L13.4614 13.5207Z"
+      d="M12.3273 12.8963L16.0002 9.02606L12.346 4.95902L10.843 6.30941L12.3623 8.00032L5.53321 8.00032L5.53321 10.0208L12.2706 10.0208L10.8617 11.5054L12.3273 12.8963Z"
       className={fill.defaultReverse}
     />
   </svg>

--- a/src/internal/svg/disconnectSvg.tsx
+++ b/src/internal/svg/disconnectSvg.tsx
@@ -1,4 +1,4 @@
-import { fill } from "../../styles/theme";
+import { fill } from '../../styles/theme';
 
 export const disconnectSvg = (
   <svg

--- a/src/internal/svg/disconnectSvg.tsx
+++ b/src/internal/svg/disconnectSvg.tsx
@@ -1,22 +1,24 @@
 import { fill } from '../../styles/theme';
 
-export const disconnectSvg = (
-  <svg
-    role="img"
-    aria-label="ock-disconnectSvg"
-    width="100%"
-    height="100%"
-    viewBox="0 0 16 20"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M11.0668 0.91803L11.0668 2.93852L2.02049 2.93852L2.02049 15.0615L11.0668 15.0615L11.0668 17.082L-7.06549e-07 17.082L0 0.918029L11.0668 0.91803Z"
-      className={fill.defaultReverse}
-    />
-    <path
-      d="M12.3273 12.8963L16.0002 9.02606L12.346 4.95902L10.843 6.30941L12.3623 8.00032L5.53321 8.00032L5.53321 10.0208L12.2706 10.0208L10.8617 11.5054L12.3273 12.8963Z"
-      className={fill.defaultReverse}
-    />
-  </svg>
-);
+export function disconnectSvg() {
+  return (
+    <svg
+      role="img"
+      aria-label="ock-disconnect-svg"
+      width="100%"
+      height="100%"
+      viewBox="0 0 16 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.0668 0.91803L11.0668 2.93852L2.02049 2.93852L2.02049 15.0615L11.0668 15.0615L11.0668 17.082L-7.06549e-07 17.082L0 0.918029L11.0668 0.91803Z"
+        className={fill.defaultReverse}
+      />
+      <path
+        d="M12.3273 12.8963L16.0002 9.02606L12.346 4.95902L10.843 6.30941L12.3623 8.00032L5.53321 8.00032L5.53321 10.0208L12.2706 10.0208L10.8617 11.5054L12.3273 12.8963Z"
+        className={fill.defaultReverse}
+      />
+    </svg>
+  );
+}

--- a/src/internal/svg/disconnectSvg.tsx
+++ b/src/internal/svg/disconnectSvg.tsx
@@ -1,24 +1,22 @@
 import { fill } from '../../styles/theme';
 
-export function disconnectSvg() {
-  return (
-    <svg
-      role="img"
-      aria-label="ock-disconnect-svg"
-      width="100%"
-      height="100%"
-      viewBox="0 0 16 20"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M11.0668 0.91803L11.0668 2.93852L2.02049 2.93852L2.02049 15.0615L11.0668 15.0615L11.0668 17.082L-7.06549e-07 17.082L0 0.918029L11.0668 0.91803Z"
-        className={fill.defaultReverse}
-      />
-      <path
-        d="M12.3273 12.8963L16.0002 9.02606L12.346 4.95902L10.843 6.30941L12.3623 8.00032L5.53321 8.00032L5.53321 10.0208L12.2706 10.0208L10.8617 11.5054L12.3273 12.8963Z"
-        className={fill.defaultReverse}
-      />
-    </svg>
-  );
-}
+export const disconnectSvg = (
+  <svg
+    role="img"
+    aria-label="ock-disconnect-svg"
+    width="100%"
+    height="100%"
+    viewBox="0 0 16 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M11.0668 0.91803L11.0668 2.93852L2.02049 2.93852L2.02049 15.0615L11.0668 15.0615L11.0668 17.082L-7.06549e-07 17.082L0 0.918029L11.0668 0.91803Z"
+      className={fill.defaultReverse}
+    />
+    <path
+      d="M12.3273 12.8963L16.0002 9.02606L12.346 4.95902L10.843 6.30941L12.3623 8.00032L5.53321 8.00032L5.53321 10.0208L12.2706 10.0208L10.8617 11.5054L12.3273 12.8963Z"
+      className={fill.defaultReverse}
+    />
+  </svg>
+);

--- a/src/wallet/components/WalletDropdownDisconnect.stories.tsx
+++ b/src/wallet/components/WalletDropdownDisconnect.stories.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { WalletDropdownDisconnect } from './WalletDropdownDisconnect';
+
+export default {
+  title: 'Wallet/WalletDropdownDisconnect',
+  component: WalletDropdownDisconnect,
+};
+
+export const Default = () => <WalletDropdownDisconnect />;
+
+export const CustomText = () => <WalletDropdownDisconnect text="Log Out" />;
+
+export const CustomClass = () => (
+  <WalletDropdownDisconnect className="custom-class" />
+);

--- a/src/wallet/components/WalletDropdownDisconnect.stories.tsx
+++ b/src/wallet/components/WalletDropdownDisconnect.stories.tsx
@@ -1,9 +1,8 @@
-import React from "react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-import { WalletDropdownDisconnect } from "./WalletDropdownDisconnect";
-import { http, WagmiProvider, createConfig } from "wagmi";
-import { baseSepolia } from "viem/chains";
+import { baseSepolia } from 'viem/chains';
+import { http, WagmiProvider, createConfig } from 'wagmi';
+import { WalletDropdownDisconnect } from './WalletDropdownDisconnect';
 
 const wagmiConfig = createConfig({
   chains: [baseSepolia],
@@ -13,7 +12,7 @@ const wagmiConfig = createConfig({
 });
 
 export default {
-  title: "Wallet/WalletDropdownDisconnect",
+  title: 'Wallet/WalletDropdownDisconnect',
   component: WalletDropdownDisconnect,
   decorators: [
     (Story) => (

--- a/src/wallet/components/WalletDropdownDisconnect.stories.tsx
+++ b/src/wallet/components/WalletDropdownDisconnect.stories.tsx
@@ -1,9 +1,29 @@
-import React from 'react';
-import { WalletDropdownDisconnect } from './WalletDropdownDisconnect';
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { WalletDropdownDisconnect } from "./WalletDropdownDisconnect";
+import { http, WagmiProvider, createConfig } from "wagmi";
+import { baseSepolia } from "viem/chains";
+
+const wagmiConfig = createConfig({
+  chains: [baseSepolia],
+  transports: {
+    [baseSepolia.id]: http(),
+  },
+});
 
 export default {
-  title: 'Wallet/WalletDropdownDisconnect',
+  title: "Wallet/WalletDropdownDisconnect",
   component: WalletDropdownDisconnect,
+  decorators: [
+    (Story) => (
+      <WagmiProvider config={wagmiConfig}>
+        <QueryClientProvider client={new QueryClient()}>
+          <Story />
+        </QueryClientProvider>
+      </WagmiProvider>
+    ),
+  ],
 };
 
 export const Default = () => <WalletDropdownDisconnect />;
@@ -11,5 +31,5 @@ export const Default = () => <WalletDropdownDisconnect />;
 export const CustomText = () => <WalletDropdownDisconnect text="Log Out" />;
 
 export const CustomClass = () => (
-  <WalletDropdownDisconnect className="custom-class" />
+  <WalletDropdownDisconnect className="bg-red-500" />
 );

--- a/src/wallet/components/WalletDropdownDisconnect.stories.tsx
+++ b/src/wallet/components/WalletDropdownDisconnect.stories.tsx
@@ -1,5 +1,4 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
 import { baseSepolia } from 'viem/chains';
 import { http, WagmiProvider, createConfig } from 'wagmi';
 import { WalletDropdownDisconnect } from './WalletDropdownDisconnect';


### PR DESCRIPTION
**What changed? Why?**
https://linear.app/coinbase/issue/BOE-326/[wallet]-update-the-disconnect-icon-to-an-updated-icon

We are upgrading to a slightly larger SVG image. 
Storybook:
<img width="1465" alt="Screenshot 2024-08-19 at 9 29 32 PM" src="https://github.com/user-attachments/assets/48323759-1c7e-4626-afbc-476ffd740a65">

<img width="1153" alt="Screenshot 2024-08-20 at 9 22 17 PM" src="https://github.com/user-attachments/assets/8de03afa-6e2c-4e6b-a2e6-fce6df302982">


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="275" alt="Screenshot 2024-08-19 at 4 52 51 PM" src="https://github.com/user-attachments/assets/bd42a835-f783-41ac-868f-8038d17ba71c">

</td>
    <td>
<img width="267" alt="Screenshot 2024-08-19 at 4 52 59 PM" src="https://github.com/user-attachments/assets/8e6fb864-f80a-480b-94ea-eced3ea66fd9">


   </td>
  </tr>
</table>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="273" alt="Screenshot 2024-08-19 at 4 53 18 PM" src="https://github.com/user-attachments/assets/5da1fa3b-2d09-4cc2-a89d-d9a91e37cc65">


</td>
    <td>
<img width="271" alt="Screenshot 2024-08-19 at 4 53 27 PM" src="https://github.com/user-attachments/assets/b7a5cba8-f32e-4a1e-a3e3-1a10cd54bbf7">


   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
