### PR TITLE
chore: remove address prop and update sponsor txn check

### DIFF
--- a/.changeset/brave-icons-fix.md
+++ b/.changeset/brave-icons-fix.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-- **patch**: Remove address prop and fix sponsor component. By @abcrane123 #1114
+- **patch**: Remove unneccessary address prop from Transaction component and fix issue where Sponsor component isn't visible. By @abcrane123 #1114

--- a/.changeset/brave-icons-fix.md
+++ b/.changeset/brave-icons-fix.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **patch**: Remove address prop and fix sponsor component. By @abcrane123 #1114

--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -72,7 +72,6 @@ export default function TransactionComponents() {
 
   return address ? (
     <Transaction // [!code focus]
-      address={address} // [!code focus]
       chainId={BASE_SEPOLIA_CHAIN_ID} // [!code focus]
       contracts={contracts} // [!code focus]
     > // [!code focus]
@@ -104,7 +103,6 @@ export default function TransactionComponents() {
       if (address) {
         return (
           <Transaction
-            address={address}
             capabilities={capabilities}
             chainId={BASE_SEPOLIA_CHAIN_ID}
             contracts={contracts}
@@ -139,7 +137,6 @@ export default function TransactionComponents() {
 // ommited for brevity
 
 <Transaction  // [!code focus]
-  address={address} // [!code focus]
   contracts={contracts} // [!code focus]
 >  // [!code focus]
   <TransactionButton /> // [!code focus]
@@ -158,7 +155,6 @@ export default function TransactionComponents() {
       if (address) {
         return (
           <Transaction
-            address={address}
             capabilities={{
               paymasterService: {
                 url: PAYMASTER_AND_BUNDLER_ENDPOINT,
@@ -204,7 +200,6 @@ export default function TransactionComponents() {
 ```tsx
 // ommited for brevity
 <Transaction
-  address={address}
   capabilities={{ // [!code focus]
     paymasterService: { // [!code focus]
       url: process.env.PAYMASTER_AND_BUNDLER_ENDPOINT, // [!code focus]
@@ -221,8 +216,7 @@ export default function TransactionComponents() {
     {({ address, contracts, onError }) => {
       if (address) {
         return (
-          <Transaction 
-            address={address} 
+          <Transaction  
             capabilities={{
               paymasterService: {
                 url: PAYMASTER_AND_BUNDLER_ENDPOINT,

--- a/site/docs/pages/transaction/types.mdx
+++ b/site/docs/pages/transaction/types.mdx
@@ -27,7 +27,7 @@ type TransactionError = {
 
 ```ts
 type TransactionReact = {
-  address: Address; // The wallet address involved in the transaction.
+  address?: Address; // The wallet address involved in the transaction (defaults to connected account if not provided).
   children: ReactNode; // The child components to be rendered within the transaction component.
   className?: string; // An optional CSS class name for styling the component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters for the transaction.

--- a/site/docs/pages/transaction/types.mdx
+++ b/site/docs/pages/transaction/types.mdx
@@ -27,7 +27,6 @@ type TransactionError = {
 
 ```ts
 type TransactionReact = {
-  address?: Address; // The wallet address involved in the transaction (defaults to connected account if not provided).
   children: ReactNode; // The child components to be rendered within the transaction component.
   className?: string; // An optional CSS class name for styling the component.
   contracts: ContractFunctionParameters[]; // An array of contract function parameters for the transaction.

--- a/src/transaction/components/Transaction.tsx
+++ b/src/transaction/components/Transaction.tsx
@@ -3,7 +3,6 @@ import type { TransactionReact } from '../types';
 import { TransactionProvider } from './TransactionProvider';
 
 export function Transaction({
-  address,
   capabilities,
   chainId,
   className,
@@ -15,7 +14,6 @@ export function Transaction({
 }: TransactionReact) {
   return (
     <TransactionProvider
-      address={address}
       capabilities={capabilities}
       chainId={chainId}
       contracts={contracts}

--- a/src/transaction/components/TransactionButton.test.tsx
+++ b/src/transaction/components/TransactionButton.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useChainId } from 'wagmi';
+import { useAccount, useChainId } from 'wagmi';
 import { useShowCallsStatus } from 'wagmi/experimental';
 import { getChainExplorer } from '../../network/getChainExplorer';
 import { TransactionButton } from './TransactionButton';
@@ -12,6 +12,7 @@ vi.mock('./TransactionProvider', () => ({
 
 vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
+  useAccount: vi.fn(),
 }));
 
 vi.mock('wagmi/experimental', () => ({
@@ -25,6 +26,7 @@ vi.mock('../../network/getChainExplorer', () => ({
 describe('TransactionButton', () => {
   beforeEach(() => {
     (useChainId as vi.Mock).mockReturnValue(123);
+    (useAccount as vi.Mock).mockReturnValue({ address: '123' });
     (useShowCallsStatus as vi.Mock).mockReturnValue({
       showCallsStatus: vi.fn(),
     });
@@ -116,7 +118,6 @@ describe('TransactionButton', () => {
 
   it('should enable button when not in progress, not missing props, and not waiting for receipt', () => {
     (useTransactionContext as vi.Mock).mockReturnValue({
-      address: '0x123',
       contracts: {},
       isLoading: false,
       lifeCycleStatus: { statusName: 'init', statusData: null },

--- a/src/transaction/components/TransactionButton.tsx
+++ b/src/transaction/components/TransactionButton.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import { useChainId } from 'wagmi';
+import { useAccount, useChainId } from 'wagmi';
 import { useShowCallsStatus } from 'wagmi/experimental';
 import { Spinner } from '../../internal/components/Spinner';
 import { getChainExplorer } from '../../network/getChainExplorer';
@@ -14,7 +14,6 @@ export function TransactionButton({
   text: buttonText = 'Transact',
 }: TransactionButtonReact) {
   const {
-    address,
     contracts,
     chainId,
     errorMessage,
@@ -25,6 +24,8 @@ export function TransactionButton({
     transactionHash,
     transactionId,
   } = useTransactionContext();
+
+  const { address } = useAccount();
 
   const accountChainId = chainId ?? useChainId();
   const { showCallsStatus } = useShowCallsStatus();

--- a/src/transaction/components/TransactionProvider.test.tsx
+++ b/src/transaction/components/TransactionProvider.test.tsx
@@ -104,7 +104,7 @@ describe('TransactionProvider', () => {
   it('should emit onError when setLifeCycleStatus is called with error', async () => {
     const onErrorMock = vi.fn();
     render(
-      <TransactionProvider address="0x123" contracts={[]} onError={onErrorMock}>
+      <TransactionProvider contracts={[]} onError={onErrorMock}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -116,11 +116,7 @@ describe('TransactionProvider', () => {
   it('should emit onStatus when setLifeCycleStatus is called with transactionLegacyExecuted', async () => {
     const onStatusMock = vi.fn();
     render(
-      <TransactionProvider
-        address="0x123"
-        contracts={[]}
-        onStatus={onStatusMock}
-      >
+      <TransactionProvider contracts={[]} onStatus={onStatusMock}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -139,11 +135,7 @@ describe('TransactionProvider', () => {
   it('should emit onStatus when setLifeCycleStatus is called', async () => {
     const onStatusMock = vi.fn();
     render(
-      <TransactionProvider
-        address="0x123"
-        contracts={[]}
-        onStatus={onStatusMock}
-      >
+      <TransactionProvider contracts={[]} onStatus={onStatusMock}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -162,7 +154,6 @@ describe('TransactionProvider', () => {
     });
     render(
       <TransactionProvider
-        address="0x123"
         contracts={[{ address: '0x123', method: 'method' }]}
         onSuccess={onSuccessMock}
       >
@@ -186,7 +177,7 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[]}>
+      <TransactionProvider contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -207,7 +198,7 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[]}>
+      <TransactionProvider contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -228,7 +219,7 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[]}>
+      <TransactionProvider contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -248,7 +239,7 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[]}>
+      <TransactionProvider contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -270,7 +261,7 @@ describe('TransactionProvider', () => {
       switchChainAsync: switchChainAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" chainId={2} contracts={[]}>
+      <TransactionProvider chainId={2} contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -287,7 +278,7 @@ describe('TransactionProvider', () => {
       writeContractsAsync: vi.fn().mockRejectedValue(new Error('Test error')),
     });
     render(
-      <TransactionProvider address="0x123" contracts={[]}>
+      <TransactionProvider contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -302,7 +293,7 @@ describe('TransactionProvider', () => {
   it('should not fetch receipts if contract list is empty', async () => {
     const waitForTransactionReceiptMock = vi.fn();
     render(
-      <TransactionProvider address="0x123" contracts={[]}>
+      <TransactionProvider contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -322,7 +313,7 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[]}>
+      <TransactionProvider contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -341,7 +332,7 @@ describe('TransactionProvider', () => {
     });
     (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({ chainId: 1 });
     render(
-      <TransactionProvider address="0x123" chainId={2} contracts={[]}>
+      <TransactionProvider chainId={2} contracts={[]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -362,11 +353,11 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
-      status: 'IDLE',
+      status: 'idle',
       writeContractAsync: writeContractAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[{}]}>
+      <TransactionProvider contracts={[{}]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -389,11 +380,11 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
-      status: 'IDLE',
+      status: 'idle',
       writeContractAsync: writeContractAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[{}]}>
+      <TransactionProvider contracts={[{}]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -421,11 +412,11 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
-      status: 'IDLE',
+      status: 'idle',
       writeContractAsync: writeContractAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[{}]}>
+      <TransactionProvider contracts={[{}]}>
         <TestComponent />
       </TransactionProvider>,
     );
@@ -453,11 +444,11 @@ describe('TransactionProvider', () => {
       writeContractsAsync: writeContractsAsyncMock,
     });
     (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
-      status: 'IDLE',
+      status: 'idle',
       writeContractAsync: writeContractAsyncMock,
     });
     render(
-      <TransactionProvider address="0x123" contracts={[{}]}>
+      <TransactionProvider contracts={[{}]}>
         <TestComponent />
       </TransactionProvider>,
     );

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -256,7 +256,7 @@ export function TransactionProvider({
   ]);
 
   const value = useValue({
-    address,
+    address: address || account.address,
     chainId,
     contracts,
     errorCode,

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -43,7 +43,6 @@ export function useTransactionContext() {
 }
 
 export function TransactionProvider({
-  address,
   capabilities,
   chainId,
   children,
@@ -256,7 +255,6 @@ export function TransactionProvider({
   ]);
 
   const value = useValue({
-    address: address || account.address,
     chainId,
     contracts,
     errorCode,

--- a/src/transaction/components/TransactionSponsor.test.tsx
+++ b/src/transaction/components/TransactionSponsor.test.tsx
@@ -8,41 +8,40 @@ vi.mock('./TransactionProvider', () => ({
 }));
 
 describe('TransactionSponsor', () => {
-  it('renders correctly', () => {
+  it('should render correctly', () => {
     (useTransactionContext as vi.Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       hasPaymaster: true,
     });
     render(<TransactionSponsor />);
-
     const element = screen.getByText('Zero transaction fee');
     expect(element).toBeInTheDocument();
   });
-  it('does not render if hasPaymaster is false', () => {
+
+  it('should not render if hasPaymaster is false', () => {
     (useTransactionContext as vi.Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       hasPaymaster: false,
     });
     render(<TransactionSponsor />);
-
     expect(screen.queryByText('Zero transaction fee')).not.toBeInTheDocument();
   });
-  it('does not render if statusName is not init', () => {
+
+  it('should not render if statusName is not init', () => {
     (useTransactionContext as vi.Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'blah', statusData: null },
       hasPaymaster: false,
     });
     render(<TransactionSponsor />);
-
     expect(screen.queryByText('Zero transaction fee')).not.toBeInTheDocument();
   });
-  it('does render if statusName is init', () => {
+
+  it('should render if statusName is init', () => {
     (useTransactionContext as vi.Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       hasPaymaster: true,
     });
     render(<TransactionSponsor />);
-
     const element = screen.getByText('Zero transaction fee');
     expect(element).toBeInTheDocument();
   });

--- a/src/transaction/components/TransactionSponsor.test.tsx
+++ b/src/transaction/components/TransactionSponsor.test.tsx
@@ -10,7 +10,7 @@ vi.mock('./TransactionProvider', () => ({
 describe('TransactionSponsor', () => {
   it('renders correctly', () => {
     (useTransactionContext as vi.Mock).mockReturnValue({
-      lifeCycleStatus: { statusName: 'transactionIdle', statusData: null },
+      lifeCycleStatus: { statusName: 'init', statusData: null },
       hasPaymaster: true,
     });
     render(<TransactionSponsor />);
@@ -20,11 +20,30 @@ describe('TransactionSponsor', () => {
   });
   it('does not render if hasPaymaster is false', () => {
     (useTransactionContext as vi.Mock).mockReturnValue({
-      lifeCycleStatus: { statusName: 'transactionIdle', statusData: null },
+      lifeCycleStatus: { statusName: 'init', statusData: null },
       hasPaymaster: false,
     });
     render(<TransactionSponsor />);
 
     expect(screen.queryByText('Zero transaction fee')).not.toBeInTheDocument();
+  });
+  it('does not render if statusName is not init', () => {
+    (useTransactionContext as vi.Mock).mockReturnValue({
+      lifeCycleStatus: { statusName: 'blah', statusData: null },
+      hasPaymaster: false,
+    });
+    render(<TransactionSponsor />);
+
+    expect(screen.queryByText('Zero transaction fee')).not.toBeInTheDocument();
+  });
+  it('does render if statusName is init', () => {
+    (useTransactionContext as vi.Mock).mockReturnValue({
+      lifeCycleStatus: { statusName: 'init', statusData: null },
+      hasPaymaster: true,
+    });
+    render(<TransactionSponsor />);
+
+    const element = screen.getByText('Zero transaction fee');
+    expect(element).toBeInTheDocument();
   });
 });

--- a/src/transaction/components/TransactionSponsor.tsx
+++ b/src/transaction/components/TransactionSponsor.tsx
@@ -14,8 +14,7 @@ export function TransactionSponsor({ className }: TransactionSponsorReact) {
 
   const transactionInProgress = transactionId || transactionHash;
   if (
-    (lifeCycleStatus.statusName !== 'transactionIdle' &&
-      lifeCycleStatus.statusName !== 'init') ||
+    lifeCycleStatus.statusName !== 'init' ||
     !hasPaymaster ||
     errorMessage ||
     transactionInProgress ||

--- a/src/transaction/components/TransactionSponsor.tsx
+++ b/src/transaction/components/TransactionSponsor.tsx
@@ -14,7 +14,8 @@ export function TransactionSponsor({ className }: TransactionSponsorReact) {
 
   const transactionInProgress = transactionId || transactionHash;
   if (
-    lifeCycleStatus.statusName !== 'transactionIdle' ||
+    (lifeCycleStatus.statusName !== 'transactionIdle' &&
+      lifeCycleStatus.statusName !== 'init') ||
     !hasPaymaster ||
     errorMessage ||
     transactionInProgress ||

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -61,7 +61,7 @@ export type TransactionButtonReact = {
 };
 
 export type TransactionContextType = {
-  address: Address; // The wallet address involved in the transaction.
+  address?: Address; // The wallet address involved in the transaction.
   chainId?: number; // The chainId for the transaction.
   contracts: ContractFunctionParameters[]; // An array of contracts for the transaction.
   errorCode?: string; // An error code used to localize errors and provide more context with unit-tests.
@@ -96,7 +96,7 @@ export type TransactionError = {
 };
 
 export type TransactionProviderReact = {
-  address: Address; // The wallet address to be provided to child components.
+  address?: Address; // The wallet address to be provided to child components.
   capabilities?: WalletCapabilities; // Capabilities that a wallet supports (e.g. paymasters, session keys, etc).
   chainId?: number; // The chainId for the transaction.
   children: ReactNode; // The child components to be rendered within the provider component.
@@ -110,7 +110,7 @@ export type TransactionProviderReact = {
  * Note: exported as public Type
  */
 export type TransactionReact = {
-  address: Address; // The wallet address involved in the transaction.
+  address?: Address; // The wallet address involved in the transaction (defaults to connected account if not provided).
   capabilities?: WalletCapabilities; // Capabilities that a wallet supports (e.g. paymasters, session keys, etc).
   chainId?: number; // The chainId for the transaction.
   children: ReactNode; // The child components to be rendered within the transaction component.

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -61,7 +61,6 @@ export type TransactionButtonReact = {
 };
 
 export type TransactionContextType = {
-  address?: Address; // The wallet address involved in the transaction.
   chainId?: number; // The chainId for the transaction.
   contracts: ContractFunctionParameters[]; // An array of contracts for the transaction.
   errorCode?: string; // An error code used to localize errors and provide more context with unit-tests.
@@ -96,7 +95,6 @@ export type TransactionError = {
 };
 
 export type TransactionProviderReact = {
-  address?: Address; // The wallet address to be provided to child components.
   capabilities?: WalletCapabilities; // Capabilities that a wallet supports (e.g. paymasters, session keys, etc).
   chainId?: number; // The chainId for the transaction.
   children: ReactNode; // The child components to be rendered within the provider component.
@@ -110,7 +108,6 @@ export type TransactionProviderReact = {
  * Note: exported as public Type
  */
 export type TransactionReact = {
-  address?: Address; // The wallet address involved in the transaction (defaults to connected account if not provided).
   capabilities?: WalletCapabilities; // Capabilities that a wallet supports (e.g. paymasters, session keys, etc).
   chainId?: number; // The chainId for the transaction.
   children: ReactNode; // The child components to be rendered within the transaction component.


### PR DESCRIPTION
**What changed? Why?**
- remove address prop and use wagmi useAccount instead
- update life cycle status check for transaction sponsor

**Notes to reviewers**

**How has it been tested?**
