### PR TITLE
feat: set `v2` as default API for `Swap`

### DIFF
--- a/.changeset/nervous-lamps-jog.md
+++ b/.changeset/nervous-lamps-jog.md
@@ -2,4 +2,4 @@
 '@coinbase/onchainkit': patch
 ---
 
-feat: set v2 as default API for Swap. by @0xAlec #1254
+**feat**: set v2 as default API for Swap. by @0xAlec #1254

--- a/.changeset/nervous-lamps-jog.md
+++ b/.changeset/nervous-lamps-jog.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+feat: set v2 as default API for Swap. by @0xAlec #1254

--- a/src/swap/components/Swap.tsx
+++ b/src/swap/components/Swap.tsx
@@ -17,7 +17,7 @@ export function Swap({
     maxSlippage: DEFAULT_MAX_SLIPPAGE,
   },
   className,
-  experimental = { useAggregator: true },
+  experimental = { useAggregator: false },
   onError,
   onStatus,
   onSuccess,


### PR DESCRIPTION
**What changed? Why?**
- turn off `v1` aggregator API (0x and 1inch)
- switch on `v2` API by default (Uniswap)

**Notes to reviewers**

**How has it been tested?**
