### PR TITLE
fix: reset lifecycle status after success

### DIFF
--- a/.changeset/quick-scissors-hug.md
+++ b/.changeset/quick-scissors-hug.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**patch**: reset lifecycle status after swap success. by @0xAlec #1183

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -255,7 +255,7 @@ describe('SwapProvider', () => {
     expect(result.current.error).toBeUndefined();
   });
 
-  it('should reset inputs when setLifeCycleStatus is called with success', async () => {
+  it('should reset inputs and lifeCycleStatus to init when setLifeCycleStatus is called with success', async () => {
     const { result } = renderHook(() => useSwapContext(), { wrapper });
     await act(async () => {
       result.current.setLifeCycleStatus({
@@ -267,6 +267,7 @@ describe('SwapProvider', () => {
       expect(mockResetFunction).toHaveBeenCalled();
     });
     expect(mockResetFunction).toHaveBeenCalledTimes(1);
+    expect(result.current.lifeCycleStatus.statusName).toEqual('init')
   });
 
   it('should emit onError when setLifeCycleStatus is called with error', async () => {

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -267,7 +267,7 @@ describe('SwapProvider', () => {
       expect(mockResetFunction).toHaveBeenCalled();
     });
     expect(mockResetFunction).toHaveBeenCalledTimes(1);
-    expect(result.current.lifeCycleStatus.statusName).toEqual('init')
+    expect(result.current.lifeCycleStatus.statusName).toEqual('init');
   });
 
   it('should emit onError when setLifeCycleStatus is called with error', async () => {

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -93,6 +93,19 @@ export function SwapProvider({
     }
     // Emit Status
     onStatus?.(lifeCycleStatus);
+
+    // Reset lifecycle status after a success
+    if (
+      lifeCycleStatus.statusName !== 'init' &&
+      lifeCycleStatus.statusName === 'success'
+    ) {
+      setLifeCycleStatus({
+        statusName: 'init',
+        statusData: {
+          isMissingRequiredField: false,
+        },
+      });
+    }
   }, [
     onError,
     onStatus,

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -93,7 +93,6 @@ export function SwapProvider({
     }
     // Emit Status
     onStatus?.(lifeCycleStatus);
-
     // Reset lifecycle status after a success
     if (
       lifeCycleStatus.statusName !== 'init' &&


### PR DESCRIPTION
**What changed? Why?**
- reset lifeCycleStatus to `init` after a swap `success`, otherwise the inputs will clear in an infinite loop

**Notes to reviewers**

**How has it been tested?**
playground
