### PR TITLE
chore: add cut before so import doesn't render for fund

### DIFF
--- a/site/docs/pages/index.mdx
+++ b/site/docs/pages/index.mdx
@@ -411,7 +411,7 @@ const swappableTokens = [ETHToken, USDCToken];
       <div className="w-[664px] max-w-full">
 ```tsx twoslash
 import { FundButton } from '@coinbase/onchainkit/fund';
-
+// ---cut-before---
 <FundButton />
 ```
       </div>


### PR DESCRIPTION
**What changed? Why?**
 - add cut before so import doesn't render for fund
<img width="1204" alt="Screenshot 2024-10-08 at 12 40 44 PM" src="https://github.com/user-attachments/assets/28a7300a-028e-45df-be58-ab09667d5d70">

**Notes to reviewers**

**How has it been tested?**
