### PR TITLE
fix: error messages

### DIFF
--- a/src/pay/components/PayProvider.tsx
+++ b/src/pay/components/PayProvider.tsx
@@ -74,19 +74,6 @@ export function PayProvider({
       onSuccess: (id) => {
         setTransactionId(id);
       },
-      onError: (e) => {
-        const errorMessage = isUserRejectedRequestError(e)
-          ? USER_REJECTED_ERROR
-          : GENERIC_ERROR_MESSAGE;
-        updateLifecycleStatus({
-          statusName: PAY_LIFECYCLESTATUS.ERROR,
-          statusData: {
-            code: PayErrorCode.USER_REJECTED_ERROR,
-            error: e.message,
-            message: errorMessage,
-          },
-        });
-      },
     },
     /* v8 ignore stop */
   });
@@ -254,9 +241,9 @@ export function PayProvider({
         contracts,
       });
     } catch (error) {
-      const isUserRejectedError = (error as Error).message?.includes(
-        'User denied connection request',
-      );
+      const isUserRejectedError =
+        (error as Error).message?.includes('User denied connection request') ||
+        isUserRejectedRequestError(error);
       const errorCode = isUserRejectedError
         ? PayErrorCode.USER_REJECTED_ERROR
         : PayErrorCode.UNEXPECTED_ERROR;

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -760,7 +760,9 @@ describe('SwapProvider', () => {
   });
 
   it('should setLifecycleStatus to error when buildSwapTransaction throws an "User rejected the request." error', async () => {
-    const mockError = new Error('User rejected the request.');
+    const mockError = {
+      shortMessage: 'User rejected the request.',
+    };
     vi.mocked(buildSwapTransaction).mockRejectedValueOnce(mockError);
     renderWithProviders({ Component: TestSwapComponent });
     fireEvent.click(screen.getByText('Swap'));

--- a/src/transaction/utils/isUserRejectedRequestError.test.ts
+++ b/src/transaction/utils/isUserRejectedRequestError.test.ts
@@ -22,7 +22,7 @@ describe('isUserRejectedRequestError', () => {
 
   it('should return true if error message includes User rejected the request.', () => {
     const error = {
-      message: 'User rejected the request.',
+      shortMessage: 'User rejected the request.',
     };
     expect(isUserRejectedRequestError(error)).toBe(true);
   });

--- a/src/transaction/utils/isUserRejectedRequestError.ts
+++ b/src/transaction/utils/isUserRejectedRequestError.ts
@@ -8,7 +8,7 @@ export function isUserRejectedRequestError(err: unknown) {
     return true;
   }
   if (
-    (err as TransactionExecutionError)?.message?.includes(
+    (err as TransactionExecutionError)?.shortMessage?.includes(
       'User rejected the request.',
     )
   ) {


### PR DESCRIPTION
**What changed? Why?**
- user rejected error is now part of `shortMessage` field in viem

tested, local PR deployment of `Transaction` now correctly shows `Request denied.` while https://onchainkit.xyz/playground does not

**Notes to reviewers**

**How has it been tested?**
