### PR TITLE
chore: update wallet link to keys.coinbase.com

### DIFF
--- a/playground/nextjs-app-router/components/demo/Wallet.tsx
+++ b/playground/nextjs-app-router/components/demo/Wallet.tsx
@@ -39,7 +39,7 @@ function WalletComponent() {
           <WalletDropdownBasename />
           <WalletDropdownLink
             icon="wallet"
-            href="https://wallet.coinbase.com"
+            href="https://keys.coinbase.com"
             target="_blank"
           >
             Wallet

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -147,7 +147,7 @@ bun add @coinbase/onchainkit
       <Address />
       <EthBalance />
     </Identity>
-    <WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com">
+    <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com">
       Wallet
     </WalletDropdownLink>
     <WalletDropdownBasename />
@@ -172,7 +172,7 @@ bun add @coinbase/onchainkit
         <Address className={color.foregroundMuted} />
         <EthBalance />
       </Identity>
-      <WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com">
+      <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com">
         Wallet
       </WalletDropdownLink>
       <WalletDropdownBasename />

--- a/site/docs/pages/wallet/wallet-dropdown-link.mdx
+++ b/site/docs/pages/wallet/wallet-dropdown-link.mdx
@@ -55,7 +55,7 @@ export function WalletComponents() {
             <Address className={color.foregroundMuted} />
             <EthBalance />
           </Identity>
-          <WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com"> // [!code focus]
+          <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com"> // [!code focus]
             Wallet // [!code focus]
           </WalletDropdownLink> // [!code focus]
           <WalletDropdownDisconnect />
@@ -79,7 +79,7 @@ export function WalletComponents() {
         <Address className={color.foregroundMuted} />
         <EthBalance />
       </Identity>
-      <WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com">
+      <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com">
         Wallet
       </WalletDropdownLink>
       <WalletDropdownDisconnect />
@@ -132,7 +132,7 @@ This allows for diverse customizations, including complex layouts and conditiona
 
 ```tsx
 // omitted for brevity
-<WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com"> // [!code focus]
+<WalletDropdownLink icon="wallet" href="https://keys.coinbase.com"> // [!code focus]
   <span className="font-bold italic">Profile</span> // [!code focus]
   <span> 🔵 </span> // [!code focus]
 </WalletDropdownLink> // [!code focus]
@@ -151,7 +151,7 @@ This allows for diverse customizations, including complex layouts and conditiona
         <Address className={color.foregroundMuted} />
         <EthBalance />
       </Identity>
-      <WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com">
+      <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com">
         <span className="font-bold italic">Profile</span>
         <span> 🔵 </span>
       </WalletDropdownLink>
@@ -165,7 +165,7 @@ You can override component styles using className.
 
 ```tsx
 // omitted for brevity
-<WalletDropdownLink className="hover:bg-red-500" icon="wallet" href="https://wallet.coinbase.com" > // [!code focus]
+<WalletDropdownLink className="hover:bg-red-500" icon="wallet" href="https://keys.coinbase.com" > // [!code focus]
   Wallet // [!code focus]
 </WalletDropdownLink> // [!code focus]
 ```
@@ -183,7 +183,7 @@ You can override component styles using className.
         <Address className={color.foregroundMuted} />
         <EthBalance />
       </Identity>
-      <WalletDropdownLink className="hover:bg-red-500" icon="wallet" href="https://wallet.coinbase.com">
+      <WalletDropdownLink className="hover:bg-red-500" icon="wallet" href="https://keys.coinbase.com">
         Wallet
       </WalletDropdownLink>
       <WalletDropdownDisconnect />

--- a/site/docs/pages/wallet/wallet.mdx
+++ b/site/docs/pages/wallet/wallet.mdx
@@ -59,7 +59,7 @@ export function WalletComponents() {
             <Address className={color.foregroundMuted} />
             <EthBalance />
           </Identity>
-          <WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com"> // [!code focus]
+          <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com"> // [!code focus]
             Wallet // [!code focus]
           </WalletDropdownLink> // [!code focus]
           <WalletDropdownDisconnect /> // [!code focus]
@@ -83,7 +83,7 @@ export function WalletComponents() {
         <Address className={color.foregroundMuted} />
         <EthBalance />
       </Identity>
-      <WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com">
+      <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com">
         Wallet
       </WalletDropdownLink>
       <WalletDropdownDisconnect />
@@ -116,7 +116,7 @@ You can override component styles using `className`.
     <WalletDropdownLink 
       className='hover:bg-blue-200' 
       icon="wallet" 
-      href="https://wallet.coinbase.com"
+      href="https://keys.coinbase.com"
     >
       Wallet
     </WalletDropdownLink>
@@ -141,7 +141,7 @@ You can override component styles using `className`.
       <WalletDropdownLink 
         className='hover:bg-blue-200' 
         icon="wallet" 
-        href="https://wallet.coinbase.com"
+        href="https://keys.coinbase.com"
       >
         Wallet
       </WalletDropdownLink>
@@ -178,7 +178,7 @@ You can override component text using `text`.
         <Address className={color.foregroundMuted} />
         <EthBalance />
       </Identity>
-      <WalletDropdownLink icon="wallet" href="https://wallet.coinbase.com">
+      <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com">
         Wallet
       </WalletDropdownLink>
       <WalletDropdownDisconnect />
@@ -244,7 +244,7 @@ OnchainKit leverages [RainbowKit](https://www.rainbowkit.com/) to offer this fea
     </Identity>
     <WalletDropdownLink 
       icon="wallet" 
-      href="https://wallet.coinbase.com"
+      href="https://keys.coinbase.com"
     >
       Wallet
     </WalletDropdownLink>
@@ -338,7 +338,7 @@ export default OnchainProviders;
         </Identity>
         <WalletDropdownLink 
           icon="wallet" 
-          href="https://wallet.coinbase.com"
+          href="https://keys.coinbase.com"
         >
           Wallet
         </WalletDropdownLink>


### PR DESCRIPTION
**What changed? Why?**
- link to keys.coinbase.com instead of wallet.coinbase.com

**Notes to reviewers**

**How has it been tested?**
