### PR TITLE
feat: pre-load transaction data in `Pay` for connected wallets

### DIFF
--- a/src/pay/components/PayButton.tsx
+++ b/src/pay/components/PayButton.tsx
@@ -27,7 +27,9 @@ export function PayButton({
   const iconSvg = useIcon({ icon });
 
   const isLoading = lifecycleStatus?.statusName === PAY_LIFECYCLESTATUS.PENDING;
-  const isDisabled = disabled || isLoading;
+  const isFetchingData =
+    lifecycleStatus?.statusName === PAY_LIFECYCLESTATUS.FETCHING_DATA;
+  const isDisabled = disabled || isLoading || isFetchingData;
   const buttonText = useMemo(() => {
     if (lifecycleStatus?.statusName === PAY_LIFECYCLESTATUS.SUCCESS) {
       return 'View payment details';

--- a/src/pay/components/PayProvider.test.tsx
+++ b/src/pay/components/PayProvider.test.tsx
@@ -269,6 +269,14 @@ describe('PayProvider', () => {
     });
     expect(onStatus).toHaveBeenNthCalledWith(
       2,
+      expect.objectContaining({ statusName: 'fetchingData' }),
+    );
+    expect(onStatus).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ statusName: 'ready' }),
+    );
+    expect(onStatus).toHaveBeenNthCalledWith(
+      4,
       expect.objectContaining({ statusName: 'success' }),
     );
   });
@@ -296,6 +304,17 @@ describe('PayProvider', () => {
   });
 
   it('should update status when writeContracts is pending', async () => {
+    (useAccount as Mock).mockReturnValue({
+      address: undefined,
+      chainId: undefined,
+      isConnected: false,
+    });
+    (useConnect as Mock).mockReturnValue({
+      connectAsync: vi
+        .fn()
+        .mockResolvedValue({ accounts: ['0x123'], chainId: 1 }),
+      connectors: [{ id: 'coinbaseWalletSDK' }],
+    });
     (useWriteContracts as Mock).mockReturnValue({
       status: 'pending',
       writeContractsAsync: vi.fn(),

--- a/src/pay/components/PayProvider.test.tsx
+++ b/src/pay/components/PayProvider.test.tsx
@@ -374,7 +374,7 @@ describe('PayProvider', () => {
     });
     fireEvent.click(screen.getByText('Submit'));
     expect(windowOpenMock).toHaveBeenCalledWith(
-      'https://keys.coinbase.com/fund',
+      'https://keys.coinbase.com/fund?asset=USDC&chainId=8453',
       '_blank',
       'noopener,noreferrer',
     );

--- a/src/pay/components/PayProvider.tsx
+++ b/src/pay/components/PayProvider.tsx
@@ -3,8 +3,10 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from 'react';
+import type { Address, ContractFunctionParameters } from 'viem';
 import { base } from 'viem/chains';
 import { useAccount, useConnect, useSwitchChain } from 'wagmi';
 import { useWaitForTransactionReceipt } from 'wagmi';
@@ -55,6 +57,40 @@ export function PayProvider({
   const [transactionId, setTransactionId] = useState('');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const isSmartWallet = useIsWalletACoinbaseSmartWallet();
+
+  // Refs
+  const fetchedDataUseEffect = useRef<boolean>(false);
+  const fetchedDataHandleSubmit = useRef<boolean>(false);
+  const contractsRef = useRef<ContractFunctionParameters[] | null>();
+  const insufficientBalanceRef = useRef<boolean>(false);
+  const priceInUSDCRef = useRef<string | undefined>('');
+
+  // Helper function used in both `useEffect` and `handleSubmit` to fetch data from the Commerce API and set state and refs
+  const fetchData = async (address: Address) => {
+    const {
+      contracts,
+      chargeId: hydratedChargeId,
+      insufficientBalance,
+      priceInUSDC,
+      error,
+    } = await fetchContracts(address);
+    if (error) {
+      setErrorMessage(GENERIC_ERROR_MESSAGE);
+      updateLifecycleStatus({
+        statusName: PAY_LIFECYCLESTATUS.ERROR,
+        statusData: {
+          code: PayErrorCode.UNEXPECTED_ERROR,
+          error: (error as Error).name,
+          message: (error as Error).message,
+        },
+      });
+      return;
+    }
+    setChargeId(hydratedChargeId);
+    contractsRef.current = contracts;
+    insufficientBalanceRef.current = insufficientBalance;
+    priceInUSDCRef.current = priceInUSDC;
+  };
 
   // Component lifecycle
   const { lifecycleStatus, updateLifecycleStatus } = useLifecycleStatus({
@@ -127,6 +163,14 @@ export function PayProvider({
     });
   }, [chargeId, receipt, updateLifecycleStatus]);
 
+  // We need to pre-load transaction data in `useEffect` when the wallet is already connected due to a Smart Wallet popup blocking issue in Safari iOS
+  useEffect(() => {
+    if (address && !fetchedDataHandleSubmit.current) {
+      fetchedDataUseEffect.current = true;
+      fetchData(address);
+    }
+  }, [address]);
+
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component to deprecate funding flow
   const handleSubmit = useCallback(async () => {
     try {
@@ -146,7 +190,7 @@ export function PayProvider({
         lifecycleStatus.statusData?.code === PayErrorCode.INSUFFICIENT_BALANCE
       ) {
         window.open(
-          'https://keys.coinbase.com/fund',
+          'https://keys.coinbase.com/fund?asset=USDC&chainId=8453',
           '_blank',
           'noopener,noreferrer',
         );
@@ -164,6 +208,7 @@ export function PayProvider({
       if (!isConnected || !isSmartWallet) {
         // Prompt for wallet connection
         // This is defaulted to Coinbase Smart Wallet
+        fetchedDataHandleSubmit.current = true; // Set this here so useEffect does not run
         const { accounts, chainId: _connectedChainId } = await connectAsync({
           connector: coinbaseWallet({ preference: 'smartWalletOnly' }),
         });
@@ -187,27 +232,11 @@ export function PayProvider({
       }
       /* v8 ignore stop */
 
-      // Fetch contracts
-      const {
-        contracts,
-        chargeId: hydratedChargeId,
-        insufficientBalance,
-        priceInUSDC,
-        error,
-      } = await fetchContracts(connectedAddress);
-      if (error) {
-        setErrorMessage(GENERIC_ERROR_MESSAGE);
-        updateLifecycleStatus({
-          statusName: PAY_LIFECYCLESTATUS.ERROR,
-          statusData: {
-            code: PayErrorCode.UNEXPECTED_ERROR,
-            error: (error as Error).name,
-            message: (error as Error).message,
-          },
-        });
-        return;
+      // Fetch contracts if not already done in useEffect
+      /* v8 ignore next 3 */
+      if (!fetchedDataUseEffect.current) {
+        await fetchData(connectedAddress);
       }
-      setChargeId(hydratedChargeId);
 
       // Switch chain, if applicable
       if (connectedChainId !== base.id) {
@@ -215,21 +244,25 @@ export function PayProvider({
       }
 
       // Check for sufficient balance
-      if (insufficientBalance && priceInUSDC) {
-        setErrorMessage(PAY_INSUFFICIENT_BALANCE_ERROR_MESSAGE(priceInUSDC));
+      if (insufficientBalanceRef.current && priceInUSDCRef.current) {
+        setErrorMessage(
+          PAY_INSUFFICIENT_BALANCE_ERROR_MESSAGE(priceInUSDCRef.current),
+        );
         updateLifecycleStatus({
           statusName: PAY_LIFECYCLESTATUS.ERROR,
           statusData: {
             code: PayErrorCode.INSUFFICIENT_BALANCE,
             error: PAY_INSUFFICIENT_BALANCE_ERROR,
-            message: PAY_INSUFFICIENT_BALANCE_ERROR_MESSAGE(priceInUSDC),
+            message: PAY_INSUFFICIENT_BALANCE_ERROR_MESSAGE(
+              priceInUSDCRef.current,
+            ),
           },
         });
         return;
       }
 
       // Contracts weren't successfully fetched from `fetchContracts`
-      if (!contracts || contracts.length === 0) {
+      if (!contractsRef.current || contractsRef.current.length === 0) {
         setErrorMessage(GENERIC_ERROR_MESSAGE);
         updateLifecycleStatus({
           statusName: PAY_LIFECYCLESTATUS.ERROR,
@@ -244,7 +277,7 @@ export function PayProvider({
 
       // Open keys.coinbase.com for payment
       await writeContractsAsync({
-        contracts,
+        contracts: contractsRef.current,
       });
     } catch (error) {
       const isUserRejectedError =

--- a/src/pay/components/PayProvider.tsx
+++ b/src/pay/components/PayProvider.tsx
@@ -66,31 +66,34 @@ export function PayProvider({
   const priceInUSDCRef = useRef<string | undefined>('');
 
   // Helper function used in both `useEffect` and `handleSubmit` to fetch data from the Commerce API and set state and refs
-  const fetchData = async (address: Address) => {
-    const {
-      contracts,
-      chargeId: hydratedChargeId,
-      insufficientBalance,
-      priceInUSDC,
-      error,
-    } = await fetchContracts(address);
-    if (error) {
-      setErrorMessage(GENERIC_ERROR_MESSAGE);
-      updateLifecycleStatus({
-        statusName: PAY_LIFECYCLESTATUS.ERROR,
-        statusData: {
-          code: PayErrorCode.UNEXPECTED_ERROR,
-          error: (error as Error).name,
-          message: (error as Error).message,
-        },
-      });
-      return;
-    }
-    setChargeId(hydratedChargeId);
-    contractsRef.current = contracts;
-    insufficientBalanceRef.current = insufficientBalance;
-    priceInUSDCRef.current = priceInUSDC;
-  };
+  const fetchData = useCallback(
+    async (address: Address) => {
+      const {
+        contracts,
+        chargeId: hydratedChargeId,
+        insufficientBalance,
+        priceInUSDC,
+        error,
+      } = await fetchContracts(address);
+      if (error) {
+        setErrorMessage(GENERIC_ERROR_MESSAGE);
+        updateLifecycleStatus({
+          statusName: PAY_LIFECYCLESTATUS.ERROR,
+          statusData: {
+            code: PayErrorCode.UNEXPECTED_ERROR,
+            error: (error as Error).name,
+            message: (error as Error).message,
+          },
+        });
+        return;
+      }
+      setChargeId(hydratedChargeId);
+      contractsRef.current = contracts;
+      insufficientBalanceRef.current = insufficientBalance;
+      priceInUSDCRef.current = priceInUSDC;
+    },
+    [setErrorMessage, setChargeId],
+  );
 
   // Component lifecycle
   const { lifecycleStatus, updateLifecycleStatus } = useLifecycleStatus({

--- a/src/pay/components/PayProvider.tsx
+++ b/src/pay/components/PayProvider.tsx
@@ -61,6 +61,7 @@ export function PayProvider({
   // Refs
   const fetchedDataUseEffect = useRef<boolean>(false);
   const fetchedDataHandleSubmit = useRef<boolean>(false);
+  const userRejectedRef = useRef<boolean>(false);
   const contractsRef = useRef<ContractFunctionParameters[] | null>();
   const insufficientBalanceRef = useRef<boolean>(false);
   const priceInUSDCRef = useRef<string | undefined>('');
@@ -233,8 +234,9 @@ export function PayProvider({
       /* v8 ignore stop */
 
       // Fetch contracts if not already done in useEffect
+      // Don't re-fetch contracts if the user rejected the previous request, and just use the cached data
       /* v8 ignore next 3 */
-      if (!fetchedDataUseEffect.current) {
+      if (!fetchedDataUseEffect.current && !userRejectedRef.current) {
         await fetchData(connectedAddress);
       }
 
@@ -289,6 +291,10 @@ export function PayProvider({
       const errorMessage = isUserRejectedError
         ? USER_REJECTED_ERROR
         : GENERIC_ERROR_MESSAGE;
+      if (isUserRejectedError) {
+        // Set the ref so that we can use the cached commerce API call
+        userRejectedRef.current = true;
+      }
 
       setErrorMessage(errorMessage);
       updateLifecycleStatus({

--- a/src/pay/components/PayProvider.tsx
+++ b/src/pay/components/PayProvider.tsx
@@ -66,34 +66,31 @@ export function PayProvider({
   const priceInUSDCRef = useRef<string | undefined>('');
 
   // Helper function used in both `useEffect` and `handleSubmit` to fetch data from the Commerce API and set state and refs
-  const fetchData = useCallback(
-    async (address: Address) => {
-      const {
-        contracts,
-        chargeId: hydratedChargeId,
-        insufficientBalance,
-        priceInUSDC,
-        error,
-      } = await fetchContracts(address);
-      if (error) {
-        setErrorMessage(GENERIC_ERROR_MESSAGE);
-        updateLifecycleStatus({
-          statusName: PAY_LIFECYCLESTATUS.ERROR,
-          statusData: {
-            code: PayErrorCode.UNEXPECTED_ERROR,
-            error: (error as Error).name,
-            message: (error as Error).message,
-          },
-        });
-        return;
-      }
-      setChargeId(hydratedChargeId);
-      contractsRef.current = contracts;
-      insufficientBalanceRef.current = insufficientBalance;
-      priceInUSDCRef.current = priceInUSDC;
-    },
-    [],
-  );
+  const fetchData = useCallback(async (address: Address) => {
+    const {
+      contracts,
+      chargeId: hydratedChargeId,
+      insufficientBalance,
+      priceInUSDC,
+      error,
+    } = await fetchContracts(address);
+    if (error) {
+      setErrorMessage(GENERIC_ERROR_MESSAGE);
+      updateLifecycleStatus({
+        statusName: PAY_LIFECYCLESTATUS.ERROR,
+        statusData: {
+          code: PayErrorCode.UNEXPECTED_ERROR,
+          error: (error as Error).name,
+          message: (error as Error).message,
+        },
+      });
+      return;
+    }
+    setChargeId(hydratedChargeId);
+    contractsRef.current = contracts;
+    insufficientBalanceRef.current = insufficientBalance;
+    priceInUSDCRef.current = priceInUSDC;
+  }, []);
 
   // Component lifecycle
   const { lifecycleStatus, updateLifecycleStatus } = useLifecycleStatus({

--- a/src/pay/components/PayProvider.tsx
+++ b/src/pay/components/PayProvider.tsx
@@ -169,7 +169,7 @@ export function PayProvider({
       fetchedDataUseEffect.current = true;
       fetchData(address);
     }
-  }, [address]);
+  }, [address, fetchData]);
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component to deprecate funding flow
   const handleSubmit = useCallback(async () => {
@@ -305,7 +305,7 @@ export function PayProvider({
     chainId,
     chargeId,
     connectAsync,
-    fetchContracts,
+    fetchData,
     isConnected,
     isSmartWallet,
     lifecycleStatus.statusData,

--- a/src/pay/components/PayProvider.tsx
+++ b/src/pay/components/PayProvider.tsx
@@ -92,7 +92,7 @@ export function PayProvider({
       insufficientBalanceRef.current = insufficientBalance;
       priceInUSDCRef.current = priceInUSDC;
     },
-    [setErrorMessage, setChargeId],
+    [],
   );
 
   // Component lifecycle

--- a/src/pay/constants.ts
+++ b/src/pay/constants.ts
@@ -34,8 +34,10 @@ export type PayErrors = {
 };
 
 export enum PAY_LIFECYCLESTATUS {
+  FETCHING_DATA = 'fetchingData',
   INIT = 'init',
   PENDING = 'paymentPending',
+  READY = 'ready',
   SUCCESS = 'success',
   ERROR = 'error',
 }

--- a/src/pay/hooks/useCommerceContracts.tsx
+++ b/src/pay/hooks/useCommerceContracts.tsx
@@ -18,11 +18,17 @@ export const useCommerceContracts = ({
         // Make the Pay request to the appropriate endpoint
         // `productId` to create and hydrate a charge for a product (serverless)
         // `chargeHandler` for a developer-provided callback used to return a charge ID (e.g. from the merchant backend)
-        const response = await handlePayRequest({
-          address,
-          chargeHandler,
-          productId,
-        });
+        const [response, usdcBalance] = await Promise.all([
+          handlePayRequest({
+            address,
+            chargeHandler,
+            productId,
+          }),
+          getUSDCBalance({
+            address,
+            config,
+          }),
+        ]);
 
         // Set the `chargeId`
         const { id: chargeId } = response;
@@ -33,10 +39,6 @@ export const useCommerceContracts = ({
         });
 
         // Calculate user's USDC balance
-        const usdcBalance = await getUSDCBalance({
-          address,
-          config,
-        });
         const priceInUSDC = formatUnits(
           BigInt(response.callData.feeAmount) +
             BigInt(response.callData.recipientAmount),

--- a/src/pay/types.ts
+++ b/src/pay/types.ts
@@ -1,4 +1,4 @@
-import type { TransactionReceipt } from 'viem';
+import type { ContractFunctionParameters, TransactionReceipt } from 'viem';
 import type { Address } from 'viem';
 import type { Config } from 'wagmi';
 import type { PayTransaction } from '../api/types';
@@ -18,6 +18,17 @@ export type LifecycleStatus =
   | {
       statusName: 'error';
       statusData: TransactionError;
+    }
+  | {
+      statusName: 'fetchingData';
+      statusData: LifecycleStatusDataShared;
+    }
+  | {
+      statusName: 'ready';
+      statusData: {
+        chargeId: string;
+        contracts: ContractFunctionParameters[];
+      };
     }
   | {
       statusName: 'paymentPending';


### PR DESCRIPTION
**What changed? Why?**
- add `fetchingData` and `ready` lifecycle status
- fetch data in `useEffect` for connected wallets

this change is due to a popup blocking issue in Safari iOS

also, adjust the funding link to pre-populate USDC on Base as an asset

**Notes to reviewers**

**How has it been tested?**
playground in other PR
