### PR TITLE
fix: Swap input amount bug fix

### DIFF
--- a/.changeset/brave-icons-fix.md
+++ b/.changeset/brave-icons-fix.md
@@ -5,3 +5,5 @@
 - **feat**: moved `onSuccess` and `onError` for Swap component at top level. By @zizzamia #1123
 - **patch**: removed unneccessary address prop from `Transaction` component and fix issue where Sponsor component isn't visible. By @abcrane123 #1114
 - **chore**: updated disconnect SVG image. By @cpcramer #1103
+- **fix**: improved issue with Swap where it wasn't fetching quote for amount without a leading 0. By @abcrane123 #1128
+g

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -103,7 +103,7 @@ export function SwapProvider({
       if (source.token === undefined || destination.token === undefined) {
         return;
       }
-      if (amount === '' || Number.parseFloat(amount) === 0) {
+      if (amount === '' || amount === '.' || Number.parseFloat(amount) === 0) {
         return destination.setAmount('');
       }
 

--- a/src/swap/utils/getAPIParamsForToken.ts
+++ b/src/swap/utils/getAPIParamsForToken.ts
@@ -33,7 +33,7 @@ export function getAPIParamsForToken(
       message: '',
     };
   }
-  if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(amount)) {
+  if (!/^(?:0|[1-9]\d*|\.\d+)(?:\.\d*)?$/.test(amount)) {
     return {
       code: 'INVALID_INPUT',
       error: 'Invalid input: amount must be a non-negative number string',


### PR DESCRIPTION
**What changed? Why?**
- resolves issue where it doesn't fetch quote if you start number with `.`
**Notes to reviewers**

**How has it been tested?**
