### PR TITLE
fix: use `shortMessage` in `isUserRejectedRequestError`

### DIFF
--- a/src/transaction/utils/isUserRejectedRequestError.ts
+++ b/src/transaction/utils/isUserRejectedRequestError.ts
@@ -8,7 +8,7 @@ export function isUserRejectedRequestError(err: unknown) {
     return true;
   }
   if (
-    (err as TransactionExecutionError)?.message?.includes(
+    (err as TransactionExecutionError)?.shortMessage?.includes(
       'User rejected the request.',
     )
   ) {


### PR DESCRIPTION
**What changed? Why?**
- in latest versions of viem, this was changed to the `shortMessage` field

**Notes to reviewers**

**How has it been tested?**
