### PR TITLE
fix: Update ConnectWalletText styling

### DIFF
--- a/.changeset/friendly-baboons-peel.md
+++ b/.changeset/friendly-baboons-peel.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+-**fix**: Updated `ConnectWalletText` component styling to match the `ConnectWallet` text prop formatting. By @cpcramer #1445

--- a/src/wallet/components/ConnectWalletText.tsx
+++ b/src/wallet/components/ConnectWalletText.tsx
@@ -6,7 +6,7 @@ export function ConnectWalletText({
   className,
 }: ConnectWalletTextReact) {
   return (
-    <span className={cn(dsText.body, color.inverse, className)}>
+    <span className={cn(dsText.headline, color.inverse, className)}>
       {children}
     </span>
   );


### PR DESCRIPTION
**What changed? Why?**
Update `ConnectWalletText` component styling to match the `ConnectWallet` text prop formatting.

<img width="174" alt="Screenshot 2024-10-17 at 2 55 37 PM" src="https://github.com/user-attachments/assets/c14bf5b1-90b3-4302-bcfa-045251792f1e">

**Notes to reviewers**

**How has it been tested?**
