### PR TITLE
Feat: Update getFrameHtmlResponse with new button-utility

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/src/frame/utils/getFrameHtmlResponse.ts
+++ b/src/frame/utils/getFrameHtmlResponse.ts
@@ -1,4 +1,5 @@
 import type { FrameMetadataType } from '../types';
+import { setFrameHtmlButtons } from './setFrameHtmlButtons';
 
 type FrameMetadataHtmlResponse = FrameMetadataType & {
   ogDescription?: string;
@@ -43,21 +44,7 @@ function getFrameHtmlResponse({
   // Set the button metadata if it exists.
   let buttonsHtml = '';
   if (buttons) {
-    buttonsHtml = buttons
-      .map((button, index) => {
-        let buttonHtml = `  <meta property="fc:frame:button:${index + 1}" content="${button.label}" />\n`;
-        if (button.action) {
-          buttonHtml += `  <meta property="fc:frame:button:${index + 1}:action" content="${button.action}" />\n`;
-        }
-        if (button.target) {
-          buttonHtml += `  <meta property="fc:frame:button:${index + 1}:target" content="${button.target}" />\n`;
-        }
-        if (button.action && button.action === 'tx' && button.postUrl) {
-          buttonHtml += `  <meta property="fc:frame:button:${index + 1}:post_url" content="${button.postUrl}" />\n`;
-        }
-        return buttonHtml;
-      })
-      .join('');
+    buttonsHtml = setFrameHtmlButtons(buttons);
   }
 
   // Set the post_url metadata if it exists.

--- a/src/frame/utils/setFrameHtmlButtons.test.ts
+++ b/src/frame/utils/setFrameHtmlButtons.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { setFrameHtmlButtons } from "./setFrameHtmlButtons.test";
+
+describe("setFrameHtmlButtons", () => {
+    it("should return no button HTML", () => {
+        const testButtonsHtml = setFrameHtmlButtons(undefined);
+
+        expect(testButtonsHtml).toEqual("");
+    });
+
+    it("should return the correct HTML", () => {
+        const testButtonsHtml = setFrameHtmlButtons([
+            { label: "button1", action: "post" },
+            { label: "button2", action: "mint", target: "https://example.com" },
+            { label: "button3", action: "post_redirect" },
+            { label: "button4" },
+        ]);
+
+        expect(testButtonsHtml).toEqual(`
+          <meta property="fc:frame:button:1" content="button1" />
+          <meta property="fc:frame:button:1:action" content="post" />
+          <meta property="fc:frame:button:2" content="button2" />
+          <meta property="fc:frame:button:2:action" content="mint" />
+          <meta property="fc:frame:button:2:target" content="https://example.com" />
+          <meta property="fc:frame:button:3" content="button3" />
+          <meta property="fc:frame:button:3:action" content="post_redirect" />
+          <meta property="fc:frame:button:4" content="button4" />
+        `);
+    });
+
+    it("should return the correct HTML for button with action mint and target", () => {
+        const testButtonsHtml = setFrameHtmlButtons([
+            {
+                label: "Mint",
+                action: "mint",
+                target: "https://zizzamia.xyz/api/frame/mint",
+            },
+        ]);
+
+        expect(testButtonsHtml).toEqual(`
+          <meta property="fc:frame:button:1" content="Mint" />
+          <meta property="fc:frame:button:1:action" content="mint" />
+          <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/mint" />
+          `);
+    });
+
+    it("should return the correct HTML for button with action tx and target", () => {
+        const testButtonsHtml = setFrameHtmlButtons([
+            {
+                label: "Tx",
+                action: "tx",
+                target: "https://zizzamia.xyz/api/frame/tx",
+            },
+        ]);
+
+        expect(testButtonsHtml).toEqual(`
+          <meta property="fc:frame:button:1" content="Tx" />
+          <meta property="fc:frame:button:1:action" content="tx" />
+          <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx" />
+        `);
+    });
+
+    it("should return the correct metadata for button with action post and post_url", () => {
+        const testButtonsHtml = setFrameHtmlButtons([
+            {
+                label: "Button1",
+                action: "post",
+                postUrl: "https://zizzamia.xyz/api/frame/post_url",
+            },
+        ]);
+
+        expect(testButtonsHtml).toEqual(`
+          <meta property="fc:frame:button:1" content="Button1" />
+          <meta property="fc:frame:button:1:action" content="post" />
+          <meta property="fc:frame:button:1:post_url" content="https://zizzamia.xyz/api/frame/post_url" />
+        `);
+    });
+
+    it("should return the correct metadata for buttons with action tx and custom targets", () => {
+        const testButtonsHtml = setFrameHtmlButtons([
+            {
+                label: "Button1",
+                action: "tx",
+                target: "https://zizzamia.xyz/api/frame/tx?queryParam=XXX",
+            },
+            {
+                label: "Button2",
+                action: "tx",
+                target: "https://zizzamia.xyz/api/frame/tx?queryParam=YYY",
+            },
+        ]);
+
+        expect(testButtonsHtml).toEqual(`
+          <meta property="fc:frame:button:1" content="Button1" />
+          <meta property="fc:frame:button:1:action" content="tx" />
+          <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=XXX" />
+          <meta property="fc:frame:button:2" content="Button2" />
+          <meta property="fc:frame:button:2:action" content="tx" />
+          <meta property="fc:frame:button:2:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=YYY" />
+        `);
+    });
+
+    it("should return the correct metadata for buttons with action post and custom post_urls", () => {
+        const testButtonsHtml = setFrameHtmlButtons([
+            {
+                label: "Button1",
+                action: "post",
+                postUrl:
+                    "https://zizzamia.xyz/api/frame/post-url?queryParam=XXX",
+            },
+            {
+                label: "Button2",
+                action: "post",
+                postUrl:
+                    "https://zizzamia.xyz/api/frame/post-url?queryParam=YYY",
+            },
+        ]);
+        expect(testButtonsHtml).toEqual(`
+          <meta property="fc:frame:button:1" content="Button1" />
+          <meta property="fc:frame:button:1:action" content="post" />
+          <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/post-url?queryParam=XXX" />
+          <meta property="fc:frame:button:2" content="Button2" />
+          <meta property="fc:frame:button:2:action" content="post" />
+          <meta property="fc:frame:button:2:target" content="https://zizzamia.xyz/api/frame/post-url?queryParam=YYY" />
+        `);
+    });
+});

--- a/src/frame/utils/setFrameHtmlButtons.test.ts
+++ b/src/frame/utils/setFrameHtmlButtons.test.ts
@@ -1,19 +1,19 @@
-import { describe, expect, it } from "vitest";
-import { setFrameHtmlButtons } from "./setFrameHtmlButtons";
+import { describe, expect, it } from 'vitest';
+import { setFrameHtmlButtons } from './setFrameHtmlButtons';
 
-describe("setFrameHtmlButtons", () => {
-  it("should return no button HTML", () => {
+describe('setFrameHtmlButtons', () => {
+  it('should return no button HTML', () => {
     const testButtonsHtml = setFrameHtmlButtons(undefined);
 
-    expect(testButtonsHtml).toEqual("");
+    expect(testButtonsHtml).toEqual('');
   });
 
-  it("should return the correct HTML", () => {
+  it('should return the correct HTML', () => {
     const testButtonsHtml = setFrameHtmlButtons([
-      { label: "button1", action: "post" },
-      { label: "button2", action: "mint", target: "https://example.com" },
-      { label: "button3", action: "post_redirect" },
-      { label: "button4" },
+      { label: 'button1', action: 'post' },
+      { label: 'button2', action: 'mint', target: 'https://example.com' },
+      { label: 'button3', action: 'post_redirect' },
+      { label: 'button4' },
     ]);
 
     expect(testButtonsHtml).toEqual(
@@ -24,69 +24,69 @@ describe("setFrameHtmlButtons", () => {
         `  <meta property="fc:frame:button:2:target" content="https://example.com" />\n` +
         `  <meta property="fc:frame:button:3" content="button3" />\n` +
         `  <meta property="fc:frame:button:3:action" content="post_redirect" />\n` +
-        `  <meta property="fc:frame:button:4" content="button4" />\n`
+        `  <meta property="fc:frame:button:4" content="button4" />\n`,
     );
   });
 
-  it("should return the correct HTML for button with action mint and target", () => {
+  it('should return the correct HTML for button with action mint and target', () => {
     const testButtonsHtml = setFrameHtmlButtons([
       {
-        label: "Mint",
-        action: "mint",
-        target: "https://zizzamia.xyz/api/frame/mint",
+        label: 'Mint',
+        action: 'mint',
+        target: 'https://zizzamia.xyz/api/frame/mint',
       },
     ]);
 
     expect(testButtonsHtml).toEqual(
       `  <meta property="fc:frame:button:1" content="Mint" />\n` +
         `  <meta property="fc:frame:button:1:action" content="mint" />\n` +
-        `  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/mint" />\n`
+        `  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/mint" />\n`,
     );
   });
 
-  it("should return the correct HTML for button with action tx and target", () => {
+  it('should return the correct HTML for button with action tx and target', () => {
     const testButtonsHtml = setFrameHtmlButtons([
       {
-        label: "Tx",
-        action: "tx",
-        target: "https://zizzamia.xyz/api/frame/tx",
+        label: 'Tx',
+        action: 'tx',
+        target: 'https://zizzamia.xyz/api/frame/tx',
       },
     ]);
 
     expect(testButtonsHtml).toEqual(
       `  <meta property="fc:frame:button:1" content="Tx" />\n` +
         `  <meta property="fc:frame:button:1:action" content="tx" />\n` +
-        `  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx" />\n`
+        `  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx" />\n`,
     );
   });
 
-  it("should return the correct metadata for button with action post and post_url", () => {
+  it('should return the correct metadata for button with action post and post_url', () => {
     const testButtonsHtml = setFrameHtmlButtons([
       {
-        label: "Button1",
-        action: "post",
-        postUrl: "https://zizzamia.xyz/api/frame/post_url",
+        label: 'Button1',
+        action: 'post',
+        postUrl: 'https://zizzamia.xyz/api/frame/post_url',
       },
     ]);
 
     expect(testButtonsHtml).toEqual(
       `  <meta property="fc:frame:button:1" content="Button1" />\n` +
         `  <meta property="fc:frame:button:1:action" content="post" />\n` +
-        `  <meta property="fc:frame:button:1:post_url" content="https://zizzamia.xyz/api/frame/post_url" />\n`
+        `  <meta property="fc:frame:button:1:post_url" content="https://zizzamia.xyz/api/frame/post_url" />\n`,
     );
   });
 
-  it("should return the correct metadata for buttons with action tx and custom targets", () => {
+  it('should return the correct metadata for buttons with action tx and custom targets', () => {
     const testButtonsHtml = setFrameHtmlButtons([
       {
-        label: "Button1",
-        action: "tx",
-        target: "https://zizzamia.xyz/api/frame/tx?queryParam=XXX",
+        label: 'Button1',
+        action: 'tx',
+        target: 'https://zizzamia.xyz/api/frame/tx?queryParam=XXX',
       },
       {
-        label: "Button2",
-        action: "tx",
-        target: "https://zizzamia.xyz/api/frame/tx?queryParam=YYY",
+        label: 'Button2',
+        action: 'tx',
+        target: 'https://zizzamia.xyz/api/frame/tx?queryParam=YYY',
       },
     ]);
 
@@ -96,21 +96,21 @@ describe("setFrameHtmlButtons", () => {
         `  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=XXX" />\n` +
         `  <meta property="fc:frame:button:2" content="Button2" />\n` +
         `  <meta property="fc:frame:button:2:action" content="tx" />\n` +
-        `  <meta property="fc:frame:button:2:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=YYY" />\n`
+        `  <meta property="fc:frame:button:2:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=YYY" />\n`,
     );
   });
 
-  it("should return the correct metadata for buttons with action post and custom post_urls", () => {
+  it('should return the correct metadata for buttons with action post and custom post_urls', () => {
     const testButtonsHtml = setFrameHtmlButtons([
       {
-        label: "Button1",
-        action: "post",
-        postUrl: "https://zizzamia.xyz/api/frame/post-url?queryParam=XXX",
+        label: 'Button1',
+        action: 'post',
+        postUrl: 'https://zizzamia.xyz/api/frame/post-url?queryParam=XXX',
       },
       {
-        label: "Button2",
-        action: "post",
-        postUrl: "https://zizzamia.xyz/api/frame/post-url?queryParam=YYY",
+        label: 'Button2',
+        action: 'post',
+        postUrl: 'https://zizzamia.xyz/api/frame/post-url?queryParam=YYY',
       },
     ]);
     expect(testButtonsHtml).toEqual(
@@ -119,7 +119,7 @@ describe("setFrameHtmlButtons", () => {
         `  <meta property="fc:frame:button:1:post_url" content="https://zizzamia.xyz/api/frame/post-url?queryParam=XXX" />\n` +
         `  <meta property="fc:frame:button:2" content="Button2" />\n` +
         `  <meta property="fc:frame:button:2:action" content="post" />\n` +
-        `  <meta property="fc:frame:button:2:post_url" content="https://zizzamia.xyz/api/frame/post-url?queryParam=YYY" />\n`
+        `  <meta property="fc:frame:button:2:post_url" content="https://zizzamia.xyz/api/frame/post-url?queryParam=YYY" />\n`,
     );
   });
 });

--- a/src/frame/utils/setFrameHtmlButtons.test.ts
+++ b/src/frame/utils/setFrameHtmlButtons.test.ts
@@ -1,127 +1,125 @@
 import { describe, expect, it } from "vitest";
-import { setFrameHtmlButtons } from "./setFrameHtmlButtons.test";
+import { setFrameHtmlButtons } from "./setFrameHtmlButtons";
 
 describe("setFrameHtmlButtons", () => {
-    it("should return no button HTML", () => {
-        const testButtonsHtml = setFrameHtmlButtons(undefined);
+  it("should return no button HTML", () => {
+    const testButtonsHtml = setFrameHtmlButtons(undefined);
 
-        expect(testButtonsHtml).toEqual("");
-    });
+    expect(testButtonsHtml).toEqual("");
+  });
 
-    it("should return the correct HTML", () => {
-        const testButtonsHtml = setFrameHtmlButtons([
-            { label: "button1", action: "post" },
-            { label: "button2", action: "mint", target: "https://example.com" },
-            { label: "button3", action: "post_redirect" },
-            { label: "button4" },
-        ]);
+  it("should return the correct HTML", () => {
+    const testButtonsHtml = setFrameHtmlButtons([
+      { label: "button1", action: "post" },
+      { label: "button2", action: "mint", target: "https://example.com" },
+      { label: "button3", action: "post_redirect" },
+      { label: "button4" },
+    ]);
 
-        expect(testButtonsHtml).toEqual(`
-          <meta property="fc:frame:button:1" content="button1" />
-          <meta property="fc:frame:button:1:action" content="post" />
-          <meta property="fc:frame:button:2" content="button2" />
-          <meta property="fc:frame:button:2:action" content="mint" />
-          <meta property="fc:frame:button:2:target" content="https://example.com" />
-          <meta property="fc:frame:button:3" content="button3" />
-          <meta property="fc:frame:button:3:action" content="post_redirect" />
-          <meta property="fc:frame:button:4" content="button4" />
-        `);
-    });
+    expect(testButtonsHtml).toEqual(
+      `  <meta property="fc:frame:button:1" content="button1" />\n` +
+        `  <meta property="fc:frame:button:1:action" content="post" />\n` +
+        `  <meta property="fc:frame:button:2" content="button2" />\n` +
+        `  <meta property="fc:frame:button:2:action" content="mint" />\n` +
+        `  <meta property="fc:frame:button:2:target" content="https://example.com" />\n` +
+        `  <meta property="fc:frame:button:3" content="button3" />\n` +
+        `  <meta property="fc:frame:button:3:action" content="post_redirect" />\n` +
+        `  <meta property="fc:frame:button:4" content="button4" />\n`
+    );
+  });
 
-    it("should return the correct HTML for button with action mint and target", () => {
-        const testButtonsHtml = setFrameHtmlButtons([
-            {
-                label: "Mint",
-                action: "mint",
-                target: "https://zizzamia.xyz/api/frame/mint",
-            },
-        ]);
+  it("should return the correct HTML for button with action mint and target", () => {
+    const testButtonsHtml = setFrameHtmlButtons([
+      {
+        label: "Mint",
+        action: "mint",
+        target: "https://zizzamia.xyz/api/frame/mint",
+      },
+    ]);
 
-        expect(testButtonsHtml).toEqual(`
-          <meta property="fc:frame:button:1" content="Mint" />
-          <meta property="fc:frame:button:1:action" content="mint" />
-          <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/mint" />
-          `);
-    });
+    expect(testButtonsHtml).toEqual(
+      `  <meta property="fc:frame:button:1" content="Mint" />\n` +
+        `  <meta property="fc:frame:button:1:action" content="mint" />\n` +
+        `  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/mint" />\n`
+    );
+  });
 
-    it("should return the correct HTML for button with action tx and target", () => {
-        const testButtonsHtml = setFrameHtmlButtons([
-            {
-                label: "Tx",
-                action: "tx",
-                target: "https://zizzamia.xyz/api/frame/tx",
-            },
-        ]);
+  it("should return the correct HTML for button with action tx and target", () => {
+    const testButtonsHtml = setFrameHtmlButtons([
+      {
+        label: "Tx",
+        action: "tx",
+        target: "https://zizzamia.xyz/api/frame/tx",
+      },
+    ]);
 
-        expect(testButtonsHtml).toEqual(`
-          <meta property="fc:frame:button:1" content="Tx" />
-          <meta property="fc:frame:button:1:action" content="tx" />
-          <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx" />
-        `);
-    });
+    expect(testButtonsHtml).toEqual(
+      `  <meta property="fc:frame:button:1" content="Tx" />\n` +
+        `  <meta property="fc:frame:button:1:action" content="tx" />\n` +
+        `  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx" />\n`
+    );
+  });
 
-    it("should return the correct metadata for button with action post and post_url", () => {
-        const testButtonsHtml = setFrameHtmlButtons([
-            {
-                label: "Button1",
-                action: "post",
-                postUrl: "https://zizzamia.xyz/api/frame/post_url",
-            },
-        ]);
+  it("should return the correct metadata for button with action post and post_url", () => {
+    const testButtonsHtml = setFrameHtmlButtons([
+      {
+        label: "Button1",
+        action: "post",
+        postUrl: "https://zizzamia.xyz/api/frame/post_url",
+      },
+    ]);
 
-        expect(testButtonsHtml).toEqual(`
-          <meta property="fc:frame:button:1" content="Button1" />
-          <meta property="fc:frame:button:1:action" content="post" />
-          <meta property="fc:frame:button:1:post_url" content="https://zizzamia.xyz/api/frame/post_url" />
-        `);
-    });
+    expect(testButtonsHtml).toEqual(
+      `  <meta property="fc:frame:button:1" content="Button1" />\n` +
+        `  <meta property="fc:frame:button:1:action" content="post" />\n` +
+        `  <meta property="fc:frame:button:1:post_url" content="https://zizzamia.xyz/api/frame/post_url" />\n`
+    );
+  });
 
-    it("should return the correct metadata for buttons with action tx and custom targets", () => {
-        const testButtonsHtml = setFrameHtmlButtons([
-            {
-                label: "Button1",
-                action: "tx",
-                target: "https://zizzamia.xyz/api/frame/tx?queryParam=XXX",
-            },
-            {
-                label: "Button2",
-                action: "tx",
-                target: "https://zizzamia.xyz/api/frame/tx?queryParam=YYY",
-            },
-        ]);
+  it("should return the correct metadata for buttons with action tx and custom targets", () => {
+    const testButtonsHtml = setFrameHtmlButtons([
+      {
+        label: "Button1",
+        action: "tx",
+        target: "https://zizzamia.xyz/api/frame/tx?queryParam=XXX",
+      },
+      {
+        label: "Button2",
+        action: "tx",
+        target: "https://zizzamia.xyz/api/frame/tx?queryParam=YYY",
+      },
+    ]);
 
-        expect(testButtonsHtml).toEqual(`
-          <meta property="fc:frame:button:1" content="Button1" />
-          <meta property="fc:frame:button:1:action" content="tx" />
-          <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=XXX" />
-          <meta property="fc:frame:button:2" content="Button2" />
-          <meta property="fc:frame:button:2:action" content="tx" />
-          <meta property="fc:frame:button:2:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=YYY" />
-        `);
-    });
+    expect(testButtonsHtml).toEqual(
+      `  <meta property="fc:frame:button:1" content="Button1" />\n` +
+        `  <meta property="fc:frame:button:1:action" content="tx" />\n` +
+        `  <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=XXX" />\n` +
+        `  <meta property="fc:frame:button:2" content="Button2" />\n` +
+        `  <meta property="fc:frame:button:2:action" content="tx" />\n` +
+        `  <meta property="fc:frame:button:2:target" content="https://zizzamia.xyz/api/frame/tx?queryParam=YYY" />\n`
+    );
+  });
 
-    it("should return the correct metadata for buttons with action post and custom post_urls", () => {
-        const testButtonsHtml = setFrameHtmlButtons([
-            {
-                label: "Button1",
-                action: "post",
-                postUrl:
-                    "https://zizzamia.xyz/api/frame/post-url?queryParam=XXX",
-            },
-            {
-                label: "Button2",
-                action: "post",
-                postUrl:
-                    "https://zizzamia.xyz/api/frame/post-url?queryParam=YYY",
-            },
-        ]);
-        expect(testButtonsHtml).toEqual(`
-          <meta property="fc:frame:button:1" content="Button1" />
-          <meta property="fc:frame:button:1:action" content="post" />
-          <meta property="fc:frame:button:1:target" content="https://zizzamia.xyz/api/frame/post-url?queryParam=XXX" />
-          <meta property="fc:frame:button:2" content="Button2" />
-          <meta property="fc:frame:button:2:action" content="post" />
-          <meta property="fc:frame:button:2:target" content="https://zizzamia.xyz/api/frame/post-url?queryParam=YYY" />
-        `);
-    });
+  it("should return the correct metadata for buttons with action post and custom post_urls", () => {
+    const testButtonsHtml = setFrameHtmlButtons([
+      {
+        label: "Button1",
+        action: "post",
+        postUrl: "https://zizzamia.xyz/api/frame/post-url?queryParam=XXX",
+      },
+      {
+        label: "Button2",
+        action: "post",
+        postUrl: "https://zizzamia.xyz/api/frame/post-url?queryParam=YYY",
+      },
+    ]);
+    expect(testButtonsHtml).toEqual(
+      `  <meta property="fc:frame:button:1" content="Button1" />\n` +
+        `  <meta property="fc:frame:button:1:action" content="post" />\n` +
+        `  <meta property="fc:frame:button:1:post_url" content="https://zizzamia.xyz/api/frame/post-url?queryParam=XXX" />\n` +
+        `  <meta property="fc:frame:button:2" content="Button2" />\n` +
+        `  <meta property="fc:frame:button:2:action" content="post" />\n` +
+        `  <meta property="fc:frame:button:2:post_url" content="https://zizzamia.xyz/api/frame/post-url?queryParam=YYY" />\n`
+    );
+  });
 });

--- a/src/frame/utils/setFrameHtmlButtons.ts
+++ b/src/frame/utils/setFrameHtmlButtons.ts
@@ -1,0 +1,35 @@
+import { FrameMetadataType } from "../types";
+
+export function setFrameHtmlButtons(buttons: FrameMetadataType["buttons"]) {
+    if (!buttons) {
+        return "";
+    }
+
+    return buttons
+        .map((button, index) => {
+            let buttonHtml = `  <meta property="fc:frame:button:${
+                index + 1
+            }" content="${button.label}" />\n`;
+            if (button.action) {
+                buttonHtml += `  <meta property="fc:frame:button:${
+                    index + 1
+                }:action" content="${button.action}" />\n`;
+            }
+            if (button.target) {
+                buttonHtml += `  <meta property="fc:frame:button:${
+                    index + 1
+                }:target" content="${button.target}" />\n`;
+            }
+            if (
+                button.action &&
+                (button.action === "tx" || button.action === "post") &&
+                button.postUrl
+            ) {
+                buttonHtml += `  <meta property="fc:frame:button:${
+                    index + 1
+                }:post_url" content="${button.postUrl}" />\n`;
+            }
+            return buttonHtml;
+        })
+        .join("");
+}

--- a/src/frame/utils/setFrameHtmlButtons.ts
+++ b/src/frame/utils/setFrameHtmlButtons.ts
@@ -1,8 +1,8 @@
-import type { FrameMetadataType } from "../types";
+import type { FrameMetadataType } from '../types';
 
-export function setFrameHtmlButtons(buttons: FrameMetadataType["buttons"]) {
+export function setFrameHtmlButtons(buttons: FrameMetadataType['buttons']) {
   if (!buttons) {
-    return "";
+    return '';
   }
 
   return buttons
@@ -22,7 +22,7 @@ export function setFrameHtmlButtons(buttons: FrameMetadataType["buttons"]) {
       }
       if (
         button.action &&
-        (button.action === "tx" || button.action === "post") &&
+        (button.action === 'tx' || button.action === 'post') &&
         button.postUrl
       ) {
         buttonHtml += `  <meta property="fc:frame:button:${
@@ -31,5 +31,5 @@ export function setFrameHtmlButtons(buttons: FrameMetadataType["buttons"]) {
       }
       return buttonHtml;
     })
-    .join("");
+    .join('');
 }

--- a/src/frame/utils/setFrameHtmlButtons.ts
+++ b/src/frame/utils/setFrameHtmlButtons.ts
@@ -1,35 +1,35 @@
-import { FrameMetadataType } from "../types";
+import type { FrameMetadataType } from "../types";
 
 export function setFrameHtmlButtons(buttons: FrameMetadataType["buttons"]) {
-    if (!buttons) {
-        return "";
-    }
+  if (!buttons) {
+    return "";
+  }
 
-    return buttons
-        .map((button, index) => {
-            let buttonHtml = `  <meta property="fc:frame:button:${
-                index + 1
-            }" content="${button.label}" />\n`;
-            if (button.action) {
-                buttonHtml += `  <meta property="fc:frame:button:${
-                    index + 1
-                }:action" content="${button.action}" />\n`;
-            }
-            if (button.target) {
-                buttonHtml += `  <meta property="fc:frame:button:${
-                    index + 1
-                }:target" content="${button.target}" />\n`;
-            }
-            if (
-                button.action &&
-                (button.action === "tx" || button.action === "post") &&
-                button.postUrl
-            ) {
-                buttonHtml += `  <meta property="fc:frame:button:${
-                    index + 1
-                }:post_url" content="${button.postUrl}" />\n`;
-            }
-            return buttonHtml;
-        })
-        .join("");
+  return buttons
+    .map((button, index) => {
+      let buttonHtml = `  <meta property="fc:frame:button:${
+        index + 1
+      }" content="${button.label}" />\n`;
+      if (button.action) {
+        buttonHtml += `  <meta property="fc:frame:button:${
+          index + 1
+        }:action" content="${button.action}" />\n`;
+      }
+      if (button.target) {
+        buttonHtml += `  <meta property="fc:frame:button:${
+          index + 1
+        }:target" content="${button.target}" />\n`;
+      }
+      if (
+        button.action &&
+        (button.action === "tx" || button.action === "post") &&
+        button.postUrl
+      ) {
+        buttonHtml += `  <meta property="fc:frame:button:${
+          index + 1
+        }:post_url" content="${button.postUrl}" />\n`;
+      }
+      return buttonHtml;
+    })
+    .join("");
 }


### PR DESCRIPTION
**What changed? Why?**
* Created `setFrameHtmlButtons` utility and test suite for creating Button Metadata HTML
* Implemented utility in `getFrameHtmlResponse`
* Updated logic for buttons to allow `post` buttons to receive custom `postUrl`s

**Notes to reviewers**

**How has it been tested?**
* 100% test coverage in `setFrameHtmlButtons.test.ts`