### PR TITLE
docs: Rename Nav Templates

### DIFF
--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -108,11 +108,11 @@ export default defineConfig({
   topNav: [
     { text: 'Docs', link: '/getting-started', match: '/docs' },
     {
-      text: 'Onchain App Template',
+      text: 'App Template',
       link: 'https://github.com/coinbase/onchain-app-template',
     },
     {
-      text: 'Frame Example',
+      text: 'Frame Template',
       link: 'https://github.com/Zizzamia/a-frame-in-100-lines',
     },
     {


### PR DESCRIPTION
**What changed? Why?**
<img width="1372" alt="Screenshot 2024-08-19 at 10 11 38 PM" src="https://github.com/user-attachments/assets/036f75fd-beee-411e-97ce-de775684b5e6">

**Notes to reviewers**

**How has it been tested?**
