### PR TITLE
trivial: add `Paymaster` as an integration in `create-onchain`

### DIFF
--- a/create-onchain/src/cli.ts
+++ b/create-onchain/src/cli.ts
@@ -165,6 +165,11 @@ async function init() {
         `Coinbase Developer Platform`
       )}`
     );
+    console.log(
+      `${pc.greenBright('\u2713')} ${pc.blueBright(
+        `Paymaster`
+      )}`
+    );
   }
 
   console.log(`\nFrameworks:`);


### PR DESCRIPTION
**What changed? Why?**
if client key is defined, add `Paymaster` as an integration

**Notes to reviewers**

**How has it been tested?**
