### PR TITLE
feat: implement two slash in docs

### DIFF
--- a/site/docs/pages/api/build-swap-transaction.mdx
+++ b/site/docs/pages/api/build-swap-transaction.mdx
@@ -8,9 +8,10 @@ Before using them, make sure to obtain a Public API Key from the [Coinbase Devel
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { setOnchainKitConfig } from '@coinbase/onchainkit';
 import { buildSwapTransaction } from '@coinbase/onchainkit/api';
+import type { Token } from '@coinbase/onchainkit/token';
 
 setOnchainKitConfig({ apiKey: 'YOUR_API_KEY' });
 
@@ -38,6 +39,7 @@ const response = await buildSwapTransaction({
   from: fromToken,
   to: toToken,
   amount: '0.1',
+  useAggregator: false,
 });
 ```
 

--- a/site/docs/pages/api/get-swap-quote.mdx
+++ b/site/docs/pages/api/get-swap-quote.mdx
@@ -8,9 +8,10 @@ Before using them, make sure to obtain a Public API Key from the [Coinbase Devel
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { setOnchainKitConfig } from '@coinbase/onchainkit';
 import { getSwapQuote } from '@coinbase/onchainkit/api';
+import type { Token } from '@coinbase/onchainkit/token';
 
 setOnchainKitConfig({ apiKey: 'YOUR_API_KEY' });
 
@@ -37,6 +38,7 @@ const quote = await getSwapQuote({
   from: fromToken,
   to: toToken,
   amount: '0.001',
+  useAggregator: false,
 });
 ```
 

--- a/site/docs/pages/api/get-tokens.mdx
+++ b/site/docs/pages/api/get-tokens.mdx
@@ -10,7 +10,7 @@ Search by symbol
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { setOnchainKitConfig } from '@coinbase/onchainkit';
 import { getTokens } from '@coinbase/onchainkit/api'; // [!code focus]
 
@@ -39,7 +39,7 @@ Search by name
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { setOnchainKitConfig } from '@coinbase/onchainkit';
 import { getTokens } from '@coinbase/onchainkit/api'; // [!code focus]
 
@@ -68,7 +68,7 @@ Search by address
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { setOnchainKitConfig } from '@coinbase/onchainkit';
 import { getTokens } from '@coinbase/onchainkit/api'; // [!code focus]
 

--- a/site/docs/pages/config/is-base.mdx
+++ b/site/docs/pages/config/is-base.mdx
@@ -6,7 +6,7 @@ The `isBase` utility is designed to verify if the chain id is a valid Base or Ba
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { isBase } from '@coinbase/onchainkit';
 
 const chainId = 8453;

--- a/site/docs/pages/config/is-ethereum.mdx
+++ b/site/docs/pages/config/is-ethereum.mdx
@@ -6,7 +6,7 @@ The `isEthereum` utility is designed to verify if the chain id is a valid Ethere
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { isEthereum } from '@coinbase/onchainkit';
 
 const chainId = 1;

--- a/site/docs/pages/config/onchainkit-provider.mdx
+++ b/site/docs/pages/config/onchainkit-provider.mdx
@@ -4,7 +4,8 @@ Provides the OnchainKit React Context to the app.
 
 ## Usage
 
-```tsx
+```tsx twoslash
+// @noErrors: 2304 - Cannot find name 'MyComponent'
 import { base } from 'viem/chains';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
 

--- a/site/docs/pages/farcaster/get-farcaster-user-address.mdx
+++ b/site/docs/pages/farcaster/get-farcaster-user-address.mdx
@@ -9,7 +9,8 @@ By default, both **custody** and **verified** addresses are provided.
 
 ## Usage
 
-```ts
+```ts twoslash
+// @noErrors: 2304 2552 - Cannot find name 'fid', Cannot find name 'options'
 import { getFarcasterUserAddress } from '@coinbase/onchainkit/farcaster';
 
 const userAddress = await getFarcasterUserAddress(fid, options); // [!code focus]
@@ -35,7 +36,10 @@ Farcaster ID
 
 Default to onchain-kit's default key.
 
-```ts
+```ts twoslash
+// @noErrors: 2304 - Cannot find name 'fid'
+import { getFarcasterUserAddress } from '@coinbase/onchainkit/farcaster';
+// ---cut-before---
 const userAddress = await getFarcasterUserAddress(fid, {
   neynarApiKey: 'MY_NEYNAR_API_KEY', // [!code focus]
 });
@@ -47,7 +51,10 @@ const userAddress = await getFarcasterUserAddress(fid, {
 
 Optional options to specify if the client wants custody addresses. Default to true.
 
-```ts
+```ts twoslash
+// @noErrors: 2304 - Cannot find name 'fid'
+import { getFarcasterUserAddress } from '@coinbase/onchainkit/farcaster';
+// ---cut-before---
 const userAddress = await getFarcasterUserAddress(fid, {
   hasCustodyAddress: false, // [!code focus]
 });
@@ -59,7 +66,10 @@ const userAddress = await getFarcasterUserAddress(fid, {
 
 Optional options to specify if the client wants verified addresses. Default to true.
 
-```ts
+```ts twoslash
+// @noErrors: 2304 - Cannot find name 'fid'
+import { getFarcasterUserAddress } from '@coinbase/onchainkit/farcaster';
+// ---cut-before---
 const userAddress = await getFarcasterUserAddress(fid, {
   hasVerifiedAddresses: false, // [!code focus]
 });

--- a/site/docs/pages/frame/frame-metadata.mdx
+++ b/site/docs/pages/frame/frame-metadata.mdx
@@ -13,7 +13,8 @@ Note: If you are using Next.js with App routing, it is recommended to use `getFr
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
+// @noErrors
 import { FrameMetadata } from '@coinbase/onchainkit/frame';
 
 export default function HomePage() {

--- a/site/docs/pages/frame/framegear.mdx
+++ b/site/docs/pages/frame/framegear.mdx
@@ -57,7 +57,8 @@ running frame (e.g., `http://localhost:3000`) and click `Fetch` to validate your
 consider building the frame using `@coinbase/onchainkit` (versions `^0.8.0`). When using the `getFrameMessage` function,
 include the `allowFramegear` option to enable **Framegear** to send mock frame actions.
 
-```ts
+```ts twoslash
+// @noErrors: 2304 - Cannot find 'body'
 import { getFrameMessage } from '@coinbase/onchainkit/frame';
 
 // ...
@@ -72,7 +73,8 @@ const { isValid, message } = await getFrameMessage(body, {
 When setting up frames in production, remember not to include the `allowFramegear` option.
 The exact setup might vary based on the application, but here's one example:
 
-```ts
+```ts twoslash
+// @noErrors: 2580 2304 - Cannot find 'process', Cannot find 'body'
 import { getFrameMessage } from '@coinbase/onchainkit/frame';
 
 const allowFramegear = process.env.NODE_ENV !== 'production'; // [!code focus]

--- a/site/docs/pages/frame/get-frame-html-response.mdx
+++ b/site/docs/pages/frame/get-frame-html-response.mdx
@@ -6,7 +6,8 @@ It generates a valid HTML string response with a frame and utilizes `FrameMetada
 
 ## Usage
 
-```ts
+```ts twoslash
+// @noErrors: 2307 1128 - Cannot find module 'next/server', Declaration or statement expected
 // Step 1. import getFrameHtmlResponse from @coinbase/onchainkit
 import { getFrameHtmlResponse } from '@coinbase/onchainkit/frame';
 import { NextRequest, NextResponse } from 'next/server';
@@ -31,7 +32,7 @@ async function getResponse(req: NextRequest): Promise<NextResponse> {
 
 export async function POST(req: NextRequest): Promise<Response> {
   return getResponse(req);
-}
+};
 ```
 
 ## Returns

--- a/site/docs/pages/frame/get-frame-message.mdx
+++ b/site/docs/pages/frame/get-frame-message.mdx
@@ -7,7 +7,8 @@ Note that if the `message` is not valid, it will be undefined.
 
 ## Usage
 
-```ts
+```ts twoslash
+// @noErrors: 2307 1128 - Cannot find module 'next/server', Declaration or statement expected
 import { FrameRequest, getFrameMessage } from '@coinbase/onchainkit/frame'; // [!code focus]
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -38,10 +39,19 @@ async function getResponse(req: NextRequest): Promise<NextResponse> {
 
 Default to OnchainKit's default key.
 
-```ts
+```ts twoslash
+// @noErrors: 2307 - Cannot find module 'next/server'
+import { FrameRequest, getFrameMessage } from '@coinbase/onchainkit/frame'; // [!code focus]
+import { NextRequest, NextResponse } from 'next/server';
+
+async function getResponse(req: NextRequest): Promise<NextResponse> {
+  const frameRequest: FrameRequest = await req.json();
+// ---cut-before---
 const { isValid, message } = await getFrameMessage(frameRequest, {
   neynarApiKey: 'MY_NEYNAR_API_KEY', // [!code focus]
 });
+// ---cut-after---
+}
 ```
 
 ### options.castReactionContext
@@ -50,10 +60,19 @@ const { isValid, message } = await getFrameMessage(frameRequest, {
 
 Whether to cast the reaction context. Default: true
 
-```ts
+```ts twoslash
+// @noErrors: 2307 - Cannot find module 'next/server'
+import { FrameRequest, getFrameMessage } from '@coinbase/onchainkit/frame'; // [!code focus]
+import { NextRequest, NextResponse } from 'next/server';
+
+async function getResponse(req: NextRequest): Promise<NextResponse> {
+  const frameRequest: FrameRequest = await req.json();
+// ---cut-before---
 const { isValid, message } = await getFrameMessage(frameRequest, {
   castReactionContext: true, // [!code focus]
 });
+// ---cut-after---
+}
 ```
 
 ### options.followContext
@@ -62,8 +81,17 @@ const { isValid, message } = await getFrameMessage(frameRequest, {
 
 Whether to follow the context. Default: true
 
-```ts
+```ts twoslash
+// @noErrors: 2307 - Cannot find module 'next/server'
+import { FrameRequest, getFrameMessage } from '@coinbase/onchainkit/frame'; // [!code focus]
+import { NextRequest, NextResponse } from 'next/server';
+
+async function getResponse(req: NextRequest): Promise<NextResponse> {
+  const frameRequest: FrameRequest = await req.json();
+// ---cut-before---
 const { isValid, message } = await getFrameMessage(frameRequest, {
   followContext: true, // [!code focus]
 });
+// ---cut-after---
+}
 ```

--- a/site/docs/pages/frame/get-frame-metadata.mdx
+++ b/site/docs/pages/frame/get-frame-metadata.mdx
@@ -4,7 +4,8 @@ With Next.js App routing, use the `getFrameMetadata()` inside your `page.ts` to 
 
 ## Usage
 
-```ts
+```ts twoslash
+// @noErrors: 2307 1005 1161 - Cannot find module 'next', Cannot find module './home'
 // Step 1. import getFrameMetadata from @coinbase/onchainkit
 import { getFrameMetadata } from '@coinbase/onchainkit/frame';
 import type { Metadata } from 'next';
@@ -31,7 +32,7 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return <HomePage />;
-}
+};
 ```
 
 ## Returns

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -61,7 +61,12 @@ PUBLIC_ONCHAINKIT_API_KEY=YOUR_PUBLIC_API_KEY
 
 #### Access the Public API Key in your code
 
-```tsx [OnchainProviders.tsx]
+```tsx twoslash [OnchainProviders.tsx]
+// @noErrors: 2580 2304 - cannot find name 'process', cannot find name 'YourComponents'
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains';
+
+// ---cut-before---
 <OnchainKitProvider 
   apiKey={process.env.PUBLIC_ONCHAINKIT_API_KEY} // [!code focus] 
   chain={base}
@@ -76,7 +81,8 @@ The `<OnchainKitProvider />` component equips your app with the essential contex
 
 Set the `chain` prop to your target chain and provide the Public API Key to access the embedded APIs.
 
-```tsx [OnchainProviders.tsx]
+```tsx twoslash [OnchainProviders.tsx]
+// @noErrors: 2580 - cannot find name 'process'
 'use client';
 import { ReactNode } from 'react';
 import { base } from 'viem/chains';
@@ -90,7 +96,7 @@ function OnchainProviders({ children }: Props) {
       apiKey={process.env.PUBLIC_ONCHAINKIT_API_KEY} 
       chain={base}
     >
-      <YourComponents />
+      {children}
     </OnchainKitProvider>
   );
 };
@@ -105,8 +111,8 @@ Many of OnchainKit's components require a WagmiProvider to access Wagmi utilitie
 If your application already includes these settings, you can skip this step.
 
 :::code-group
-
-```tsx [OnchainProviders.tsx]
+```tsx twoslash [OnchainProviders.tsx]
+// @noErrors: 2307 2580 - cannot find 'process', cannot find './wagmi'
 'use client';
 import { ReactNode } from 'react';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
@@ -137,7 +143,7 @@ function OnchainProviders({ children }: Props) {
 export default OnchainProviders;
 ```
 
-```tsx [wagmi.ts]
+```tsx twoslash [wagmi.ts]
 import { http, createConfig } from 'wagmi';
 import { base } from 'wagmi/chains';
 import { coinbaseWallet } from 'wagmi/connectors';
@@ -166,7 +172,8 @@ Wrap your app with the `OnchainProviders` component to enable OnchainKit compone
 
 :::code-group
 
-```tsx [layout.tsx]
+```tsx twoslash [layout.tsx]
+// @noErrors: 2307 7031 2304 - cannot find module './OnChainProviders', children has implicit any
 import { OnchainProviders } from './OnchainProviders' // [!code focus]
 
 export default function RootLayout({ children }) {
@@ -178,7 +185,8 @@ export default function RootLayout({ children }) {
 }  
 ```
 
-```tsx [OnchainProviders.tsx]
+```tsx twoslash [OnchainProviders.tsx]
+// @noErrors: 2307 2580 - cannot find 'process', cannot find './wagmi'
 'use client';
 import { ReactNode } from 'react';
 import { OnchainKitProvider } from '@coinbase/onchainkit';

--- a/site/docs/pages/guides/lifecycle-status.mdx
+++ b/site/docs/pages/guides/lifecycle-status.mdx
@@ -31,10 +31,13 @@ can tap into the rhythm and customize the behavior of your components. 🎶
 The Lifecycle Status is a TypeScript object that provides easy access to the `statusName` and `statusData` properties, 
 allowing you to stay informed and responsive.
 
-```ts
+```tsx twoslash
+import { useCallback } from 'react';
+import { Transaction } from '@coinbase/onchainkit/transaction';
+// ---cut-before---
 import type { LifeCycleStatus } from '@coinbase/onchainkit/transaction';
 
-const handleOnStatus = useCallback(status: LifeCycleStatus) => {
+const handleOnStatus = useCallback((status: LifeCycleStatus) => {
   console.log('LifecycleStatus', status);
 }, []);
 

--- a/site/docs/pages/guides/use-basename-in-onchain-app.mdx
+++ b/site/docs/pages/guides/use-basename-in-onchain-app.mdx
@@ -32,8 +32,9 @@ Use the [`<Avatar>`](/identity/avatar) and [`<Name>`](/identity/name) components
 
 The `chain` prop is optional and setting to Base, it's what makes the components switch from ENS to Basenames.
 
-```tsx
-import { Name } from '@coinbase/onchainkit/identity';
+```tsx twoslash
+// @noErrors: 2657 - JSX expressions must have one parent element
+import { Avatar, Name } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';
@@ -56,14 +57,14 @@ The hooks are incredibly useful for building custom components while leveraging 
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { useAvatar, useName } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';
 const basename = 'zizzamia.base.eth';
-const { data: avatar, isLoading } = await useAvatar({ ensName: basename, chain: base });
-const { data: name, isLoading } = await useName({ address, chain: base });
+const { data: avatar, isLoading: avatarIsLoading } = await useAvatar({ ensName: basename, chain: base });
+const { data: name, isLoading: nameIsLoading } = await useName({ address, chain: base });
 ```
 
 ```ts [return value]
@@ -81,8 +82,8 @@ Being pure functions, it seamlessly integrates into any TypeScript project, incl
 
 :::code-group
 
-```tsx [code]
-import { getName } from '@coinbase/onchainkit/identity';
+```tsx twoslash [code]
+import { getAvatar, getName } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';

--- a/site/docs/pages/identity/address.mdx
+++ b/site/docs/pages/identity/address.mdx
@@ -10,7 +10,7 @@ The `Address` component is used to render shorten user account address.
 
 Sliced account address:
 
-```tsx
+```tsx twoslash
 import { Address } from '@coinbase/onchainkit/identity';
 <Address address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" /> // [!code focus]
 ```
@@ -23,7 +23,7 @@ import { Address } from '@coinbase/onchainkit/identity';
 
 Set `isSliced` to false, to display the full address:
 
-```tsx
+```tsx twoslash
 import { Address } from '@coinbase/onchainkit/identity';
 <Address address="0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1" isSliced={false}/> // [!code focus]
 ```
@@ -36,7 +36,7 @@ import { Address } from '@coinbase/onchainkit/identity';
 
 You can override component styles using `className`.
 
-```tsx
+```tsx twoslash
 import { Address } from '@coinbase/onchainkit/identity';
 <Address
   className="bg-emerald-400 px-2 py-1 rounded" // [!code focus]

--- a/site/docs/pages/identity/avatar.mdx
+++ b/site/docs/pages/identity/avatar.mdx
@@ -10,7 +10,7 @@ When an avatar is not available, it defaults to blue color avatar.
 ## Usage
 
 Address with an ENS avatar:
-```tsx
+```tsx twoslash
 import { Avatar } from '@coinbase/onchainkit/identity';
 <Avatar address="0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9" /> // [!code focus]
 ```
@@ -20,7 +20,7 @@ import { Avatar } from '@coinbase/onchainkit/identity';
 
 Address without an ENS or Basenames avatar defaults to a plain avatar:
 
-```tsx
+```tsx twoslash
 import { Avatar } from '@coinbase/onchainkit/identity';
 <Avatar address="0x1234567890abcdef1234567890abcdef12345678" /> // [!code focus]
 ```
@@ -31,7 +31,7 @@ import { Avatar } from '@coinbase/onchainkit/identity';
 
 Address with a Basename avatar:
 
-```tsx
+```tsx twoslash
 import { Avatar } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains'; // [!code focus]
 
@@ -44,7 +44,7 @@ import { base } from 'viem/chains'; // [!code focus]
 
 Override styles via `className` prop:
 
-```tsx
+```tsx twoslash
 import { Avatar } from '@coinbase/onchainkit/identity';
 <Avatar // [!code focus]
   className="bg-white rounded-full" // [!code focus]
@@ -56,7 +56,7 @@ import { Avatar } from '@coinbase/onchainkit/identity';
 </App>
 Use `defaultComponent` prop to change the default avatar when ENS avatar is not found.
 Use `loadingComponent` prop to change the loading placeholder:
-```tsx
+```tsx twoslash
 import { Avatar } from '@coinbase/onchainkit/identity';
 <Avatar
   address="0x1234567890abcdef1234567890abcdef12345678"
@@ -97,7 +97,7 @@ import { Avatar } from '@coinbase/onchainkit/identity';
 </App>
 Show attestation on ENV avatar with [`Badge`](/identity/badge) component.
 Use [`OnchainKitProvider`](/config/onchainkit-provider) or [`Identity`](/identity/identity) component with the `schemaId` prop.
-```tsx
+```tsx twoslash
 import { Avatar, Badge, Identity } from '@coinbase/onchainkit/identity'; // [!code focus]
 <Identity
   schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9" // [!code focus]

--- a/site/docs/pages/identity/badge.mdx
+++ b/site/docs/pages/identity/badge.mdx
@@ -13,7 +13,7 @@ Badge with default colors:
 
 :::code-group
 
-```tsx [tsx]
+```tsx twoslash [tsx]
 import { Badge } from '@coinbase/onchainkit/identity';
 <Badge className="badge" /> // [!code focus]
 ```
@@ -35,7 +35,7 @@ import { Badge } from '@coinbase/onchainkit/identity';
 
 Badge with custom colors:
 
-```tsx
+```tsx twoslash
 import { Badge } from '@coinbase/onchainkit/identity';
 <Badge className="bg-blue-400 border-white"/> // [!code focus]
 ```
@@ -54,9 +54,9 @@ Badge with [`<Name />`](/identity/name), best used when [`<Name />`](/identity/n
 
 In both examples we use the Coinbase [Verified Account](https://base.easscan.org/schema/view/0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9) schema ID to show the Coinbase verified badge on the Name and Avatar components.
 
-```tsx
+```tsx twoslash
 import { base } from 'viem/chains';
-import { Bage, Name, Identity } from '@coinbase/onchainkit/identity';
+import { Badge, Name, Identity } from '@coinbase/onchainkit/identity';
 
 const address = '0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9';
 const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID =
@@ -86,7 +86,7 @@ const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID =
 
 Badge with [`<Avatar />`](/identity/avatar), best used when [`<Avatar />`](/identity/avatar) is not paired with any labels.
 
-```tsx
+```tsx twoslash
 import { base } from 'viem/chains';
 import { Avatar, Badge, Identity } from '@coinbase/onchainkit/identity';
 

--- a/site/docs/pages/identity/get-address.mdx
+++ b/site/docs/pages/identity/get-address.mdx
@@ -7,7 +7,7 @@ The `getAddress` utility is designed to retrieve an address from an onchain iden
 Get ENS Name from mainnet chain
 
 :::code-group
-```tsx [code]
+```tsx twoslash [code]
 import { getAddress } from '@coinbase/onchainkit/identity';
 
 const address = await getAddress({ name: 'zizzamia.eth' });
@@ -23,7 +23,7 @@ Get Basename from base chain
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { getAddress } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 

--- a/site/docs/pages/identity/get-attestations.mdx
+++ b/site/docs/pages/identity/get-attestations.mdx
@@ -10,7 +10,8 @@ In the example, we use the Coinbase [Verified Account](https://base.easscan.org/
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
+// @noErrors: 2345 - Argument of type string is not assignable to 0x{string}
 import { getAttestations } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 

--- a/site/docs/pages/identity/get-avatar.mdx
+++ b/site/docs/pages/identity/get-avatar.mdx
@@ -16,7 +16,7 @@ Supported providers:
 Get Basename avatar:
 
 :::code-group
-```tsx [code]
+```tsx twoslash [code]
 import { getAvatar } from '@coinbase/onchainkit/identity';
 import { base, mainnet } from 'viem/chains';
 
@@ -33,7 +33,7 @@ Get ENS avatar:
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { getAvatar } from '@coinbase/onchainkit/identity';
 import { mainnet } from 'viem/chains';
 

--- a/site/docs/pages/identity/get-name.mdx
+++ b/site/docs/pages/identity/get-name.mdx
@@ -12,7 +12,7 @@ Get ENS name from an address:
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { getName } from '@coinbase/onchainkit/identity';
 
 const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';
@@ -29,7 +29,7 @@ Get Basename from an address:
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { getName } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
@@ -47,7 +47,7 @@ Get a sliced address when address does not have an ENS name:
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { getName } from '@coinbase/onchainkit/identity';
 
 const address = '0x1234567890abcdef1234567890abcdef12345678';

--- a/site/docs/pages/identity/identity.mdx
+++ b/site/docs/pages/identity/identity.mdx
@@ -14,7 +14,7 @@ import App from '../../components/App';
 
 Show user avatar, name with attestation and address:
 
-```tsx
+```tsx twoslash
 import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/identity';
 
 <Identity // [!code focus]
@@ -45,7 +45,7 @@ import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/ide
 
 Modify any styles with `className` prop.
 
-```tsx
+```tsx twoslash
 import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/identity';
 
 <Identity
@@ -75,8 +75,11 @@ import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/ide
 
 Choose which identity components to render:
 
-```tsx
+```tsx twoslash
 import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/identity';
+// ---cut-start---
+<div>
+// ---cut-end---
 
 <Identity address="0x838..." schemaId="0xf8b...">
   <Avatar /> // [!code focus]
@@ -91,6 +94,8 @@ import { Avatar, Identity, Name, Badge, Address } from '@coinbase/onchainkit/ide
   </Name> // [!code focus]
   <Address /> // [!code focus]
 </Identity>
+// ---cut-after---
+</div>
 ```
 
 <App>

--- a/site/docs/pages/identity/name.mdx
+++ b/site/docs/pages/identity/name.mdx
@@ -10,7 +10,7 @@ The `Name` component is used to display ENS or [Basenames](https://www.base.org/
 
 Address with an ENS:
 
-```tsx
+```tsx twoslash
 import { Name } from '@coinbase/onchainkit/identity';
 
 const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';
@@ -23,7 +23,7 @@ const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';
 
 Address with a Basename:
 
-```tsx
+```tsx twoslash
 import { Name } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains'; // [!code focus]
 
@@ -39,7 +39,7 @@ const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';
 
 You can override component styles using `className`.
 
-```tsx
+```tsx twoslash
 import { Name } from '@coinbase/onchainkit/identity';
 
 const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';
@@ -59,7 +59,7 @@ Show attestation on ENV name with [`Badge`](/identity/badge) component.
 
 Use [`OnchainKitProvider`](/config/onchainkit-provider) or [`Identity`](/identity/identity) component with the `schemaId` prop.
 
-```tsx
+```tsx twoslash
 import { Badge, Name, Identity } from '@coinbase/onchainkit/identity'; // [!code focus]
 
 const address = '0x838aD0EAE54F99F1926dA7C3b6bFbF617389B4D9';

--- a/site/docs/pages/identity/use-address.mdx
+++ b/site/docs/pages/identity/use-address.mdx
@@ -4,7 +4,7 @@ The `useAddress` hook is used to get an address from an onchain identity provide
 
 ## Usage
 
-```tsx
+```tsx twoslash
 import { useAddress } from '@coinbase/onchainkit/identity';
 
 const { data: address, isLoading } = useAddress({ name: 'zizzamia.base.eth' });

--- a/site/docs/pages/identity/use-avatar.mdx
+++ b/site/docs/pages/identity/use-avatar.mdx
@@ -5,7 +5,7 @@ provider for a given name.
 
 ## Usage
 
-```tsx
+```tsx twoslash
 import { useAvatar } from '@coinbase/onchainkit/identity';
 
 const { data: avatar, isLoading } = useAvatar({ ensName: 'vitalik.eth' });

--- a/site/docs/pages/identity/use-name.mdx
+++ b/site/docs/pages/identity/use-name.mdx
@@ -9,7 +9,7 @@ Get ENS name from an address:
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { useName } from '@coinbase/onchainkit/identity';
 
 const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';
@@ -26,8 +26,8 @@ Get Basename from an address:
 
 :::code-group
 
-```tsx [code]
-import { getName } from '@coinbase/onchainkit/identity';
+```tsx twoslash [code]
+import { useName } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 const address = '0x02feeb0AdE57b6adEEdE5A4EEea6Cf8c21BeB6B1';

--- a/site/docs/pages/swap/swap.mdx
+++ b/site/docs/pages/swap/swap.mdx
@@ -19,7 +19,7 @@ Before using them, ensure you've completed all [Getting Started steps](/getting-
 
 Example using `@coinbase/onchainkit/swap` and `@coinbase/onchainkit/wallet`.
 
-```tsx
+```tsx twoslash
 import { Avatar, Name } from '@coinbase/onchainkit/identity';
 import { // [!code focus]
   Swap, // [!code focus]
@@ -131,7 +131,42 @@ The swap will execute and work out of the box when you implement the component i
 
 You can adjust to only allow swap between a token pair.
 
-```tsx
+```tsx twoslash
+import { Avatar, Name } from '@coinbase/onchainkit/identity';
+import {
+  Swap,
+  SwapAmountInput,
+  SwapToggleButton,
+  SwapButton,
+  SwapMessage,
+} from '@coinbase/onchainkit/swap';
+import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
+import { useAccount } from 'wagmi';
+import type { Token } from '@coinbase/onchainkit/token';
+
+export default function SwapComponents() {
+  const { address } = useAccount();
+
+  const ETHToken: Token = {
+    address: "",
+    chainId: 8453,
+    decimals: 18,
+    name: "Ethereum",
+    symbol: "ETH",
+    image: "https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png",
+  };
+
+  const USDCToken: Token = {
+    address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    chainId: 8453,
+    decimals: 6,
+    name: "USDC",
+    symbol: "USDC",
+    image: "https://dynamic-assets.coinbase.com/3c15df5e2ac7d4abbe9499ed9335041f00c620f28e8de2f93474a9f432058742cdf4674bd43f309e69778a26969372310135be97eb183d91c492154176d455b8/asset_icons/9d67b728b6c8f457717154b3a35f9ddc702eae7e76c4684ee39302c4d7fd0bb8.png",
+  };
+
+return (
+// ---cut-before---
 // omitted for brevity
 
 <Swap> // [!code focus]
@@ -149,6 +184,9 @@ You can adjust to only allow swap between a token pair.
   <SwapButton /> // [!code focus]
   <SwapMessage /> // [!code focus]
 </Swap> // [!code focus]
+// ---cut-after---
+);
+}
 ```
 
 <App>
@@ -189,7 +227,42 @@ You can adjust to only allow swap between a token pair.
 
 You can remove `SwapToggleButton` to make swap unidirectional.
 
-```tsx
+```tsx twoslash
+import { Avatar, Name } from '@coinbase/onchainkit/identity';
+import {
+  Swap,
+  SwapAmountInput,
+  SwapToggleButton,
+  SwapButton,
+  SwapMessage,
+} from '@coinbase/onchainkit/swap';
+import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
+import { useAccount } from 'wagmi';
+import type { Token } from '@coinbase/onchainkit/token';
+
+export default function SwapComponents() {
+  const { address } = useAccount();
+
+  const ETHToken: Token = {
+    address: "",
+    chainId: 8453,
+    decimals: 18,
+    name: "Ethereum",
+    symbol: "ETH",
+    image: "https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png",
+  };
+
+  const USDCToken: Token = {
+    address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    chainId: 8453,
+    decimals: 6,
+    name: "USDC",
+    symbol: "USDC",
+    image: "https://dynamic-assets.coinbase.com/3c15df5e2ac7d4abbe9499ed9335041f00c620f28e8de2f93474a9f432058742cdf4674bd43f309e69778a26969372310135be97eb183d91c492154176d455b8/asset_icons/9d67b728b6c8f457717154b3a35f9ddc702eae7e76c4684ee39302c4d7fd0bb8.png",
+  };
+
+return (
+// ---cut-before---
 // omitted for brevity
 
 <Swap> // [!code focus]
@@ -206,6 +279,9 @@ You can remove `SwapToggleButton` to make swap unidirectional.
   <SwapButton /> // [!code focus]
   <SwapMessage /> // [!code focus]
 </Swap> // [!code focus]
+// ---cut-after---
+);
+}
 ```
 
 <App>
@@ -245,7 +321,42 @@ You can remove `SwapToggleButton` to make swap unidirectional.
 
 You can remove `SwapMessage` component.
 
-```tsx
+```tsx twoslash
+import { Avatar, Name } from '@coinbase/onchainkit/identity';
+import {
+  Swap,
+  SwapAmountInput,
+  SwapToggleButton,
+  SwapButton,
+  SwapMessage,
+} from '@coinbase/onchainkit/swap';
+import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
+import { useAccount } from 'wagmi';
+import type { Token } from '@coinbase/onchainkit/token';
+
+export default function SwapComponents() {
+  const { address } = useAccount();
+
+  const ETHToken: Token = {
+    address: "",
+    chainId: 8453,
+    decimals: 18,
+    name: "Ethereum",
+    symbol: "ETH",
+    image: "https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png",
+  };
+
+  const USDCToken: Token = {
+    address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    chainId: 8453,
+    decimals: 6,
+    name: "USDC",
+    symbol: "USDC",
+    image: "https://dynamic-assets.coinbase.com/3c15df5e2ac7d4abbe9499ed9335041f00c620f28e8de2f93474a9f432058742cdf4674bd43f309e69778a26969372310135be97eb183d91c492154176d455b8/asset_icons/9d67b728b6c8f457717154b3a35f9ddc702eae7e76c4684ee39302c4d7fd0bb8.png",
+  };
+
+return (
+// ---cut-before---
 // omitted for brevity
 
 <Swap> // [!code focus]
@@ -262,8 +373,10 @@ You can remove `SwapMessage` component.
   /> // [!code focus]
   <SwapButton /> // [!code focus]
 </Swap> // [!code focus]
+// ---cut-after---
+);
+}
 ```
-
 <App>
   <SwapWrapper>
     {({ address, swappableTokens }) => {
@@ -301,26 +414,62 @@ You can remove `SwapMessage` component.
 
 You can override component styles using `className`.
 
-```tsx
+```tsx twoslash
+import { Avatar, Name } from '@coinbase/onchainkit/identity';
+import {
+  Swap,
+  SwapAmountInput,
+  SwapToggleButton,
+  SwapButton,
+  SwapMessage,
+} from '@coinbase/onchainkit/swap';
+import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
+import { useAccount } from 'wagmi';
+import type { Token } from '@coinbase/onchainkit/token';
+
+export default function SwapComponents() {
+  const { address } = useAccount();
+
+  const ETHToken: Token = {
+    address: "",
+    chainId: 8453,
+    decimals: 18,
+    name: "Ethereum",
+    symbol: "ETH",
+    image: "https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png",
+  };
+
+  const USDCToken: Token = {
+    address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    chainId: 8453,
+    decimals: 6,
+    name: "USDC",
+    symbol: "USDC",
+    image: "https://dynamic-assets.coinbase.com/3c15df5e2ac7d4abbe9499ed9335041f00c620f28e8de2f93474a9f432058742cdf4674bd43f309e69778a26969372310135be97eb183d91c492154176d455b8/asset_icons/9d67b728b6c8f457717154b3a35f9ddc702eae7e76c4684ee39302c4d7fd0bb8.png",
+  };
+
+return (
+// ---cut-before---
 // omitted for brevity
 
 <Swap>
   <SwapAmountInput
     label="Sell"
-    swappableTokens={swappableTokens}
-    token={swappableTokens[1]}
+    token={ETHToken}
     type="from"
   />
   <SwapToggleButton className='border-[#EA580C]'/> // [!code focus]
   <SwapAmountInput
     label="Buy"
-    swappableTokens={swappableTokens}
-    token={swappableTokens[2]}
+    token={USDCToken}
     type="to"
   />
   <SwapButton className='bg-[#EA580C]'/> // [!code focus]
   <SwapMessage />
 </Swap>
+// ---cut-after---
+);
+}
 ```
 
 <App>

--- a/site/docs/pages/swap/types.mdx
+++ b/site/docs/pages/swap/types.mdx
@@ -26,7 +26,7 @@ type QuoteWarning = {
 };
 ```
 
-## `LifeCycleStatus`
+## `LifecycleStatus`
 
 ```ts
 type LifecycleStatusDataShared = {
@@ -34,7 +34,7 @@ type LifecycleStatusDataShared = {
   maxSlippage: number;
 };
 
-type LifeCycleStatus =
+type LifecycleStatus =
   | {
       statusName: 'init';
       statusData: LifecycleStatusDataShared;

--- a/site/docs/pages/token/format-amount.mdx
+++ b/site/docs/pages/token/format-amount.mdx
@@ -6,10 +6,10 @@ The `formatAmount` utility is designed for consistent number formatting.
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { formatAmount } from '@coinbase/onchainkit/token';
 
-const amount = formatAmount(10000, { minimumFractionDigits: 2 });
+const amount = formatAmount('10000', { minimumFractionDigits: 2 });
 ```
 
 ```ts [return value]

--- a/site/docs/pages/token/token-chip.mdx
+++ b/site/docs/pages/token/token-chip.mdx
@@ -7,7 +7,8 @@ The `TokenChip` component is a button that displays the token symbol.
 
 ## Usage
 
-```tsx
+```tsx twoslash
+// @noErrors: 2322 - type 'string' is not assignable to type 0x{string}
 import { TokenChip } from '@coinbase/onchainkit/token';
 import '@coinbase/onchainkit/styles.css';
 

--- a/site/docs/pages/token/token-image.mdx
+++ b/site/docs/pages/token/token-image.mdx
@@ -11,16 +11,26 @@ With `token` props has no image, render partial token symbol and deterministic d
 
 `TokenImage` with an url
 
-```tsx
+```tsx twoslash
+// @noErrors: 2739 - missing properties from Token
+import { TokenImage } from '@coinbase/onchainkit/token';
+<div>
+// ---cut-before---
 <TokenImage
-  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  token={{
+    image: "https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png",
+  }}
   size={24}
 />
 
 <TokenImage
-  src="https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png"
+  token={{
+    image: "https://dynamic-assets.coinbase.com/dbb4b4983bde81309ddab83eb598358eb44375b930b94687ebe38bc22e52c3b2125258ffb8477a5ef22e33d6bd72e32a506c391caa13af64c00e46613c3e5806/asset_icons/4113b082d21cc5fab17fc8f2d19fb996165bcce635e6900f7fc2d57c4ef33ae9.png",
+  }}
   size={32}
 />
+// ---cut-after---
+</div>
 ```
 
 <App>
@@ -32,7 +42,6 @@ With `token` props has no image, render partial token symbol and deterministic d
         symbol: 'ETH',
         decimals: 18,
         image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
-        blockchain: 'eth',
         chainId: 8453,
       }}
       size={24}
@@ -45,7 +54,6 @@ With `token` props has no image, render partial token symbol and deterministic d
         symbol: 'ETH',
         decimals: 18,
         image: 'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
-        blockchain: 'eth',
         chainId: 8453,
       }}
       size={32}
@@ -56,7 +64,10 @@ With `token` props has no image, render partial token symbol and deterministic d
 
 `TokenImage` with null as src
 
-```tsx
+```tsx twoslash
+import { TokenImage } from '@coinbase/onchainkit/token';
+<div>
+// ---cut-before---
 <TokenImage
   token={{
     name: 'USDC',
@@ -64,7 +75,6 @@ With `token` props has no image, render partial token symbol and deterministic d
     symbol: 'USDC',
     decimals: 6,
     image: null,
-    blockchain: 'eth',
     chainId: 8453,
   }}
   size={24}
@@ -77,11 +87,12 @@ With `token` props has no image, render partial token symbol and deterministic d
     symbol: 'USDC',
     decimals: 6,
     image: null,
-    blockchain: 'eth',
     chainId: 8453,
   }}
   size={32}
 />
+// ---cut-after---
+</div>
 ```
 
 <App>

--- a/site/docs/pages/token/token-row.mdx
+++ b/site/docs/pages/token/token-row.mdx
@@ -9,7 +9,8 @@ The `TokenRow` component displays token information in a row format to be used i
 
 Token with an image url
 
-```tsx
+```tsx twoslash
+// @noErrors: 1109 - Expression expected
 import { TokenRow } from '@coinbase/onchainkit/token';
 
 const token = { ... };
@@ -33,7 +34,8 @@ const token = { ... };
 
 Token without an image url
 
-```tsx
+```tsx twoslash
+// @noErrors: 1109 - Expression expected
 import { TokenRow } from '@coinbase/onchainkit/token';
 
 const token = { ... };
@@ -57,7 +59,8 @@ const token = { ... };
 
 Token with an amount
 
-```tsx
+```tsx twoslash
+// @noErrors: 1109 - Expression expected
 import { TokenRow } from '@coinbase/onchainkit/token';
 
 const token = { ... };
@@ -95,7 +98,8 @@ const token = { ... };
 
 Variations with `hideImage` and `hideSymbol`
 
-```tsx
+```tsx twoslash
+// @noErrors: 1109 - Expression expected
 import { TokenRow } from '@coinbase/onchainkit/token';
 
 const token = { ... };

--- a/site/docs/pages/token/token-search.mdx
+++ b/site/docs/pages/token/token-search.mdx
@@ -11,7 +11,11 @@ If you want to handle debounce delay outside of this component, set `delayMs` to
 
 Use [`getTokens`](/api/get-tokens) and `<TokenSearch />` combined to search the [Tokens](/token/types#token).
 
-```tsx
+```tsx twoslash
+// @noErrors: 7006 2322 1128 - 'value' implicitly has any type, Type GetTokensResponse is not assignable to type Token[]
+import { useCallback } from 'react';
+import { base } from 'viem/chains';
+// ---cut-before---
 import { OnchainKitProvider } from '@coinbase/onchainkit';
 import { getTokens } from '@coinbase/onchainkit/api'; // [!code focus]
 import { TokenSearch } from '@coinbase/onchainkit/token'; // [!code focus]
@@ -20,13 +24,13 @@ import type { Token } from '@coinbase/onchainkit/token'; // [!code focus]
 ...
 
 // example of async onChange handler
-const handleChange = useCallback((value) => {
+const handleChange = useCallback((value: string) => {
   async function getData(value) {
     const tokens: Token[] = await getTokens({ search: value }); // [!code focus]
     // Do something with tokens here
   }
-  getData(value)
-}, [])
+  getData(value);
+}, []);
 
 ...
 

--- a/site/docs/pages/token/token-select-dropdown.mdx
+++ b/site/docs/pages/token/token-select-dropdown.mdx
@@ -1,4 +1,3 @@
-{/* import { TokenSelectDropdown } from '../../../../src/token'; */}
 import { TokenSelectDropdown } from '@coinbase/onchainkit/token';
 import TokenSelectorContainer from '../../components/TokenSelectorContainer.tsx';
 import App from '../../components/App';
@@ -9,7 +8,11 @@ The `TokenSelectDropdown` component is a dropdown component that selects a token
 
 ## Usage
 
-```tsx
+```tsx twoslash
+import { TokenSelectDropdown, Token } from '@coinbase/onchainkit/token';
+const token = {} as Token;
+const setToken = (token: Token) => {};
+// ---cut-before---
 <TokenSelectDropdown // [!code focus]
   token={token} // [!code focus]
   setToken={setToken} // [!code focus]

--- a/site/docs/pages/transaction/types.mdx
+++ b/site/docs/pages/transaction/types.mdx
@@ -11,10 +11,10 @@ description: Glossary of Types in Transaction components & utilities.
 type Call = { to: Hex; data?: Hex; value?: bigint };
 ```
 
-## `LifeCycleStatus`
+## `LifecycleStatus`
 
 ```ts
-type LifeCycleStatus =
+type LifecycleStatus =
   | {
       statusName: 'init';
       statusData: null;
@@ -76,7 +76,7 @@ type TransactionReact = {
   className?: string; // An optional CSS class name for styling the component.
   contracts?: ContractFunctionParameters[]; // An array of contract function parameters for the transaction. Mutually exclusive with the `calls` prop.
   onError?: (e: TransactionError) => void; // An optional callback function that handles transaction errors.
-  onStatus?: (lifeCycleStatus: LifeCycleStatus) => void; // An optional callback function that exposes the component lifecycle state
+  onStatus?: (lifecycleStatus: LifecycleStatus) => void; // An optional callback function that exposes the component lifecycle state
   onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes the transaction receipts
 };
 ```

--- a/site/docs/pages/wallet/is-valid-aa-entrypoint.mdx
+++ b/site/docs/pages/wallet/is-valid-aa-entrypoint.mdx
@@ -6,10 +6,10 @@ The `isValidAAEntrypoint` utility is designed to verify the Account-Abstraction 
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
 import { isValidAAEntrypoint } from '@coinbase/onchainkit/wallet';
 
-const AAImplementationAddress = '0x123`;
+const AAImplementationAddress = '0x123';
 const isValid = isValidAAEntrypoint({ entrypoint: AAImplementationAddress });
 
 if (isValid) {

--- a/site/docs/pages/wallet/is-wallet-a-coinbase-smart-wallet.mdx
+++ b/site/docs/pages/wallet/is-wallet-a-coinbase-smart-wallet.mdx
@@ -6,12 +6,13 @@ The `isWalletASmartCoinbaseWallet` utility is designed to verify if a given send
 
 :::code-group
 
-```tsx [code]
+```tsx twoslash [code]
+// @noErrors: 2352 2801 2719
 import { isWalletACoinbaseSmartWallet } from '@coinbase/onchainkit/wallet';
 import { http } from 'viem';
 import { baseSepolia } from 'viem/chains';
 import type { UserOperation } from 'permissionless';
-import type { PublicClient } from 'viem';
+import { type PublicClient, createPublicClient } from 'viem';
 
 export const publicClient = createPublicClient({
   chain: baseSepolia,

--- a/site/docs/pages/wallet/wallet-dropdown-basename.mdx
+++ b/site/docs/pages/wallet/wallet-dropdown-basename.mdx
@@ -26,7 +26,7 @@ This component enhances the wallet interface by providing easy access to Basenam
 
 ## Usage
 
-```tsx
+```tsx twoslash
 import {
   Address,
   Avatar,

--- a/site/docs/pages/wallet/wallet-dropdown-disconnect.mdx
+++ b/site/docs/pages/wallet/wallet-dropdown-disconnect.mdx
@@ -22,7 +22,7 @@ The `WalletDropdownDisconnect` component is used to disconnect the wallet from t
 
 ## Usage 
 
-```tsx
+```tsx twoslash
 import {
   Address,
   Avatar,

--- a/site/docs/pages/wallet/wallet-dropdown-fund-link.mdx
+++ b/site/docs/pages/wallet/wallet-dropdown-fund-link.mdx
@@ -31,7 +31,7 @@ Users can buy and receive crypto, or use their Coinbase balances onchain with [M
 
 ## Usage
 
-```tsx
+```tsx twoslash
 import {
   ConnectWallet,
   Wallet,

--- a/site/docs/pages/wallet/wallet-dropdown-link.mdx
+++ b/site/docs/pages/wallet/wallet-dropdown-link.mdx
@@ -23,7 +23,7 @@ The `WalletDropdownLink` component creates customizable, interactive links withi
 
 ## Usage 
 
-```tsx
+```tsx twoslash
 import {
   Address,
   Avatar,
@@ -90,7 +90,12 @@ export function WalletComponents() {
 ### Custom link
 Add a custom link to the wallet dropdown menu, allowing users to navigate to external resources directly from the wallet interface.
 
-```tsx
+```tsx twoslash
+// @noErrors: 2304 Cannot find name 'BaseIcon'
+import {
+  WalletDropdownLink,
+} from '@coinbase/onchainkit/wallet';
+// ---cut-before---
 // omitted for brevity
 <WalletDropdownLink // [!code focus] 
   icon={BaseIcon} // [!code focus] 
@@ -130,7 +135,12 @@ Add a custom link to the wallet dropdown menu, allowing users to navigate to ext
 Accepts React children, enabling the use of custom elements, styled text, icons, and complex components.
 This allows for diverse customizations, including complex layouts and conditional rendering based on your app's state.
 
-```tsx
+```tsx twoslash
+// @noErrors: 2322 - type 'Element' is not assignable to type 'string'
+import {
+  WalletDropdownLink,
+} from '@coinbase/onchainkit/wallet';
+// ---cut-before---
 // omitted for brevity
 <WalletDropdownLink icon="wallet" href="https://keys.coinbase.com"> // [!code focus]
   <span className="font-bold italic">Profile</span> // [!code focus]
@@ -163,7 +173,11 @@ This allows for diverse customizations, including complex layouts and conditiona
 ### Override styles
 You can override component styles using className.
 
-```tsx
+```tsx twoslash
+import {
+  WalletDropdownLink,
+} from '@coinbase/onchainkit/wallet';
+// ---cut-before---
 // omitted for brevity
 <WalletDropdownLink className="hover:bg-red-500" icon="wallet" href="https://keys.coinbase.com" > // [!code focus]
   Wallet // [!code focus]

--- a/site/docs/pages/wallet/wallet.mdx
+++ b/site/docs/pages/wallet/wallet.mdx
@@ -27,7 +27,7 @@ The Wallet components provide a comprehensive interface for users to connect the
 
 ## Usage
 
-```tsx
+```tsx twoslash
 import { // [!code focus]
   ConnectWallet, // [!code focus]
   Wallet, // [!code focus]
@@ -95,7 +95,23 @@ export function WalletComponents() {
 
 You can override component styles using `className`.
 
-```tsx
+```tsx twoslash
+import {
+  ConnectWallet,
+  Wallet,
+  WalletDropdown,
+  WalletDropdownLink,
+  WalletDropdownDisconnect,
+} from '@coinbase/onchainkit/wallet';
+import {
+  Address,
+  Avatar,
+  Name,
+  Identity,
+  EthBalance,
+} from '@coinbase/onchainkit/identity';
+import { color } from '@coinbase/onchainkit/theme';
+// ---cut-before---
 // omitted for brevity
 
 <Wallet>
@@ -154,7 +170,16 @@ You can override component styles using `className`.
 
 You can override component text using `text`.
 
-```tsx
+```tsx twoslash
+import {
+  ConnectWallet,
+  Wallet,
+} from '@coinbase/onchainkit/wallet';
+import {
+  Avatar,
+  Name,
+} from '@coinbase/onchainkit/identity';
+// ---cut-before---
 // omitted for brevity
 
 <Wallet>
@@ -191,7 +216,7 @@ You can override component text using `text`.
 If you are using any of the provided components, you will need to install
 and configure `wagmi` and wrap your app in `<WagmiProvider>`.
 
-```tsx
+```tsx twoslash
 import { ReactNode } from 'react';
 import { WagmiProvider, createConfig, http } from 'wagmi';
 import { baseSepolia } from 'wagmi/chains';
@@ -227,7 +252,22 @@ OnchainKit leverages [RainbowKit](https://www.rainbowkit.com/) to offer this fea
 
 :::code-group
 
-```tsx [myApp.tsx]
+```tsx twoslash [myApp.tsx]
+import {
+  ConnectWallet,
+  Wallet,
+  WalletDropdown,
+  WalletDropdownLink,
+  WalletDropdownDisconnect,
+} from '@coinbase/onchainkit/wallet';
+import {
+  Address,
+  Avatar,
+  Name,
+  Identity,
+  EthBalance,
+} from '@coinbase/onchainkit/identity';
+// ---cut-before---
 // omitted for brevity
 
 <Wallet>
@@ -253,7 +293,8 @@ OnchainKit leverages [RainbowKit](https://www.rainbowkit.com/) to offer this fea
 </Wallet>
 ```
 
-```tsx [OnchainProviders.tsx]
+```tsx twoslash [OnchainProviders.tsx]
+// @noErrors: 2304 2322 - Cannot find VITE_WALLET_CONNECT_PROJECT_ID, Canoot find name Props
 'use client';
 import type { ReactNode } from 'react';
 import { OnchainKitProvider } from '@coinbase/onchainkit';

--- a/site/docs/pages/xmtp/get-xmtp-frame-message.mdx
+++ b/site/docs/pages/xmtp/get-xmtp-frame-message.mdx
@@ -12,7 +12,8 @@ You can also use `getXmtpFrameMessage` to access useful information such as:
 
 Note that if the `message` is not valid, it will be undefined.
 
-```ts
+```ts twoslash
+// @noErrors: 2307 2339 - Cannot find module 'next/server', Property 'verifiedWalletAddress' does not exist on type
 import { isXmtpFrameRequest, getXmtpFrameMessage } from '@coinbase/onchainkit/xmtp'; // [!code focus]
 import { NextResponse } from 'next/server';
 import type { FrameRequest } from '@coinbase/onchainkit/frame';

--- a/site/docs/pages/xmtp/is-xmtp-frame-request.mdx
+++ b/site/docs/pages/xmtp/is-xmtp-frame-request.mdx
@@ -1,6 +1,7 @@
 # `isXmtpFrameRequest`
 
-```ts
+```ts twoslash
+// @noErrors: 2307 - Cannot find module 'next/server'
 import { FrameRequest } from '@coinbase/onchainkit/frame';
 import { isXmtpFrameRequest } from '@coinbase/onchainkit/xmtp'; // [!code focus]
 import { NextResponse } from 'next/server';
@@ -8,8 +9,6 @@ import { NextResponse } from 'next/server';
 async function getResponse(req: any): Promise<NextResponse> {
   const body: FrameRequest = await req.json();
   if (isXmtpFrameRequest(body)) {
-    // [!code focus]
-    // [!code focus]
     // ...
   }
 }

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -28,6 +28,8 @@
   .vocs_Code {
     background-color: #1F2937 !important;
     border-color: #1F2937 !important;
+    --vocs-twoslash_popupBackground: #1F2937;
+    --vocs-color_background5: #1F2937;
   }
 
   .vocs_Tabs_trigger {
@@ -38,7 +40,7 @@
 
 .vocs_CodeGroup {
   border-radius: 8px;
-  overflow: hidden;
+  overflow: visible;
   display: flex;
   flex-direction: column;
   height: 100%;


### PR DESCRIPTION
**What changed? Why?**
Added twoslash to all codeblocks

![image](https://github.com/user-attachments/assets/7218d87a-a4df-47f4-b13b-254812ba9ef0)

**Notes to reviewers**
Twoslash needs to be [explicitly triggered](https://github.com/wevm/vocs/blob/main/src/vite/plugins/mdx.ts#L107) on each codeblock


**How has it been tested?**
