### PR TITLE
fix: re-add `error` so `SwapMessage` renders

### DIFF
--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -17,6 +17,7 @@ import { useFromTo } from '../hooks/useFromTo';
 import type {
   LifeCycleStatus,
   SwapContextType,
+  SwapError,
   SwapProviderReact,
 } from '../types';
 import { isSwapError } from '../utils/isSwapError';
@@ -48,6 +49,7 @@ export function SwapProvider({
   // Core Hooks
   const config = useConfig();
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<SwapError>();
   const [isTransactionPending, setPendingTransaction] = useState(false);
   const [lifeCycleStatus, setLifeCycleStatus] = useState<LifeCycleStatus>({
     statusName: 'init',
@@ -62,6 +64,7 @@ export function SwapProvider({
     if (lifeCycleStatus.statusName === 'error') {
       setLoading(false);
       setPendingTransaction(false);
+      setError(lifeCycleStatus.statusData);
       onError?.(lifeCycleStatus.statusData);
     }
     if (lifeCycleStatus.statusName === 'transactionPending') {
@@ -233,6 +236,7 @@ export function SwapProvider({
   ]);
 
   const value = useValue({
+    error,
     from,
     loading,
     handleAmountChange,


### PR DESCRIPTION
**What changed? Why?**
- readd the `error` field on context, and set by the component lifecycle emitters so `SwapMessage` renders

**Notes to reviewers**

**How has it been tested?**
playground
<img width="738" alt="image" src="https://github.com/user-attachments/assets/0a18ab38-303e-45fb-9d38-7180f900541e">

