### PR TITLE
chore: Update Swap Slippage v1 API for getting the Swap Quote

### DIFF
--- a/.changeset/shy-foxes-jog.md
+++ b/.changeset/shy-foxes-jog.md
@@ -4,4 +4,4 @@
 
 - **feat**: introduced `config` for the `Swap` component, with the first option for `maxSlippage`. By @zizzamia & @cpcramer #1242
 - **fix**: added spacing between swap input and token select. By @alessey #1229 
-- **feat**: added slippage support in `Swap` component with settings UI. This combined feat incorporates slippage functionality into the Swap component, including a dedicated settings section with a title, description, and input field for configuring slippage tolerance. By @cpcramer #1187 #1192 #1191 #1189 #1195 #1196 #1206
+- **feat**: added slippage support in `Swap` component with settings UI. This combined feat incorporates slippage functionality into the Swap component, including a dedicated settings section with a title, description, and input field for configuring slippage tolerance. By @cpcramer #1187 #1192 #1191 #1189 #1195 #1196 #1206 #1248

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -160,4 +160,80 @@ describe('getSwapQuote', () => {
       message: '',
     });
   });
+
+
+  it('should adjust slippage for V1 API when useAggregator is true', async () => {
+    const mockParams = {
+      useAggregator: true,
+      maxSlippage: '3',
+      amountReference: testAmountReference,
+      from: ETH_TOKEN,
+      to: DEGEN_TOKEN,
+      amount: testAmount,
+    };
+    const mockApiParams = getAPIParamsForToken(mockParams);
+    const mockResponse = {
+      id: 1,
+      jsonrpc: '2.0',
+      result: {
+        from: ETH_TOKEN,
+        to: DEGEN_TOKEN,
+        fromAmount: '100000000000000000',
+        toAmount: '16732157880511600003860',
+        amountReference: 'from',
+        priceImpact: '0.07',
+        chainId: 8453,
+        hasHighPriceImpact: false,
+        slippage: '30',
+      },
+    };
+    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    await getSwapQuote(mockParams);
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
+      {
+        ...mockApiParams,
+        slippagePercentage: '30',
+      },
+    ]);
+  });
+
+  it('should not adjust slippage when useAggregator is false', async () => {
+    const mockParams = {
+      useAggregator: false,
+      maxSlippage: '3',
+      amountReference: testAmountReference,
+      from: ETH_TOKEN,
+      to: DEGEN_TOKEN,
+      amount: testAmount,
+    };
+    const mockApiParams = getAPIParamsForToken(mockParams);
+    const mockResponse = {
+      id: 1,
+      jsonrpc: '2.0',
+      result: {
+        from: ETH_TOKEN,
+        to: DEGEN_TOKEN,
+        fromAmount: '100000000000000000',
+        toAmount: '16732157880511600003860',
+        amountReference: 'from',
+        priceImpact: '0.07',
+        chainId: 8453,
+        hasHighPriceImpact: false,
+        slippage: '3',
+      },
+    };
+    (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
+    
+    await getSwapQuote(mockParams);
+    
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
+      {
+        ...mockApiParams,
+        v2Enabled: true,
+        slippagePercentage: '3',
+      },
+    ]);
+  });
 });

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -223,9 +223,7 @@ describe('getSwapQuote', () => {
       },
     };
     (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
-
     await getSwapQuote(mockParams);
-
     expect(sendRequest).toHaveBeenCalledTimes(1);
     expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
       {

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -161,7 +161,6 @@ describe('getSwapQuote', () => {
     });
   });
 
-
   it('should adjust slippage for V1 API when useAggregator is true', async () => {
     const mockParams = {
       useAggregator: true,
@@ -224,9 +223,9 @@ describe('getSwapQuote', () => {
       },
     };
     (sendRequest as vi.Mock).mockResolvedValue(mockResponse);
-    
+
     await getSwapQuote(mockParams);
-    
+
     expect(sendRequest).toHaveBeenCalledTimes(1);
     expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
       {

--- a/src/api/getSwapQuote.ts
+++ b/src/api/getSwapQuote.ts
@@ -14,7 +14,7 @@ import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
  * Retrieves a quote for a swap from Token A to Token B.
  */
 export async function getSwapQuote(
-  params: GetSwapQuoteParams,
+  params: GetSwapQuoteParams
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {
@@ -37,8 +37,14 @@ export async function getSwapQuote(
     };
   }
   if (params.maxSlippage) {
+    let slippagePercentage = params.maxSlippage;
+    // Adjust slippage for V1 API (aggregator)
+    // V1 expects slippage in tenths of a percent (e.g., 30 = 3%)
+    if (params.useAggregator) {
+      slippagePercentage = (Number(params.maxSlippage) * 10).toString();
+    }
     apiParams = {
-      slippagePercentage: params.maxSlippage,
+      slippagePercentage: slippagePercentage,
       ...apiParams,
     };
   }
@@ -46,7 +52,7 @@ export async function getSwapQuote(
   try {
     const res = await sendRequest<SwapAPIParams, SwapQuote>(
       CDP_GET_SWAP_QUOTE,
-      [apiParams],
+      [apiParams]
     );
     if (res.error) {
       return {

--- a/src/api/getSwapQuote.ts
+++ b/src/api/getSwapQuote.ts
@@ -14,7 +14,7 @@ import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
  * Retrieves a quote for a swap from Token A to Token B.
  */
 export async function getSwapQuote(
-  params: GetSwapQuoteParams
+  params: GetSwapQuoteParams,
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {
@@ -52,7 +52,7 @@ export async function getSwapQuote(
   try {
     const res = await sendRequest<SwapAPIParams, SwapQuote>(
       CDP_GET_SWAP_QUOTE,
-      [apiParams]
+      [apiParams],
     );
     if (res.error) {
       return {


### PR DESCRIPTION
**What changed? Why?**
 Adjust slippage for V1 API (aggregator). V1 expects slippage in tenths of a percent (e.g., 30 = 3%). This was implemented when creating the transaction but not when fetching the quote 


**Notes to reviewers**

**How has it been tested?**
