### PR TITLE
chore: remove address prop from Swap component

### DIFF
--- a/.changeset/modern-ladybugs-deliver.md
+++ b/.changeset/modern-ladybugs-deliver.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix**: Remove address prop from Swap component. @abcrane123 #1145

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -87,7 +87,6 @@ function SwapComponent() {
       )}
       {address ? (
         <Swap
-          address={address}
           className="border bg-[#ffffff]"
           onStatus={handleOnStatus}
         >

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -86,10 +86,7 @@ function SwapComponent() {
         </div>
       )}
       {address ? (
-        <Swap
-          className="border bg-[#ffffff]"
-          onStatus={handleOnStatus}
-        >
+        <Swap className="border bg-[#ffffff]" onStatus={handleOnStatus}>
           <SwapAmountInput
             label="Sell"
             swappableTokens={swappableTokens}

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -200,7 +200,6 @@ bun add @coinbase/onchainkit
     <div className="w-[664px] max-w-full">
 ```tsx
 <Transaction
-  address={address}
   chainId={base.id}
   contracts={[
     {
@@ -232,7 +231,6 @@ bun add @coinbase/onchainkit
             if (address) {
               return (
                 <Transaction
-                  address={address}
                   capabilities={capabilities}
                   chainId={84532}
                   contracts={contracts}
@@ -279,7 +277,7 @@ bun add @coinbase/onchainkit
     <div className="flex grow flex-col items-center md:flex-row pt-[44px] md:pt-[20px]">
       <div className="w-[664px] max-w-full">
 ```tsx
-<Swap address={address}>
+<Swap>
   <SwapAmountInput
     label="Sell"
     swappableTokens={swappableTokens}
@@ -304,7 +302,7 @@ bun add @coinbase/onchainkit
     {({ address, swappableTokens }) => {
       if (address) {
         return (
-          <Swap address={address}>
+          <Swap>
             <SwapAmountInput
               label="Sell"
               swappableTokens={swappableTokens}

--- a/site/docs/pages/swap/swap.mdx
+++ b/site/docs/pages/swap/swap.mdx
@@ -53,7 +53,7 @@ export default function SwapComponents() {
   const swappableTokens: Token[] = [ ... ];
 
   return address ? (
-    <Swap address={address}> // [!code focus]
+    <Swap> // [!code focus]
       <SwapAmountInput // [!code focus]
         label="Sell" // [!code focus]
         swappableTokens={swappableTokens} // [!code focus]
@@ -86,7 +86,7 @@ export default function SwapComponents() {
     {({ address, swappableTokens }) => {
       if (address) {
         return (
-          <Swap address={address}>
+          <Swap>
             <SwapAmountInput
               label="Sell"
               swappableTokens={swappableTokens}
@@ -130,7 +130,7 @@ You can adjust to only allow swap between a token pair.
 ```tsx
 // omitted for brevity
 
-<Swap address={address}> // [!code focus]
+<Swap> // [!code focus]
   <SwapAmountInput // [!code focus]
     label="Sell" // [!code focus]
     token={ETHToken} // [!code focus]
@@ -152,7 +152,7 @@ You can adjust to only allow swap between a token pair.
     {({ address, swappableTokens }) => {
       if (address) {
         return (
-          <Swap address={address}>
+          <Swap>
             <SwapAmountInput
               label="Sell"
               token={swappableTokens[1]}
@@ -188,7 +188,7 @@ You can remove `SwapToggleButton` to make swap unidirectional.
 ```tsx
 // omitted for brevity
 
-<Swap address={address}> // [!code focus]
+<Swap> // [!code focus]
   <SwapAmountInput // [!code focus]
     label="Sell" // [!code focus]
     token={ETHToken} // [!code focus]
@@ -209,7 +209,7 @@ You can remove `SwapToggleButton` to make swap unidirectional.
     {({ address, swappableTokens }) => {
       if (address) {
         return (
-          <Swap address={address}>
+          <Swap>
             <SwapAmountInput
               label="Sell"
               token={swappableTokens[1]}
@@ -244,7 +244,7 @@ You can remove `SwapMessage` component.
 ```tsx
 // omitted for brevity
 
-<Swap address={address}> // [!code focus]
+<Swap> // [!code focus]
   <SwapAmountInput // [!code focus]
     label="Sell" // [!code focus]
     token={ETHToken} // [!code focus]
@@ -265,7 +265,7 @@ You can remove `SwapMessage` component.
     {({ address, swappableTokens }) => {
       if (address) {
         return (
-          <Swap address={address}>
+          <Swap>
             <SwapAmountInput
               label="Sell"
               token={swappableTokens[1]}
@@ -300,7 +300,7 @@ You can override component styles using `className`.
 ```tsx
 // omitted for brevity
 
-<Swap address={address}>
+<Swap>
   <SwapAmountInput
     label="Sell"
     swappableTokens={swappableTokens}
@@ -324,7 +324,7 @@ You can override component styles using `className`.
     {({ address, swappableTokens }) => {
       if (address) {
         return (
-          <Swap address={address} >
+          <Swap >
             <SwapAmountInput
               label="Sell"
               swappableTokens={swappableTokens}

--- a/site/docs/pages/swap/types.mdx
+++ b/site/docs/pages/swap/types.mdx
@@ -171,7 +171,6 @@ type SwapQuote = {
 
 ```ts
 type SwapReact = {
-  address: Address; // Connected address from connector.
   children: ReactNode;
   className?: string; // Optional className override for top div element.
   onError?: (error: SwapError) => void; // An optional callback function that handles errors within the provider.

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -10,7 +10,6 @@ import { SwapProvider } from './SwapProvider';
 import { SwapToggleButton } from './SwapToggleButton';
 
 export function Swap({
-  address,
   children,
   className,
   experimental = { useAggregator: true },
@@ -38,7 +37,6 @@ export function Swap({
 
   return (
     <SwapProvider
-      address={address}
       experimental={experimental}
       onError={onError}
       onStatus={onStatus}

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -72,7 +72,6 @@ const renderWithProviders = ({
   onStatus = vi.fn(),
   onSuccess = vi.fn(),
 }) => {
-  const mockAddress = '0x1234567890123456789012345678901234567890';
   const mockExperimental = { useAggregator: true, maxSlippage: 10 };
   return render(
     <WagmiProvider config={config}>

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@testing-library/react';
 import React, { act, useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { http, WagmiProvider, createConfig } from 'wagmi';
+import { http, WagmiProvider, createConfig, useAccount } from 'wagmi';
 import { base } from 'wagmi/chains';
 import { mock } from 'wagmi/connectors';
 import { DEGEN_TOKEN, ETH_TOKEN } from '../mocks';
@@ -31,6 +31,13 @@ vi.mock('../utils/processSwapTransaction', () => ({
   processSwapTransaction: vi.fn(),
 }));
 
+vi.mock('wagmi', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('wagmi')>()),
+    useAccount: vi.fn(),
+  };
+});
+
 const queryClient = new QueryClient();
 
 const config = createConfig({
@@ -52,10 +59,7 @@ const config = createConfig({
 const wrapper = ({ children }) => (
   <WagmiProvider config={config}>
     <QueryClientProvider client={queryClient}>
-      <SwapProvider
-        address="0x1234567890123456789012345678901234567890"
-        experimental={{ useAggregator: true, maxSlippage: 5 }}
-      >
+      <SwapProvider experimental={{ useAggregator: true, maxSlippage: 5 }}>
         {children}
       </SwapProvider>
     </QueryClientProvider>
@@ -74,7 +78,6 @@ const renderWithProviders = ({
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
         <SwapProvider
-          address={mockAddress}
           experimental={mockExperimental}
           onError={onError}
           onStatus={onStatus}
@@ -158,6 +161,9 @@ const TestSwapComponent = () => {
 describe('useSwapContext', () => {
   beforeEach(async () => {
     vi.resetAllMocks();
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
+      address: '0x123',
+    });
     await act(async () => {
       renderWithProviders({ Component: () => null });
     });
@@ -198,6 +204,12 @@ describe('useSwapContext', () => {
 });
 
 describe('SwapProvider', () => {
+  beforeEach(async () => {
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
+      address: '0x123',
+    });
+  });
+
   it('should emit onError when setLifeCycleStatus is called with error', async () => {
     const onErrorMock = vi.fn();
     renderWithProviders({ Component: TestSwapComponent, onError: onErrorMock });

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -5,7 +5,7 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { useConfig, useSendTransaction } from 'wagmi';
+import { useAccount, useConfig, useSendTransaction } from 'wagmi';
 import { useValue } from '../../internal/hooks/useValue';
 import { formatTokenAmount } from '../../internal/utils/formatTokenAmount';
 import type { Token } from '../../token';
@@ -35,13 +35,13 @@ export function useSwapContext() {
 }
 
 export function SwapProvider({
-  address,
   children,
   experimental,
   onError,
   onStatus,
   onSuccess,
 }: SwapProviderReact) {
+  const { address } = useAccount();
   // Feature flags
   const { useAggregator } = experimental;
 

--- a/src/swap/hooks/useFromTo.ts
+++ b/src/swap/hooks/useFromTo.ts
@@ -4,7 +4,7 @@ import { useValue } from '../../internal/hooks/useValue';
 import type { Token } from '../../token';
 import { useSwapBalances } from './useSwapBalances';
 
-export const useFromTo = (address: Address) => {
+export const useFromTo = (address?: Address) => {
   const [fromAmount, setFromAmount] = useState('');
   const [fromToken, setFromToken] = useState<Token>();
   const [toAmount, setToAmount] = useState('');

--- a/src/swap/hooks/useSwapBalances.tsx
+++ b/src/swap/hooks/useSwapBalances.tsx
@@ -9,7 +9,7 @@ export function useSwapBalances({
   fromToken,
   toToken,
 }: {
-  address: Address;
+  address?: Address;
   fromToken?: Token;
   toToken?: Token;
 }) {

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -235,7 +235,6 @@ export type SwapParams = {
 };
 
 export type SwapProviderReact = {
-  address: Address;
   children: React.ReactNode;
   experimental: {
     useAggregator: boolean; // Whether to use a DEX aggregator. (default: true)
@@ -250,7 +249,6 @@ export type SwapProviderReact = {
  * Note: exported as public Type
  */
 export type SwapReact = {
-  address: Address; // Connected address from connector.
   children: ReactNode;
   className?: string; // Optional className override for top div element.
   experimental?: {

--- a/src/wallet/hooks/useGetETHBalance.ts
+++ b/src/wallet/hooks/useGetETHBalance.ts
@@ -10,7 +10,7 @@ import type { UseGetETHBalanceResponse } from '../types';
 
 const ETH_DECIMALS = 18;
 
-export function useGetETHBalance(address: Address): UseGetETHBalanceResponse {
+export function useGetETHBalance(address?: Address): UseGetETHBalanceResponse {
   const ethBalanceResponse: UseBalanceReturnType = useBalance({ address });
 
   return useMemo(() => {

--- a/src/wallet/hooks/useGetTokenBalance.test.ts
+++ b/src/wallet/hooks/useGetTokenBalance.test.ts
@@ -82,4 +82,21 @@ describe('useGetTokenBalance', () => {
       error: null,
     });
   });
+
+  it('should return empty balance when address is undefined', () => {
+    (useReadContract as Mock).mockReturnValue({
+      data: null,
+      error: null,
+    });
+    const { result } = renderHook(() =>
+      useGetTokenBalance(undefined, USDC_TOKEN),
+    );
+    expect(result.current.convertedBalance).toBe('');
+    expect(result.current.roundedBalance).toBe('');
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.response).toEqual({
+      data: null,
+      error: null,
+    });
+  });
 });

--- a/src/wallet/hooks/useGetTokenBalance.ts
+++ b/src/wallet/hooks/useGetTokenBalance.ts
@@ -10,14 +10,14 @@ import type { Token } from '../../token';
 import type { UseGetTokenBalanceResponse } from '../types';
 
 export function useGetTokenBalance(
-  address: Address,
+  address?: Address,
   token?: Token,
 ): UseGetTokenBalanceResponse {
   const tokenBalanceResponse: UseReadContractReturnType = useReadContract({
     abi: erc20Abi,
     address: token?.address as Address,
     functionName: 'balanceOf',
-    args: [address],
+    args: address ? [address] : [],
     query: {
       enabled: !!token?.address && !!address,
     },


### PR DESCRIPTION
**What changed? Why?**
- use wagmi's `useAccount` to retrieve address instead

**Notes to reviewers**

**How has it been tested?**
