### PR TITLE
chore: Fix wallet hydration issue on next.js

### DIFF
--- a/.changeset/green-elephants-matter.md
+++ b/.changeset/green-elephants-matter.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix**: Handle SSR hydration issues. @abcrane123 #1117

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -7,6 +7,7 @@ import { SwapButton } from './SwapButton';
 import { SwapMessage } from './SwapMessage';
 import { SwapProvider } from './SwapProvider';
 import { SwapToggleButton } from './SwapToggleButton';
+import { useIsMounted } from '../../useIsMounted';
 
 export function Swap({
   address,
@@ -25,6 +26,13 @@ export function Swap({
       swapMessage: childrenArray.find(findComponent(SwapMessage)),
     };
   }, [children]);
+
+  const isMounted = useIsMounted();
+
+  // prevents SSR hydration issue
+  if (!isMounted) {
+    return null;
+  }
 
   return (
     <SwapProvider

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -1,13 +1,13 @@
 import { Children, useMemo } from 'react';
 import { findComponent } from '../../internal/utils/findComponent';
 import { background, cn, text } from '../../styles/theme';
+import { useIsMounted } from '../../useIsMounted';
 import type { SwapReact } from '../types';
 import { SwapAmountInput } from './SwapAmountInput';
 import { SwapButton } from './SwapButton';
 import { SwapMessage } from './SwapMessage';
 import { SwapProvider } from './SwapProvider';
 import { SwapToggleButton } from './SwapToggleButton';
-import { useIsMounted } from '../../useIsMounted';
 
 export function Swap({
   address,

--- a/src/transaction/components/Transaction.tsx
+++ b/src/transaction/components/Transaction.tsx
@@ -1,4 +1,5 @@
 import { cn } from '../../styles/theme';
+import { useIsMounted } from '../../useIsMounted';
 import type { TransactionReact } from '../types';
 import { TransactionProvider } from './TransactionProvider';
 
@@ -13,6 +14,13 @@ export function Transaction({
   onStatus,
   onSuccess,
 }: TransactionReact) {
+  const isMounted = useIsMounted();
+
+  // prevents SSR hydration issue
+  if (!isMounted) {
+    return null;
+  }
+
   return (
     <TransactionProvider
       address={address}

--- a/src/useIsMounted.ts
+++ b/src/useIsMounted.ts
@@ -1,0 +1,9 @@
+import { useEffect, useState } from 'react';
+
+export function useIsMounted() {
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  });
+  return isMounted;
+}

--- a/src/wallet/components/Wallet.tsx
+++ b/src/wallet/components/Wallet.tsx
@@ -1,4 +1,4 @@
-import { Children, useEffect, useMemo, useRef } from 'react';
+import { Children, useEffect, useMemo, useState, useRef } from 'react';
 import { findComponent } from '../../internal/utils/findComponent';
 import type { WalletReact } from '../types';
 import { ConnectWallet } from './ConnectWallet';
@@ -43,6 +43,16 @@ const WalletContent = ({ children }: WalletReact) => {
 };
 
 export const Wallet = ({ children }: WalletReact) => {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  if (!isClient) {
+    return null;
+  }
+
   return (
     <WalletProvider>
       <WalletContent>{children}</WalletContent>

--- a/src/wallet/components/Wallet.tsx
+++ b/src/wallet/components/Wallet.tsx
@@ -49,6 +49,7 @@ export const Wallet = ({ children }: WalletReact) => {
     setIsClient(true);
   }, []);
 
+  // prevents SSR hydration issue
   if (!isClient) {
     return null;
   }

--- a/src/wallet/components/Wallet.tsx
+++ b/src/wallet/components/Wallet.tsx
@@ -1,4 +1,4 @@
-import { Children, useEffect, useMemo, useState, useRef } from 'react';
+import { Children, useEffect, useMemo, useRef, useState } from 'react';
 import { findComponent } from '../../internal/utils/findComponent';
 import type { WalletReact } from '../types';
 import { ConnectWallet } from './ConnectWallet';

--- a/src/wallet/components/Wallet.tsx
+++ b/src/wallet/components/Wallet.tsx
@@ -1,4 +1,4 @@
-import { Children, useEffect, useMemo, useRef, useState } from 'react';
+import { Children, useEffect, useMemo, useRef } from 'react';
 import { findComponent } from '../../internal/utils/findComponent';
 import type { WalletReact } from '../types';
 import { ConnectWallet } from './ConnectWallet';

--- a/src/wallet/components/Wallet.tsx
+++ b/src/wallet/components/Wallet.tsx
@@ -4,6 +4,7 @@ import type { WalletReact } from '../types';
 import { ConnectWallet } from './ConnectWallet';
 import { WalletDropdown } from './WalletDropdown';
 import { WalletProvider, useWalletContext } from './WalletProvider';
+import { useIsMounted } from '../../useIsMounted';
 
 const WalletContent = ({ children }: WalletReact) => {
   const { isOpen, setIsOpen } = useWalletContext();
@@ -43,14 +44,10 @@ const WalletContent = ({ children }: WalletReact) => {
 };
 
 export const Wallet = ({ children }: WalletReact) => {
-  const [isClient, setIsClient] = useState(false);
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
+  const isMounted = useIsMounted();
 
   // prevents SSR hydration issue
-  if (!isClient) {
+  if (!isMounted) {
     return null;
   }
 

--- a/src/wallet/components/Wallet.tsx
+++ b/src/wallet/components/Wallet.tsx
@@ -1,10 +1,10 @@
 import { Children, useEffect, useMemo, useRef } from 'react';
 import { findComponent } from '../../internal/utils/findComponent';
+import { useIsMounted } from '../../useIsMounted';
 import type { WalletReact } from '../types';
 import { ConnectWallet } from './ConnectWallet';
 import { WalletDropdown } from './WalletDropdown';
 import { WalletProvider, useWalletContext } from './WalletProvider';
-import { useIsMounted } from '../../useIsMounted';
 
 const WalletContent = ({ children }: WalletReact) => {
   const { isOpen, setIsOpen } = useWalletContext();


### PR DESCRIPTION
**What changed? Why?**
Following up on https://github.com/coinbase/onchainkit/issues/1077

User reported receiving a hydration warning from their next.js app when integrating the `Wallet` component which is likely because the `Wallet` component depends on client-specific data. The user is using pages routing and components in the pages/ directory are considered to be client-side by default, which, in this case, results in a hydration error. 

I am resolving this issue by returning `null` in `Wallet` component until the component mounts. 


**Notes to reviewers**

**How has it been tested?**
