### PR TITLE
fix: Upgrade to Neynar V2 Endpoints

### DIFF
--- a/src/network/neynar/getCustodyAddressForFidNeynar.test.ts
+++ b/src/network/neynar/getCustodyAddressForFidNeynar.test.ts
@@ -17,9 +17,11 @@ describe('getCustodyAddressForFidNeynar', () => {
 
   it('should return mocked response correctly', async () => {
     const mockedResponse = {
-      result: {
-        custodyAddress: '0x00123',
-      },
+      users: [
+        {
+          custody_address: '0x00123',
+        },
+      ],
     };
     fetchMock.mockResolvedValue(mockedResponse);
     const resp = await getCustodyAddressForFidNeynar(42);
@@ -28,9 +30,22 @@ describe('getCustodyAddressForFidNeynar', () => {
 
   it('throw an error on a bad result', async () => {
     const mockedResponse = {
-      badResult: {
-        custodyAddress: '0x00123',
-      },
+      badResult: [
+        {
+          custody_address: '0x00123',
+        },
+      ],
+    };
+    fetchMock.mockResolvedValue(mockedResponse);
+    expect.assertions(1);
+    await expect(getCustodyAddressForFidNeynar(42)).rejects.toEqual(
+      new Error('No custody address found for FID 42'),
+    );
+  });
+
+  it('throw an error on missing user', async () => {
+    const mockedResponse = {
+      users: [],
     };
     fetchMock.mockResolvedValue(mockedResponse);
     expect.assertions(1);
@@ -41,7 +56,7 @@ describe('getCustodyAddressForFidNeynar', () => {
 
   it('throw an error on missing custodyAddress', async () => {
     const mockedResponse = {
-      result: {},
+      users: [{}],
     };
     fetchMock.mockResolvedValue(mockedResponse);
     expect.assertions(1);

--- a/src/network/neynar/getCustodyAddressForFidNeynar.ts
+++ b/src/network/neynar/getCustodyAddressForFidNeynar.ts
@@ -5,14 +5,10 @@ export async function getCustodyAddressForFidNeynar(
   fid: number,
   apiKey: string = NEYNAR_DEFAULT_API_KEY,
 ): Promise<string> {
-  const url = `https://api.neynar.com/v1/farcaster/custody-address?fid=${fid}`;
+  const url = `https://api.neynar.com/v2/farcaster/user/bulk?fids=${fid}`;
   const responseBody = await getDataFromNeynar(url, apiKey);
-  if (
-    !responseBody ||
-    !responseBody.result ||
-    !responseBody.result.custodyAddress
-  ) {
+  if (!responseBody?.users?.[0]?.custody_address) {
     throw new Error(`No custody address found for FID ${fid}`);
   }
-  return responseBody.result.custodyAddress;
+  return responseBody.users[0].custody_address;
 }

--- a/src/network/neynar/getVerifiedAddressesForFidNeynar.test.ts
+++ b/src/network/neynar/getVerifiedAddressesForFidNeynar.test.ts
@@ -17,9 +17,11 @@ describe('getVerifiedAddressesForFidNeynar', () => {
 
   it('should return mocked response correctly', async () => {
     const mockedResponse = {
-      result: {
-        verifications: ['0x00123'],
-      },
+      users: [
+        {
+          verifications: ['0x00123'],
+        },
+      ],
     };
     fetchMock.mockResolvedValue(mockedResponse);
     const resp = await getVerifiedAddressesForFidNeynar(42);
@@ -28,9 +30,22 @@ describe('getVerifiedAddressesForFidNeynar', () => {
 
   it('throw an error on a bad result', async () => {
     const mockedResponse = {
-      badResult: {
-        verifications: ['0x00123'],
-      },
+      badResult: [
+        {
+          verifications: ['0x00123'],
+        },
+      ],
+    };
+    fetchMock.mockResolvedValue(mockedResponse);
+    expect.assertions(1);
+    await expect(getVerifiedAddressesForFidNeynar(42)).rejects.toEqual(
+      new Error('No verified addresses found for FID 42'),
+    );
+  });
+
+  it('throw an error on missing user', async () => {
+    const mockedResponse = {
+      users: [],
     };
     fetchMock.mockResolvedValue(mockedResponse);
     expect.assertions(1);
@@ -41,7 +56,7 @@ describe('getVerifiedAddressesForFidNeynar', () => {
 
   it('throw an error on missing verifications', async () => {
     const mockedResponse = {
-      result: {},
+      users: [{}],
     };
     fetchMock.mockResolvedValue(mockedResponse);
     expect.assertions(1);

--- a/src/network/neynar/getVerifiedAddressesForFidNeynar.ts
+++ b/src/network/neynar/getVerifiedAddressesForFidNeynar.ts
@@ -5,15 +5,10 @@ export async function getVerifiedAddressesForFidNeynar(
   fid: number,
   apiKey: string = NEYNAR_DEFAULT_API_KEY,
 ): Promise<string[]> {
-  const url = `https://api.neynar.com/v1/farcaster/verifications?fid=${fid}`;
+  const url = `https://api.neynar.com/v2/farcaster/user/bulk?fids=${fid}`;
   const responseBody = await getDataFromNeynar(url, apiKey);
-  if (
-    !responseBody ||
-    !responseBody.result ||
-    !responseBody.result.verifications ||
-    responseBody.result.verifications.length === 0
-  ) {
+  if (!responseBody?.users?.[0]?.verifications?.length) {
     throw new Error(`No verified addresses found for FID ${fid}`);
   }
-  return responseBody.result.verifications;
+  return responseBody.users[0].verifications;
 }


### PR DESCRIPTION
**What changed? Why?**

This PR updates the `getCustodyAddressForFidNeynar` and `getVerifiedAddressesForFidNeynar` functions to use Neynar's V2 endpoints.

The V1 endpoints have been deprecated, and the verification endpoint (`https://api.neynar.com/v1/farcaster/verifications?fid=...`) has stopped returning verification data entirely.

**Notes to reviewers**

**How has it been tested?**

Unit tests