### PR TITLE
fix: clear error on success

### DIFF
--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -209,6 +209,33 @@ describe('SwapProvider', () => {
     });
   });
 
+  it('should call setError when setLifeCycleStatus is called with error', async () => {
+    const { result } = renderHook(() => useSwapContext(), { wrapper });
+    const errorStatusData = {
+      code: 'code',
+      error: 'error_long_messages',
+      message: 'test',
+    };
+    await act(async () => {
+      result.current.setLifeCycleStatus({
+        statusName: 'error',
+        statusData: errorStatusData,
+      });
+    });
+    expect(result.current.error).toBe(errorStatusData);
+  });
+
+  it('should call setError with undefined when setLifeCycleStatus is called with success', async () => {
+    const { result } = renderHook(() => useSwapContext(), { wrapper });
+    await act(async () => {
+      result.current.setLifeCycleStatus({
+        statusName: 'success',
+        statusData: { receipt: ['0x123'] },
+      });
+    });
+    expect(result.current.error).toBeUndefined();
+  });
+
   it('should emit onError when setLifeCycleStatus is called with error', async () => {
     const onErrorMock = vi.fn();
     renderWithProviders({ Component: TestSwapComponent, onError: onErrorMock });

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -76,6 +76,7 @@ export function SwapProvider({
     }
     // Success
     if (lifeCycleStatus.statusName === 'success') {
+      setError(undefined);
       setLoading(false);
       setPendingTransaction(false);
       onSuccess?.(lifeCycleStatus.statusData.transactionReceipt);


### PR DESCRIPTION
**What changed? Why?**
- if a user rejects a transaction then retries it, the error message stays after the swap succeeds (i.e. error state hasn't been reset)
- clear the errors on `success` state

**Notes to reviewers**

**How has it been tested?**
playground