### PR TITLE
fix: remove circular dependency

### DIFF
--- a/src/swap/constants.ts
+++ b/src/swap/constants.ts
@@ -11,3 +11,15 @@ export const UNCAUGHT_SWAP_ERROR_CODE = 'UNCAUGHT_SWAP_ERROR';
 export const UNIVERSALROUTER_CONTRACT_ADDRESS =
   '0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD';
 export const USER_REJECTED_ERROR_CODE = 'USER_REJECTED';
+export enum SwapMessage {
+  BALANCE_ERROR = 'Error fetching token balance',
+  CONFIRM_IN_WALLET = 'Confirm in wallet',
+  FETCHING_QUOTE = 'Fetching quote...',
+  FETCHING_BALANCE = 'Fetching balance...',
+  INCOMPLETE_FIELD = 'Complete the fields to continue',
+  INSUFFICIENT_BALANCE = 'Insufficient balance',
+  LOW_LIQUIDITY = 'Liquidity too low for the token',
+  SWAP_IN_PROGRESS = 'Swap in progress...',
+  TOO_MANY_REQUESTS = 'Too many requests. Please try again later.',
+  USER_REJECTED = 'User rejected the transaction',
+}

--- a/src/swap/utils/getErrorMessage.test.ts
+++ b/src/swap/utils/getErrorMessage.test.ts
@@ -1,12 +1,12 @@
-import { describe, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   LOW_LIQUIDITY_ERROR_CODE,
+  SwapMessage,
   TOO_MANY_REQUESTS_ERROR_CODE,
   USER_REJECTED_ERROR_CODE,
 } from '../constants';
 import type { SwapError } from '../types';
 import { getErrorMessage } from './getErrorMessage';
-import { SwapMessage } from './getSwapMessage';
 
 describe('getSwapError', () => {
   it('should return TOO_MANY_REQUESTS when error code is TOO_MANY_REQUESTS_ERROR_CODE', () => {

--- a/src/swap/utils/getErrorMessage.ts
+++ b/src/swap/utils/getErrorMessage.ts
@@ -1,10 +1,10 @@
 import {
   LOW_LIQUIDITY_ERROR_CODE,
+  SwapMessage,
   TOO_MANY_REQUESTS_ERROR_CODE,
   USER_REJECTED_ERROR_CODE,
 } from '../constants';
 import type { SwapError } from '../types';
-import { SwapMessage } from './getSwapMessage';
 
 export function getErrorMessage(error: SwapError): string | undefined {
   // error states handled below

--- a/src/swap/utils/getSwapMessage.test.ts
+++ b/src/swap/utils/getSwapMessage.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   LOW_LIQUIDITY_ERROR_CODE,
+  SwapMessage,
   TOO_MANY_REQUESTS_ERROR_CODE,
   USER_REJECTED_ERROR_CODE,
 } from '../constants';
@@ -8,7 +9,7 @@ import { ETH_TOKEN, USDC_TOKEN } from '../mocks';
 /**
  * @vitest-environment node
  */
-import { SwapMessage, getSwapMessage } from './getSwapMessage';
+import { getSwapMessage } from './getSwapMessage';
 
 describe('getSwapMessage', () => {
   const baseParams = {

--- a/src/swap/utils/getSwapMessage.ts
+++ b/src/swap/utils/getSwapMessage.ts
@@ -1,18 +1,6 @@
+import { SwapMessage } from '../constants';
 import type { GetSwapMessageParams } from '../types';
 import { getErrorMessage } from './getErrorMessage';
-
-export enum SwapMessage {
-  BALANCE_ERROR = 'Error fetching token balance',
-  CONFIRM_IN_WALLET = 'Confirm in wallet',
-  FETCHING_QUOTE = 'Fetching quote...',
-  FETCHING_BALANCE = 'Fetching balance...',
-  INCOMPLETE_FIELD = 'Complete the fields to continue',
-  INSUFFICIENT_BALANCE = 'Insufficient balance',
-  LOW_LIQUIDITY = 'Liquidity too low for the token',
-  SWAP_IN_PROGRESS = 'Swap in progress...',
-  TOO_MANY_REQUESTS = 'Too many requests. Please try again later.',
-  USER_REJECTED = 'User rejected the transaction',
-}
 
 export function getSwapMessage({
   address,


### PR DESCRIPTION
**What changed? Why?**
extracting SwapMessage to constants to avoid circular dependency
getSwapMessage -> getErrorMessage -> getSwapMessage

**Notes to reviewers**

**How has it been tested?**
