### PR TITLE
docs: update remove redundant <TransactionStatusAction /> from docs

### DIFF
--- a/site/docs/pages/transaction/transaction.mdx
+++ b/site/docs/pages/transaction/transaction.mdx
@@ -42,7 +42,6 @@ import { // [!code focus]
   TransactionStatus, // [!code focus]
   TransactionStatusAction, // [!code focus]
   TransactionStatusLabel, // [!code focus]
-  TransactionStatusAction, // [!code focus]
 } from '@coinbase/onchainkit/transaction'; // [!code focus]
 import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
 import { useAccount } from 'wagmi';


### PR DESCRIPTION
**What changed? Why?**
Update remove redundant <TransactionStatusAction /> from docs

**Notes to reviewers**

**How has it been tested?**
