### PR TITLE
fix: `WalletDropdownBasename` in playground

### DIFF
--- a/playground/nextjs-app-router/components/demo/Wallet.tsx
+++ b/playground/nextjs-app-router/components/demo/Wallet.tsx
@@ -10,6 +10,7 @@ import {
   ConnectWallet,
   Wallet,
   WalletDropdown,
+  WalletDropdownBasename,
   WalletDropdownDisconnect,
   WalletDropdownFundLink,
   WalletDropdownLink,
@@ -33,7 +34,7 @@ function WalletComponent() {
             <Address className={color.foregroundMuted} />
             <EthBalance />
           </Identity>
-          <WalletDropdownBaseName />
+          <WalletDropdownBasename />
           <WalletDropdownLink
             icon="wallet"
             href="https://wallet.coinbase.com"


### PR DESCRIPTION
**What changed? Why?**
- fix the missing import in playground & casing

**Notes to reviewers**

**How has it been tested?**
