### PR TITLE
docs: Update getSwapQuote API and type SwapQuote

### DIFF
--- a/site/docs/pages/api/get-swap-quote.mdx
+++ b/site/docs/pages/api/get-swap-quote.mdx
@@ -51,20 +51,26 @@ const quote = await getSwapQuote({
     "chainId": 8453,
     "decimals": 18,
     "image": "https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png",
-    "name": "ETH"
+    "name": "ETH",
+    "symbol": "ETH"
   },
-  "fromAmount": "1000000000000000",
-  "highPriceImpact": false,
-  "priceImpact": "0.16",
-  "slippage": "3",
   "to": {
     "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
     "chainId": 8453,
     "decimals": 6,
     "image": "https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/…-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2",
-    "name": "USDC"
+    "name": "USDC",
+    "symbol": "USDC"
   },
-  "toAmount": "3547037"
+    "fromAmount": "1000000000000000",
+    "fromAmountUSD": "2.6519265340000002",
+    "toAmount": "2650405",
+    "toAmountUSD": "2.64980125",
+    "amountReference": "from",
+    "priceImpact": "0",
+    "chainId": 8453,
+    "highPriceImpact": false,
+    "slippage": "3"
 }
 ```
 

--- a/site/docs/pages/swap/types.mdx
+++ b/site/docs/pages/swap/types.mdx
@@ -122,11 +122,13 @@ type SwapQuote = {
   amountReference: string; // The reference amount for the quote
   from: Token; // The source token for the swap
   fromAmount: string; // The amount of the source token
+  fromAmountUSD: string; // The USD value of the source token
   hasHighPriceImpact: boolean; // Whether the price impact is high
   priceImpact: string; // The price impact of the swap
   slippage: string; // The slippage of the swap
   to: Token; // The destination token for the swap
   toAmount: string; // The amount of the destination token
+  toAmountUSD: string; // The USD value of the destination token
   warning?: QuoteWarning; // The warning associated with the quote
 };
 ```


### PR DESCRIPTION
**What changed? Why?**
<img width="759" alt="Screenshot 2024-09-24 at 2 27 35 PM" src="https://github.com/user-attachments/assets/a67e2f97-859b-431b-97df-66a1c6fdd298">

<img width="754" alt="Screenshot 2024-09-24 at 2 27 54 PM" src="https://github.com/user-attachments/assets/ef208dd4-509b-4805-aa9c-d4901981767d">

**Notes to reviewers**

**How has it been tested?**
