### PR TITLE
feat: batched Swap transactions from ERC-20

### DIFF
--- a/.changeset/itchy-socks-drop.md
+++ b/.changeset/itchy-socks-drop.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+**feat**: added batched Swap transactions from ERC-20. by @0xAlec #1264

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -267,11 +267,9 @@ describe('SwapProvider', () => {
     (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
       address: '0x123',
     });
-    (useCallsStatus as ReturnType<typeof vi.fn>).mockImplementation(
-      ({ query }) => {
-        return { data: {} };
-      },
-    );
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {},
+    });
     (useSendCalls as ReturnType<typeof vi.fn>).mockReturnValue({
       status: 'idle',
       sendCallsAsync: vi.fn(),
@@ -296,7 +294,7 @@ describe('SwapProvider', () => {
   });
 
   it('should handle `useCallsStatus` for batched transactions', async () => {
-    const { result } = renderHook(() => useSwapContext(), { wrapper });
+    const {} = renderHook(() => useSwapContext(), { wrapper });
     const mockData = {
       status: 'CONFIRMED',
       receipts: [{}],
@@ -334,7 +332,7 @@ describe('SwapProvider', () => {
       },
     );
 
-    const { result } = renderHook(() => useSwapContext(), { wrapper });
+    const {} = renderHook(() => useSwapContext(), { wrapper });
   });
 
   it('should use the appropriate refetch interval for non-CONFIRMED', async () => {
@@ -352,7 +350,7 @@ describe('SwapProvider', () => {
       },
     );
 
-    const { result } = renderHook(() => useSwapContext(), { wrapper });
+    const {} = renderHook(() => useSwapContext(), { wrapper });
   });
 
   it('should emit onError when setLifecycleStatus is called with error', async () => {

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -294,7 +294,7 @@ describe('SwapProvider', () => {
   });
 
   it('should handle `useCallsStatus` for batched transactions', async () => {
-    const {} = renderHook(() => useSwapContext(), { wrapper });
+    renderHook(() => useSwapContext(), { wrapper });
     const mockData = {
       status: 'CONFIRMED',
       receipts: [{}],
@@ -332,7 +332,7 @@ describe('SwapProvider', () => {
       },
     );
 
-    const {} = renderHook(() => useSwapContext(), { wrapper });
+    renderHook(() => useSwapContext(), { wrapper });
   });
 
   it('should use the appropriate refetch interval for non-CONFIRMED', async () => {
@@ -350,7 +350,7 @@ describe('SwapProvider', () => {
       },
     );
 
-    const {} = renderHook(() => useSwapContext(), { wrapper });
+    renderHook(() => useSwapContext(), { wrapper });
   });
 
   it('should emit onError when setLifecycleStatus is called with error', async () => {

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -9,10 +9,13 @@ import {
 import React, { act, useCallback, useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { http, WagmiProvider, createConfig, useAccount } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
 import { base } from 'wagmi/chains';
 import { mock } from 'wagmi/connectors';
+import { useCallsStatus, useSendCalls } from 'wagmi/experimental';
 import { buildSwapTransaction } from '../../api/buildSwapTransaction';
 import { getSwapQuote } from '../../api/getSwapQuote';
+import { useCapabilitiesSafe } from '../../internal/hooks/useCapabilitiesSafe';
 import { DEGEN_TOKEN, ETH_TOKEN } from '../mocks';
 import { getSwapErrorCode } from '../utils/getSwapErrorCode';
 import { SwapProvider, useSwapContext } from './SwapProvider';
@@ -42,6 +45,24 @@ vi.mock('wagmi', async (importOriginal) => {
     useAccount: vi.fn(),
   };
 });
+
+const mockAwaitCalls = vi.fn();
+vi.mock('../hooks/useAwaitCalls', () => ({
+  useAwaitCalls: () => useCallback(mockAwaitCalls, []),
+}));
+
+vi.mock('../../internal/hooks/useCapabilitiesSafe', () => ({
+  useCapabilitiesSafe: vi.fn(),
+}));
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn(),
+}));
+
+vi.mock('wagmi/experimental', () => ({
+  useCallsStatus: vi.fn(),
+  useSendCalls: vi.fn(),
+}));
 
 vi.mock('../path/to/maxSlippageModule', () => ({
   getMaxSlippage: vi.fn().mockReturnValue(10),
@@ -194,6 +215,13 @@ describe('useSwapContext', () => {
     (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
       address: '0x123',
     });
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {},
+    });
+    (useSendCalls as ReturnType<typeof vi.fn>).mockReturnValue({
+      status: 'idle',
+      sendCallsAsync: vi.fn(),
+    });
     await act(async () => {
       renderWithProviders({ Component: () => null });
     });
@@ -239,6 +267,16 @@ describe('SwapProvider', () => {
     (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
       address: '0x123',
     });
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ query }) => {
+        return { data: {} };
+      },
+    );
+    (useSendCalls as ReturnType<typeof vi.fn>).mockReturnValue({
+      status: 'idle',
+      sendCallsAsync: vi.fn(),
+    });
+    (useCapabilitiesSafe as ReturnType<typeof vi.fn>).mockReturnValue({});
   });
 
   it('should reset inputs when setLifecycleStatus is called with success', async () => {
@@ -255,6 +293,66 @@ describe('SwapProvider', () => {
       expect(mockResetFunction).toHaveBeenCalled();
     });
     expect(mockResetFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle `useCallsStatus` for batched transactions', async () => {
+    const { result } = renderHook(() => useSwapContext(), { wrapper });
+    const mockData = {
+      status: 'CONFIRMED',
+      receipts: [{}],
+    };
+    (useCapabilitiesSafe as ReturnType<typeof vi.fn>).mockReturnValue({
+      atomicBatch: { supported: true },
+      paymasterService: { supported: true },
+      auxiliaryFunds: { supported: true },
+    });
+    (waitForTransactionReceipt as ReturnType<typeof vi.fn>).mockResolvedValue({
+      transactionHash: 'receiptHash',
+    });
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: mockData,
+    });
+    await waitFor(() => {
+      expect(mockAwaitCalls).toHaveBeenCalled();
+    });
+    expect(mockAwaitCalls).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use the appropriate refetch interval for CONFIRMED', async () => {
+    const mockData = {
+      status: 'CONFIRMED',
+      receipts: [{}],
+    };
+    // Mocking useCallsStatusWagmi to return the specific data and simulate refetchInterval logic
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ query }) => {
+        const refetchInterval = query.refetchInterval({
+          state: { data: mockData },
+        });
+        expect(refetchInterval).toBe(false);
+        return { data: mockData };
+      },
+    );
+
+    const { result } = renderHook(() => useSwapContext(), { wrapper });
+  });
+
+  it('should use the appropriate refetch interval for non-CONFIRMED', async () => {
+    const mockData = {
+      status: 'PENDING',
+    };
+    // Mocking useCallsStatusWagmi to return the specific data and simulate refetchInterval logic
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ query }) => {
+        const refetchInterval = query.refetchInterval({
+          state: { data: mockData },
+        });
+        expect(refetchInterval).toBe(1000);
+        return { data: mockData };
+      },
+    );
+
+    const { result } = renderHook(() => useSwapContext(), { wrapper });
   });
 
   it('should emit onError when setLifecycleStatus is called with error', async () => {

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -58,7 +58,7 @@ export function SwapProvider({
   // Core Hooks
   const accountConfig = useConfig();
   const [callsId, setCallsId] = useState<Hex>();
-  const { data } = useCallsStatus({
+  const callsStatus = useCallsStatus({
     id: callsId || '0x',
     query: {
       refetchInterval: (query) => {
@@ -79,7 +79,7 @@ export function SwapProvider({
   const awaitCallsStatus = useAwaitCalls({
     accountConfig,
     config,
-    data,
+    callsStatus,
     setLifecycleStatus,
   });
 
@@ -355,7 +355,6 @@ export function SwapProvider({
     lifecycleStatus,
     sendCallsAsync,
     sendTransactionAsync,
-    setCallsId,
     to.token,
     updateLifecycleStatus,
     useAggregator,

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -59,7 +59,7 @@ export function SwapProvider({
   const accountConfig = useConfig();
   const [callsId, setCallsId] = useState<Hex>();
   const { data } = useCallsStatus({
-    id: callsId!,
+    id: callsId || '0x',
     query: {
       refetchInterval: (query) => {
         return query.state.data?.status === 'CONFIRMED' ? false : 1000;
@@ -86,7 +86,7 @@ export function SwapProvider({
   // Lifecycle listener for batched transactions
   useEffect(() => {
     awaitCallsStatus();
-  }, []);
+  }, [awaitCallsStatus]);
 
   // Update lifecycle status, statusData will be persisted for the full lifeCycle
   const updateLifecycleStatus = useCallback(
@@ -353,10 +353,13 @@ export function SwapProvider({
     from.amount,
     from.token,
     lifecycleStatus,
+    sendCallsAsync,
     sendTransactionAsync,
+    setCallsId,
     to.token,
     updateLifecycleStatus,
     useAggregator,
+    walletCapabilities,
   ]);
 
   const value = useValue({

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -8,7 +8,7 @@ import {
 import type { Hex } from 'viem';
 import { base } from 'viem/chains';
 import { useAccount, useConfig, useSendTransaction } from 'wagmi';
-import { useCallsStatus, useSendCalls } from 'wagmi/experimental';
+import { useSendCalls } from 'wagmi/experimental';
 import { buildSwapTransaction } from '../../api/buildSwapTransaction';
 import { getSwapQuote } from '../../api/getSwapQuote';
 import { useCapabilitiesSafe } from '../../internal/hooks/useCapabilitiesSafe';
@@ -58,15 +58,6 @@ export function SwapProvider({
   // Core Hooks
   const accountConfig = useConfig();
   const [callsId, setCallsId] = useState<Hex>();
-  const callsStatus = useCallsStatus({
-    id: callsId || '0x',
-    query: {
-      refetchInterval: (query) => {
-        return query.state.data?.status === 'CONFIRMED' ? false : 1000;
-      },
-      enabled: callsId !== undefined,
-    },
-  });
   const walletCapabilities = useCapabilitiesSafe({ chainId: base.id }); // Swap is only available on Base
   const [lifecycleStatus, setLifecycleStatus] = useState<LifecycleStatus>({
     statusName: 'init',
@@ -78,8 +69,8 @@ export function SwapProvider({
 
   const awaitCallsStatus = useAwaitCalls({
     accountConfig,
+    callsId,
     config,
-    callsStatus,
     setLifecycleStatus,
   });
 

--- a/src/swap/hooks/useAwaitCalls.test.ts
+++ b/src/swap/hooks/useAwaitCalls.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import { useAwaitCalls } from './useAwaitCalls';
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn(),
+}));
+
+describe('useAwaitCalls', () => {
+  const mockAccountConfig = {} as any;
+  const mockConfig = { maxSlippage: 0.1 };
+  const mockSetLifecycleStatus = vi.fn();
+
+  it('should not call waitForTransactionReceipt when data status is not CONFIRMED', async () => {
+    const { result } = renderHook(() =>
+      useAwaitCalls({
+        accountConfig: mockAccountConfig,
+        config: mockConfig,
+        data: { status: 'PENDING' },
+        setLifecycleStatus: mockSetLifecycleStatus,
+      }),
+    );
+    await act(async () => {
+      await result.current();
+    });
+    expect(waitForTransactionReceipt).not.toHaveBeenCalled();
+    expect(mockSetLifecycleStatus).not.toHaveBeenCalled();
+  });
+
+  it('should call waitForTransactionReceipt and update lifecycle status when data status is CONFIRMED', async () => {
+    const mockTransactionReceipt = { blockNumber: 123 };
+    (waitForTransactionReceipt as jest.Mock).mockResolvedValue(
+      mockTransactionReceipt,
+    );
+    const mockData = {
+      status: 'CONFIRMED',
+      receipts: [{ transactionHash: '0x123' }],
+    };
+    const { result } = renderHook(() =>
+      useAwaitCalls({
+        accountConfig: mockAccountConfig,
+        config: mockConfig,
+        data: mockData,
+        setLifecycleStatus: mockSetLifecycleStatus,
+      }),
+    );
+    await act(async () => {
+      await result.current();
+    });
+    expect(waitForTransactionReceipt).toHaveBeenCalledWith(mockAccountConfig, {
+      confirmations: 1,
+      hash: '0x123',
+    });
+    expect(mockSetLifecycleStatus).toHaveBeenCalledWith({
+      statusName: 'success',
+      statusData: {
+        isMissingRequiredField: false,
+        maxSlippage: mockConfig.maxSlippage,
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+});

--- a/src/swap/hooks/useAwaitCalls.test.ts
+++ b/src/swap/hooks/useAwaitCalls.test.ts
@@ -8,7 +8,9 @@ vi.mock('wagmi/actions', () => ({
 }));
 
 describe('useAwaitCalls', () => {
-  const mockAccountConfig = {} as any;
+  const mockAccountConfig = {
+    address: '0x123',
+  };
   const mockConfig = { maxSlippage: 0.1 };
   const mockSetLifecycleStatus = vi.fn();
 

--- a/src/swap/hooks/useAwaitCalls.test.ts
+++ b/src/swap/hooks/useAwaitCalls.test.ts
@@ -1,10 +1,15 @@
 import { act, renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { waitForTransactionReceipt } from 'wagmi/actions';
+import { useCallsStatus } from 'wagmi/experimental';
 import { useAwaitCalls } from './useAwaitCalls';
 
 vi.mock('wagmi/actions', () => ({
   waitForTransactionReceipt: vi.fn(),
+}));
+
+vi.mock('wagmi/experimental', () => ({
+  useCallsStatus: vi.fn(),
 }));
 
 describe('useAwaitCalls', () => {
@@ -13,14 +18,23 @@ describe('useAwaitCalls', () => {
   };
   const mockConfig = { maxSlippage: 0.1 };
   const mockSetLifecycleStatus = vi.fn();
+  const mockCallsId = '0x456';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: {},
+    });
+  });
 
   it('should not call waitForTransactionReceipt when data status is not CONFIRMED', async () => {
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: { status: 'PENDING' },
+    });
     const { result } = renderHook(() =>
       useAwaitCalls({
         accountConfig: mockAccountConfig,
-        callsStatus: {
-          data: { status: 'PENDING' },
-        },
+        callsId: mockCallsId,
         config: mockConfig,
         setLifecycleStatus: mockSetLifecycleStatus,
       }),
@@ -39,14 +53,15 @@ describe('useAwaitCalls', () => {
     );
     const mockData = {
       status: 'CONFIRMED',
-      receipts: [{ transactionHash: '0x123' }],
+      receipts: [{ transactionHash: '0x789' }],
     };
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: mockData,
+    });
     const { result } = renderHook(() =>
       useAwaitCalls({
         accountConfig: mockAccountConfig,
-        callsStatus: {
-          data: mockData,
-        },
+        callsId: mockCallsId,
         config: mockConfig,
         setLifecycleStatus: mockSetLifecycleStatus,
       }),
@@ -56,7 +71,7 @@ describe('useAwaitCalls', () => {
     });
     expect(waitForTransactionReceipt).toHaveBeenCalledWith(mockAccountConfig, {
       confirmations: 1,
-      hash: '0x123',
+      hash: '0x789',
     });
     expect(mockSetLifecycleStatus).toHaveBeenCalledWith({
       statusName: 'success',
@@ -66,5 +81,71 @@ describe('useAwaitCalls', () => {
         transactionReceipt: mockTransactionReceipt,
       },
     });
+  });
+
+  it('should use the appropriate refetch interval for CONFIRMED status', () => {
+    const mockData = {
+      status: 'CONFIRMED',
+      receipts: [{}],
+    };
+    let refetchIntervalFn: Function;
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ query }) => {
+        refetchIntervalFn = query.refetchInterval;
+        return { data: mockData };
+      },
+    );
+    renderHook(() =>
+      useAwaitCalls({
+        accountConfig: mockAccountConfig,
+        callsId: mockCallsId,
+        config: mockConfig,
+        setLifecycleStatus: mockSetLifecycleStatus,
+      }),
+    );
+    const result = refetchIntervalFn({ state: { data: mockData } });
+    expect(result).toBe(false);
+  });
+
+  it('should use the appropriate refetch interval for non-CONFIRMED status', () => {
+    const mockData = {
+      status: 'PENDING',
+    };
+    let refetchIntervalFn: Function;
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ query }) => {
+        refetchIntervalFn = query.refetchInterval;
+        return { data: mockData };
+      },
+    );
+    renderHook(() =>
+      useAwaitCalls({
+        accountConfig: mockAccountConfig,
+        callsId: mockCallsId,
+        config: mockConfig,
+        setLifecycleStatus: mockSetLifecycleStatus,
+      }),
+    );
+    const result = refetchIntervalFn({ state: { data: mockData } });
+    expect(result).toBe(1000);
+  });
+
+  it('should disable the query when callsId is undefined', () => {
+    let queryEnabled: boolean | undefined;
+    (useCallsStatus as ReturnType<typeof vi.fn>).mockImplementation(
+      ({ query }) => {
+        queryEnabled = query.enabled;
+        return { data: {} };
+      },
+    );
+    renderHook(() =>
+      useAwaitCalls({
+        accountConfig: mockAccountConfig,
+        callsId: undefined,
+        config: mockConfig,
+        setLifecycleStatus: mockSetLifecycleStatus,
+      }),
+    );
+    expect(queryEnabled).toBe(false);
   });
 });

--- a/src/swap/hooks/useAwaitCalls.test.ts
+++ b/src/swap/hooks/useAwaitCalls.test.ts
@@ -18,8 +18,10 @@ describe('useAwaitCalls', () => {
     const { result } = renderHook(() =>
       useAwaitCalls({
         accountConfig: mockAccountConfig,
+        callsStatus: {
+          data: { status: 'PENDING' },
+        },
         config: mockConfig,
-        data: { status: 'PENDING' },
         setLifecycleStatus: mockSetLifecycleStatus,
       }),
     );
@@ -42,8 +44,10 @@ describe('useAwaitCalls', () => {
     const { result } = renderHook(() =>
       useAwaitCalls({
         accountConfig: mockAccountConfig,
+        callsStatus: {
+          data: mockData,
+        },
         config: mockConfig,
-        data: mockData,
         setLifecycleStatus: mockSetLifecycleStatus,
       }),
     );

--- a/src/swap/hooks/useAwaitCalls.ts
+++ b/src/swap/hooks/useAwaitCalls.ts
@@ -1,23 +1,31 @@
 import { useCallback } from 'react';
 import type { Config } from 'wagmi';
 import { waitForTransactionReceipt } from 'wagmi/actions';
-import type { UseCallsStatusReturnType } from 'wagmi/experimental';
+import { useCallsStatus } from 'wagmi/experimental';
 import type { LifecycleStatus } from '../types';
 
 export function useAwaitCalls({
   accountConfig,
+  callsId,
   config,
-  callsStatus,
   setLifecycleStatus,
 }: {
   accountConfig: Config;
+  callsId: string | undefined;
   config: {
     maxSlippage: number;
   };
-  callsStatus: UseCallsStatusReturnType;
   setLifecycleStatus: React.Dispatch<React.SetStateAction<LifecycleStatus>>;
 }) {
-  const { data } = callsStatus;
+  const { data } = useCallsStatus({
+    id: callsId || '0x',
+    query: {
+      refetchInterval: (query) => {
+        return query.state.data?.status === 'CONFIRMED' ? false : 1000;
+      },
+      enabled: callsId !== undefined,
+    },
+  });
 
   return useCallback(async () => {
     if (data?.status === 'CONFIRMED' && data?.receipts) {

--- a/src/swap/hooks/useAwaitCalls.ts
+++ b/src/swap/hooks/useAwaitCalls.ts
@@ -34,5 +34,5 @@ export function useAwaitCalls({
         },
       });
     }
-  }, [accountConfig, config.maxSlippage, data]);
+  }, [accountConfig, config.maxSlippage, data, setLifecycleStatus]);
 }

--- a/src/swap/hooks/useAwaitCalls.ts
+++ b/src/swap/hooks/useAwaitCalls.ts
@@ -1,22 +1,14 @@
 import { useCallback } from 'react';
-import type { Config } from 'wagmi';
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import { useCallsStatus } from 'wagmi/experimental';
-import type { LifecycleStatus } from '../types';
+import type { UseAwaitCallsParams } from '../types';
 
 export function useAwaitCalls({
   accountConfig,
   callsId,
   config,
   setLifecycleStatus,
-}: {
-  accountConfig: Config;
-  callsId: string | undefined;
-  config: {
-    maxSlippage: number;
-  };
-  setLifecycleStatus: React.Dispatch<React.SetStateAction<LifecycleStatus>>;
-}) {
+}: UseAwaitCallsParams) {
   const { data } = useCallsStatus({
     id: callsId || '0x',
     query: {

--- a/src/swap/hooks/useAwaitCalls.ts
+++ b/src/swap/hooks/useAwaitCalls.ts
@@ -1,25 +1,24 @@
 import { useCallback } from 'react';
-import type { WalletCallReceipt } from 'viem';
 import type { Config } from 'wagmi';
 import { waitForTransactionReceipt } from 'wagmi/actions';
+import type { UseCallsStatusReturnType } from 'wagmi/experimental';
 import type { LifecycleStatus } from '../types';
 
 export function useAwaitCalls({
   accountConfig,
   config,
-  data,
+  callsStatus,
   setLifecycleStatus,
 }: {
   accountConfig: Config;
   config: {
     maxSlippage: number;
   };
-  data: {
-    status: 'PENDING' | 'CONFIRMED';
-    receipts?: WalletCallReceipt<bigint, 'success' | 'reverted'>[] | undefined;
-  };
+  callsStatus: UseCallsStatusReturnType;
   setLifecycleStatus: React.Dispatch<React.SetStateAction<LifecycleStatus>>;
 }) {
+  const { data } = callsStatus;
+
   return useCallback(async () => {
     if (data?.status === 'CONFIRMED' && data?.receipts) {
       const transactionReceipt = await waitForTransactionReceipt(

--- a/src/swap/hooks/useAwaitCalls.ts
+++ b/src/swap/hooks/useAwaitCalls.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import type { WalletCallReceipt } from 'viem';
 import type { Config } from 'wagmi';
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import type { LifecycleStatus } from '../types';
@@ -13,7 +14,10 @@ export function useAwaitCalls({
   config: {
     maxSlippage: number;
   };
-  data: any;
+  data: {
+    status: 'PENDING' | 'CONFIRMED';
+    receipts?: WalletCallReceipt<bigint, 'success' | 'reverted'>[] | undefined;
+  };
   setLifecycleStatus: React.Dispatch<React.SetStateAction<LifecycleStatus>>;
 }) {
   return useCallback(async () => {

--- a/src/swap/hooks/useAwaitCalls.ts
+++ b/src/swap/hooks/useAwaitCalls.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react';
+import type { Config } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import type { LifecycleStatus } from '../types';
+
+export function useAwaitCalls({
+  accountConfig,
+  config,
+  data,
+  setLifecycleStatus,
+}: {
+  accountConfig: Config;
+  config: {
+    maxSlippage: number;
+  };
+  data: any;
+  setLifecycleStatus: React.Dispatch<React.SetStateAction<LifecycleStatus>>;
+}) {
+  return useCallback(async () => {
+    if (data?.status === 'CONFIRMED' && data?.receipts) {
+      const transactionReceipt = await waitForTransactionReceipt(
+        accountConfig,
+        {
+          confirmations: 1,
+          hash: data.receipts[data.receipts.length - 1].transactionHash,
+        },
+      );
+      setLifecycleStatus({
+        statusName: 'success',
+        statusData: {
+          isMissingRequiredField: false,
+          maxSlippage: config.maxSlippage,
+          transactionReceipt,
+        },
+      });
+    }
+  }, [accountConfig, config.maxSlippage, data]);
+}

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -13,6 +13,18 @@ import type {
 import type { SendTransactionMutateAsync } from 'wagmi/query';
 import type { BuildSwapTransaction, RawTransactionData } from '../api/types';
 import type { Token } from '../token/types';
+import type { Call } from '../transaction/types';
+
+export type ExecuteSwapTransactionParams = {
+  config: Config;
+  // biome-ignore lint: cannot find module 'wagmi/experimental/query'
+  sendCallsAsync: any;
+  sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
+  setCallsId: Dispatch<SetStateAction<Hex | undefined>>;
+  updateLifecycleStatus: (state: LifecycleStatusUpdate) => void;
+  transactions: Call[];
+  walletCapabilities: WalletCapabilities;
+};
 
 /**
  * Note: exported as public Type

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -349,3 +349,12 @@ export type Transaction = {
   to: Address; // The recipient address
   value: bigint; // The value of the transaction
 };
+
+export type UseAwaitCallsParams = {
+  accountConfig: Config;
+  callsId: string | undefined;
+  config: {
+    maxSlippage: number;
+  };
+  setLifecycleStatus: React.Dispatch<React.SetStateAction<LifecycleStatus>>;
+};

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -1,5 +1,10 @@
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
-import type { Address, Hex, TransactionReceipt } from 'viem';
+import type {
+  Address,
+  Hex,
+  TransactionReceipt,
+  WalletCapabilities,
+} from 'viem';
 import type {
   Config,
   UseBalanceReturnType,
@@ -128,10 +133,14 @@ export type LifecycleStatusUpdate = LifecycleStatus extends infer T
 
 export type ProcessSwapTransactionParams = {
   config: Config;
-  updateLifecycleStatus: (state: LifecycleStatusUpdate) => void;
+  // biome-ignore lint: cannot find module 'wagmi/experimental/query'
+  sendCallsAsync: any;
   sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
+  setCallsId: Dispatch<SetStateAction<Hex | undefined>>;
   swapTransaction: BuildSwapTransaction;
+  updateLifecycleStatus: (state: LifecycleStatusUpdate) => void;
   useAggregator: boolean;
+  walletCapabilities: WalletCapabilities;
 };
 
 /**

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -26,6 +26,13 @@ export type ExecuteSwapTransactionParams = {
   walletCapabilities: WalletCapabilities;
 };
 
+export type ExecuteSingleTransactionsParams = {
+  config: Config;
+  sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
+  updateLifecycleStatus: (state: LifecycleStatusUpdate) => void;
+  transactions: Call[];
+};
+
 /**
  * Note: exported as public Type
  */

--- a/src/swap/utils/executeSingleTransactions.test.ts
+++ b/src/swap/utils/executeSingleTransactions.test.ts
@@ -1,0 +1,148 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, createConfig } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import { mainnet, sepolia } from 'wagmi/chains';
+import { mock } from 'wagmi/connectors';
+import type { Call } from '../../transaction/types';
+import { executeSingleTransactions } from './executeSingleTransactions';
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn().mockResolvedValue({
+    transactionHash: 'receiptHash',
+  }),
+}));
+
+describe('executeSingleTransactions', () => {
+  const updateLifecycleStatus = vi.fn();
+  let sendTransactionAsync: Mock;
+  const mockTransactionReceipt = {
+    transactionHash: 'receiptHash',
+  };
+
+  const config = createConfig({
+    chains: [mainnet, sepolia],
+    connectors: [
+      mock({
+        accounts: [
+          '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+          '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+        ],
+      }),
+    ],
+    transports: {
+      [mainnet.id]: http(),
+      [sepolia.id]: http(),
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    sendTransactionAsync = vi
+      .fn()
+      .mockResolvedValueOnce('txHash1')
+      .mockResolvedValueOnce('txHash2')
+      .mockResolvedValueOnce('txHash3');
+  });
+
+  it('should execute a single transaction correctly', async () => {
+    const transactions: Call[] = [{ to: '0x123', value: 0n, data: '0x' }];
+
+    await executeSingleTransactions({
+      config,
+      sendTransactionAsync,
+      transactions,
+      updateLifecycleStatus,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(1);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(1);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(2);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(1, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+
+  it('should execute non-batched transactions sequentially', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+    ];
+
+    await executeSingleTransactions({
+      config,
+      sendTransactionAsync,
+      transactions,
+      updateLifecycleStatus,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(2);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(4);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(1, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash1',
+        transactionType: 'ERC20',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(3, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(4, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+
+  it('should handle Permit2 approval process', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+      { to: '0x789', value: 0n, data: '0x' },
+    ];
+
+    await executeSingleTransactions({
+      config,
+      sendTransactionAsync,
+      transactions,
+      updateLifecycleStatus,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(3);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(3);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(6);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash1',
+        transactionType: 'Permit2',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(4, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash2',
+        transactionType: 'ERC20',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(6, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+});

--- a/src/swap/utils/executeSingleTransactions.ts
+++ b/src/swap/utils/executeSingleTransactions.ts
@@ -1,0 +1,56 @@
+import type { TransactionReceipt } from 'viem';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import type { ExecuteSingleTransactionsParams } from '../types';
+
+export async function executeSingleTransactions({
+  config,
+  sendTransactionAsync,
+  transactions,
+  updateLifecycleStatus,
+}: ExecuteSingleTransactionsParams) {
+  let transactionReceipt: TransactionReceipt | undefined;
+
+  // Execute the non-batched transactions sequentially
+  for (let i = 0; i < transactions.length; i++) {
+    const tx = transactions[i];
+    updateLifecycleStatus({
+      statusName: 'transactionPending',
+    });
+    const txHash = await sendTransactionAsync(tx);
+    transactionReceipt = await waitForTransactionReceipt(config, {
+      hash: txHash,
+      confirmations: 1,
+    });
+
+    if (transactions.length === 3) {
+      if (i === transactions.length - 3) {
+        updateLifecycleStatus({
+          statusName: 'transactionApproved',
+          statusData: {
+            transactionHash: txHash,
+            transactionType: 'Permit2',
+          },
+        });
+      }
+    }
+    if (i === transactions.length - 2) {
+      updateLifecycleStatus({
+        statusName: 'transactionApproved',
+        statusData: {
+          transactionHash: txHash,
+          transactionType: 'ERC20',
+        },
+      });
+    }
+  }
+
+  // For non-batched transactions, emit the last transaction receipt
+  if (transactionReceipt) {
+    updateLifecycleStatus({
+      statusName: 'success',
+      statusData: {
+        transactionReceipt,
+      },
+    });
+  }
+}

--- a/src/swap/utils/executeSingleTransactions.ts
+++ b/src/swap/utils/executeSingleTransactions.ts
@@ -23,6 +23,7 @@ export async function executeSingleTransactions({
     });
 
     if (transactions.length === 3) {
+      // Permit2 has 3 transactions, 2nd to last is the `Permit2` approval
       if (i === transactions.length - 3) {
         updateLifecycleStatus({
           statusName: 'transactionApproved',
@@ -33,6 +34,7 @@ export async function executeSingleTransactions({
         });
       }
     }
+    // 2nd to last transaction is the `ERC20` approval
     if (i === transactions.length - 2) {
       updateLifecycleStatus({
         statusName: 'transactionApproved',

--- a/src/swap/utils/executeSwapTransactions.test.ts
+++ b/src/swap/utils/executeSwapTransactions.test.ts
@@ -1,0 +1,161 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, createConfig } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import { mainnet, sepolia } from 'wagmi/chains';
+import { mock } from 'wagmi/connectors';
+import { Capabilities } from '../../constants';
+import type { Call } from '../../transaction/types';
+import { executeSwapTransactions } from './executeSwapTransactions';
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn().mockResolvedValue({
+    transactionHash: 'receiptHash',
+  }),
+}));
+
+describe('executeSwapTransactions', () => {
+  const updateLifecycleStatus = vi.fn();
+  let sendTransactionAsync: Mock;
+  let sendCallsAsync: Mock;
+  let setCallsId: Mock;
+  const mockTransactionReceipt = {
+    transactionHash: 'receiptHash',
+  };
+
+  const config = createConfig({
+    chains: [mainnet, sepolia],
+    connectors: [
+      mock({
+        accounts: [
+          '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+          '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+        ],
+      }),
+    ],
+    transports: {
+      [mainnet.id]: http(),
+      [sepolia.id]: http(),
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    sendTransactionAsync = vi
+      .fn()
+      .mockResolvedValueOnce('txHash1')
+      .mockResolvedValueOnce('txHash2')
+      .mockResolvedValueOnce('txHash3');
+
+    sendCallsAsync = vi.fn().mockResolvedValue('callsId');
+    setCallsId = vi.fn();
+  });
+
+  it('should execute atomic batch transactions when supported', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+    ];
+
+    await executeSwapTransactions({
+      config,
+      sendTransactionAsync,
+      sendCallsAsync,
+      setCallsId,
+      updateLifecycleStatus,
+      walletCapabilities: { [Capabilities.AtomicBatch]: { supported: true } },
+      transactions,
+    });
+
+    expect(sendCallsAsync).toHaveBeenCalledTimes(1);
+    expect(sendCallsAsync).toHaveBeenCalledWith({ calls: transactions });
+    expect(setCallsId).toHaveBeenCalledWith('callsId');
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(1);
+    expect(updateLifecycleStatus).toHaveBeenCalledWith({
+      statusName: 'transactionPending',
+    });
+  });
+
+  it('should execute non-batched transactions sequentially', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+    ];
+
+    await executeSwapTransactions({
+      config,
+      sendTransactionAsync,
+      sendCallsAsync,
+      setCallsId,
+      updateLifecycleStatus,
+      walletCapabilities: { [Capabilities.AtomicBatch]: { supported: false } },
+      transactions,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(2);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(4);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(1, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash1',
+        transactionType: 'ERC20',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(3, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(4, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+
+  it('should handle Permit2 approval process', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+      { to: '0x789', value: 0n, data: '0x' },
+    ];
+
+    await executeSwapTransactions({
+      config,
+      sendTransactionAsync,
+      sendCallsAsync,
+      setCallsId,
+      updateLifecycleStatus,
+      walletCapabilities: { [Capabilities.AtomicBatch]: { supported: false } },
+      transactions,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(3);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(3);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(6);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash1',
+        transactionType: 'Permit2',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(4, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash2',
+        transactionType: 'ERC20',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(6, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+});

--- a/src/swap/utils/executeSwapTransactions.ts
+++ b/src/swap/utils/executeSwapTransactions.ts
@@ -1,0 +1,71 @@
+import type { TransactionReceipt } from 'viem';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import { Capabilities } from '../../constants';
+import type { ExecuteSwapTransactionParams } from '../types';
+
+export async function executeSwapTransactions({
+  config,
+  sendCallsAsync,
+  sendTransactionAsync,
+  setCallsId,
+  updateLifecycleStatus,
+  walletCapabilities,
+  transactions,
+}: ExecuteSwapTransactionParams) {
+  let transactionReceipt: TransactionReceipt | undefined;
+
+  if (walletCapabilities[Capabilities.AtomicBatch]?.supported) {
+    // For batched transactions, we'll use `SwapProvider` to listen for calls to emit the `success` state
+    updateLifecycleStatus({
+      statusName: 'transactionPending',
+    });
+    const callsId = await sendCallsAsync({
+      calls: transactions,
+    });
+    setCallsId(callsId);
+  } else {
+    // Execute the non-batched transactions sequentially
+    for (let i = 0; i < transactions.length; i++) {
+      const tx = transactions[i];
+      updateLifecycleStatus({
+        statusName: 'transactionPending',
+      });
+      const txHash = await sendTransactionAsync(tx);
+      transactionReceipt = await waitForTransactionReceipt(config, {
+        hash: txHash,
+        confirmations: 1,
+      });
+
+      if (transactions.length === 3) {
+        if (i === transactions.length - 3) {
+          updateLifecycleStatus({
+            statusName: 'transactionApproved',
+            statusData: {
+              transactionHash: txHash,
+              transactionType: 'Permit2',
+            },
+          });
+        }
+      }
+      if (i === transactions.length - 2) {
+        updateLifecycleStatus({
+          statusName: 'transactionApproved',
+          statusData: {
+            transactionHash: txHash,
+            transactionType: 'ERC20',
+          },
+        });
+      }
+    }
+  }
+
+  // For non-batched transactions, emit the last transaction receipt
+  if (transactionReceipt) {
+    updateLifecycleStatus({
+      statusName: 'success',
+      statusData: {
+        transactionReceipt,
+      },
+    });
+  }
+}

--- a/src/swap/utils/processSwapTransaction.ts
+++ b/src/swap/utils/processSwapTransaction.ts
@@ -91,12 +91,24 @@ export async function processSwapTransaction({
         hash: txHash,
         confirmations: 1,
       });
+
+      if (transactions.length === 3) {
+        if (i === transactions.length - 3) {
+          updateLifecycleStatus({
+            statusName: 'transactionApproved',
+            statusData: {
+              transactionHash: txHash,
+              transactionType: 'Permit2',
+            },
+          });
+        }
+      }
       if (i === transactions.length - 2) {
         updateLifecycleStatus({
           statusName: 'transactionApproved',
           statusData: {
             transactionHash: txHash,
-            transactionType: useAggregator ? 'ERC20' : 'Permit2',
+            transactionType: 'ERC20',
           },
         });
       }


### PR DESCRIPTION
**What changed? Why?**
- add `useAwaitCalls` hook
- add support for atomic batching methods in `processSwapTransaction`

this will allow smart wallets to execute a swap from an ERC-20 in a single transaction (as opposed to 3 previously)

also, updated the inaccurate Swap lifecycle statuses.

**Notes to reviewers**

**How has it been tested?**
playground and unit tests
