### PR TITLE
fix: hardcoded `amountReference` in Swap

### DIFF
--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -232,7 +232,7 @@ export function SwapProvider({
         const maxSlippage = lifecycleStatus.statusData.maxSlippage;
         const response = await getSwapQuote({
           amount,
-          amountReference: 'from',
+          amountReference: type,
           from: source.token,
           maxSlippage: String(maxSlippage),
           to: destination.token,


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
