### PR TITLE
docs: Update the Landing Page Figma example to be interactive

### DIFF
--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -528,7 +528,14 @@ import { FrameMetadata } from '@coinbase/onchainkit/frame';
 
 <section className="css-alternate-container w-full flex items-center justify-center">
   <aside className="flex flex-col pb-10 md:flex-row md:px-2 w-[940px]">
-    <img alt="OnchainKit figma" src="/assets/onchain-figma.png" width="924" loading="lazy" />
+    <iframe 
+      style={{border: '1px solid rgba(0, 0, 0, 0.1)'}}
+      width="924"
+      height="520"
+      src="https://embed.figma.com/design/wrzyLn1Gu4UapcQRPxTbis/OnchainKit-(Community)?node-id=18-195&m=dev&embed-host=share"
+      allowFullScreen
+      title="OnchainKit Figma Design"
+    />
   </aside>
 </section>
 

--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -529,9 +529,7 @@ import { FrameMetadata } from '@coinbase/onchainkit/frame';
 <section className="css-alternate-container w-full flex items-center justify-center">
   <aside className="flex flex-col pb-10 md:flex-row md:px-2 w-[940px]">
     <iframe 
-      style={{border: '1px solid rgba(0, 0, 0, 0.1)'}}
-      width="924"
-      height="520"
+      className="border border-gray-200 w-full max-w-[924px] h-[520px] mx-auto my-8 rounded-lg shadow-md"
       src="https://embed.figma.com/design/wrzyLn1Gu4UapcQRPxTbis/OnchainKit-(Community)?node-id=18-195&m=dev&embed-host=share"
       allowFullScreen
       title="OnchainKit Figma Design"


### PR DESCRIPTION
**What changed? Why?**
Update to the Figma example to be interactive - it was previously a static image.

![Export-1727295877703](https://github.com/user-attachments/assets/c02f4f75-2525-4420-8a4f-1ad351345abd)

**Notes to reviewers**

**How has it been tested?**
