### PR TITLE
fix: add space between swap input and select

### DIFF
--- a/.changeset/modern-walls-relax.md
+++ b/.changeset/modern-walls-relax.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+- **fix**: add spacing between swap input and token select. By @alessey #1229

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -80,7 +80,7 @@ export function SwapAmountInput({
       <div className="flex w-full items-center justify-between">
         <TextInput
           className={cn(
-            'w-full border-[none] bg-transparent font-display text-[2.5rem]',
+            'mr-2 w-full border-[none] bg-transparent font-display text-[2.5rem]',
             'leading-none outline-none',
             hasInsufficientBalance && address ? color.error : color.foreground,
           )}


### PR DESCRIPTION
**What changed? Why?**
Added space between swap input and select
| before | after |
| ----- | ---- |
| ![image](https://github.com/user-attachments/assets/8e16f13e-3e03-4ba5-b5af-a406d61334be) | ![image](https://github.com/user-attachments/assets/9469cb2d-df4b-485b-a3d0-a571c1acf2dd) |

**Notes to reviewers**

**How has it been tested?**
