### PR TITLE
fix: Fund and Disconnect hover styling in mobile

### DIFF
--- a/.changeset/great-dolls-kiss.md
+++ b/.changeset/great-dolls-kiss.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+-**fix**: fixed hover styling for the Fund and Disconnect wallet components during the mobile view. By @cpcramer #1211

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -83,7 +83,7 @@ function SwapComponent() {
         </div>
       ) : null}
 
-      <Swap className="border bg-[#ffffff]" onStatus={handleOnStatus}>
+      <Swap className="border" onStatus={handleOnStatus}>
         <SwapAmountInput
           label="Sell"
           swappableTokens={swappableTokens}

--- a/src/wallet/components/WalletDropdownDisconnect.tsx
+++ b/src/wallet/components/WalletDropdownDisconnect.tsx
@@ -19,7 +19,7 @@ export function WalletDropdownDisconnect({
       type="button"
       className={cn(
         pressable.default,
-        'relative flex items-center px-4 pt-3 pb-4',
+        'relative flex w-full items-center px-4 pt-3 pb-4',
         className,
       )}
       onClick={handleDisconnect}

--- a/src/wallet/components/WalletDropdownFundLink.tsx
+++ b/src/wallet/components/WalletDropdownFundLink.tsx
@@ -46,7 +46,7 @@ export function WalletDropdownFundLink({
 
   const overrideClassName = cn(
     pressable.default,
-    'relative flex items-center px-4 py-3',
+    'relative flex items-center px-4 py-3 w-full',
     className,
   );
 


### PR DESCRIPTION
**What changed? Why?**

- fixed hover styling for the `Fund` and `Disconnect` wallet components during the mobile view
- fix playground dark mode styling for the `Swap` component

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>
<img width="138" alt="Screenshot 2024-09-04 at 2 25 12 PM" src="https://github.com/user-attachments/assets/40a41906-0eae-4720-9646-992fef7f7825">


</td>
    <td>
<img width="131" alt="Screenshot 2024-09-04 at 2 25 32 PM" src="https://github.com/user-attachments/assets/7262ab71-7919-4460-85b0-6dad90390c30">


   </td>
  </tr>
</table>

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="1270" alt="Screenshot 2024-09-04 at 2 26 42 PM" src="https://github.com/user-attachments/assets/3e3fb020-3d5e-4714-aa48-cc5a15276d2c">

</td>
    <td>
<img width="1494" alt="Screenshot 2024-09-04 at 2 23 58 PM" src="https://github.com/user-attachments/assets/134b0057-30a0-41e3-9d46-faa1a0437ab0">


   </td>
  </tr>
</table>

<img width="1223" alt="Screenshot 2024-09-04 at 2 24 06 PM" src="https://github.com/user-attachments/assets/24b1285d-4435-4479-aebc-510b0869bc06">

**Notes to reviewers**

**How has it been tested?**
