### PR TITLE
fix: extract lifecycleStatus to hook

### DIFF
--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -20,13 +20,9 @@ import { isUserRejectedRequestError } from '../../transaction/utils/isUserReject
 import { DEFAULT_MAX_SLIPPAGE } from '../constants';
 import { useAwaitCalls } from '../hooks/useAwaitCalls';
 import { useFromTo } from '../hooks/useFromTo';
+import { useLifecycleStatus } from '../hooks/useLifecycleStatus';
 import { useResetInputs } from '../hooks/useResetInputs';
-import type {
-  LifecycleStatus,
-  LifecycleStatusUpdate,
-  SwapContextType,
-  SwapProviderReact,
-} from '../types';
+import type { SwapContextType, SwapProviderReact } from '../types';
 import { isSwapError } from '../utils/isSwapError';
 import { processSwapTransaction } from '../utils/processSwapTransaction';
 
@@ -63,7 +59,7 @@ export function SwapProvider({
   const walletCapabilities = useCapabilitiesSafe({
     chainId: base.id,
   }); // Swap is only available on Base
-  const [lifecycleStatus, setLifecycleStatus] = useState<LifecycleStatus>({
+  const [lifecycleStatus, updateLifecycleStatus] = useLifecycleStatus({
     statusName: 'init',
     statusData: {
       isMissingRequiredField: true,
@@ -73,30 +69,6 @@ export function SwapProvider({
 
   const [isToastVisible, setIsToastVisible] = useState(false);
   const [transactionHash, setTransactionHash] = useState('');
-
-  // Update lifecycle status, statusData will be persisted for the full lifecycle
-  const updateLifecycleStatus = useCallback(
-    (newStatus: LifecycleStatusUpdate) => {
-      setLifecycleStatus((prevStatus: LifecycleStatus) => {
-        // do not persist errors
-        const persistedStatusData =
-          prevStatus.statusName === 'error'
-            ? (({ error, code, message, ...statusData }) => statusData)(
-                prevStatus.statusData,
-              )
-            : prevStatus.statusData;
-        return {
-          statusName: newStatus.statusName,
-          statusData: {
-            ...persistedStatusData,
-            ...newStatus.statusData,
-          },
-        } as LifecycleStatus;
-      });
-    },
-    [],
-  );
-
   const [hasHandledSuccess, setHasHandledSuccess] = useState(false);
   const { from, to } = useFromTo(address);
   const { sendTransactionAsync } = useSendTransaction(); // Sending the transaction (and approval, if applicable)

--- a/src/swap/hooks/useLifecycleStatus.test.ts
+++ b/src/swap/hooks/useLifecycleStatus.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { describe, expect, it } from 'vitest';
+import type { LifecycleStatus } from '../types';
+import { useLifecycleStatus } from './useLifecycleStatus';
+
+const initialLifecycleStatus = {
+  statusName: 'init',
+  statusData: {
+    isMissingRequiredField: true,
+    maxSlippage: 0.5,
+  },
+} as LifecycleStatus;
+
+describe('useLifecycleStatus', () => {
+  it('should initialize correctly', () => {
+    const { result } = renderHook(() =>
+      useLifecycleStatus(initialLifecycleStatus),
+    );
+
+    const [lifecycleStatus] = result.current;
+    expect(lifecycleStatus).toEqual(initialLifecycleStatus);
+  });
+
+  it('should persist statusData for the full lifecycle', async () => {
+    const { result } = renderHook(() =>
+      useLifecycleStatus(initialLifecycleStatus),
+    );
+
+    const [initialStatus, updateLifecycleStatus] = result.current;
+
+    expect(initialStatus).toEqual(initialLifecycleStatus);
+
+    await act(async () => {
+      updateLifecycleStatus({
+        statusName: 'transactionPending',
+      });
+    });
+
+    const [updatedStatus] = result.current;
+
+    expect(updatedStatus).toEqual({
+      statusName: 'transactionPending',
+      statusData: {
+        isMissingRequiredField: true,
+        maxSlippage: 0.5,
+      },
+    });
+  });
+
+  it('should not persist errors', async () => {
+    const { result } = renderHook(() =>
+      useLifecycleStatus(initialLifecycleStatus),
+    );
+
+    const [initialStatus, updateLifecycleStatus] = result.current;
+
+    expect(initialStatus).toEqual(initialLifecycleStatus);
+
+    await act(async () => {
+      updateLifecycleStatus({
+        statusName: 'error',
+        statusData: {
+          error: 'error',
+          code: 'error code',
+          message: 'error message',
+        },
+      });
+    });
+
+    let [updatedStatus] = result.current;
+
+    expect(updatedStatus).toEqual({
+      statusName: 'error',
+      statusData: {
+        error: 'error',
+        code: 'error code',
+        message: 'error message',
+        isMissingRequiredField: true,
+        maxSlippage: 0.5,
+      },
+    });
+
+    await act(async () => {
+      updateLifecycleStatus({
+        statusName: 'transactionPending',
+      });
+    });
+
+    [updatedStatus] = result.current;
+
+    expect(updatedStatus).toEqual({
+      statusName: 'transactionPending',
+      statusData: {
+        isMissingRequiredField: true,
+        maxSlippage: 0.5,
+      },
+    });
+  });
+
+  it('should overwrite passed in statusData', async () => {
+    const { result } = renderHook(() =>
+      useLifecycleStatus(initialLifecycleStatus),
+    );
+
+    const [, updateLifecycleStatus] = result.current;
+
+    await act(async () => {
+      updateLifecycleStatus({
+        statusName: 'slippageChange',
+        statusData: {
+          maxSlippage: 3,
+        },
+      });
+    });
+
+    const [updatedStatus] = result.current;
+
+    expect(updatedStatus).toEqual({
+      statusName: 'slippageChange',
+      statusData: {
+        maxSlippage: 3,
+        isMissingRequiredField: true,
+      },
+    });
+  });
+});

--- a/src/swap/hooks/useLifecycleStatus.ts
+++ b/src/swap/hooks/useLifecycleStatus.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react';
+import type { LifecycleStatus, LifecycleStatusUpdate } from '../types';
+
+type UseLifecycleStatusReturn = [
+  lifecycleStatus: LifecycleStatus,
+  updatelifecycleStatus: (newStatus: LifecycleStatusUpdate) => void,
+];
+
+export function useLifecycleStatus(
+  initialState: LifecycleStatus,
+): UseLifecycleStatusReturn {
+  const [lifecycleStatus, setLifecycleStatus] =
+    useState<LifecycleStatus>(initialState); // Component lifecycle
+
+  // Update lifecycle status, statusData will be persisted for the full lifecycle
+  const updateLifecycleStatus = useCallback(
+    (newStatus: LifecycleStatusUpdate) => {
+      setLifecycleStatus((prevStatus: LifecycleStatus) => {
+        // do not persist errors
+        const persistedStatusData =
+          prevStatus.statusName === 'error'
+            ? (({ error, code, message, ...statusData }) => statusData)(
+                prevStatus.statusData,
+              )
+            : prevStatus.statusData;
+        return {
+          statusName: newStatus.statusName,
+          statusData: {
+            ...persistedStatusData,
+            ...newStatus.statusData,
+          },
+        } as LifecycleStatus;
+      });
+    },
+    [],
+  );
+
+  return [lifecycleStatus, updateLifecycleStatus];
+}


### PR DESCRIPTION
**What changed? Why?**
Extract lifecycleStatus to a hook, this is a step towards using this hook for all components which will require it to use generic types for LifecycleStatus and LifecycleStatusUpdate.

**Notes to reviewers**

**How has it been tested?**
