### PR TITLE
docs: Fix tweet bottom border

### DIFF
--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -248,6 +248,7 @@ footer a.vocs_Anchor {
 
 #twitter-widget-0 {
   width: 27.375rem !important;
+  margin-bottom: -1px; 
 }
 
 #twitter-widget-1 {


### PR DESCRIPTION
**What changed? Why?**

<img width="490" alt="Screenshot 2024-10-01 at 12 34 24 PM" src="https://github.com/user-attachments/assets/deef5e30-03f8-48f2-93d8-0c8826e39507">

**Notes to reviewers**

**How has it been tested?**
