### PR TITLE
docs: consistent titles

### DIFF
--- a/site/docs/pages/farcaster/get-farcaster-user-address.mdx
+++ b/site/docs/pages/farcaster/get-farcaster-user-address.mdx
@@ -1,4 +1,4 @@
-# getFarcasterUserAddress
+# `getFarcasterUserAddress`
 
 The `getFarcasterUserAddress` function retrieves the user address associated
 with a given Farcaster ID (fid). It provides options to specify whether

--- a/site/docs/pages/frame/get-frame-html-response.mdx
+++ b/site/docs/pages/frame/get-frame-html-response.mdx
@@ -1,4 +1,4 @@
-# getFrameHtmlResponse
+# `getFrameHtmlResponse`
 
 When you need to send an HTML Frame Response, the `getFrameHtmlResponse` method is here to assist you.
 

--- a/site/docs/pages/frame/get-frame-message.mdx
+++ b/site/docs/pages/frame/get-frame-message.mdx
@@ -1,4 +1,4 @@
-# getFrameMessage
+# `getFrameMessage`
 
 When a user interacts with your Frame, you receive a JSON message called
 the "**Frame Signature Packet**". Decode and validate this message using the `getFrameMessage` function.

--- a/site/docs/pages/frame/get-frame-metadata.mdx
+++ b/site/docs/pages/frame/get-frame-metadata.mdx
@@ -1,4 +1,4 @@
-# getFrameMetadata
+# `getFrameMetadata`
 
 With Next.js App routing, use the `getFrameMetadata()` inside your `page.ts` to get the metadata need it for your Frame.
 

--- a/site/docs/pages/identity/get-attestations.mdx
+++ b/site/docs/pages/identity/get-attestations.mdx
@@ -1,4 +1,4 @@
-# getAttestations
+# `getAttestations`
 
 The `getAttestations` function fetches attestations for a specified address
 and blockchain in Ethereum Attestation Service (EAS). It allows optional filtering

--- a/site/docs/pages/xmtp/get-xmtp-frame-message.mdx
+++ b/site/docs/pages/xmtp/get-xmtp-frame-message.mdx
@@ -1,4 +1,4 @@
-# getXmtpFrameMessage
+# `getXmtpFrameMessage`
 
 Frames can receive interactions from apps outside of Farcaster, such as from XMTP conversations.
 When receiving these interactions you can expect a slightly different response format,

--- a/site/docs/pages/xmtp/is-xmtp-frame-request.mdx
+++ b/site/docs/pages/xmtp/is-xmtp-frame-request.mdx
@@ -1,4 +1,4 @@
-# isXmtpFrameRequest
+# `isXmtpFrameRequest`
 
 ```ts
 import { FrameRequest } from '@coinbase/onchainkit/frame';


### PR DESCRIPTION
**What changed? Why?**
Added backticks to titles where it should be

Example:
Before:
<img width="565" alt="image" src="https://github.com/user-attachments/assets/592f389c-a81a-4620-9e81-f7b3942582bf">

After:
<img width="558" alt="image" src="https://github.com/user-attachments/assets/7c4f713e-df1f-4e6a-b9fa-09ad4cc9f066">

**Notes to reviewers**

**How has it been tested?**
