### PR TITLE
docs: align wagmi config naming convention

### DIFF
--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -58,13 +58,13 @@ import { base } from 'wagmi/chains'; // [!code ++]
 import { type ReactNode, useState } from 'react';
 import { type State, WagmiProvider } from 'wagmi';
 
-import { getConfig } from '@/wagmi';
+import { wagmiConfig } from '@/wagmi';
 
 export function Providers(props: {
   children: ReactNode;
   initialState?: State;
 }) {
-  const [config] = useState(() => getConfig());
+  const [config] = useState(() => wagmiConfig);
   const [queryClient] = useState(() => new QueryClient());
 
   return (
@@ -124,7 +124,7 @@ import { headers } from 'next/headers';
 import { type ReactNode } from 'react';
 import { cookieToInitialState } from 'wagmi';
 
-import { getConfig } from '../wagmi';
+import { wagmiConfig } from '../wagmi';
 import { Providers } from './providers';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -136,7 +136,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout(props: { children: ReactNode }) {
   const initialState = cookieToInitialState(
-    getConfig(),
+    wagmiConfig,
     headers().get('cookie')
   );
   return (

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -64,11 +64,10 @@ export function Providers(props: {
   children: ReactNode;
   initialState?: State;
 }) {
-  const [config] = useState(() => wagmiConfig);
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <WagmiProvider config={config} initialState={props.initialState}>
+    <WagmiProvider config={wagmiConfig} initialState={props.initialState}>
       <QueryClientProvider client={queryClient}>
         <OnchainKitProvider // [!code ++]
           apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY} // [!code ++]


### PR DESCRIPTION
**What changed? Why?**

- basic example should work out of the box with copy-paste
- at current docs, `getConfig` is not defined at `wagmi.ts`

**Notes to reviewers**

**How has it been tested?**
