### PR TITLE
trivial: prefix api key envar in template with `NEXT_PUBLIC`

### DIFF
--- a/create-onchain/templates/next/app/providers.tsx
+++ b/create-onchain/templates/next/app/providers.tsx
@@ -37,7 +37,7 @@ export function Providers(props: {
     <WagmiProvider config={config} initialState={props.initialState}>
       <QueryClientProvider client={queryClient}>
         <OnchainKitProvider
-          apiKey={process.env.ONCHAINKIT_CDP_KEY}
+          apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_CDP_KEY}
           chain={base}
         >
           {props.children}


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
