### PR TITLE
chore: Update Swap USD 0 value render

### DIFF
--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -64,7 +64,7 @@ export function SwapAmountInput({
     type === 'from' && Number(source.balance) < Number(source.amount);
 
   const formatUSD = (amount: string) => {
-    if (!amount) {
+    if (!amount || amount === '0') {
       return null;
     }
     const roundedAmount = Number(getRoundedAmount(amount, 2));


### PR DESCRIPTION
**What changed? Why?**
Update the Swap USD value to NOT render when the qupte value is $0.00

![image](https://github.com/user-attachments/assets/2bb63388-6466-4ee3-b9c3-3ff2f353d7c9)

**Notes to reviewers**

**How has it been tested?**
