### PR TITLE
chore: reset state in `Pay` component after `Get USDC` is clicked

### DIFF
--- a/src/pay/components/PayProvider.tsx
+++ b/src/pay/components/PayProvider.tsx
@@ -150,6 +150,12 @@ export function PayProvider({
           '_blank',
           'noopener,noreferrer',
         );
+        // Reset status
+        setErrorMessage('');
+        updateLifecycleStatus({
+          statusName: PAY_LIFECYCLESTATUS.INIT,
+          statusData: {},
+        });
         return;
       }
 


### PR DESCRIPTION
**What changed? Why?**
- reset error message and `init` state after funding flow is started

**Notes to reviewers**

**How has it been tested?**
