### PR TITLE
chore: Add light and dark mode in Playground

### DIFF
--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -9,7 +9,8 @@ import SwapDemo from './demo/Swap';
 import TransactionDemo from './demo/Transaction';
 import WalletDemo from './demo/Wallet';
 import { ActiveComponent } from './form/active-component';
-
+      
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component
 function Demo() {
   const { activeComponent } = useContext(AppContext);
   const [isDarkMode, setIsDarkMode] = useState(true);
@@ -31,6 +32,7 @@ function Demo() {
       <div className="hidden w-1/4 min-w-120 flex-col border-r bg-background p-6 sm:flex">
         <div className="mb-12 font-semibold text-lg">OnchainKit Playground</div>
         <button
+          type="button"
           onClick={toggleDarkMode}
           className={`rounded border px-3 py-2 transition-colors ${
             isDarkMode

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -32,7 +32,11 @@ function Demo() {
         <div className="mb-12 font-semibold text-lg">OnchainKit Playground</div>
         <button
           onClick={toggleDarkMode}
-          className="rounded border border-gray-300 bg-white px-3 py-2 text-black transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+          className={`rounded border px-3 py-2 transition-colors ${
+            isDarkMode
+              ? 'border-gray-600 bg-gray-800 text-white hover:bg-gray-700'
+              : 'border-gray-300 bg-white text-black hover:bg-gray-100'
+          }`}
         >
           {isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
         </button>

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { useContext, useEffect, useState } from 'react';
 import { AppContext, OnchainKitComponent } from '@/components/AppProvider';
 import { Chain } from '@/components/form/chain';
@@ -31,7 +32,9 @@ function Demo() {
         <div className="mb-12 font-semibold text-lg">OnchainKit Playground</div>
         <button
           onClick={toggleDarkMode}
-          className='rounded border border-gray-300 bg-white px-3 py-2 text-black transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700'
+          className='rounded border border-gray-300 bg-white px-3 py-2 text-black 
+          transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 
+          dark:text-white dark:hover:bg-gray-700'
         >
           {isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
         </button>

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -1,9 +1,8 @@
-'use client';
+import { useContext, useEffect, useState } from 'react';
 import { AppContext, OnchainKitComponent } from '@/components/AppProvider';
 import { Chain } from '@/components/form/chain';
 import { PaymasterUrl } from '@/components/form/paymaster';
 import { WalletType } from '@/components/form/wallet-type';
-import { useContext, useEffect } from 'react';
 import IdentityDemo from './demo/Identity';
 import SwapDemo from './demo/Swap';
 import TransactionDemo from './demo/Transaction';
@@ -12,15 +11,31 @@ import { ActiveComponent } from './form/active-component';
 
 function Demo() {
   const { activeComponent } = useContext(AppContext);
+  const [isDarkMode, setIsDarkMode] = useState(true);
+
   useEffect(() => {
     console.log('Playground.activeComponent:', activeComponent);
   }, [activeComponent]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', isDarkMode);
+  }, [isDarkMode]);
+
+  const toggleDarkMode = () => {
+    setIsDarkMode(!isDarkMode);
+  };
 
   return (
     <>
       <div className="hidden w-1/4 min-w-120 flex-col border-r bg-background p-6 sm:flex">
         <div className="mb-12 font-semibold text-lg">OnchainKit Playground</div>
-        <form className="grid gap-8">
+        <button
+          onClick={toggleDarkMode}
+          className='rounded border border-gray-300 bg-white px-3 py-2 text-black transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700'
+        >
+          {isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
+        </button>
+        <form className='mt-4 grid gap-8'>
           <ActiveComponent />
           <WalletType />
           <Chain />

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -1,9 +1,9 @@
 'use client';
-import { useContext, useEffect, useState } from 'react';
 import { AppContext, OnchainKitComponent } from '@/components/AppProvider';
 import { Chain } from '@/components/form/chain';
 import { PaymasterUrl } from '@/components/form/paymaster';
 import { WalletType } from '@/components/form/wallet-type';
+import { useContext, useEffect, useState } from 'react';
 import IdentityDemo from './demo/Identity';
 import SwapDemo from './demo/Swap';
 import TransactionDemo from './demo/Transaction';
@@ -32,9 +32,7 @@ function Demo() {
         <div className="mb-12 font-semibold text-lg">OnchainKit Playground</div>
         <button
           onClick={toggleDarkMode}
-          className="rounded border border-gray-300 bg-white px-3 py-2 text-black 
-          transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 
-          dark:text-white dark:hover:bg-gray-700"
+          className="rounded border border-gray-300 bg-white px-3 py-2 text-black transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
         >
           {isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
         </button>
@@ -54,10 +52,7 @@ function Demo() {
           View Github
         </a>
       </div>
-      <div
-        className="flex flex-1 flex-col bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),
-      linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] bg-[size:6rem_4rem]"
-      >
+      <div className="linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] flex flex-1 flex-col bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px), bg-[size:6rem_4rem]">
         <div className="flex h-full w-full flex-col justify-center">
           {activeComponent === OnchainKitComponent.Identity ? (
             <IdentityDemo />

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -9,7 +9,7 @@ import SwapDemo from './demo/Swap';
 import TransactionDemo from './demo/Transaction';
 import WalletDemo from './demo/Wallet';
 import { ActiveComponent } from './form/active-component';
-      
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component
 function Demo() {
   const { activeComponent } = useContext(AppContext);

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -32,13 +32,13 @@ function Demo() {
         <div className="mb-12 font-semibold text-lg">OnchainKit Playground</div>
         <button
           onClick={toggleDarkMode}
-          className='rounded border border-gray-300 bg-white px-3 py-2 text-black 
+          className="rounded border border-gray-300 bg-white px-3 py-2 text-black 
           transition-colors hover:bg-gray-100 dark:border-gray-600 dark:bg-gray-800 
-          dark:text-white dark:hover:bg-gray-700'
+          dark:text-white dark:hover:bg-gray-700"
         >
           {isDarkMode ? 'Switch to Light Mode' : 'Switch to Dark Mode'}
         </button>
-        <form className='mt-4 grid gap-8'>
+        <form className="mt-4 grid gap-8">
           <ActiveComponent />
           <WalletType />
           <Chain />
@@ -54,7 +54,10 @@ function Demo() {
           View Github
         </a>
       </div>
-      <div className="flex flex-1 flex-col bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] bg-[size:6rem_4rem]">
+      <div
+        className="flex flex-1 flex-col bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px),
+      linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] bg-[size:6rem_4rem]"
+      >
         <div className="flex h-full w-full flex-col justify-center">
           {activeComponent === OnchainKitComponent.Identity ? (
             <IdentityDemo />

--- a/playground/nextjs-app-router/tailwind.config.ts
+++ b/playground/nextjs-app-router/tailwind.config.ts
@@ -6,6 +6,8 @@ const config: Config = {
     './components/**/*.{js,ts,jsx,tsx,mdx}',
     './app/**/*.{js,ts,jsx,tsx,mdx}',
   ],
+  darkMode: ['class'],
+  safelist: ['dark'],
   theme: {
     extend: {
       backgroundImage: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./src/**/*.{ts,tsx}'],
+  darkMode: ['class'],
   safelist: ['dark'],
   theme: {
     fontFamily: {


### PR DESCRIPTION
**What changed? Why?**

Add light and dark mode in Playground
- Add darkMode: ['class'] and safelist: ['dark'] in our tailwind.config.ts files. This prevents the users personal mac settings from overriding our components styling.

<img width="1400" alt="Screenshot 2024-08-27 at 5 06 51 PM" src="https://github.com/user-attachments/assets/de331eef-23b7-428b-b9a9-fdb54e71a322">


<img width="1415" alt="Screenshot 2024-08-27 at 5 06 58 PM" src="https://github.com/user-attachments/assets/94ac2083-89b6-43c3-81fe-26a3d19e9042">

**Notes to reviewers**

**How has it been tested?**
