### PR TITLE
chore: standardize test typings

### DIFF
--- a/src/api/buildSwapTransaction.test.ts
+++ b/src/api/buildSwapTransaction.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CDP_GET_SWAP_TRADE } from '../network/definitions/swap';
 import { sendRequest } from '../network/request';
 import { DEGEN_TOKEN, ETH_TOKEN } from '../swap/mocks';
@@ -93,7 +93,7 @@ describe('buildSwapTransaction', () => {
         chainId: '8453',
       },
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const trade = mockResponse.result;
     const expectedResponse = {
       approveTransaction: undefined,
@@ -175,7 +175,7 @@ describe('buildSwapTransaction', () => {
         chainId: '8453',
       },
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const trade = mockResponse.result;
     const expectedResponse = {
       approveTransaction: undefined,
@@ -262,7 +262,7 @@ describe('buildSwapTransaction', () => {
         chainId: '8453',
       },
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const trade = mockResponse.result;
     const expectedResponse = {
       approveTransaction: getSwapTransaction(trade.approveTx, trade.chainId),
@@ -302,7 +302,7 @@ describe('buildSwapTransaction', () => {
     const mockError = new Error(
       'buildSwapTransaction: Error: Failed to send request',
     );
-    (sendRequest as vi.Mock).mockRejectedValue(mockError);
+    (sendRequest as Mock).mockRejectedValue(mockError);
     const error = await buildSwapTransaction(mockParams);
     expect(error).toEqual({
       code: 'UNCAUGHT_SWAP_ERROR',
@@ -333,7 +333,7 @@ describe('buildSwapTransaction', () => {
         message: 'Invalid response',
       },
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const error = await buildSwapTransaction(mockParams);
     expect(error).toEqual({
       code: 'SWAP_ERROR',

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, afterEach, describe, expect, it, vi } from 'vitest';
 import { CDP_GET_SWAP_QUOTE } from '../network/definitions/swap';
 import { sendRequest } from '../network/request';
 import { DEGEN_TOKEN, ETH_TOKEN } from '../swap/mocks';
@@ -42,7 +42,7 @@ describe('getSwapQuote', () => {
         slippage: '3',
       },
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const quote = await getSwapQuote(mockParams);
     expect(quote).toEqual(mockResponse.result);
     expect(sendRequest).toHaveBeenCalledTimes(1);
@@ -79,7 +79,7 @@ describe('getSwapQuote', () => {
         slippage: '3',
       },
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const quote = await getSwapQuote(mockParams);
     expect(quote).toEqual(mockResponse.result);
     expect(sendRequest).toHaveBeenCalledTimes(1);
@@ -101,7 +101,7 @@ describe('getSwapQuote', () => {
     };
     const mockApiParams = getAPIParamsForToken(mockParams);
     const mockError = new Error('getSwapQuote: Error: Failed to send request');
-    (sendRequest as vi.Mock).mockRejectedValue(mockError);
+    (sendRequest as Mock).mockRejectedValue(mockError);
     const error = await getSwapQuote(mockParams);
     expect(error).toEqual({
       code: 'UNCAUGHT_SWAP_QUOTE_ERROR',
@@ -131,7 +131,7 @@ describe('getSwapQuote', () => {
         message: 'Invalid response',
       },
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const error = await getSwapQuote(mockParams);
     expect(error).toEqual({
       code: 'SWAP_QUOTE_ERROR',

--- a/src/api/getTokens.test.ts
+++ b/src/api/getTokens.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, afterEach, describe, expect, it, vi } from 'vitest';
 import { CDP_LIST_SWAP_ASSETS } from '../network/definitions/swap';
 import { sendRequest } from '../network/request';
 /**
@@ -35,7 +35,7 @@ describe('getTokens', () => {
       ],
       error: null,
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const tokens = await getTokens();
     expect(tokens).toEqual([
       {
@@ -75,7 +75,7 @@ describe('getTokens', () => {
       ],
       error: null,
     };
-    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
     const tokens = await getTokens({ limit: '1', page: '1' });
     expect(tokens).toEqual([
       {
@@ -94,7 +94,7 @@ describe('getTokens', () => {
   });
 
   it('should return an error object if sendRequest returns an error', async () => {
-    (sendRequest as vi.Mock).mockResolvedValue({
+    (sendRequest as Mock).mockResolvedValue({
       result: null,
       error: {
         code: -1,
@@ -118,7 +118,7 @@ describe('getTokens', () => {
     const mockError = new Error(
       'getTokens: error retrieving tokens: Token retrieval failed',
     );
-    (sendRequest as vi.Mock).mockRejectedValue(mockError);
+    (sendRequest as Mock).mockRejectedValue(mockError);
     const error = await getTokens();
     expect(error).toEqual({
       code: 'AmGTa02',

--- a/src/farcaster/getFarcasterUserAddress.test.ts
+++ b/src/farcaster/getFarcasterUserAddress.test.ts
@@ -1,3 +1,4 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getCustodyAddressForFidNeynar } from '../network/neynar/getCustodyAddressForFidNeynar';
 import { getVerifiedAddressesForFidNeynar } from '../network/neynar/getVerifiedAddressesForFidNeynar';
 import { getFarcasterUserAddress } from './getFarcasterUserAddress';
@@ -13,17 +14,17 @@ describe('getFarcasterUserAddress function', () => {
 
   it('should return null if any API call fails', async () => {
     const error = new Error('Something went wrong');
-    (getVerifiedAddressesForFidNeynar as vi.Mock).mockRejectedValue(error);
+    (getVerifiedAddressesForFidNeynar as Mock).mockRejectedValue(error);
     const result = await getFarcasterUserAddress(123);
     expect(result).toBeNull();
   });
 
   it('should return both custody and verified addresses by default', async () => {
     const expectedCustodyAddress = 'mock-custody-address';
-    (getCustodyAddressForFidNeynar as vi.Mock).mockResolvedValue(
+    (getCustodyAddressForFidNeynar as Mock).mockResolvedValue(
       expectedCustodyAddress,
     );
-    (getVerifiedAddressesForFidNeynar as vi.Mock).mockResolvedValue([
+    (getVerifiedAddressesForFidNeynar as Mock).mockResolvedValue([
       expectedCustodyAddress,
     ]);
 
@@ -48,10 +49,10 @@ describe('getFarcasterUserAddress function', () => {
       'mock-verified-address-1',
       'mock-verified-address-2',
     ];
-    (getCustodyAddressForFidNeynar as vi.Mock).mockResolvedValue(
+    (getCustodyAddressForFidNeynar as Mock).mockResolvedValue(
       expectedCustodyAddress,
     );
-    (getVerifiedAddressesForFidNeynar as vi.Mock).mockResolvedValue(
+    (getVerifiedAddressesForFidNeynar as Mock).mockResolvedValue(
       expectedVerifiedAddresses,
     );
     const result = await getFarcasterUserAddress(123, {
@@ -66,7 +67,7 @@ describe('getFarcasterUserAddress function', () => {
 
   it('should only return custodyAddress  when hasVerifiedAddresses is false', async () => {
     const expectedCustodyAddress = 'mock-custody-address';
-    (getCustodyAddressForFidNeynar as vi.Mock).mockResolvedValue(
+    (getCustodyAddressForFidNeynar as Mock).mockResolvedValue(
       expectedCustodyAddress,
     );
     const result = await getFarcasterUserAddress(123, {
@@ -80,7 +81,7 @@ describe('getFarcasterUserAddress function', () => {
       'mock-verified-address-1',
       'mock-verified-address-2',
     ];
-    (getVerifiedAddressesForFidNeynar as vi.Mock).mockResolvedValue(
+    (getVerifiedAddressesForFidNeynar as Mock).mockResolvedValue(
       expectedVerifiedAddresses,
     );
     const result = await getFarcasterUserAddress(123, {

--- a/src/identity/components/Address.test.tsx
+++ b/src/identity/components/Address.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@testing-library/react';
-import { vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { getSlicedAddress } from '../utils/getSlicedAddress';
 import { Address } from './Address';
 import { useIdentityContext } from './IdentityProvider';
 
 function mock<T>(func: T) {
-  return func as vi.Mock;
+  return func as Mock;
 }
 
 const silenceError = () => {
@@ -53,7 +53,7 @@ describe('Address component', () => {
     useIdentityContextMock.mockReturnValue({
       address: testAddressComponentAddress,
     });
-    (getSlicedAddress as vi.Mock).mockReturnValue(
+    (getSlicedAddress as Mock).mockReturnValue(
       mockGetSlicedAddress(testAddressComponentAddress),
     );
 
@@ -65,7 +65,7 @@ describe('Address component', () => {
 
   it('renders the sliced address when address supplied to Identity', () => {
     useIdentityContextMock.mockReturnValue({});
-    (getSlicedAddress as vi.Mock).mockReturnValue(
+    (getSlicedAddress as Mock).mockReturnValue(
       mockGetSlicedAddress(testAddressComponentAddress),
     );
 
@@ -79,7 +79,7 @@ describe('Address component', () => {
 
   it('displays sliced address when ENS name is not available and isSliced is set to true', () => {
     useIdentityContextMock.mockReturnValue({});
-    (getSlicedAddress as vi.Mock).mockReturnValue(
+    (getSlicedAddress as Mock).mockReturnValue(
       mockGetSlicedAddress(testAddressComponentAddress),
     );
 

--- a/src/identity/components/Avatar.test.tsx
+++ b/src/identity/components/Avatar.test.tsx
@@ -1,5 +1,5 @@
 import { base, baseSepolia, optimism } from 'viem/chains';
-import { vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import { useOnchainKit } from '../../useOnchainKit';
@@ -11,7 +11,7 @@ import { Badge } from './Badge';
 import { useIdentityContext } from './IdentityProvider';
 
 function mock<T>(func: T) {
-  return func as vi.Mock;
+  return func as Mock;
 }
 
 const silenceError = () => {

--- a/src/identity/components/DisplayBadge.test.tsx
+++ b/src/identity/components/DisplayBadge.test.tsx
@@ -1,3 +1,4 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { useOnchainKit } from '../../useOnchainKit';
@@ -7,7 +8,7 @@ import { DisplayBadge } from './DisplayBadge';
 import { useIdentityContext } from './IdentityProvider';
 
 function mock<T>(func: T) {
-  return func as vi.Mock;
+  return func as Mock;
 }
 
 vi.mock('../../useOnchainKit', () => ({

--- a/src/identity/components/EthBalance.test.tsx
+++ b/src/identity/components/EthBalance.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { getRoundedAmount } from '../../internal/utils/getRoundedAmount';
 import { useGetETHBalance } from '../../wallet/hooks/useGetETHBalance';
 import { EthBalance } from './EthBalance';
 import { useIdentityContext } from './IdentityProvider';
 
 function mock<T>(func: T) {
-  return func as vi.Mock;
+  return func as Mock;
 }
 
 const silenceError = () => {
@@ -54,7 +54,7 @@ describe('EthBalance', () => {
       convertedBalance: balance,
       error: null,
     });
-    (getRoundedAmount as vi.Mock).mockReturnValue('1.2346');
+    (getRoundedAmount as Mock).mockReturnValue('1.2346');
 
     render(
       <EthBalance
@@ -91,7 +91,7 @@ describe('EthBalance', () => {
       convertedBalance: balance,
       error: null,
     });
-    (getRoundedAmount as vi.Mock).mockReturnValue('1.2346');
+    (getRoundedAmount as Mock).mockReturnValue('1.2346');
 
     render(<EthBalance className="custom-class" />);
 
@@ -109,7 +109,7 @@ describe('EthBalance', () => {
       convertedBalance: balance,
       error: null,
     });
-    (getRoundedAmount as vi.Mock).mockReturnValue('1.2346');
+    (getRoundedAmount as Mock).mockReturnValue('1.2346');
 
     render(
       <EthBalance

--- a/src/identity/components/Identity.test.tsx
+++ b/src/identity/components/Identity.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useGetETHBalance } from '../../wallet/hooks/useGetETHBalance';
@@ -11,7 +11,7 @@ import { Identity } from './Identity';
 import { Name } from './Name';
 
 function mock<T>(func: T) {
-  return func as vi.Mock;
+  return func as Mock;
 }
 
 vi.mock('../hooks/useAvatar', () => ({

--- a/src/identity/components/Identity.test.tsx
+++ b/src/identity/components/Identity.test.tsx
@@ -171,7 +171,7 @@ describe('Identity Component', () => {
 
   it('should not call handleCopy when address is not provided', async () => {
     render(
-      <Identity address={null} hasCopyAddressOnClick={true}>
+      <Identity address={undefined} hasCopyAddressOnClick={true}>
         <div>Child Component</div>
       </Identity>,
     );

--- a/src/identity/components/Name.test.tsx
+++ b/src/identity/components/Name.test.tsx
@@ -1,4 +1,4 @@
-import { type Mock, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
 import { render, screen, waitFor } from '@testing-library/react';
 import { base, baseSepolia, optimism } from 'viem/chains';
@@ -45,7 +45,7 @@ describe('Name', () => {
   });
 
   it('should throw an error when no address is provided', () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
     });
     const restore = silenceError();
@@ -58,7 +58,7 @@ describe('Name', () => {
   });
 
   it('displays ENS name when available', () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
     });
     mockUseName.mockReturnValue({
@@ -70,7 +70,7 @@ describe('Name', () => {
   });
 
   it('use identity context address if provided', () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
       address: testIdentityProviderAddress,
     });
@@ -89,7 +89,7 @@ describe('Name', () => {
   });
 
   it('use identity context chain if provided', () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
       chain: optimism,
     });
@@ -108,7 +108,7 @@ describe('Name', () => {
   });
 
   it('use component address over identity context if both are provided', () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
       chain: optimism,
       address: testIdentityProviderAddress,
@@ -128,7 +128,7 @@ describe('Name', () => {
   });
 
   it('use component chain over identity context if both are provided', () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
       chain: optimism,
       address: testIdentityProviderAddress,
@@ -148,7 +148,7 @@ describe('Name', () => {
   });
 
   it('displays custom chain ENS name when available', () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
     });
     mockUseName.mockReturnValue({
@@ -160,14 +160,14 @@ describe('Name', () => {
   });
 
   it('displays sliced address when ENS name is not available', () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
     });
     mockUseName.mockReturnValue({
       data: null,
       isLoading: false,
     });
-    (getSlicedAddress as vi.Mock).mockReturnValue('0xName...ess');
+    (getSlicedAddress as Mock).mockReturnValue('0xName...ess');
     render(<Name address={testNameComponentAddress} />);
     expect(screen.getByText('0xName...ess')).toBeInTheDocument();
   });
@@ -180,11 +180,11 @@ describe('Name', () => {
   });
 
   it('renders badge when Badge is passed, user is attested and address set in Identity', async () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       address: testNameComponentAddress,
       schemaId: '0x123',
     });
-    (useAttestations as vi.Mock).mockReturnValue(['attestation']);
+    (useAttestations as Mock).mockReturnValue(['attestation']);
     mockUseName.mockReturnValue({
       data: 'ens_name',
       isLoading: false,
@@ -203,10 +203,10 @@ describe('Name', () => {
   });
 
   it('renders badge when Badge is passed, user is attested and address set in Name', async () => {
-    (useIdentityContext as vi.Mock).mockReturnValue({
+    (useIdentityContext as Mock).mockReturnValue({
       schemaId: '0x123',
     });
-    (useAttestations as vi.Mock).mockReturnValue(['attestation']);
+    (useAttestations as Mock).mockReturnValue(['attestation']);
     mockUseName.mockReturnValue({
       address: testNameComponentAddress,
       data: 'ens_name',

--- a/src/identity/hooks/useAddress.test.tsx
+++ b/src/identity/hooks/useAddress.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { base, baseSepolia, mainnet } from 'viem/chains';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { publicClient } from '../../network/client';
 import { getChainPublicClient } from '../../network/getChainPublicClient';
 import { getNewReactQueryTestProvider } from './getNewReactQueryTestProvider';
@@ -14,7 +14,7 @@ vi.mock('../../network/getChainPublicClient', () => ({
 }));
 
 describe('useAddress', () => {
-  const mockGetEnsAddress = publicClient.getEnsAddress as vi.Mock;
+  const mockGetEnsAddress = publicClient.getEnsAddress as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/identity/hooks/useAttestations.test.ts
+++ b/src/identity/hooks/useAttestations.test.ts
@@ -3,6 +3,7 @@
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import { base } from 'viem/chains';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAttestations } from '../utils/getAttestations';
 import { useAttestations } from './useAttestations';
 
@@ -28,7 +29,7 @@ describe('useAttestations', () => {
   });
 
   it('returns an empty array if no attestations found', async () => {
-    (getAttestations as vi.Mock).mockReturnValue([]);
+    (getAttestations as Mock).mockReturnValue([]);
 
     const address = '0xaddress';
     const chain = base;
@@ -43,7 +44,7 @@ describe('useAttestations', () => {
   });
 
   it('returns attestations if found', async () => {
-    (getAttestations as vi.Mock).mockReturnValue([
+    (getAttestations as Mock).mockReturnValue([
       {
         schemaId: '0xschema',
       },

--- a/src/identity/hooks/useAvatar.test.tsx
+++ b/src/identity/hooks/useAvatar.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { base, baseSepolia, mainnet, optimism } from 'viem/chains';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { publicClient } from '../../network/client';
 import { getChainPublicClient } from '../../network/getChainPublicClient';
 import { getNewReactQueryTestProvider } from './getNewReactQueryTestProvider';
@@ -14,7 +14,7 @@ vi.mock('../../network/getChainPublicClient', () => ({
 }));
 
 describe('useAvatar', () => {
-  const mockGetEnsAvatar = publicClient.getEnsAvatar as vi.Mock;
+  const mockGetEnsAvatar = publicClient.getEnsAvatar as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/identity/utils/getAddress.test.tsx
+++ b/src/identity/utils/getAddress.test.tsx
@@ -1,5 +1,5 @@
 import { base, baseSepolia, mainnet } from 'viem/chains';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { publicClient } from '../../network/client';
 import { getChainPublicClient } from '../../network/getChainPublicClient';
 import { getAddress } from './getAddress';
@@ -12,7 +12,7 @@ vi.mock('../../network/getChainPublicClient', () => ({
 }));
 
 describe('getAddress', () => {
-  const mockGetEnsAddress = publicClient.getEnsAddress as vi.Mock;
+  const mockGetEnsAddress = publicClient.getEnsAddress as Mock;
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/src/identity/utils/getAttestations.test.ts
+++ b/src/identity/utils/getAttestations.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { base, opBNBTestnet } from 'viem/chains';
-import { vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAttestationsByFilter } from '../../network/attestations';
 import type { GetAttestationsOptions } from '../types';
 import { getAttestations } from './getAttestations';
@@ -40,7 +40,7 @@ describe('getAttestations', () => {
   });
 
   it('fetches attestations for supported chains', async () => {
-    (getAttestationsByFilter as vi.Mock).mockResolvedValue(mockAttestations);
+    (getAttestationsByFilter as Mock).mockResolvedValue(mockAttestations);
     const result = await getAttestations(mockAddress, base, mockOptions);
     expect(result).toEqual(mockAttestations); // Replace [] with expected mockAttestations once implemented
   });
@@ -57,7 +57,7 @@ describe('getAttestations', () => {
   });
 
   it('handles errors from getAttestationsByFilter correctly', async () => {
-    (getAttestationsByFilter as vi.Mock).mockRejectedValue(
+    (getAttestationsByFilter as Mock).mockRejectedValue(
       new Error('Network error'),
     );
     const result = await getAttestations(mockAddress, base);

--- a/src/identity/utils/getAvatar.test.tsx
+++ b/src/identity/utils/getAvatar.test.tsx
@@ -1,5 +1,5 @@
 import { base, baseSepolia, mainnet, optimism } from 'viem/chains';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { publicClient } from '../../network/client';
 import { getChainPublicClient } from '../../network/getChainPublicClient';
 import { RESOLVER_ADDRESSES_BY_CHAIN_ID } from '../constants';
@@ -13,7 +13,7 @@ vi.mock('../../network/getChainPublicClient', () => ({
 }));
 
 describe('getAvatar', () => {
-  const mockGetEnsAvatar = publicClient.getEnsAvatar as vi.Mock;
+  const mockGetEnsAvatar = publicClient.getEnsAvatar as Mock;
   beforeEach(() => {
     vi.clearAllMocks();
   });

--- a/src/network/attestations.test.ts
+++ b/src/network/attestations.test.ts
@@ -1,4 +1,5 @@
 import { base } from 'viem/chains';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import {
   type GetAttestationsByFilterOptions,
   attestationQuery,
@@ -49,7 +50,7 @@ describe('EAS Attestation Service', () => {
           attestations: [],
         }),
       };
-      (createEasGraphQLClient as vi.Mock).mockReturnValue(mockClient);
+      (createEasGraphQLClient as Mock).mockReturnValue(mockClient);
 
       const result = await getAttestationsByFilter(
         mockAddress,

--- a/src/network/neynar/getCustodyAddressForFidNeynar.test.ts
+++ b/src/network/neynar/getCustodyAddressForFidNeynar.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getCustodyAddressForFidNeynar } from './getCustodyAddressForFidNeynar';
 
 describe('getCustodyAddressForFidNeynar', () => {
@@ -12,7 +12,7 @@ describe('getCustodyAddressForFidNeynar', () => {
         status,
         json: fetchMock,
       }),
-    ) as vi.Mock;
+    ) as Mock;
   });
 
   it('should return mocked response correctly', async () => {

--- a/src/network/neynar/getDataFromNeynar.test.ts
+++ b/src/network/neynar/getDataFromNeynar.test.ts
@@ -1,3 +1,4 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { version } from '../../version';
 import { getDataFromNeynar } from './getDataFromNeynar';
 import { NEYNAR_DEFAULT_API_KEY } from './neynarFrameValidation';
@@ -13,7 +14,7 @@ describe('getDataFromNeynar', () => {
         status,
         json: fetchMock,
       }),
-    ) as vi.Mock;
+    ) as Mock;
   });
 
   it('should call fetch correctly', async () => {

--- a/src/network/neynar/getVerifiedAddressesForFidNeynar.test.ts
+++ b/src/network/neynar/getVerifiedAddressesForFidNeynar.test.ts
@@ -1,4 +1,4 @@
-import { expect } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getVerifiedAddressesForFidNeynar } from './getVerifiedAddressesForFidNeynar';
 
 describe('getVerifiedAddressesForFidNeynar', () => {
@@ -12,7 +12,7 @@ describe('getVerifiedAddressesForFidNeynar', () => {
         status,
         json: fetchMock,
       }),
-    ) as vi.Mock;
+    ) as Mock;
   });
 
   it('should return mocked response correctly', async () => {

--- a/src/network/neynar/neynarBulkUserLookup.test.ts
+++ b/src/network/neynar/neynarBulkUserLookup.test.ts
@@ -1,3 +1,4 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FetchError } from './FetchError';
 import { neynarBulkUserLookup } from './neynarBulkUserLookup';
 
@@ -12,7 +13,7 @@ describe('neynar user functions', () => {
         status,
         json: fetchMock,
       }),
-    ) as vi.Mock;
+    ) as Mock;
   });
 
   it('should return fetch response correctly', async () => {

--- a/src/network/neynar/neynarFrameValidation.test.ts
+++ b/src/network/neynar/neynarFrameValidation.test.ts
@@ -1,3 +1,4 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FetchError } from './FetchError';
 import { neynarFrameValidation } from './neynarFrameValidation';
 
@@ -12,7 +13,7 @@ describe('neynar frame functions', () => {
         status,
         json: fetchMock,
       }),
-    ) as vi.Mock;
+    ) as Mock;
   });
 
   it('should return fetch response correctly', async () => {

--- a/src/network/neynar/postDataToNeynar.test.ts
+++ b/src/network/neynar/postDataToNeynar.test.ts
@@ -1,3 +1,4 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { version } from '../../version';
 import { NEYNAR_DEFAULT_API_KEY } from './neynarFrameValidation';
 import { postDataToNeynar } from './postDataToNeynar';
@@ -13,7 +14,7 @@ describe('postDataToNeynar', () => {
         status,
         json: fetchMock,
       }),
-    ) as vi.Mock;
+    ) as Mock;
   });
 
   it('should call fetch correctly', async () => {

--- a/src/swap/components/SwapAmountInput.test.tsx
+++ b/src/swap/components/SwapAmountInput.test.tsx
@@ -1,6 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type Mock,
+  type MockedFunction,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import type { Token } from '../../token';
 import { DAI_TOKEN, ETH_TOKEN, USDC_TOKEN } from '../mocks';
 import type { SwapContextType } from '../types';
@@ -211,7 +219,7 @@ describe('SwapAmountInput', () => {
   });
 
   it('should correctly select a token from the dropdown using mouse and keyboard', () => {
-    const useSwapContextMock = useSwapContext as vi.MockedFunction<
+    const useSwapContextMock = useSwapContext as MockedFunction<
       typeof useSwapContext
     >;
     useSwapContextMock.mockReturnValue(mockContextValue);

--- a/src/swap/components/SwapAmountInput.test.tsx
+++ b/src/swap/components/SwapAmountInput.test.tsx
@@ -64,6 +64,14 @@ const mockContextValue = {
   handleToggle: vi.fn(),
   handleSubmit: vi.fn(),
   handleAmountChange: vi.fn(),
+  lifeCycleStatus: {
+    statusName: 'init',
+    statusData: {
+      isMissingRequiredField: false,
+    },
+  },
+  isTransactionPending: false,
+  setLifeCycleStatus: vi.fn(),
 } as SwapContextType;
 
 const mockSwappableTokens: Token[] = [ETH_TOKEN, USDC_TOKEN, DAI_TOKEN];

--- a/src/swap/components/SwapMessage.test.tsx
+++ b/src/swap/components/SwapMessage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getSwapMessage } from '../utils/getSwapMessage';
 import { SwapMessage } from './SwapMessage';
 import { useSwapContext } from './SwapProvider';
@@ -13,10 +13,10 @@ vi.mock('../utils/getSwapMessage', () => ({
   getSwapMessage: vi.fn(),
 }));
 
-const useSwapContextMock = useSwapContext as vi.Mock;
+const useSwapContextMock = useSwapContext as Mock;
 
 describe('SwapMessage', () => {
-  const mockGetSwapMessage = getSwapMessage as vi.Mock;
+  const mockGetSwapMessage = getSwapMessage as Mock;
 
   beforeEach(() => {
     mockGetSwapMessage.mockClear();

--- a/src/swap/hooks/useFromTo.test.ts
+++ b/src/swap/hooks/useFromTo.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useValue } from '../../internal/hooks/useValue';
 import { USDC_TOKEN } from '../mocks';
 import { useFromTo } from './useFromTo';
@@ -19,7 +19,7 @@ describe('useFromTo', () => {
   });
 
   it('should return correct values', () => {
-    (useSwapBalances as vi.Mock).mockReturnValue({
+    (useSwapBalances as Mock).mockReturnValue({
       fromBalanceString: '100',
       fromTokenBalanceError: null,
       fromTokenResponse: { refetch: vi.fn() },
@@ -27,7 +27,7 @@ describe('useFromTo', () => {
       toTokenBalanceError: null,
       toTokenResponse: { refetch: vi.fn() },
     });
-    (useValue as vi.Mock).mockImplementation((props) => ({
+    (useValue as Mock).mockImplementation((props) => ({
       ...props,
       amount: '100',
       response: props.response,
@@ -64,11 +64,11 @@ describe('useFromTo', () => {
   it('should call fromTokenResponse.refetch when from.response.refetch is called', async () => {
     const mockFromRefetch = vi.fn().mockResolvedValue(undefined);
     const mockToRefetch = vi.fn().mockResolvedValue(undefined);
-    (useSwapBalances as vi.Mock).mockReturnValue({
+    (useSwapBalances as Mock).mockReturnValue({
       fromTokenResponse: { refetch: mockFromRefetch },
       toTokenResponse: { refetch: mockToRefetch },
     });
-    (useValue as vi.Mock).mockImplementation((props) => ({
+    (useValue as Mock).mockImplementation((props) => ({
       ...props,
       response: props.response,
     }));
@@ -83,11 +83,11 @@ describe('useFromTo', () => {
   it('should call toTokenResponse.refetch when to.response.refetch is called', async () => {
     const mockFromRefetch = vi.fn().mockResolvedValue(undefined);
     const mockToRefetch = vi.fn().mockResolvedValue(undefined);
-    (useSwapBalances as vi.Mock).mockReturnValue({
+    (useSwapBalances as Mock).mockReturnValue({
       fromTokenResponse: { refetch: mockFromRefetch },
       toTokenResponse: { refetch: mockToRefetch },
     });
-    (useValue as vi.Mock).mockImplementation((props) => ({
+    (useValue as Mock).mockImplementation((props) => ({
       ...props,
       response: props.response,
     }));

--- a/src/transaction/components/TransactionButton.test.tsx
+++ b/src/transaction/components/TransactionButton.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccount, useChainId } from 'wagmi';
 import { useShowCallsStatus } from 'wagmi/experimental';
 import { getChainExplorer } from '../../network/getChainExplorer';
@@ -25,15 +25,15 @@ vi.mock('../../network/getChainExplorer', () => ({
 
 describe('TransactionButton', () => {
   beforeEach(() => {
-    (useChainId as vi.Mock).mockReturnValue(123);
-    (useAccount as vi.Mock).mockReturnValue({ address: '123' });
-    (useShowCallsStatus as vi.Mock).mockReturnValue({
+    (useChainId as Mock).mockReturnValue(123);
+    (useAccount as Mock).mockReturnValue({ address: '123' });
+    (useShowCallsStatus as Mock).mockReturnValue({
       showCallsStatus: vi.fn(),
     });
   });
 
   it('renders correctly', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       lifeCycleStatus: { statusName: 'init', statusData: null },
     });
@@ -43,7 +43,7 @@ describe('TransactionButton', () => {
   });
 
   it('renders spinner correctly', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       isLoading: true,
     });
@@ -53,7 +53,7 @@ describe('TransactionButton', () => {
   });
 
   it('renders view txn text when receipt exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
       lifeCycleStatus: { statusName: 'init', statusData: null },
       receipt: '123',
@@ -64,7 +64,7 @@ describe('TransactionButton', () => {
   });
 
   it('renders try again when error exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
       lifeCycleStatus: { statusName: 'init', statusData: null },
       errorMessage: '123',
@@ -83,7 +83,7 @@ describe('TransactionButton', () => {
   });
 
   it('should have disabled attribute when txn is in progress', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
       lifeCycleStatus: { statusName: 'init', statusData: null },
     });
@@ -93,7 +93,7 @@ describe('TransactionButton', () => {
   });
 
   it('should have disabled when contracts are missing', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       contracts: undefined,
       lifeCycleStatus: { statusName: 'init', statusData: null },
     });
@@ -104,8 +104,8 @@ describe('TransactionButton', () => {
 
   it('should call showCallsStatus when receipt and transactionId exist', () => {
     const showCallsStatus = vi.fn();
-    (useShowCallsStatus as vi.Mock).mockReturnValue({ showCallsStatus });
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useShowCallsStatus as Mock).mockReturnValue({ showCallsStatus });
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       receipt: '123',
       transactionId: '456',
@@ -117,7 +117,7 @@ describe('TransactionButton', () => {
   });
 
   it('should enable button when not in progress, not missing props, and not waiting for receipt', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       contracts: {},
       isLoading: false,
       lifeCycleStatus: { statusName: 'init', statusData: null },
@@ -133,14 +133,14 @@ describe('TransactionButton', () => {
   it('should open transaction link when only receipt exists', () => {
     const onSubmit = vi.fn();
     const chainExplorerUrl = 'https://explorer.com';
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       receipt: 'receipt-123',
       transactionId: undefined,
       transactionHash: 'hash-789',
       onSubmit,
     });
-    (getChainExplorer as vi.Mock).mockReturnValue(chainExplorerUrl);
+    (getChainExplorer as Mock).mockReturnValue(chainExplorerUrl);
     window.open = vi.fn();
     render(<TransactionButton text="Transact" />);
     const button = screen.getByText('View transaction');
@@ -155,7 +155,7 @@ describe('TransactionButton', () => {
 
   it('should call onSubmit when neither receipt nor transactionId exists', () => {
     const onSubmit = vi.fn();
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       address: '123',
       contracts: [{}],
       lifeCycleStatus: { statusName: 'init', statusData: null },

--- a/src/transaction/components/TransactionSponsor.test.tsx
+++ b/src/transaction/components/TransactionSponsor.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useTransactionContext } from './TransactionProvider';
 import { TransactionSponsor } from './TransactionSponsor';
 
@@ -9,7 +9,7 @@ vi.mock('./TransactionProvider', () => ({
 
 describe('TransactionSponsor', () => {
   it('should render correctly', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       paymasterUrl: 'paymasterUrl',
     });
@@ -19,7 +19,7 @@ describe('TransactionSponsor', () => {
   });
 
   it('should not render if paymasterUrl is null', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       paymasterUrl: null,
     });
@@ -28,7 +28,7 @@ describe('TransactionSponsor', () => {
   });
 
   it('should not render if statusName is not init', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'blah', statusData: null },
       paymasterUrl: null,
     });
@@ -37,7 +37,7 @@ describe('TransactionSponsor', () => {
   });
 
   it('should render if statusName is init', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       paymasterUrl: 'paymasterUrl',
     });

--- a/src/transaction/components/TransactionStatusAction.test.tsx
+++ b/src/transaction/components/TransactionStatusAction.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useGetTransactionStatusAction } from '../hooks/useGetTransactionStatusAction';
 import { TransactionStatusAction } from './TransactionStatusAction';
 
@@ -9,7 +9,7 @@ vi.mock('../hooks/useGetTransactionStatusAction', () => ({
 
 describe('TransactionStatusAction', () => {
   it('renders transaction status action', () => {
-    (useGetTransactionStatusAction as vi.Mock).mockReturnValue({
+    (useGetTransactionStatusAction as Mock).mockReturnValue({
       actionElement: <button type="button">Try again</button>,
     });
 

--- a/src/transaction/components/TransactionStatusLabel.test.tsx
+++ b/src/transaction/components/TransactionStatusLabel.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useGetTransactionStatusLabel } from '../hooks/useGetTransactionStatusLabel';
 import { TransactionStatusLabel } from './TransactionStatusLabel';
 
@@ -9,7 +9,7 @@ vi.mock('../hooks/useGetTransactionStatusLabel', () => ({
 
 describe('TransactionStatusLabel', () => {
   it('renders transaction status label', () => {
-    (useGetTransactionStatusLabel as vi.Mock).mockReturnValue({
+    (useGetTransactionStatusLabel as Mock).mockReturnValue({
       label: 'Successful!',
       labelClassName: 'text-ock-foreground-muted',
     });

--- a/src/transaction/components/TransactionToast.test.tsx
+++ b/src/transaction/components/TransactionToast.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useTransactionContext } from './TransactionProvider';
 import { TransactionToast } from './TransactionToast';
 
@@ -13,7 +13,7 @@ describe('TransactionToast', () => {
   });
 
   it('renders children correctly', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
       isToastVisible: true,
     });
@@ -29,7 +29,7 @@ describe('TransactionToast', () => {
   });
 
   it('does not render when not visible', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: '',
       isLoading: false,
       isToastVisible: false,
@@ -45,7 +45,7 @@ describe('TransactionToast', () => {
 
   it('closes when the close button is clicked', () => {
     const setIsToastVisible = vi.fn();
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: '',
       isLoading: false,
       isToastVisible: true,
@@ -62,7 +62,7 @@ describe('TransactionToast', () => {
   });
 
   it('displays loading state correctly', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
       isToastVisible: true,
       transactionHash: '',
@@ -76,7 +76,7 @@ describe('TransactionToast', () => {
 
   it('displays transaction hash when available', () => {
     const mockTransactionHash = '0x123';
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: mockTransactionHash,
@@ -90,7 +90,7 @@ describe('TransactionToast', () => {
 
   it('displays error message when present', () => {
     const mockErrorMessage = 'Transaction failed';
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '',
@@ -103,7 +103,7 @@ describe('TransactionToast', () => {
   });
 
   it('does not render when in progress', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '',
@@ -118,7 +118,7 @@ describe('TransactionToast', () => {
   });
 
   it('applies correct position class for bottom-right', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '0x123',
@@ -136,7 +136,7 @@ describe('TransactionToast', () => {
   });
 
   it('applies correct position class for top-right', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '0x123',
@@ -154,7 +154,7 @@ describe('TransactionToast', () => {
   });
 
   it('applies correct position class for top-center', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '0x123',
@@ -172,7 +172,7 @@ describe('TransactionToast', () => {
   });
 
   it('applies default position class when not specified', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '0x123',
@@ -190,7 +190,7 @@ describe('TransactionToast', () => {
   it('hides toast after specified duration when receipt is available', () => {
     vi.useFakeTimers();
     const setIsToastVisible = vi.fn();
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '',
@@ -209,7 +209,7 @@ describe('TransactionToast', () => {
   it('hides toast after specified duration when error message is present', () => {
     vi.useFakeTimers();
     const setIsToastVisible = vi.fn();
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '',

--- a/src/transaction/components/TransactionToastAction.test.tsx
+++ b/src/transaction/components/TransactionToastAction.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useGetTransactionToastAction } from '../hooks/useGetTransactionToastAction';
 import { TransactionToastAction } from './TransactionToastAction';
 
@@ -9,7 +9,7 @@ vi.mock('../hooks/useGetTransactionToastAction', () => ({
 
 describe('TransactionToastAction', () => {
   it('renders transaction status action', () => {
-    (useGetTransactionToastAction as vi.Mock).mockReturnValue({
+    (useGetTransactionToastAction as Mock).mockReturnValue({
       actionElement: <button type="button">Try again</button>,
     });
 

--- a/src/transaction/components/TransactionToastIcon.test.tsx
+++ b/src/transaction/components/TransactionToastIcon.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useTransactionContext } from '../components/TransactionProvider';
 import { TransactionToastIcon } from './TransactionToastIcon';
 
@@ -9,7 +9,7 @@ vi.mock('../components/TransactionProvider', () => ({
 
 describe('TransactionToastIcon', () => {
   it('renders success icon when receipt exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       receipt: '123',
     });
 
@@ -19,7 +19,7 @@ describe('TransactionToastIcon', () => {
     expect(iconElement).toBeInTheDocument();
   });
   it('renders error icon when error exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: 'error',
     });
 
@@ -29,7 +29,7 @@ describe('TransactionToastIcon', () => {
     expect(iconElement).toBeInTheDocument();
   });
   it('renders loading icon when txn is in progress', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
     });
 
@@ -39,7 +39,7 @@ describe('TransactionToastIcon', () => {
     expect(iconElement).toBeInTheDocument();
   });
   it('renders null when if no status exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
     });
 

--- a/src/transaction/components/TransactionToastLabel.test.tsx
+++ b/src/transaction/components/TransactionToastLabel.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useGetTransactionToastLabel } from '../hooks/useGetTransactionToastLabel';
 import { TransactionToastLabel } from './TransactionToastLabel';
 
@@ -9,7 +9,7 @@ vi.mock('../hooks/useGetTransactionToastLabel', () => ({
 
 describe('TransactionToastLabel', () => {
   it('renders transaction status action', () => {
-    (useGetTransactionToastLabel as vi.Mock).mockReturnValue({
+    (useGetTransactionToastLabel as Mock).mockReturnValue({
       label: 'Successful',
     });
 

--- a/src/transaction/hooks/useGetTransactionStatusAction.test.tsx
+++ b/src/transaction/hooks/useGetTransactionStatusAction.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChainId } from 'wagmi';
 import { useShowCallsStatus } from 'wagmi/experimental';
 import { getChainExplorer } from '../../network/getChainExplorer';
@@ -26,15 +26,15 @@ const mockGetChainExplorer = 'https://etherscan.io';
 
 describe('useGetTransactionStatusAction', () => {
   beforeEach(() => {
-    (useChainId as vi.Mock).mockReturnValue(123);
-    (useShowCallsStatus as vi.Mock).mockReturnValue({
+    (useChainId as Mock).mockReturnValue(123);
+    (useShowCallsStatus as Mock).mockReturnValue({
       showCallsStatus: vi.fn(),
     });
-    (getChainExplorer as vi.Mock).mockReturnValue(mockGetChainExplorer);
+    (getChainExplorer as Mock).mockReturnValue(mockGetChainExplorer);
   });
 
   it('should return actionElement when transaction hash exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       transactionHash: '0x123',
     });
 
@@ -56,13 +56,13 @@ describe('useGetTransactionStatusAction', () => {
   });
 
   it('should return actionElement when transaction id exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       transactionId: 'ab123',
       onSubmit: vi.fn(),
     });
 
     const showCallsStatus = vi.fn();
-    (useShowCallsStatus as vi.Mock).mockReturnValue({ showCallsStatus });
+    (useShowCallsStatus as Mock).mockReturnValue({ showCallsStatus });
 
     const { result } = renderHook(() => useGetTransactionStatusAction());
 
@@ -72,7 +72,7 @@ describe('useGetTransactionStatusAction', () => {
   });
 
   it('should return null when receipt exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       receipt: 'receipt',
       transactionHash: '123',
     });
@@ -83,7 +83,7 @@ describe('useGetTransactionStatusAction', () => {
   });
 
   it('should return actionElement when error occurs', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: 'error',
     });
 
@@ -93,7 +93,7 @@ describe('useGetTransactionStatusAction', () => {
   });
 
   it('should return actionElement when no status available', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: '',
     });
 
@@ -104,8 +104,8 @@ describe('useGetTransactionStatusAction', () => {
 
   it('should call showCallsStatus when button is clicked', () => {
     const showCallsStatus = vi.fn();
-    (useShowCallsStatus as vi.Mock).mockReturnValue({ showCallsStatus });
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useShowCallsStatus as Mock).mockReturnValue({ showCallsStatus });
+    (useTransactionContext as Mock).mockReturnValue({
       transactionId: 'ab123',
     });
 

--- a/src/transaction/hooks/useGetTransactionStatusLabel.test.tsx
+++ b/src/transaction/hooks/useGetTransactionStatusLabel.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChainId } from 'wagmi';
 import { useShowCallsStatus } from 'wagmi/experimental';
 import { getChainExplorer } from '../../network/getChainExplorer';
@@ -25,15 +25,15 @@ vi.mock('../../network/getChainExplorer', () => ({
 const mockGetChainExplorer = 'https://etherscan.io';
 describe('useGetTransactionStatusLabel', () => {
   beforeEach(() => {
-    (useChainId as vi.Mock).mockReturnValue(123);
-    (useShowCallsStatus as vi.Mock).mockReturnValue({
+    (useChainId as Mock).mockReturnValue(123);
+    (useShowCallsStatus as Mock).mockReturnValue({
       showCallsStatus: vi.fn(),
     });
-    (getChainExplorer as vi.Mock).mockReturnValue(mockGetChainExplorer);
+    (getChainExplorer as Mock).mockReturnValue(mockGetChainExplorer);
   });
 
   it('should return correct status when transaction is pending', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'transactionPending', statusData: null },
     });
     const { result } = renderHook(() => useGetTransactionStatusLabel());
@@ -41,7 +41,7 @@ describe('useGetTransactionStatusLabel', () => {
   });
 
   it('should return status when transaction hash exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       transactionHash: '0x123',
     });
@@ -50,19 +50,19 @@ describe('useGetTransactionStatusLabel', () => {
   });
 
   it('should return status when transaction id exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       transactionId: 'ab123',
       onSubmit: vi.fn(),
     });
     const showCallsStatus = vi.fn();
-    (useShowCallsStatus as vi.Mock).mockReturnValue({ showCallsStatus });
+    (useShowCallsStatus as Mock).mockReturnValue({ showCallsStatus });
     const { result } = renderHook(() => useGetTransactionStatusLabel());
     expect(result.current.label).toBe('Transaction in progress...');
   });
 
   it('should return status when receipt exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       receipt: 'receipt',
       transactionHash: '123',
@@ -72,7 +72,7 @@ describe('useGetTransactionStatusLabel', () => {
   });
 
   it('should return status when error occurs', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       errorMessage: 'error',
     });
@@ -81,7 +81,7 @@ describe('useGetTransactionStatusLabel', () => {
   });
 
   it('should return status when no status available', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       lifeCycleStatus: { statusName: 'init', statusData: null },
       errorMessage: '',
     });

--- a/src/transaction/hooks/useGetTransactionToastAction.test.tsx
+++ b/src/transaction/hooks/useGetTransactionToastAction.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChainId } from 'wagmi';
 import { useShowCallsStatus } from 'wagmi/experimental';
 import { getChainExplorer } from '../../network/getChainExplorer';
@@ -26,15 +26,15 @@ const mockGetChainExplorer = 'https://etherscan.io';
 
 describe('useGetTransactionToastAction', () => {
   beforeEach(() => {
-    (useChainId as vi.Mock).mockReturnValue(123);
-    (useShowCallsStatus as vi.Mock).mockReturnValue({
+    (useChainId as Mock).mockReturnValue(123);
+    (useShowCallsStatus as Mock).mockReturnValue({
       showCallsStatus: vi.fn(),
     });
-    (getChainExplorer as vi.Mock).mockReturnValue(mockGetChainExplorer);
+    (getChainExplorer as Mock).mockReturnValue(mockGetChainExplorer);
   });
 
   it('should return actionElement when transaction hash exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       transactionHash: '0x123',
     });
 
@@ -56,13 +56,13 @@ describe('useGetTransactionToastAction', () => {
   });
 
   it('should return actionElement when transaction id exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       transactionId: 'ab123',
       onSubmit: vi.fn(),
     });
 
     const showCallsStatus = vi.fn();
-    (useShowCallsStatus as vi.Mock).mockReturnValue({ showCallsStatus });
+    (useShowCallsStatus as Mock).mockReturnValue({ showCallsStatus });
 
     const { result } = renderHook(() => useGetTransactionToastAction());
 
@@ -72,7 +72,7 @@ describe('useGetTransactionToastAction', () => {
   });
 
   it('should return actionElement when receipt exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       receipt: 'receipt',
       transactionHash: '0x123',
     });
@@ -96,7 +96,7 @@ describe('useGetTransactionToastAction', () => {
 
   it('should return actionElement when error occurs', () => {
     const onSubmitMock = vi.fn();
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: 'error',
       onSubmit: onSubmitMock,
     });
@@ -108,7 +108,7 @@ describe('useGetTransactionToastAction', () => {
   });
 
   it('should return actionElement when no status available', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: '',
     });
 
@@ -119,11 +119,11 @@ describe('useGetTransactionToastAction', () => {
 
   it('should prioritize transactionId over transactionHash when both are provided', () => {
     const showCallsStatus = vi.fn();
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       transactionHash: '0x123',
       transactionId: 'ab123',
     });
-    (useShowCallsStatus as vi.Mock).mockReturnValue({ showCallsStatus });
+    (useShowCallsStatus as Mock).mockReturnValue({ showCallsStatus });
 
     const { result } = renderHook(() => useGetTransactionToastAction());
 
@@ -133,7 +133,7 @@ describe('useGetTransactionToastAction', () => {
   });
 
   it('should use accountChainId from useChainId when chainId is not available in context', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       chainId: undefined,
       transactionHash: '0x123',
     });
@@ -157,8 +157,8 @@ describe('useGetTransactionToastAction', () => {
 
   it('should call showCallsStatus when button is clicked', () => {
     const showCallsStatus = vi.fn();
-    (useShowCallsStatus as vi.Mock).mockReturnValue({ showCallsStatus });
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useShowCallsStatus as Mock).mockReturnValue({ showCallsStatus });
+    (useTransactionContext as Mock).mockReturnValue({
       transactionId: 'ab123',
     });
 

--- a/src/transaction/hooks/useGetTransactionToastLabel.test.tsx
+++ b/src/transaction/hooks/useGetTransactionToastLabel.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChainId } from 'wagmi';
 import { useShowCallsStatus } from 'wagmi/experimental';
 import { getChainExplorer } from '../../network/getChainExplorer';
@@ -26,14 +26,14 @@ const mockGetChainExplorer = 'https://etherscan.io';
 
 describe('useGetTransactionToastLabel', () => {
   beforeEach(() => {
-    (useChainId as vi.Mock).mockReturnValue(123);
-    (useShowCallsStatus as vi.Mock).mockReturnValue({
+    (useChainId as Mock).mockReturnValue(123);
+    (useShowCallsStatus as Mock).mockReturnValue({
       showCallsStatus: vi.fn(),
     });
-    (getChainExplorer as vi.Mock).mockReturnValue(mockGetChainExplorer);
+    (getChainExplorer as Mock).mockReturnValue(mockGetChainExplorer);
   });
   it('should return correct toast and actionElement when transaction is loading', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
     });
 
@@ -43,7 +43,7 @@ describe('useGetTransactionToastLabel', () => {
   });
 
   it('should return status when transaction hash exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       transactionHash: '0x123',
     });
 
@@ -53,13 +53,13 @@ describe('useGetTransactionToastLabel', () => {
   });
 
   it('should return status when transaction id exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       transactionId: 'ab123',
       onSubmit: vi.fn(),
     });
 
     const showCallsStatus = vi.fn();
-    (useShowCallsStatus as vi.Mock).mockReturnValue({ showCallsStatus });
+    (useShowCallsStatus as Mock).mockReturnValue({ showCallsStatus });
 
     const { result } = renderHook(() => useGetTransactionToastLabel());
 
@@ -67,7 +67,7 @@ describe('useGetTransactionToastLabel', () => {
   });
 
   it('should return status when receipt exists', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       receipt: 'receipt',
       transactionHash: '0x123',
     });
@@ -79,7 +79,7 @@ describe('useGetTransactionToastLabel', () => {
 
   it('should return status when error occurs', () => {
     const onSubmitMock = vi.fn();
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: 'error',
       onSubmit: onSubmitMock,
     });
@@ -90,7 +90,7 @@ describe('useGetTransactionToastLabel', () => {
   });
 
   it('should return status when no status available', () => {
-    (useTransactionContext as vi.Mock).mockReturnValue({
+    (useTransactionContext as Mock).mockReturnValue({
       errorMessage: '',
     });
 

--- a/src/transaction/hooks/useSendCall.test.ts
+++ b/src/transaction/hooks/useSendCall.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSendTransaction as useSendCallWagmi } from 'wagmi';
 import { GENERIC_ERROR_MESSAGE } from '../constants';
 import { isUserRejectedRequestError } from '../utils/isUserRejectedRequestError';
@@ -96,7 +96,7 @@ describe('useSendCall', () => {
         } as MockUseSendCallReturn;
       },
     );
-    (isUserRejectedRequestError as vi.Mock).mockReturnValue(true);
+    (isUserRejectedRequestError as Mock).mockReturnValue(true);
     renderHook(() =>
       useSendCall({
         setLifeCycleStatus: mockSetLifeCycleStatus,

--- a/src/transaction/hooks/useSendCalls.test.ts
+++ b/src/transaction/hooks/useSendCalls.test.ts
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import type { TransactionExecutionError } from 'viem';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSendCalls as useSendCallsWagmi } from 'wagmi/experimental';
 import { GENERIC_ERROR_MESSAGE } from '../constants';
 import { isUserRejectedRequestError } from '../utils/isUserRejectedRequestError';
@@ -64,7 +64,7 @@ describe('useSendCalls', () => {
         };
       },
     );
-    (isUserRejectedRequestError as vi.Mock).mockReturnValue(false);
+    (isUserRejectedRequestError as Mock).mockReturnValue(false);
     renderHook(() =>
       useSendCalls({
         setLifeCycleStatus: mockSetLifeCycleStatus,
@@ -98,7 +98,7 @@ describe('useSendCalls', () => {
         };
       },
     );
-    (isUserRejectedRequestError as vi.Mock).mockReturnValue(true);
+    (isUserRejectedRequestError as Mock).mockReturnValue(true);
     renderHook(() =>
       useSendCalls({
         setLifeCycleStatus: mockSetLifeCycleStatus,

--- a/src/transaction/hooks/useWriteContract.test.ts
+++ b/src/transaction/hooks/useWriteContract.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useWriteContract as useWriteContractWagmi } from 'wagmi';
 import { isUserRejectedRequestError } from '../utils/isUserRejectedRequestError';
 import { useWriteContract } from './useWriteContract';
@@ -95,7 +95,7 @@ describe('useWriteContract', () => {
         } as MockUseWriteContractReturn;
       },
     );
-    (isUserRejectedRequestError as vi.Mock).mockReturnValue(true);
+    (isUserRejectedRequestError as Mock).mockReturnValue(true);
     renderHook(() =>
       useWriteContract({
         setLifeCycleStatus: mockSetLifeCycleStatus,

--- a/src/wallet/components/WalletBottomSheet.test.tsx
+++ b/src/wallet/components/WalletBottomSheet.test.tsx
@@ -6,6 +6,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { Identity } from '../../identity/components/Identity';
 import {
@@ -29,8 +30,8 @@ vi.mock('../../identity/components/Identity', () => ({
   )),
 }));
 
-const useWalletContextMock = useWalletContext as vi.Mock;
-const useAccountMock = useAccount as vi.Mock;
+const useWalletContextMock = useWalletContext as Mock;
+const useAccountMock = useAccount as Mock;
 
 describe('WalletBottomSheet', () => {
   it('renders null when address is not provided', () => {

--- a/src/wallet/components/WalletDropdown.test.tsx
+++ b/src/wallet/components/WalletDropdown.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import { type Mock, beforeEach, describe, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { Identity } from '../../identity/components/Identity';
 import {
@@ -28,10 +29,10 @@ vi.mock('../../identity/components/Identity', () => ({
   )),
 }));
 
-const useWalletContextMock = useWalletContext as vi.Mock;
+const useWalletContextMock = useWalletContext as Mock;
 
-const useAccountMock = useAccount as vi.Mock;
-const useBreakpointsMock = useBreakpoints as vi.Mock;
+const useAccountMock = useAccount as Mock;
+const useBreakpointsMock = useBreakpoints as Mock;
 
 describe('WalletDropdown', () => {
   beforeEach(() => {

--- a/src/wallet/components/WalletDropdown.test.tsx
+++ b/src/wallet/components/WalletDropdown.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
-import { type Mock, beforeEach, describe, it, vi } from 'vitest';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { Identity } from '../../identity/components/Identity';
 import {

--- a/src/wallet/components/WalletDropdownBasename.test.tsx
+++ b/src/wallet/components/WalletDropdownBasename.test.tsx
@@ -2,7 +2,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import type { GetAccountReturnType } from '@wagmi/core';
 import { base } from 'viem/chains';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { useName } from '../../identity/hooks/useName';
 import { WalletDropdownBasename } from './WalletDropdownBasename';
@@ -22,15 +22,15 @@ vi.mock('./WalletProvider', () => ({
 
 describe('WalletDropdownBasename', () => {
   it('should render "Claim Basename" when no basename', () => {
-    (useAccount as vi.Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+    (useAccount as Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
       address: '0x1234' as `0x${string}`,
       isConnected: true,
     });
-    (useWalletContext as vi.Mock).mockReturnValue({
+    (useWalletContext as Mock).mockReturnValue({
       chain: base,
     });
     (
-      useName as vi.Mock<[], Partial<UseQueryResult<string | null, Error>>>
+      useName as Mock<[], Partial<UseQueryResult<string | null, Error>>>
     ).mockReturnValue({
       data: null,
       isLoading: false,
@@ -44,15 +44,15 @@ describe('WalletDropdownBasename', () => {
   });
 
   it('should render "Profile" when basename exists', () => {
-    (useAccount as vi.Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+    (useAccount as Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
       address: '0x1234' as `0x${string}`,
       isConnected: true,
     });
-    (useWalletContext as vi.Mock).mockReturnValue({
+    (useWalletContext as Mock).mockReturnValue({
       chain: base,
     });
     (
-      useName as vi.Mock<[], Partial<UseQueryResult<string | null, Error>>>
+      useName as Mock<[], Partial<UseQueryResult<string | null, Error>>>
     ).mockReturnValue({
       data: 'test.base',
       isLoading: false,
@@ -66,15 +66,15 @@ describe('WalletDropdownBasename', () => {
   });
 
   it('should render Spinner when loading', () => {
-    (useAccount as vi.Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+    (useAccount as Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
       address: '0x1234' as `0x${string}`,
       isConnected: true,
     });
-    (useWalletContext as vi.Mock).mockReturnValue({
+    (useWalletContext as Mock).mockReturnValue({
       chain: base,
     });
     (
-      useName as vi.Mock<[], Partial<UseQueryResult<string | null, Error>>>
+      useName as Mock<[], Partial<UseQueryResult<string | null, Error>>>
     ).mockReturnValue({
       data: null,
       isLoading: true,
@@ -90,11 +90,11 @@ describe('WalletDropdownBasename', () => {
   });
 
   it('should return null if there is no address', () => {
-    (useAccount as vi.Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+    (useAccount as Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
       address: undefined,
       isConnected: false,
     });
-    (useWalletContext as vi.Mock).mockReturnValue({
+    (useWalletContext as Mock).mockReturnValue({
       chain: base,
     });
 

--- a/src/wallet/components/WalletDropdownBasename.test.tsx
+++ b/src/wallet/components/WalletDropdownBasename.test.tsx
@@ -22,7 +22,7 @@ vi.mock('./WalletProvider', () => ({
 
 describe('WalletDropdownBasename', () => {
   it('should render "Claim Basename" when no basename', () => {
-    (useAccount as Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+    (useAccount as Mock<() => Partial<GetAccountReturnType>>).mockReturnValue({
       address: '0x1234' as `0x${string}`,
       isConnected: true,
     });
@@ -30,7 +30,7 @@ describe('WalletDropdownBasename', () => {
       chain: base,
     });
     (
-      useName as Mock<[], Partial<UseQueryResult<string | null, Error>>>
+      useName as Mock<() => Partial<UseQueryResult<string | null, Error>>>
     ).mockReturnValue({
       data: null,
       isLoading: false,
@@ -44,7 +44,7 @@ describe('WalletDropdownBasename', () => {
   });
 
   it('should render "Profile" when basename exists', () => {
-    (useAccount as Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+    (useAccount as Mock<() => Partial<GetAccountReturnType>>).mockReturnValue({
       address: '0x1234' as `0x${string}`,
       isConnected: true,
     });
@@ -52,7 +52,7 @@ describe('WalletDropdownBasename', () => {
       chain: base,
     });
     (
-      useName as Mock<[], Partial<UseQueryResult<string | null, Error>>>
+      useName as Mock<() => Partial<UseQueryResult<string | null, Error>>>
     ).mockReturnValue({
       data: 'test.base',
       isLoading: false,
@@ -66,7 +66,7 @@ describe('WalletDropdownBasename', () => {
   });
 
   it('should render Spinner when loading', () => {
-    (useAccount as Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+    (useAccount as Mock<() => Partial<GetAccountReturnType>>).mockReturnValue({
       address: '0x1234' as `0x${string}`,
       isConnected: true,
     });
@@ -74,9 +74,9 @@ describe('WalletDropdownBasename', () => {
       chain: base,
     });
     (
-      useName as Mock<[], Partial<UseQueryResult<string | null, Error>>>
+      useName as Mock<() => Partial<UseQueryResult<string | null, Error>>>
     ).mockReturnValue({
-      data: null,
+      data: undefined,
       isLoading: true,
       isError: false,
       error: null,
@@ -90,7 +90,7 @@ describe('WalletDropdownBasename', () => {
   });
 
   it('should return null if there is no address', () => {
-    (useAccount as Mock<[], Partial<GetAccountReturnType>>).mockReturnValue({
+    (useAccount as Mock<() => Partial<GetAccountReturnType>>).mockReturnValue({
       address: undefined,
       isConnected: false,
     });

--- a/src/wallet/utils/isWalletACoinbaseSmartWallet.test.ts
+++ b/src/wallet/utils/isWalletACoinbaseSmartWallet.test.ts
@@ -1,5 +1,6 @@
 import type { UserOperation } from 'permissionless';
 import type { PublicClient } from 'viem';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import {
   CB_SW_PROXY_BYTECODE,
   CB_SW_V1_IMPLEMENTATION_ADDRESS,
@@ -17,7 +18,7 @@ describe('isWalletACoinbaseSmartWallet', () => {
       initCode: 'other-factory',
     } as unknown as UserOperation<'v0.6'>;
 
-    (client.getBytecode as vi.Mock).mockReturnValue(undefined);
+    (client.getBytecode as Mock).mockReturnValue(undefined);
 
     const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
@@ -32,7 +33,7 @@ describe('isWalletACoinbaseSmartWallet', () => {
       initCode: '0x0BA5ED0c6AA8c49038F819E587E2633c4A9F428a1234',
     } as unknown as UserOperation<'v0.6'>;
 
-    (client.getBytecode as vi.Mock).mockReturnValue(undefined);
+    (client.getBytecode as Mock).mockReturnValue(undefined);
 
     const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
@@ -45,8 +46,8 @@ describe('isWalletACoinbaseSmartWallet', () => {
       sender: 'invalid-proxy-address',
     } as unknown as UserOperation<'v0.6'>;
 
-    (client.getBytecode as vi.Mock).mockReturnValue('invalid bytecode');
-    (client.request as vi.Mock).mockResolvedValue(
+    (client.getBytecode as Mock).mockReturnValue('invalid bytecode');
+    (client.request as Mock).mockResolvedValue(
       '0x0000000000000000000000000000000000000000000000000000000000000000',
     );
 
@@ -63,13 +64,11 @@ describe('isWalletACoinbaseSmartWallet', () => {
       sender: 'valid-proxy-address',
     } as unknown as UserOperation<'v0.6'>;
 
-    (client.getBytecode as vi.Mock).mockResolvedValue(CB_SW_PROXY_BYTECODE);
+    (client.getBytecode as Mock).mockResolvedValue(CB_SW_PROXY_BYTECODE);
     const differentImplementationAddress =
       '0x0000000000000000000000000000000000000000000000000000000000000001';
 
-    (client.request as vi.Mock).mockResolvedValue(
-      differentImplementationAddress,
-    );
+    (client.request as Mock).mockResolvedValue(differentImplementationAddress);
 
     const result = await isWalletACoinbaseSmartWallet({ client, userOp });
     expect(result).toEqual({
@@ -89,8 +88,8 @@ describe('isWalletACoinbaseSmartWallet', () => {
       sender: 'valid-proxy-address',
     } as unknown as UserOperation<'v0.6'>;
 
-    (client.getBytecode as vi.Mock).mockResolvedValue(CB_SW_PROXY_BYTECODE);
-    (client.request as vi.Mock).mockResolvedValue(
+    (client.getBytecode as Mock).mockResolvedValue(CB_SW_PROXY_BYTECODE);
+    (client.request as Mock).mockResolvedValue(
       `0x${CB_SW_V1_IMPLEMENTATION_ADDRESS.slice(2).padStart(64, '0')}`,
     );
 
@@ -103,10 +102,10 @@ describe('isWalletACoinbaseSmartWallet', () => {
       sender: 'error-address',
     } as unknown as UserOperation<'v0.6'>;
 
-    (client.getBytecode as vi.Mock).mockRejectedValue(
+    (client.getBytecode as Mock).mockRejectedValue(
       new Error('Failed to fetch bytecode'),
     );
-    (client.request as vi.Mock).mockResolvedValue(
+    (client.request as Mock).mockResolvedValue(
       '0x0000000000000000000000000000000000000000000000000000000000000000',
     );
 
@@ -123,8 +122,8 @@ describe('isWalletACoinbaseSmartWallet', () => {
       sender: 'valid-proxy-address',
     } as unknown as UserOperation<'v0.6'>;
 
-    (client.getBytecode as vi.Mock).mockResolvedValue(CB_SW_PROXY_BYTECODE);
-    (client.request as vi.Mock).mockRejectedValue(
+    (client.getBytecode as Mock).mockResolvedValue(CB_SW_PROXY_BYTECODE);
+    (client.request as Mock).mockRejectedValue(
       new Error('Failed to fetch implementation address'),
     );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "**/*.test.*", "**/*.stories.*"]
+  "exclude": ["node_modules", "**/*.stories.*"]
 }


### PR DESCRIPTION
My editor was showing type errors in many test files, these were fixable by adding the Mock import from vitest. There was also inconsistency across files whether vitest primitives were imported or not.

**What changed? Why?**
- Alter all test files to import vitest primitives, as well as the Mock/MockReturnFn types from the vitest package
- Enable typechecking of test files
- Fix a few instances of incorrect typings in files

**Notes to reviewers**
- Please pull this down and view in vscode (after restarting your editor). The intended experience is that there are no highlighted type errors
- Diff is large, but changes should only impact test files

**How has it been tested?**
- CI, running editor locally
