### PR TITLE
feat: add utils for batch Swap transactions

### DIFF
--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -103,8 +103,8 @@ export type LifecycleStatus =
   | {
       statusName: 'transactionApproved';
       statusData: {
-        transactionHash: Hex;
-        transactionType: 'ERC20' | 'Permit2';
+        transactionHash?: Hex;
+        transactionType: 'ERC20' | 'Permit2' | 'Batched';
       } & LifecycleStatusDataShared;
     }
   | {

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -1,5 +1,10 @@
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
-import type { Address, Hex, TransactionReceipt } from 'viem';
+import type {
+  Address,
+  Hex,
+  TransactionReceipt,
+  WalletCapabilities,
+} from 'viem';
 import type {
   Config,
   UseBalanceReturnType,
@@ -8,6 +13,25 @@ import type {
 import type { SendTransactionMutateAsync } from 'wagmi/query';
 import type { BuildSwapTransaction, RawTransactionData } from '../api/types';
 import type { Token } from '../token/types';
+import type { Call } from '../transaction/types';
+
+export type SendSwapTransactionParams = {
+  config: Config;
+  // biome-ignore lint: cannot find module 'wagmi/experimental/query'
+  sendCallsAsync: any;
+  sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
+  setCallsId: Dispatch<SetStateAction<Hex | undefined>>;
+  updateLifecycleStatus: (state: LifecycleStatusUpdate) => void;
+  transactions: Call[];
+  walletCapabilities: WalletCapabilities;
+};
+
+export type SendSingleTransactionsParams = {
+  config: Config;
+  sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
+  updateLifecycleStatus: (state: LifecycleStatusUpdate) => void;
+  transactions: Call[];
+};
 
 /**
  * Note: exported as public Type

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -20,17 +20,17 @@ export type SendSwapTransactionParams = {
   // biome-ignore lint: cannot find module 'wagmi/experimental/query'
   sendCallsAsync: any;
   sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
-  setCallsId: Dispatch<SetStateAction<Hex | undefined>>;
+  setCallsId: Dispatch<SetStateAction<Hex | undefined>>; // For atomic batched transactions only, used in `useCallsStatus`
+  transactions: Call[]; // A list of transactions to execute
   updateLifecycleStatus: (state: LifecycleStatusUpdate) => void;
-  transactions: Call[];
-  walletCapabilities: WalletCapabilities;
+  walletCapabilities: WalletCapabilities; // EIP-5792 wallet capabilities
 };
 
 export type SendSingleTransactionsParams = {
   config: Config;
   sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
+  transactions: Call[]; // A list of transactions to execute
   updateLifecycleStatus: (state: LifecycleStatusUpdate) => void;
-  transactions: Call[];
 };
 
 /**

--- a/src/swap/utils/sendSingleTransactions.test.ts
+++ b/src/swap/utils/sendSingleTransactions.test.ts
@@ -18,7 +18,6 @@ describe('sendSingleTransactions', () => {
   const mockTransactionReceipt = {
     transactionHash: 'receiptHash',
   };
-
   const config = createConfig({
     chains: [mainnet, sepolia],
     connectors: [
@@ -48,14 +47,12 @@ describe('sendSingleTransactions', () => {
 
   it('should execute a single transaction correctly', async () => {
     const transactions: Call[] = [{ to: '0x123', value: 0n, data: '0x' }];
-
     await sendSingleTransactions({
       config,
       sendTransactionAsync,
       transactions,
       updateLifecycleStatus,
     });
-
     expect(sendTransactionAsync).toHaveBeenCalledTimes(1);
     expect(waitForTransactionReceipt).toHaveBeenCalledTimes(1);
     expect(updateLifecycleStatus).toHaveBeenCalledTimes(2);
@@ -75,14 +72,12 @@ describe('sendSingleTransactions', () => {
       { to: '0x123', value: 0n, data: '0x' },
       { to: '0x456', value: 0n, data: '0x' },
     ];
-
     await sendSingleTransactions({
       config,
       sendTransactionAsync,
       transactions,
       updateLifecycleStatus,
     });
-
     expect(sendTransactionAsync).toHaveBeenCalledTimes(2);
     expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
     expect(updateLifecycleStatus).toHaveBeenCalledTimes(4);
@@ -113,14 +108,12 @@ describe('sendSingleTransactions', () => {
       { to: '0x456', value: 0n, data: '0x' },
       { to: '0x789', value: 0n, data: '0x' },
     ];
-
     await sendSingleTransactions({
       config,
       sendTransactionAsync,
       transactions,
       updateLifecycleStatus,
     });
-
     expect(sendTransactionAsync).toHaveBeenCalledTimes(3);
     expect(waitForTransactionReceipt).toHaveBeenCalledTimes(3);
     expect(updateLifecycleStatus).toHaveBeenCalledTimes(6);

--- a/src/swap/utils/sendSingleTransactions.test.ts
+++ b/src/swap/utils/sendSingleTransactions.test.ts
@@ -1,0 +1,148 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, createConfig } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import { mainnet, sepolia } from 'wagmi/chains';
+import { mock } from 'wagmi/connectors';
+import type { Call } from '../../transaction/types';
+import { sendSingleTransactions } from './sendSingleTransactions';
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn().mockResolvedValue({
+    transactionHash: 'receiptHash',
+  }),
+}));
+
+describe('sendSingleTransactions', () => {
+  const updateLifecycleStatus = vi.fn();
+  let sendTransactionAsync: Mock;
+  const mockTransactionReceipt = {
+    transactionHash: 'receiptHash',
+  };
+
+  const config = createConfig({
+    chains: [mainnet, sepolia],
+    connectors: [
+      mock({
+        accounts: [
+          '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+          '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+        ],
+      }),
+    ],
+    transports: {
+      [mainnet.id]: http(),
+      [sepolia.id]: http(),
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    sendTransactionAsync = vi
+      .fn()
+      .mockResolvedValueOnce('txHash1')
+      .mockResolvedValueOnce('txHash2')
+      .mockResolvedValueOnce('txHash3');
+  });
+
+  it('should execute a single transaction correctly', async () => {
+    const transactions: Call[] = [{ to: '0x123', value: 0n, data: '0x' }];
+
+    await sendSingleTransactions({
+      config,
+      sendTransactionAsync,
+      transactions,
+      updateLifecycleStatus,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(1);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(1);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(2);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(1, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+
+  it('should execute non-batched transactions sequentially', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+    ];
+
+    await sendSingleTransactions({
+      config,
+      sendTransactionAsync,
+      transactions,
+      updateLifecycleStatus,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(2);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(4);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(1, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash1',
+        transactionType: 'ERC20',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(3, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(4, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+
+  it('should handle Permit2 approval process', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+      { to: '0x789', value: 0n, data: '0x' },
+    ];
+
+    await sendSingleTransactions({
+      config,
+      sendTransactionAsync,
+      transactions,
+      updateLifecycleStatus,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(3);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(3);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(6);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash1',
+        transactionType: 'Permit2',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(4, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash2',
+        transactionType: 'ERC20',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(6, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+});

--- a/src/swap/utils/sendSingleTransactions.ts
+++ b/src/swap/utils/sendSingleTransactions.ts
@@ -1,0 +1,58 @@
+import type { TransactionReceipt } from 'viem';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import type { SendSingleTransactionsParams } from '../types';
+
+export async function sendSingleTransactions({
+  config,
+  sendTransactionAsync,
+  transactions,
+  updateLifecycleStatus,
+}: SendSingleTransactionsParams) {
+  let transactionReceipt: TransactionReceipt | undefined;
+
+  // Execute the non-batched transactions sequentially
+  for (let i = 0; i < transactions.length; i++) {
+    const tx = transactions[i];
+    updateLifecycleStatus({
+      statusName: 'transactionPending',
+    });
+    const txHash = await sendTransactionAsync(tx);
+    transactionReceipt = await waitForTransactionReceipt(config, {
+      hash: txHash,
+      confirmations: 1,
+    });
+
+    if (transactions.length === 3) {
+      // Permit2 has 3 transactions, 2nd to last is the `Permit2` approval
+      if (i === transactions.length - 3) {
+        updateLifecycleStatus({
+          statusName: 'transactionApproved',
+          statusData: {
+            transactionHash: txHash,
+            transactionType: 'Permit2',
+          },
+        });
+      }
+    }
+    // 2nd to last transaction is the `ERC20` approval
+    if (i === transactions.length - 2) {
+      updateLifecycleStatus({
+        statusName: 'transactionApproved',
+        statusData: {
+          transactionHash: txHash,
+          transactionType: 'ERC20',
+        },
+      });
+    }
+  }
+
+  // For non-batched transactions, emit the last transaction receipt
+  if (transactionReceipt) {
+    updateLifecycleStatus({
+      statusName: 'success',
+      statusData: {
+        transactionReceipt,
+      },
+    });
+  }
+}

--- a/src/swap/utils/sendSingleTransactions.ts
+++ b/src/swap/utils/sendSingleTransactions.ts
@@ -17,10 +17,6 @@ export async function sendSingleTransactions({
       statusName: 'transactionPending',
     });
     const txHash = await sendTransactionAsync(tx);
-    transactionReceipt = await waitForTransactionReceipt(config, {
-      hash: txHash,
-      confirmations: 1,
-    });
 
     if (transactions.length === 3) {
       // Permit2 has 3 transactions, 2nd to last is the `Permit2` approval
@@ -44,6 +40,11 @@ export async function sendSingleTransactions({
         },
       });
     }
+
+    transactionReceipt = await waitForTransactionReceipt(config, {
+      hash: txHash,
+      confirmations: 1,
+    });
   }
 
   // For non-batched transactions, emit the last transaction receipt

--- a/src/swap/utils/sendSwapTransactions.test.ts
+++ b/src/swap/utils/sendSwapTransactions.test.ts
@@ -69,9 +69,15 @@ describe('sendSwapTransactions', () => {
     expect(sendCallsAsync).toHaveBeenCalledTimes(1);
     expect(sendCallsAsync).toHaveBeenCalledWith({ calls: transactions });
     expect(setCallsId).toHaveBeenCalledWith('callsId');
-    expect(updateLifecycleStatus).toHaveBeenCalledTimes(1);
-    expect(updateLifecycleStatus).toHaveBeenCalledWith({
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(2);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(1, {
       statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionType: 'Batched',
+      },
     });
   });
 

--- a/src/swap/utils/sendSwapTransactions.test.ts
+++ b/src/swap/utils/sendSwapTransactions.test.ts
@@ -1,0 +1,161 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, createConfig } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import { mainnet, sepolia } from 'wagmi/chains';
+import { mock } from 'wagmi/connectors';
+import { Capabilities } from '../../constants';
+import type { Call } from '../../transaction/types';
+import { sendSwapTransactions } from './sendSwapTransactions';
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn().mockResolvedValue({
+    transactionHash: 'receiptHash',
+  }),
+}));
+
+describe('sendSwapTransactions', () => {
+  const updateLifecycleStatus = vi.fn();
+  let sendTransactionAsync: Mock;
+  let sendCallsAsync: Mock;
+  let setCallsId: Mock;
+  const mockTransactionReceipt = {
+    transactionHash: 'receiptHash',
+  };
+
+  const config = createConfig({
+    chains: [mainnet, sepolia],
+    connectors: [
+      mock({
+        accounts: [
+          '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+          '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+          '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+        ],
+      }),
+    ],
+    transports: {
+      [mainnet.id]: http(),
+      [sepolia.id]: http(),
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    sendTransactionAsync = vi
+      .fn()
+      .mockResolvedValueOnce('txHash1')
+      .mockResolvedValueOnce('txHash2')
+      .mockResolvedValueOnce('txHash3');
+
+    sendCallsAsync = vi.fn().mockResolvedValue('callsId');
+    setCallsId = vi.fn();
+  });
+
+  it('should execute atomic batch transactions when supported', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+    ];
+
+    await sendSwapTransactions({
+      config,
+      sendTransactionAsync,
+      sendCallsAsync,
+      setCallsId,
+      updateLifecycleStatus,
+      walletCapabilities: { [Capabilities.AtomicBatch]: { supported: true } },
+      transactions,
+    });
+
+    expect(sendCallsAsync).toHaveBeenCalledTimes(1);
+    expect(sendCallsAsync).toHaveBeenCalledWith({ calls: transactions });
+    expect(setCallsId).toHaveBeenCalledWith('callsId');
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(1);
+    expect(updateLifecycleStatus).toHaveBeenCalledWith({
+      statusName: 'transactionPending',
+    });
+  });
+
+  it('should execute non-batched transactions sequentially', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+    ];
+
+    await sendSwapTransactions({
+      config,
+      sendTransactionAsync,
+      sendCallsAsync,
+      setCallsId,
+      updateLifecycleStatus,
+      walletCapabilities: { [Capabilities.AtomicBatch]: { supported: false } },
+      transactions,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(2);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(4);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(1, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash1',
+        transactionType: 'ERC20',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(3, {
+      statusName: 'transactionPending',
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(4, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+
+  it('should handle Permit2 approval process', async () => {
+    const transactions: Call[] = [
+      { to: '0x123', value: 0n, data: '0x' },
+      { to: '0x456', value: 0n, data: '0x' },
+      { to: '0x789', value: 0n, data: '0x' },
+    ];
+
+    await sendSwapTransactions({
+      config,
+      sendTransactionAsync,
+      sendCallsAsync,
+      setCallsId,
+      updateLifecycleStatus,
+      walletCapabilities: { [Capabilities.AtomicBatch]: { supported: false } },
+      transactions,
+    });
+
+    expect(sendTransactionAsync).toHaveBeenCalledTimes(3);
+    expect(waitForTransactionReceipt).toHaveBeenCalledTimes(3);
+    expect(updateLifecycleStatus).toHaveBeenCalledTimes(6);
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(2, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash1',
+        transactionType: 'Permit2',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(4, {
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionHash: 'txHash2',
+        transactionType: 'ERC20',
+      },
+    });
+    expect(updateLifecycleStatus).toHaveBeenNthCalledWith(6, {
+      statusName: 'success',
+      statusData: {
+        transactionReceipt: mockTransactionReceipt,
+      },
+    });
+  });
+});

--- a/src/swap/utils/sendSwapTransactions.test.ts
+++ b/src/swap/utils/sendSwapTransactions.test.ts
@@ -57,7 +57,6 @@ describe('sendSwapTransactions', () => {
       { to: '0x123', value: 0n, data: '0x' },
       { to: '0x456', value: 0n, data: '0x' },
     ];
-
     await sendSwapTransactions({
       config,
       sendTransactionAsync,
@@ -67,7 +66,6 @@ describe('sendSwapTransactions', () => {
       walletCapabilities: { [Capabilities.AtomicBatch]: { supported: true } },
       transactions,
     });
-
     expect(sendCallsAsync).toHaveBeenCalledTimes(1);
     expect(sendCallsAsync).toHaveBeenCalledWith({ calls: transactions });
     expect(setCallsId).toHaveBeenCalledWith('callsId');
@@ -82,7 +80,6 @@ describe('sendSwapTransactions', () => {
       { to: '0x123', value: 0n, data: '0x' },
       { to: '0x456', value: 0n, data: '0x' },
     ];
-
     await sendSwapTransactions({
       config,
       sendTransactionAsync,
@@ -92,7 +89,6 @@ describe('sendSwapTransactions', () => {
       walletCapabilities: { [Capabilities.AtomicBatch]: { supported: false } },
       transactions,
     });
-
     expect(sendTransactionAsync).toHaveBeenCalledTimes(2);
     expect(waitForTransactionReceipt).toHaveBeenCalledTimes(2);
     expect(updateLifecycleStatus).toHaveBeenCalledTimes(4);
@@ -123,7 +119,6 @@ describe('sendSwapTransactions', () => {
       { to: '0x456', value: 0n, data: '0x' },
       { to: '0x789', value: 0n, data: '0x' },
     ];
-
     await sendSwapTransactions({
       config,
       sendTransactionAsync,
@@ -133,7 +128,6 @@ describe('sendSwapTransactions', () => {
       walletCapabilities: { [Capabilities.AtomicBatch]: { supported: false } },
       transactions,
     });
-
     expect(sendTransactionAsync).toHaveBeenCalledTimes(3);
     expect(waitForTransactionReceipt).toHaveBeenCalledTimes(3);
     expect(updateLifecycleStatus).toHaveBeenCalledTimes(6);

--- a/src/swap/utils/sendSwapTransactions.ts
+++ b/src/swap/utils/sendSwapTransactions.ts
@@ -1,6 +1,6 @@
 import { Capabilities } from '../../constants';
 import type { SendSwapTransactionParams } from '../types';
-import { executeSingleTransactions } from './executeSingleTransactions';
+import { sendSingleTransactions } from './sendSingleTransactions';
 
 export async function sendSwapTransactions({
   config,
@@ -21,7 +21,7 @@ export async function sendSwapTransactions({
     });
     setCallsId(callsId);
   } else {
-    await executeSingleTransactions({
+    await sendSingleTransactions({
       config,
       sendTransactionAsync,
       transactions,

--- a/src/swap/utils/sendSwapTransactions.ts
+++ b/src/swap/utils/sendSwapTransactions.ts
@@ -19,6 +19,12 @@ export async function sendSwapTransactions({
     const callsId = await sendCallsAsync({
       calls: transactions,
     });
+    updateLifecycleStatus({
+      statusName: 'transactionApproved',
+      statusData: {
+        transactionType: 'Batched',
+      },
+    });
     setCallsId(callsId);
   } else {
     await sendSingleTransactions({

--- a/src/swap/utils/sendSwapTransactions.ts
+++ b/src/swap/utils/sendSwapTransactions.ts
@@ -1,0 +1,31 @@
+import { Capabilities } from '../../constants';
+import type { SendSwapTransactionParams } from '../types';
+import { executeSingleTransactions } from './executeSingleTransactions';
+
+export async function sendSwapTransactions({
+  config,
+  sendCallsAsync,
+  sendTransactionAsync,
+  setCallsId,
+  updateLifecycleStatus,
+  walletCapabilities,
+  transactions,
+}: SendSwapTransactionParams) {
+  if (walletCapabilities[Capabilities.AtomicBatch]?.supported) {
+    // For batched transactions, we'll use `SwapProvider` to listen for calls to emit the `success` state
+    updateLifecycleStatus({
+      statusName: 'transactionPending',
+    });
+    const callsId = await sendCallsAsync({
+      calls: transactions,
+    });
+    setCallsId(callsId);
+  } else {
+    await executeSingleTransactions({
+      config,
+      sendTransactionAsync,
+      transactions,
+      updateLifecycleStatus,
+    });
+  }
+}


### PR DESCRIPTION
**What changed? Why?**
- add `executeSingleTransactions` (EOA)
- add `executeSwapTransactions` (atomic batch with `useSendCalls`, and single with `executeSingleTransactions`)

these utils will be used for batching all 3 Swap transactions (from ERC-20) for smart wallets

**Notes to reviewers**

**How has it been tested?**
main PR playground - https://github.com/coinbase/onchainkit/pull/1264
