### PR TITLE
playground: enable `Swap` in preview

### DIFF
--- a/playground/nextjs-app-router/components/OnchainProviders.tsx
+++ b/playground/nextjs-app-router/components/OnchainProviders.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ENVIRONMENT, ENVARS } from '@/lib/constants';
+import { ENVARS, ENVIRONMENT } from '@/lib/constants';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';

--- a/playground/nextjs-app-router/components/OnchainProviders.tsx
+++ b/playground/nextjs-app-router/components/OnchainProviders.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ENVARS, ENVIRONMENT } from '@/lib/constants';
+import { ENVIRONMENT, ENVIRONMENT_VARIABLES } from '@/lib/constants';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -34,7 +34,7 @@ function OnchainProviders({ children }: { children: ReactNode }) {
     <WagmiProvider config={config} reconnectOnMount={false}>
       <QueryClientProvider client={queryClient}>
         <OnchainKitProvider
-          apiKey={ENVARS[ENVIRONMENT.API_KEY]}
+          apiKey={ENVIRONMENT_VARIABLES[ENVIRONMENT.API_KEY]}
           chain={base}
           schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
         >

--- a/playground/nextjs-app-router/components/OnchainProviders.tsx
+++ b/playground/nextjs-app-router/components/OnchainProviders.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ENVIRONMENT, ENVARS } from '@/lib/constants';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -33,7 +34,7 @@ function OnchainProviders({ children }: { children: ReactNode }) {
     <WagmiProvider config={config} reconnectOnMount={false}>
       <QueryClientProvider client={queryClient}>
         <OnchainKitProvider
-          apiKey={process.env.NEXT_PUBLIC_OCK_API_KEY}
+          apiKey={ENVARS[ENVIRONMENT.API_KEY]}
           chain={base}
           schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
         >

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -1,4 +1,4 @@
-import { ENVARS, ENVIRONMENT } from '@/lib/constants';
+import { ENVIRONMENT, ENVIRONMENT_VARIABLES } from '@/lib/constants';
 import {
   Swap,
   SwapAmountInput,
@@ -95,7 +95,11 @@ function SwapComponent() {
             token={usdcToken}
             type="to"
           />
-          <SwapButton disabled={ENVARS[ENVIRONMENT.ENVIRONMENT] != 'preview'} />
+          <SwapButton
+            disabled={
+              ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] != 'preview'
+            }
+          />
           <SwapMessage />
         </Swap>
       ) : (

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -97,7 +97,7 @@ function SwapComponent() {
           />
           <SwapButton
             disabled={
-              ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] != 'preview'
+              ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] === 'production'
             }
           />
           <SwapMessage />

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -1,3 +1,4 @@
+import { ENVARS, ENVIRONMENT } from '@/lib/constants';
 import {
   Swap,
   SwapAmountInput,
@@ -9,7 +10,6 @@ import type { Token } from '@coinbase/onchainkit/token';
 import { useContext } from 'react';
 import { useAccount } from 'wagmi';
 import { AppContext } from '../AppProvider';
-import { ENVARS, ENVIRONMENT } from '@/lib/constants';
 
 function SwapComponent() {
   const { address } = useAccount();

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -95,9 +95,7 @@ function SwapComponent() {
             token={usdcToken}
             type="to"
           />
-          <SwapButton
-            disabled={ENVARS[ENVIRONMENT.ENVIRONMENT] != 'development'}
-          />
+          <SwapButton disabled={ENVARS[ENVIRONMENT.ENVIRONMENT] != 'preview'} />
           <SwapMessage />
         </Swap>
       ) : (

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -9,6 +9,7 @@ import type { Token } from '@coinbase/onchainkit/token';
 import { useContext } from 'react';
 import { useAccount } from 'wagmi';
 import { AppContext } from '../AppProvider';
+import { ENVARS, ENVIRONMENT } from '@/lib/constants';
 
 function SwapComponent() {
   const { address } = useAccount();
@@ -94,7 +95,9 @@ function SwapComponent() {
             token={usdcToken}
             type="to"
           />
-          <SwapButton disabled={true} />
+          <SwapButton
+            disabled={ENVARS[ENVIRONMENT.ENVIRONMENT] != 'development'}
+          />
           <SwapMessage />
         </Swap>
       ) : (

--- a/playground/nextjs-app-router/lib/constants.ts
+++ b/playground/nextjs-app-router/lib/constants.ts
@@ -18,5 +18,5 @@ type EnvironmentKey = (typeof ENVIRONMENT)[keyof typeof ENVIRONMENT];
 
 export const ENVARS: Record<EnvironmentKey, string | undefined> = {
   [ENVIRONMENT.API_KEY]: process.env.NEXT_PUBLIC_OCK_API_KEY,
-  [ENVIRONMENT.ENVIRONMENT]: process.env.VERCEL_ENV,
+  [ENVIRONMENT.ENVIRONMENT]: process.env.NEXT_PUBLIC_VERCEL_ENV,
 };

--- a/playground/nextjs-app-router/lib/constants.ts
+++ b/playground/nextjs-app-router/lib/constants.ts
@@ -16,7 +16,8 @@ export const ENVIRONMENT = {
 
 type EnvironmentKey = (typeof ENVIRONMENT)[keyof typeof ENVIRONMENT];
 
-export const ENVARS: Record<EnvironmentKey, string | undefined> = {
-  [ENVIRONMENT.API_KEY]: process.env.NEXT_PUBLIC_OCK_API_KEY,
-  [ENVIRONMENT.ENVIRONMENT]: process.env.NEXT_PUBLIC_VERCEL_ENV,
-};
+export const ENVIRONMENT_VARIABLES: Record<EnvironmentKey, string | undefined> =
+  {
+    [ENVIRONMENT.API_KEY]: process.env.NEXT_PUBLIC_OCK_API_KEY,
+    [ENVIRONMENT.ENVIRONMENT]: process.env.NEXT_PUBLIC_VERCEL_ENV,
+  };

--- a/playground/nextjs-app-router/lib/constants.ts
+++ b/playground/nextjs-app-router/lib/constants.ts
@@ -18,5 +18,5 @@ type EnvironmentKey = (typeof ENVIRONMENT)[keyof typeof ENVIRONMENT];
 
 export const ENVARS: Record<EnvironmentKey, string | undefined> = {
   [ENVIRONMENT.API_KEY]: process.env.NEXT_PUBLIC_OCK_API_KEY,
-  [ENVIRONMENT.ENVIRONMENT]: process.env.NEXT_PUBLIC_VERCEL_ENV,
+  [ENVIRONMENT.ENVIRONMENT]: process.env.VERCEL_ENV,
 };

--- a/playground/nextjs-app-router/lib/constants.ts
+++ b/playground/nextjs-app-router/lib/constants.ts
@@ -8,3 +8,15 @@ export const deployedContracts: Record<number, { click: Address }> = {
     click: '0x7d662A03CC7f493D447EB8b499cF4533f5B640E2',
   },
 };
+
+export const ENVIRONMENT = {
+  API_KEY: 'API_KEY',
+  ENVIRONMENT: 'ENVIRONMENT',
+} as const;
+
+type EnvironmentKey = (typeof ENVIRONMENT)[keyof typeof ENVIRONMENT];
+
+export const ENVARS: Record<EnvironmentKey, string | undefined> = {
+  [ENVIRONMENT.API_KEY]: process.env.NEXT_PUBLIC_OCK_API_KEY,
+  [ENVIRONMENT.ENVIRONMENT]: process.env.NEXT_PUBLIC_VERCEL_ENV,
+};


### PR DESCRIPTION
**What changed? Why?**
- create `ENVIRONMENT_VARIABLES` map
- disable `SwapButton` only on `production` deployments (i.e. onchainkit.xyz/playground)

we can swap on preview deployments off PRs since they are behind authentication

**Notes to reviewers**

**How has it been tested?**
can swap on preview deployment attached to this PR