### PR TITLE
chore: Adjust style so Swap component doesn't shift

### DIFF
--- a/.changeset/tame-islands-unite.md
+++ b/.changeset/tame-islands-unite.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **patch**: Adjust Swap component style to prevent UI shifting. By @abcrane123 #1184

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -69,7 +69,7 @@ export function SwapAmountInput({
       className={cn(
         background.alternate,
         'box-border flex w-full flex-col items-start',
-        'rounded-md p-4 h-[148px]',
+        'h-[148px] rounded-md p-4',
         className,
       )}
       data-testid="ockSwapAmountInput_Container"

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -69,7 +69,7 @@ export function SwapAmountInput({
       className={cn(
         background.alternate,
         'box-border flex w-full flex-col items-start',
-        'rounded-md p-4',
+        'rounded-md p-4 h-[148px]',
         className,
       )}
       data-testid="ockSwapAmountInput_Container"

--- a/src/swap/components/SwapMessage.tsx
+++ b/src/swap/components/SwapMessage.tsx
@@ -31,7 +31,7 @@ export function SwapMessage({ className }: SwapMessageReact) {
 
   return (
     <div
-      className={cn('flex pt-2 h-7', text.label2, className)}
+      className={cn('flex h-7 pt-2', text.label2, className)}
       data-testid="ockSwapMessage_Message"
     >
       {message}

--- a/src/swap/components/SwapMessage.tsx
+++ b/src/swap/components/SwapMessage.tsx
@@ -31,7 +31,7 @@ export function SwapMessage({ className }: SwapMessageReact) {
 
   return (
     <div
-      className={cn('flex pt-2', text.label2, className)}
+      className={cn('flex pt-2 h-7', text.label2, className)}
       data-testid="ockSwapMessage_Message"
     >
       {message}


### PR DESCRIPTION
**What changed? Why?**


https://github.com/user-attachments/assets/066b4ac7-847e-4b94-a7c8-3ea9f1c4fa7b



**Notes to reviewers**

**How has it been tested?**
