### PR TITLE
prompt for wallet connection in `TransactionButton`

### DIFF
--- a/.changeset/polite-starfishes-sniff.md
+++ b/.changeset/polite-starfishes-sniff.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+**feat**: added prompt for wallet connection in `TransactionButton`. by @0xAlec #1216

--- a/src/transaction/components/TransactionButton.tsx
+++ b/src/transaction/components/TransactionButton.tsx
@@ -83,6 +83,7 @@ export function TransactionButton({
     address,
     accountChainId,
     connectAsync,
+    connectors[0],
     onSubmit,
     receipt,
     showCallsStatus,


### PR DESCRIPTION
**What changed? Why?**
- do not disable `Transaction` if missing `address`
- instead, prompt the user to connect their wallet

**Notes to reviewers**

**How has it been tested?**
- playground
