### PR TITLE
chore: Update SwapSettingsSlippageInput to use Config

### DIFF
--- a/.changeset/late-bottles-greet.md
+++ b/.changeset/late-bottles-greet.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+-**chore**: updated `SwapSettingsSlippageInput` to use the input config defaultMaxSlippage value. By @cpcramer #1263.

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -330,6 +330,7 @@ export function SwapProvider({
 
   const value = useValue({
     address,
+    config,
     from,
     handleAmountChange,
     handleToggle,

--- a/src/swap/components/SwapSettingsSlippageInput.test.tsx
+++ b/src/swap/components/SwapSettingsSlippageInput.test.tsx
@@ -207,7 +207,7 @@ describe('SwapSettingsSlippageInput', () => {
     expect(mockSetLifecycleStatus).toHaveBeenLastCalledWith({
       statusName: 'slippageChange',
       statusData: {
-        maxSlippage: DEFAULT_MAX_SLIPPAGE,
+        maxSlippage: 5,
       },
     });
   });

--- a/src/swap/components/SwapSettingsSlippageInput.tsx
+++ b/src/swap/components/SwapSettingsSlippageInput.tsx
@@ -12,23 +12,22 @@ const SLIPPAGE_SETTINGS = {
 export function SwapSettingsSlippageInput({
   className,
 }: SwapSettingsSlippageInputReact) {
-  const { updateLifecycleStatus, lifecycleStatus } = useSwapContext();
-  const getMaxSlippage = useCallback(() => {
-    return lifecycleStatus.statusData.maxSlippage;
-  }, [lifecycleStatus.statusData]);
+  const {
+    updateLifecycleStatus,
+    lifecycleStatus,
+    config: { maxSlippage: defaultMaxSlippage },
+  } = useSwapContext();
 
   // Set initial slippage values to match previous selection or default,
   // ensuring consistency when dropdown is reopened
-  const [slippage, setSlippage] = useState(getMaxSlippage());
   const [slippageSetting, setSlippageSetting] = useState(
-    getMaxSlippage() === DEFAULT_MAX_SLIPPAGE
+    lifecycleStatus.statusData.maxSlippage === defaultMaxSlippage
       ? SLIPPAGE_SETTINGS.AUTO
       : SLIPPAGE_SETTINGS.CUSTOM,
   );
 
   const updateSlippage = useCallback(
     (newSlippage: number) => {
-      setSlippage(newSlippage);
       updateLifecycleStatus({
         statusName: 'slippageChange',
         statusData: {
@@ -39,20 +38,15 @@ export function SwapSettingsSlippageInput({
     [updateLifecycleStatus],
   );
 
-  // Handles user input for custom slippage
-  // Parses the input and updates slippage if valid
+  // Handles user input for custom slippage.
+  // Parses the input and updates slippage state.
   const handleSlippageChange = useCallback(
     (newSlippage: string) => {
-      // Empty '' when the input field is cleared.
-      if (newSlippage === '') {
-        setSlippage(0);
-        return;
-      }
+      const parsedSlippage = Number.parseFloat(newSlippage);
+      const isValidNumber = !isNaN(parsedSlippage);
 
-      const newSlippageNumber = Number.parseFloat(newSlippage);
-      if (!Number.isNaN(newSlippageNumber)) {
-        updateSlippage(newSlippageNumber);
-      }
+      // Update slippage to parsed value if valid, otherwise set to 0
+      updateSlippage(isValidNumber ? parsedSlippage : 0);
     },
     [updateSlippage],
   );
@@ -119,7 +113,7 @@ export function SwapSettingsSlippageInput({
         <input
           id="slippage-input"
           type="text"
-          value={slippage}
+          value={lifecycleStatus.statusData.maxSlippage}
           onChange={(e) => handleSlippageChange(e.target.value)}
           disabled={slippageSetting === SLIPPAGE_SETTINGS.AUTO}
           className={cn(

--- a/src/swap/components/SwapSettingsSlippageInput.tsx
+++ b/src/swap/components/SwapSettingsSlippageInput.tsx
@@ -13,9 +13,9 @@ export function SwapSettingsSlippageInput({
   className,
 }: SwapSettingsSlippageInputReact) {
   const {
+    config: { maxSlippage: defaultMaxSlippage },
     updateLifecycleStatus,
     lifecycleStatus,
-    config: { maxSlippage: defaultMaxSlippage },
   } = useSwapContext();
 
   // Set initial slippage values to match previous selection or default,
@@ -28,12 +28,14 @@ export function SwapSettingsSlippageInput({
 
   const updateSlippage = useCallback(
     (newSlippage: number) => {
-      updateLifecycleStatus({
-        statusName: 'slippageChange',
-        statusData: {
-          maxSlippage: newSlippage,
-        },
-      });
+      if (newSlippage !== lifecycleStatus.statusData.maxSlippage) {
+        updateLifecycleStatus({
+          statusName: 'slippageChange',
+          statusData: {
+            maxSlippage: newSlippage,
+          },
+        });
+      }
     },
     [updateLifecycleStatus],
   );

--- a/src/swap/components/SwapSettingsSlippageInput.tsx
+++ b/src/swap/components/SwapSettingsSlippageInput.tsx
@@ -43,7 +43,7 @@ export function SwapSettingsSlippageInput({
   const handleSlippageChange = useCallback(
     (newSlippage: string) => {
       const parsedSlippage = Number.parseFloat(newSlippage);
-      const isValidNumber = !isNaN(parsedSlippage);
+      const isValidNumber = !Number.isNaN(parsedSlippage);
 
       // Update slippage to parsed value if valid, otherwise set to 0
       updateSlippage(isValidNumber ? parsedSlippage : 0);

--- a/src/swap/components/SwapSettingsSlippageInput.tsx
+++ b/src/swap/components/SwapSettingsSlippageInput.tsx
@@ -43,7 +43,8 @@ export function SwapSettingsSlippageInput({
   // Handles user input for custom slippage.
   // Parses the input and updates slippage state.
   const handleSlippageChange = useCallback(
-    (newSlippage: string) => {
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newSlippage = e.target.value;
       const parsedSlippage = Number.parseFloat(newSlippage);
       const isValidNumber = !Number.isNaN(parsedSlippage);
 
@@ -116,7 +117,7 @@ export function SwapSettingsSlippageInput({
           id="slippage-input"
           type="text"
           value={lifecycleStatus.statusData.maxSlippage}
-          onChange={(e) => handleSlippageChange(e.target.value)}
+          onChange={handleSlippageChange}
           disabled={slippageSetting === SLIPPAGE_SETTINGS.AUTO}
           className={cn(
             color.foreground,

--- a/src/swap/components/SwapSettingsSlippageInput.tsx
+++ b/src/swap/components/SwapSettingsSlippageInput.tsx
@@ -37,7 +37,7 @@ export function SwapSettingsSlippageInput({
         });
       }
     },
-    [updateLifecycleStatus],
+    [lifecycleStatus.statusData.maxSlippage, updateLifecycleStatus],
   );
 
   // Handles user input for custom slippage.

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -164,6 +164,9 @@ export type SwapButtonReact = {
 
 export type SwapContextType = {
   address?: Address; // Used to check if user is connected in SwapButton
+  config: {
+    maxSlippage: number; // Maximum acceptable slippage for a swap. (default: 10) This is as a percent, not basis points
+  };
   from: SwapUnit;
   lifecycleStatus: LifecycleStatus;
   handleAmountChange: (

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -162,11 +162,13 @@ export type SwapButtonReact = {
   disabled?: boolean; // Disables swap button
 };
 
+type SwapConfig = {
+  maxSlippage: number; // Maximum acceptable slippage for a swap. (default: 10) This is as a percent, not basis points;
+};
+
 export type SwapContextType = {
   address?: Address; // Used to check if user is connected in SwapButton
-  config: {
-    maxSlippage: number; // Maximum acceptable slippage for a swap. (default: 10) This is as a percent, not basis points
-  };
+  config: SwapConfig;
   from: SwapUnit;
   lifecycleStatus: LifecycleStatus;
   handleAmountChange: (
@@ -242,9 +244,7 @@ export type SwapProviderReact = {
 export type SwapReact = {
   children: ReactNode;
   className?: string; // Optional className override for top div element.
-  config?: {
-    maxSlippage: number; // Maximum acceptable slippage for a swap. (default: 10) This is as a percent, not basis points
-  };
+  config?: SwapConfig;
   experimental?: {
     useAggregator: boolean; // Whether to use a DEX aggregator. (default: true)
   };


### PR DESCRIPTION
**What changed? Why?**
Add the Swap Config to the Context.

Update `SwapSettingsSlippageInput` updates:

- Use the config `defaultMaxSlippage` rather than our hardcoded maxSlippage value.
- Remove local slippage state.
- Remove `getMaxSlippage` function. `useCallback` is not providing many performance benefits here. Likely it's even slower than accessing `lifecycleStatus.statusData.maxSlippage` directly.

**Notes to reviewers**

**How has it been tested?**
![Export-1726524676893](https://github.com/user-attachments/assets/46968f08-b167-4deb-8011-bf74dd00847d)
