### PR TITLE
chore: Connect Wallet and Identity theming clean up 

### DIFF
--- a/playground/nextjs-app-router/components/demo/Wallet.tsx
+++ b/playground/nextjs-app-router/components/demo/Wallet.tsx
@@ -8,7 +8,6 @@ import {
 import { color } from '@coinbase/onchainkit/theme';
 import {
   ConnectWallet,
-  ConnectWalletText,
   Wallet,
   WalletDropdown,
   WalletDropdownBasename,
@@ -24,8 +23,7 @@ function WalletComponent() {
   return (
     <div className="flex justify-end">
       <Wallet>
-        <ConnectWallet>
-          <ConnectWalletText>Connect Wallet</ConnectWalletText>
+        <ConnectWallet text="Connect Wallet">
           <Avatar address={address} className="h-6 w-6" />
           <Name />
         </ConnectWallet>

--- a/src/identity/components/Name.tsx
+++ b/src/identity/components/Name.tsx
@@ -1,6 +1,6 @@
 import { Children, useMemo } from 'react';
 import { findComponent } from '../../internal/utils/findComponent';
-import { cn, text } from '../../styles/theme';
+import { cn, color, text } from '../../styles/theme';
 import { useName } from '../hooks/useName';
 import type { NameReact } from '../types';
 import { getSlicedAddress } from '../utils/getSlicedAddress';
@@ -45,7 +45,7 @@ export function Name({
     <div className="flex items-center gap-1">
       <span
         data-testid="ockIdentity_Text"
-        className={cn(text.headline, className)}
+        className={cn(text.headline, color.foreground, className)}
         {...props}
       >
         {name || getSlicedAddress(accountAddress)}

--- a/src/wallet/components/ConnectButton.tsx
+++ b/src/wallet/components/ConnectButton.tsx
@@ -1,4 +1,10 @@
-import { cn, color, text as dsText, pressable } from '../../styles/theme';
+import {
+  border,
+  cn,
+  color,
+  text as dsText,
+  pressable,
+} from '../../styles/theme';
 import type { ConnectButtonReact } from '../types';
 
 export function ConnectButton({
@@ -14,9 +20,10 @@ export function ConnectButton({
       data-testid="ockConnectButton"
       className={cn(
         pressable.primary,
+        border.radius,
         dsText.headline,
         color.inverse,
-        'inline-flex min-w-[153px] items-center justify-center rounded-xl px-4 py-3',
+        'inline-flex min-w-[153px] items-center justify-center px-4 py-3',
         className,
       )}
       onClick={onClick}
@@ -24,7 +31,7 @@ export function ConnectButton({
       {connectWalletText ? (
         connectWalletText
       ) : (
-        <span className={cn(dsText.body, color.inverse)}>{text}</span>
+        <span className={cn(color.inverse)}>{text}</span>
       )}
     </button>
   );


### PR DESCRIPTION
**What changed? Why?**
Updated border and font weight. 

Updated playground to use text property.

Fix Identity text for all themes.

<img width="505" alt="Screenshot 2024-10-11 at 3 20 38 PM" src="https://github.com/user-attachments/assets/880a206f-c749-4bbc-ad01-f514cb46c6e5">


<img width="411" alt="Screenshot 2024-10-11 at 3 13 23 PM" src="https://github.com/user-attachments/assets/83f76913-7fcc-4607-9339-56f1ee99d851">

**Notes to reviewers**

**How has it been tested?**
