### PR TITLE
chore: Update Swap Settings icon styling

### DIFF
--- a/src/internal/svg/swapSettings.tsx
+++ b/src/internal/svg/swapSettings.tsx
@@ -4,8 +4,8 @@ export const swapSettingsSvg = (
   <svg
     role="img"
     aria-label="ock-swapSettingsSvg"
-    width="19"
-    height="20"
+    width="100%"
+    height="100%"
     viewBox="0 0 19 20"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/src/swap/components/SwapSettings.tsx
+++ b/src/swap/components/SwapSettings.tsx
@@ -57,7 +57,7 @@ export function SwapSettings({
           )}
           onClick={handleToggle}
         >
-          {iconSvg}
+          <div className="h-[1.125rem] w-[1.125rem]">{iconSvg}</div>
         </button>
         {breakpoint === 'sm' ? (
           <div


### PR DESCRIPTION
**What changed? Why?**
Moving SVG sizing to be handled by the parent component.

This fixes a bug where a custom icon would be unrestrained

**Notes to reviewers**

**How has it been tested?**
