### PR TITLE
docs: SwapSettings

### DIFF
--- a/site/docs/pages/swap/swap-settings.mdx
+++ b/site/docs/pages/swap/swap-settings.mdx
@@ -1,0 +1,378 @@
+---
+title: <SwapSettings /> · OnchainKit
+description: Swap component slippage controls
+---
+
+import { Avatar, Name } from '@coinbase/onchainkit/identity';
+import {
+  Swap,
+  SwapAmountInput,
+  SwapButton,
+  SwapMessage,
+  SwapSettings,
+  SwapSettingsSlippageDescription,
+  SwapSettingsSlippageInput,
+  SwapSettingsSlippageTitle,
+  SwapToggleButton,
+} from '@coinbase/onchainkit/swap';
+import { Wallet, ConnectWallet } from '@coinbase/onchainkit/wallet';
+import App from '../../components/App';
+import SwapWrapper from '../../components/SwapWrapper';
+import { walletDropdownLinkCustomBaseIconSvg } from '../../components/svg/walletDropdownLinkCustomBaseIconSvg';
+
+# `SwapSettings`
+The `SwapSettings` component allows users to configure the maximum acceptable price difference (slippage) for their token swap transactions. 
+It provides a simple interface to set and adjust this tolerance level.
+
+## Usage 
+
+```tsx twoslash 
+// omitted for brevity  
+import {
+  Swap,
+  SwapSettings, // [!code focus]
+  SwapSettingsSlippageDescription, // [!code focus]
+  SwapSettingsSlippageInput, // [!code focus]
+  SwapSettingsSlippageTitle, // [!code focus]
+} from '@coinbase/onchainkit/swap';
+
+<Swap> 
+  <SwapSettings>// [!code focus]
+    <SwapSettingsSlippageTitle>// [!code focus]
+      Max. slippage// [!code focus]
+    </SwapSettingsSlippageTitle>// [!code focus]
+    <SwapSettingsSlippageDescription>// [!code focus]
+      Your swap will revert if the prices change by more than the selected// [!code focus]
+      percentage.// [!code focus]
+    </SwapSettingsSlippageDescription>// [!code focus]
+    <SwapSettingsSlippageInput />// [!code focus]
+  </SwapSettings>// [!code focus]
+</Swap> 
+```
+
+<App>
+  <SwapWrapper>
+    {({ address, swappableTokens }) => {
+      if (address) {
+        return (
+          <Swap>
+            <SwapSettings>
+             <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
+             <SwapSettingsSlippageDescription>
+              Your swap will revert if the prices change by more than the selected
+              percentage.
+             </SwapSettingsSlippageDescription>
+             <SwapSettingsSlippageInput />
+            </SwapSettings>
+            <SwapAmountInput
+              label="Sell"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[1]}
+              type="from"
+            />
+            <SwapToggleButton />
+            <SwapAmountInput
+              label="Buy"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[2]}
+              type="to"
+            />
+            <SwapButton disabled />
+            <SwapMessage />
+          </Swap>
+        )
+      }
+      return <>
+        <Wallet>
+          <ConnectWallet>
+            <Avatar className="h-6 w-6" />
+            <Name />
+          </ConnectWallet>
+        </Wallet>
+      </>;
+    }}
+  </SwapWrapper>
+</App>
+
+### Override styles
+
+You can override component styles using `className`.
+
+```tsx twoslash 
+import {
+  Swap,
+  SwapSettings,
+  SwapSettingsSlippageDescription,
+  SwapSettingsSlippageInput,
+  SwapSettingsSlippageTitle,
+} from '@coinbase/onchainkit/swap';
+// ---cut-before---
+// omitted for brevity  
+<Swap> 
+  <SwapSettings>
+    <SwapSettingsSlippageTitle className="text-[#EA580C]">// [!code focus]
+      Max. slippage
+    </SwapSettingsSlippageTitle>
+    <SwapSettingsSlippageDescription className="text-[#EA580C]">// [!code focus]
+      Your swap will revert if the prices change by more than the selected
+      percentage.
+    </SwapSettingsSlippageDescription>
+    <SwapSettingsSlippageInput/>
+  </SwapSettings>
+</Swap> 
+```
+
+
+<App>
+  <SwapWrapper>
+    {({ address, swappableTokens }) => {
+      if (address) {
+        return (
+          <Swap>
+            <SwapSettings>
+             <SwapSettingsSlippageTitle className="text-[#EA580C]">Max. slippage</SwapSettingsSlippageTitle>
+             <SwapSettingsSlippageDescription className="text-[#EA580C]">
+              Your swap will revert if the prices change by more than the selected
+              percentage.
+             </SwapSettingsSlippageDescription>
+             <SwapSettingsSlippageInput/>
+            </SwapSettings>
+            <SwapAmountInput
+              label="Sell"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[1]}
+              type="from"
+            />
+            <SwapToggleButton />
+            <SwapAmountInput
+              label="Buy"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[2]}
+              type="to"
+            />
+            <SwapButton disabled />
+            <SwapMessage />
+          </Swap>
+        )
+      }
+      return <>
+        <Wallet>
+          <ConnectWallet>
+            <Avatar className="h-6 w-6" />
+            <Name />
+          </ConnectWallet>
+        </Wallet>
+      </>;
+    }}
+  </SwapWrapper>
+</App>
+
+### Override icon
+You can override the icon using the icon prop.
+
+
+```tsx twoslash 
+// suppress twoslash error
+declare const baseIcon: any;
+
+import {
+  Swap,
+  SwapSettings,
+  SwapSettingsSlippageDescription,
+  SwapSettingsSlippageInput,
+  SwapSettingsSlippageTitle,
+} from '@coinbase/onchainkit/swap';
+// ---cut-before---
+// omitted for brevity  
+<SwapSettings icon={baseIcon}>// [!code focus]
+// ---cut-after---
+</SwapSettings>
+```
+
+<App>
+  <SwapWrapper>
+    {({ address, swappableTokens }) => {
+      if (address) {
+        return (
+          <Swap>
+            <SwapSettings icon={walletDropdownLinkCustomBaseIconSvg}>
+             <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
+             <SwapSettingsSlippageDescription>
+              Your swap will revert if the prices change by more than the selected
+              percentage.
+             </SwapSettingsSlippageDescription>
+             <SwapSettingsSlippageInput/>
+            </SwapSettings>
+            <SwapAmountInput
+              label="Sell"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[1]}
+              type="from"
+            />
+            <SwapToggleButton />
+            <SwapAmountInput
+              label="Buy"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[2]}
+              type="to"
+            />
+            <SwapButton disabled />
+            <SwapMessage />
+          </Swap>
+        )
+      }
+      return <>
+        <Wallet>
+          <ConnectWallet>
+            <Avatar className="h-6 w-6" />
+            <Name />
+          </ConnectWallet>
+        </Wallet>
+      </>;
+    }}
+  </SwapWrapper>
+</App>
+
+### Add text
+You can add text next to the `SwapSettings` component using text.
+
+```tsx twoslash 
+import {
+  Swap,
+  SwapSettings,
+  SwapSettingsSlippageDescription,
+  SwapSettingsSlippageInput,
+  SwapSettingsSlippageTitle,
+} from '@coinbase/onchainkit/swap';
+// ---cut-before---
+// omitted for brevity  
+<SwapSettings text="Settings">// [!code focus]
+// ---cut-after---
+</SwapSettings>
+```
+
+<App>
+  <SwapWrapper>
+    {({ address, swappableTokens }) => {
+      if (address) {
+        return (
+          <Swap>
+            <SwapSettings text="Settings">
+             <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
+             <SwapSettingsSlippageDescription>
+              Your swap will revert if the prices change by more than the selected
+              percentage.
+             </SwapSettingsSlippageDescription>
+             <SwapSettingsSlippageInput/>
+            </SwapSettings>
+            <SwapAmountInput
+              label="Sell"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[1]}
+              type="from"
+            />
+            <SwapToggleButton />
+            <SwapAmountInput
+              label="Buy"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[2]}
+              type="to"
+            />
+            <SwapButton disabled />
+            <SwapMessage />
+          </Swap>
+        )
+      }
+      return <>
+        <Wallet>
+          <ConnectWallet>
+            <Avatar className="h-6 w-6" />
+            <Name />
+          </ConnectWallet>
+        </Wallet>
+      </>;
+    }}
+  </SwapWrapper>
+</App>
+
+### Override text
+You can override component text by providing children text.
+
+```tsx twoslash 
+import {
+  Swap,
+  SwapSettings,
+  SwapSettingsSlippageDescription,
+  SwapSettingsSlippageInput,
+  SwapSettingsSlippageTitle,
+} from '@coinbase/onchainkit/swap';
+<Swap>  
+// ---cut-before---
+// omitted for brevity  
+
+<SwapSettingsSlippageTitle>
+  Slippage Settings// [!code focus]
+</SwapSettingsSlippageTitle>
+<SwapSettingsSlippageDescription>
+  Set a max slippage you are willing to accept.// [!code focus]
+</SwapSettingsSlippageDescription>
+// ---cut-after---
+</Swap> 
+```
+
+<App>
+  <SwapWrapper>
+    {({ address, swappableTokens }) => {
+      if (address) {
+        return (
+          <Swap>
+            <SwapSettings>
+             <SwapSettingsSlippageTitle>Slippage Settings</SwapSettingsSlippageTitle>
+             <SwapSettingsSlippageDescription>
+              Set a max slippage you are willing to accept.
+             </SwapSettingsSlippageDescription>
+             <SwapSettingsSlippageInput/>
+            </SwapSettings>
+            <SwapAmountInput
+              label="Sell"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[1]}
+              type="from"
+            />
+            <SwapToggleButton />
+            <SwapAmountInput
+              label="Buy"
+              swappableTokens={swappableTokens}
+              token={swappableTokens[2]}
+              type="to"
+            />
+            <SwapButton disabled />
+            <SwapMessage />
+          </Swap>
+        )
+      }
+      return <>
+        <Wallet>
+          <ConnectWallet>
+            <Avatar className="h-6 w-6" />
+            <Name />
+          </ConnectWallet>
+        </Wallet>
+      </>;
+    }}
+  </SwapWrapper>
+</App>
+
+## Components
+
+- `<SwapSettings />` - Container component for swap slippage settings.
+- `<SwapSettingsSlippageDescription />` - Displays description text explaining the slippage setting.
+- `<SwapSettingsSlippageInput />` - Input field for users to enter their desired max slippage percentage
+- `<SwapSettingsSlippageTitle />` - Displays the title for the slippage settings section
+
+## Props
+
+- [`SwapsSettingsReact`](/swap/types#swapsettingsreact)
+- [`SwapSettingsSlippageDescriptionReact`](/swap/types#swapsettingsslippagedescriptionreact)
+- [`SwapSettingsSlippageInputReact`](/swap/types#swapsettingsslippageinputreact)
+- [`SwapSettingsSlippageTitleReact`](/swap/types#swapsettingsslippagetitlereact)

--- a/site/docs/pages/swap/swap-settings.mdx
+++ b/site/docs/pages/swap/swap-settings.mdx
@@ -1,6 +1,6 @@
 ---
 title: <SwapSettings /> · OnchainKit
-description: Swap component slippage controls
+description: Customizable components for token Swap settings and slippage configuration
 ---
 
 import { Avatar, Name } from '@coinbase/onchainkit/identity';
@@ -21,8 +21,7 @@ import SwapWrapper from '../../components/SwapWrapper';
 import { walletDropdownLinkCustomBaseIconSvg } from '../../components/svg/walletDropdownLinkCustomBaseIconSvg';
 
 # `SwapSettings`
-The `SwapSettings` component allows users to configure the maximum acceptable price difference (slippage) for their token swap transactions. 
-It provides a simple interface to set and adjust this tolerance level.
+The `SwapSettings` component enables customizable slippage configuration in the `Swap` component. 
 
 ## Usage 
 

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -104,6 +104,10 @@ export const sidebar = [
             text: 'Swap',
             link: '/swap/swap',
           },
+          {
+            text: 'SwapSettings',
+            link: '/swap/swap-settings',
+          },
         ],
       },
       {


### PR DESCRIPTION
**What changed? Why?**
Add `SwapSettings` docs covering   `SwapSettings`, `SwapSettingsSlippageDescription`, `SwapSettingsSlippageInput`, and  `SwapSettingsSlippageTitle`.

Examples include general usage, overriding styles, overriding icons, adding text, and updating text!

![Export-1726612507142](https://github.com/user-attachments/assets/8c2436bd-a03f-4437-8410-5e9a3709e1f3)


<img width="1272" alt="Screenshot 2024-09-17 at 3 31 06 PM" src="https://github.com/user-attachments/assets/44ce4f62-125e-4df2-b250-62cf66af4a85">

<img width="544" alt="Screenshot 2024-09-17 at 3 31 20 PM" src="https://github.com/user-attachments/assets/ebd91775-749b-427d-ab2f-7751bd7a4fb3">

<img width="562" alt="Screenshot 2024-09-17 at 3 31 30 PM" src="https://github.com/user-attachments/assets/0dc28eef-9014-420e-9f5f-68e20c91421b">

<img width="273" alt="Screenshot 2024-09-17 at 3 31 47 PM" src="https://github.com/user-attachments/assets/a34e4a7c-c25b-491f-9718-0cce224c474e">

<img width="539" alt="Screenshot 2024-09-17 at 3 32 04 PM" src="https://github.com/user-attachments/assets/f4e03630-fd34-436b-b5d5-8b79076ec40e">

<img width="394" alt="Screenshot 2024-09-17 at 3 32 15 PM" src="https://github.com/user-attachments/assets/a21cc72f-411e-467d-b5d3-047b6f1e01e2">

<img width="433" alt="Screenshot 2024-09-17 at 3 32 27 PM" src="https://github.com/user-attachments/assets/3c43566c-af53-4711-afdf-d4d529b83a9d">

<img width="553" alt="Screenshot 2024-09-17 at 3 32 36 PM" src="https://github.com/user-attachments/assets/43ae3fa5-790e-4a19-b367-0a59456c1338">

**Notes to reviewers**

**How has it been tested?**
