### PR TITLE
feat: add commerce charge hydration utilities and supporting types

### DIFF
--- a/src/pay/types/charge.ts
+++ b/src/pay/types/charge.ts
@@ -1,121 +1,120 @@
 export type CommerceCharge = {
-    code: string;
-    description?: string;
-    expires_at: string;
-    hosted_url: string;
-    id: string;
-    name?: string;
-    organization_name?: string;
-    pricing: Pricing;
-    pricing_type: PricingType;
-    redirects?: Redirects;
-    support_email: string;
-    timeline: TimelineItem[];
-    web3_data: Web3Data;
-  };
-  
-  export type SettlementCurrencyAddresses = {
-    [chainId: string]: `0x${string}`;
-  };
-  
-  export type ContractAddresses = {
-    [chainId: string]: `0x${string}`;
-  };
-  
-  export type Web3Data = {
-    failure_events: FailureEventsItem[];
-    success_events: SuccessEventsItem[];
-    transfer_intent: TransferIntent;
-    contract_addresses: ContractAddresses;
-    settlement_currency_addresses?: SettlementCurrencyAddresses;
-  };
-  
-  export type TransferIntentMetadata = {
-    chain_id: number;
-    sender: string;
-  };
-  
-  export type TransferIntentCallData = {
-    deadline: string;
-    fee_amount: string;
-    id: `0x${string}`;
-    operator: `0x${string}`;
-    prefix: `0x${string}`;
-    recipient: `0x${string}`;
-    recipient_amount: string;
-    recipient_currency: `0x${string}`;
-    refund_destination: `0x${string}`;
-    signature: `0x${string}`;
-  };
-  
-  export type TransferIntent = {
-    call_data: TransferIntentCallData;
-    metadata: TransferIntentMetadata;
-  };
-  
-  export type SuccessEventsItem = {
-    chain_id: number;
-    finalized: boolean;
-    input_token_address: string;
-    input_token_amount: string;
-    network_fee_paid: string;
-    network_fee_paid_local?: string;
-    recipient: string;
-    sender: string;
-    timestamp: string;
-    tx_hsh: string;
-  };
-  
-  export type FailureEventsItem = {
-    chain_id?: number;
-    input_token_address?: string;
-    network_fee_paid?: string;
-    reason?: string;
-    sender?: string;
-    timestamp?: string;
-    tx_hsh?: string;
-  };
-  
-  export type TimelineItemStatus =
-    (typeof TimelineItemStatuses)[keyof typeof TimelineItemStatuses];
-  
-  export const TimelineItemStatuses = {
-    COMPLETED: 'COMPLETED',
-    EXPIRED: 'EXPIRED',
-    FAILED: 'FAILED',
-    NEW: 'NEW',
-    PENDING: 'PENDING',
-    SIGNED: 'SIGNED',
-    CANCELED: 'CANCELED',
-  } as const;
-  
-  export type TimelineItem = {
-    status: TimelineItemStatus;
-    time: string;
-  };
-  
-  export type Redirects = {
-    cancel_url?: string;
-    success_url?: string;
-    will_redirect_after_success?: boolean;
-  };
-  
-  export type PricingType =
-    (typeof PricingTypes)[keyof typeof PricingTypes];
-  
-  export const PricingTypes = {
-    fixed_price: 'fixed_price',
-    no_price: 'no_price',
-  } as const;
-  
-  export type Pricing = {
-    local: Currency;
-    settlement: Currency;
-  };
-  
-  export type Metadata = { [key: string]: string };
-  
-  export type Currency = {
-    amount: string;
-    currency: string;
-  };
+  code: string;
+  description?: string;
+  expires_at: string;
+  hosted_url: string;
+  id: string;
+  name?: string;
+  organization_name?: string;
+  pricing: Pricing;
+  pricing_type: PricingType;
+  redirects?: Redirects;
+  support_email: string;
+  timeline: TimelineItem[];
+  web3_data: Web3Data;
+};
+
+export type SettlementCurrencyAddresses = {
+  [chainId: string]: `0x${string}`;
+};
+
+export type ContractAddresses = {
+  [chainId: string]: `0x${string}`;
+};
+
+export type Web3Data = {
+  failure_events: FailureEventsItem[];
+  success_events: SuccessEventsItem[];
+  transfer_intent: TransferIntent;
+  contract_addresses: ContractAddresses;
+  settlement_currency_addresses?: SettlementCurrencyAddresses;
+};
+
+export type TransferIntentMetadata = {
+  chain_id: number;
+  sender: string;
+};
+
+export type TransferIntentCallData = {
+  deadline: string;
+  fee_amount: string;
+  id: `0x${string}`;
+  operator: `0x${string}`;
+  prefix: `0x${string}`;
+  recipient: `0x${string}`;
+  recipient_amount: string;
+  recipient_currency: `0x${string}`;
+  refund_destination: `0x${string}`;
+  signature: `0x${string}`;
+};
+
+export type TransferIntent = {
+  call_data: TransferIntentCallData;
+  metadata: TransferIntentMetadata;
+};
+
+export type SuccessEventsItem = {
+  chain_id: number;
+  finalized: boolean;
+  input_token_address: string;
+  input_token_amount: string;
+  network_fee_paid: string;
+  network_fee_paid_local?: string;
+  recipient: string;
+  sender: string;
+  timestamp: string;
+  tx_hsh: string;
+};
+
+export type FailureEventsItem = {
+  chain_id?: number;
+  input_token_address?: string;
+  network_fee_paid?: string;
+  reason?: string;
+  sender?: string;
+  timestamp?: string;
+  tx_hsh?: string;
+};
+
+export type TimelineItemStatus =
+  (typeof TimelineItemStatuses)[keyof typeof TimelineItemStatuses];
+
+export const TimelineItemStatuses = {
+  COMPLETED: 'COMPLETED',
+  EXPIRED: 'EXPIRED',
+  FAILED: 'FAILED',
+  NEW: 'NEW',
+  PENDING: 'PENDING',
+  SIGNED: 'SIGNED',
+  CANCELED: 'CANCELED',
+} as const;
+
+export type TimelineItem = {
+  status: TimelineItemStatus;
+  time: string;
+};
+
+export type Redirects = {
+  cancel_url?: string;
+  success_url?: string;
+  will_redirect_after_success?: boolean;
+};
+
+export type PricingType = (typeof PricingTypes)[keyof typeof PricingTypes];
+
+export const PricingTypes = {
+  fixed_price: 'fixed_price',
+  no_price: 'no_price',
+} as const;
+
+export type Pricing = {
+  local: Currency;
+  settlement: Currency;
+};
+
+export type Metadata = { [key: string]: string };
+
+export type Currency = {
+  amount: string;
+  currency: string;
+};

--- a/src/pay/types/charge.ts
+++ b/src/pay/types/charge.ts
@@ -1,0 +1,121 @@
+export type CommerceCharge = {
+    code: string;
+    description?: string;
+    expires_at: string;
+    hosted_url: string;
+    id: string;
+    name?: string;
+    organization_name?: string;
+    pricing: Pricing;
+    pricing_type: PricingType;
+    redirects?: Redirects;
+    support_email: string;
+    timeline: TimelineItem[];
+    web3_data: Web3Data;
+  };
+  
+  export type SettlementCurrencyAddresses = {
+    [chainId: string]: `0x${string}`;
+  };
+  
+  export type ContractAddresses = {
+    [chainId: string]: `0x${string}`;
+  };
+  
+  export type Web3Data = {
+    failure_events: FailureEventsItem[];
+    success_events: SuccessEventsItem[];
+    transfer_intent: TransferIntent;
+    contract_addresses: ContractAddresses;
+    settlement_currency_addresses?: SettlementCurrencyAddresses;
+  };
+  
+  export type TransferIntentMetadata = {
+    chain_id: number;
+    sender: string;
+  };
+  
+  export type TransferIntentCallData = {
+    deadline: string;
+    fee_amount: string;
+    id: `0x${string}`;
+    operator: `0x${string}`;
+    prefix: `0x${string}`;
+    recipient: `0x${string}`;
+    recipient_amount: string;
+    recipient_currency: `0x${string}`;
+    refund_destination: `0x${string}`;
+    signature: `0x${string}`;
+  };
+  
+  export type TransferIntent = {
+    call_data: TransferIntentCallData;
+    metadata: TransferIntentMetadata;
+  };
+  
+  export type SuccessEventsItem = {
+    chain_id: number;
+    finalized: boolean;
+    input_token_address: string;
+    input_token_amount: string;
+    network_fee_paid: string;
+    network_fee_paid_local?: string;
+    recipient: string;
+    sender: string;
+    timestamp: string;
+    tx_hsh: string;
+  };
+  
+  export type FailureEventsItem = {
+    chain_id?: number;
+    input_token_address?: string;
+    network_fee_paid?: string;
+    reason?: string;
+    sender?: string;
+    timestamp?: string;
+    tx_hsh?: string;
+  };
+  
+  export type TimelineItemStatus =
+    (typeof TimelineItemStatuses)[keyof typeof TimelineItemStatuses];
+  
+  export const TimelineItemStatuses = {
+    COMPLETED: 'COMPLETED',
+    EXPIRED: 'EXPIRED',
+    FAILED: 'FAILED',
+    NEW: 'NEW',
+    PENDING: 'PENDING',
+    SIGNED: 'SIGNED',
+    CANCELED: 'CANCELED',
+  } as const;
+  
+  export type TimelineItem = {
+    status: TimelineItemStatus;
+    time: string;
+  };
+  
+  export type Redirects = {
+    cancel_url?: string;
+    success_url?: string;
+    will_redirect_after_success?: boolean;
+  };
+  
+  export type PricingType =
+    (typeof PricingTypes)[keyof typeof PricingTypes];
+  
+  export const PricingTypes = {
+    fixed_price: 'fixed_price',
+    no_price: 'no_price',
+  } as const;
+  
+  export type Pricing = {
+    local: Currency;
+    settlement: Currency;
+  };
+  
+  export type Metadata = { [key: string]: string };
+  
+  export type Currency = {
+    amount: string;
+    currency: string;
+  };

--- a/src/pay/types/errorResponse.ts
+++ b/src/pay/types/errorResponse.ts
@@ -1,0 +1,4 @@
+export type CommerceApiError = {
+  type: string;
+  message: string;
+};

--- a/src/pay/utils/handleCommerceApiError.ts
+++ b/src/pay/utils/handleCommerceApiError.ts
@@ -1,4 +1,4 @@
-import { CommerceApiError } from "../types/errorResponse";
+import type { CommerceApiError } from '../types/errorResponse';
 
 export async function parseCommerceApiError(resp: Response): Promise<Error> {
   const baseErrorMessage = `${resp.status} response from Commerce`;

--- a/src/pay/utils/handleCommerceApiError.ts
+++ b/src/pay/utils/handleCommerceApiError.ts
@@ -1,0 +1,11 @@
+import { CommerceApiError } from "../types/errorResponse";
+
+export async function parseCommerceApiError(resp: Response): Promise<Error> {
+  const baseErrorMessage = `${resp.status} response from Commerce`;
+  try {
+    const errorResponse = (await resp.json()) as CommerceApiError;
+    return new Error(`${baseErrorMessage}: ${errorResponse.message}`);
+  } catch (_) {
+    return new Error(baseErrorMessage);
+  }
+}

--- a/src/pay/utils/hydrateCommerceCharge.ts
+++ b/src/pay/utils/hydrateCommerceCharge.ts
@@ -1,0 +1,27 @@
+import type { CommerceCharge } from "../types/charge";
+import { base } from "viem/chains";
+import { parseCommerceApiError } from "./handleCommerceApiError";
+
+export async function hydrateCommerceCharge(
+  baseUrl: string,
+  chargeId: string,
+  senderAddress: string
+) {
+  const options = {
+    method: "PUT",
+    url: `${baseUrl}/charges/${chargeId}/hydrate`,
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      chain_id: base.id,
+      sender: senderAddress,
+    }),
+  };
+  const resp = await fetch(options.url, options);
+  if (!resp.ok) {
+    throw await parseCommerceApiError(resp);
+  }
+  return (await resp.json()) as { data: CommerceCharge };
+}

--- a/src/pay/utils/hydrateCommerceCharge.ts
+++ b/src/pay/utils/hydrateCommerceCharge.ts
@@ -1,18 +1,18 @@
-import type { CommerceCharge } from "../types/charge";
-import { base } from "viem/chains";
-import { parseCommerceApiError } from "./handleCommerceApiError";
+import { base } from 'viem/chains';
+import type { CommerceCharge } from '../types/charge';
+import { parseCommerceApiError } from './handleCommerceApiError';
 
 export async function hydrateCommerceCharge(
   baseUrl: string,
   chargeId: string,
-  senderAddress: string
+  senderAddress: string,
 ) {
   const options = {
-    method: "PUT",
+    method: 'PUT',
     url: `${baseUrl}/charges/${chargeId}/hydrate`,
     headers: {
-      accept: "application/json",
-      "content-type": "application/json",
+      accept: 'application/json',
+      'content-type': 'application/json',
     },
     body: JSON.stringify({
       chain_id: base.id,


### PR DESCRIPTION
**What changed? Why?**
- Adds network util to hydrate a Commerce change via commerce api, with error parsing utility
- Adds types for response and errors

**Notes to reviewers**
- The Charge is a large type, I added only the fields that I deemed necessary for this milestone of the project; we can extend it later if we need to

**How has it been tested?**
- Have tested it locally with a larger component, which is not included in this PR
