### PR TITLE
docs: Remove landing page figma image

### DIFF
--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -440,7 +440,7 @@ bun add @coinbase/onchainkit
 
 {' '}
 
-<section className="css-alternate-container w-full flex flex-col items-center py-24">
+<section className="css-alternate-container w-full flex flex-col items-center pt-20">
   <div className="w-[1225px] max-w-full flex flex-col justify-between">
     <div className="flex flex-col md:flex-row justify-between items-center pb-[20px]">
       <div>
@@ -461,17 +461,7 @@ bun add @coinbase/onchainkit
   </div>
 </section>
 
-{' '}
-
-<section className="css-alternate-container w-full flex items-center justify-center">
-  <aside className="flex flex-col pb-10 md:flex-row md:px-2 w-[940px]">
-    <img alt="OnchainKit figma" src="/assets/onchain-figma.png" width="auto" />
-  </aside>
-</section>
-
-{' '}
-
-<section className="css-alternate-container w-full flex flex-col items-center py-24 gap-[72px]">
+<section className="css-alternate-container w-full flex flex-col items-center pt-20 pb-24 gap-[72px]">
   <div>
     <h3 className="basis-1/2 py-[15px] text-4xl md:text-4xl max-w-[525px] text-center text-gray-950 dark:text-gray-50">Builders ship faster with OnchainKit</h3>
   </div>


### PR DESCRIPTION
**What changed? Why?**
We are removing the figma image on the landing page because the example was meant to be interactive, but the current image is static. Perhaps once we have bandwidth we can add back in the interactive figma demo. 


<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="1571" alt="Screenshot 2024-08-21 at 10 15 15 AM" src="https://github.com/user-attachments/assets/be4f9bbc-b927-49ae-bed3-b1949f0778a0">

</td>
    <td>
<img width="1577" alt="Screenshot 2024-08-21 at 10 14 49 AM" src="https://github.com/user-attachments/assets/6f3248a4-3ea9-4d35-b612-53d5fefddc4c">


   </td>
  </tr>
</table>

**Notes to reviewers**

**How has it been tested?**
