### PR TITLE
feat: add promises to transactions and calls

### DIFF
--- a/.changeset/mighty-kings-knock.md
+++ b/.changeset/mighty-kings-knock.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': minor
+---
+
+-**feat**: Add handling for calls and contracts promises in Transactions component. By @alessey #1450

--- a/playground/nextjs-app-router/components/AppProvider.tsx
+++ b/playground/nextjs-app-router/components/AppProvider.tsx
@@ -21,6 +21,8 @@ export enum OnchainKitComponent {
 export enum TransactionTypes {
   Calls = 'calls',
   Contracts = 'contracts',
+  CallsPromise = 'callsPromise',
+  ContractsPromise = 'contractsPromise',
 }
 
 export type Paymaster = {

--- a/playground/nextjs-app-router/components/demo/Transaction.tsx
+++ b/playground/nextjs-app-router/components/demo/Transaction.tsx
@@ -12,37 +12,89 @@ import {
   TransactionToastIcon,
   TransactionToastLabel,
 } from '@coinbase/onchainkit/transaction';
-import { useCallback, useContext, useEffect } from 'react';
+import { useCallback, useContext, useEffect, useMemo } from 'react';
 import { AppContext, TransactionTypes } from '../AppProvider';
+import { Call } from '@/onchainkit/esm/transaction/types';
+import { ContractFunctionParameters } from 'viem';
+import { LifecycleStatus } from '@/onchainkit/src/transaction';
 
 function TransactionDemo() {
   const { chainId, transactionType } = useContext(AppContext);
   const capabilities = useCapabilities();
-  const contracts = clickContracts;
-  const calls = clickCalls;
+  const contracts = clickContracts as ContractFunctionParameters[];
+  const calls = clickCalls as Call[];
+  const promiseCalls = new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(calls);
+    }, 4000);
+  }) as Promise<Call[]>;
+  const promiseContracts = new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(contracts);
+    }, 4000);
+  }) as Promise<ContractFunctionParameters[]>;
   useEffect(() => {
     console.log('Playground.Transaction.chainId:', chainId);
   }, [chainId]);
-  const handleOnStatus = useCallback((status) => {
+  const handleOnStatus = useCallback((status: LifecycleStatus) => {
     console.log('Playground.Transaction.onStatus:', status);
   }, []);
 
   useEffect(() => {
     console.log('Playground.Transaction.transactionType:', transactionType);
-    if (transactionType === TransactionTypes.Calls) {
-      console.log('Playground.Transaction.calls:', calls);
-    } else {
-      console.log('Playground.Transaction.contracts:', contracts);
+    switch (transactionType) {
+      case TransactionTypes.Calls:
+        console.log('Playground.Transaction.calls:', calls);
+        break;
+      case TransactionTypes.Contracts:
+        console.log('Playground.Transaction.contracts:', contracts);
+        break;
+      case TransactionTypes.CallsPromise:
+        console.log('Playground.Transaction.callsPromise');
+        break;
+      case TransactionTypes.ContractsPromise:
+        console.log('Playground.Transaction.contractsPromise');
+        break;
     }
   }, [transactionType, calls, contracts]);
+
+  const transactions = useMemo(() => {
+    if (transactionType === TransactionTypes.Calls) {
+      return {
+        calls,
+        contracts: undefined,
+      };
+    }
+
+    if (transactionType === TransactionTypes.Contracts) {
+      return {
+        calls: undefined,
+        contracts,
+      };
+    }
+
+    if (transactionType === TransactionTypes.CallsPromise) {
+      return {
+        calls: promiseCalls,
+        contracts: undefined,
+      };
+    }
+
+    if (transactionType === TransactionTypes.ContractsPromise) {
+      return {
+        contracts: promiseContracts,
+        calls: undefined,
+      };
+    }
+
+    return { calls: undefined, contracts: undefined };
+  }, []);
 
   return (
     <div className="mx-auto grid w-1/2 gap-8">
       <Transaction
         chainId={chainId ?? 84532} // something breaks if we don't have default network?
-        {...(transactionType === TransactionTypes.Calls
-          ? { calls }
-          : { contracts })}
+        {...transactions}
         capabilities={capabilities}
         onStatus={handleOnStatus}
       >

--- a/playground/nextjs-app-router/components/demo/Transaction.tsx
+++ b/playground/nextjs-app-router/components/demo/Transaction.tsx
@@ -1,5 +1,7 @@
 import { useCapabilities } from '@/lib/hooks';
 import { clickCalls, clickContracts } from '@/lib/transactions';
+import type { Call } from '@/onchainkit/esm/transaction/types';
+import type { LifecycleStatus } from '@/onchainkit/src/transaction';
 import {
   Transaction,
   TransactionButton,
@@ -13,10 +15,8 @@ import {
   TransactionToastLabel,
 } from '@coinbase/onchainkit/transaction';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
+import type { ContractFunctionParameters } from 'viem';
 import { AppContext, TransactionTypes } from '../AppProvider';
-import { Call } from '@/onchainkit/esm/transaction/types';
-import { ContractFunctionParameters } from 'viem';
-import { LifecycleStatus } from '@/onchainkit/src/transaction';
 
 function TransactionDemo() {
   const { chainId, transactionType } = useContext(AppContext);
@@ -88,7 +88,7 @@ function TransactionDemo() {
     }
 
     return { calls: undefined, contracts: undefined };
-  }, []);
+  }, [calls, promiseCalls, contracts, promiseContracts, transactionType]);
 
   return (
     <div className="mx-auto grid w-1/2 gap-8">

--- a/playground/nextjs-app-router/components/form/transaction-options.tsx
+++ b/playground/nextjs-app-router/components/form/transaction-options.tsx
@@ -36,6 +36,12 @@ export function TransactionOptions() {
             <SelectItem value={TransactionTypes.Contracts}>
               Contracts
             </SelectItem>
+            <SelectItem value={TransactionTypes.CallsPromise}>
+              Calls Promise
+            </SelectItem>
+            <SelectItem value={TransactionTypes.ContractsPromise}>
+              Contracts Promise
+            </SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",

--- a/src/transaction/components/Transaction.tsx
+++ b/src/transaction/components/Transaction.tsx
@@ -18,11 +18,12 @@ export function Transaction({
 }: TransactionReact) {
   const isMounted = useIsMounted();
   const componentTheme = useTheme();
+  const { chain } = useOnchainKit();
+
   // prevents SSR hydration issue
   if (!isMounted) {
     return null;
   }
-  const { chain } = useOnchainKit();
 
   // If chainId is not provided,
   // use the default chainId from the OnchainKit context

--- a/src/transaction/components/TransactionButton.tsx
+++ b/src/transaction/components/TransactionButton.tsx
@@ -31,7 +31,9 @@ export function TransactionButton({
   const { showCallsStatus } = useShowCallsStatus();
 
   const isInProgress =
-    lifecycleStatus.statusName === 'transactionPending' || isLoading;
+    lifecycleStatus.statusName === 'buildingTransaction' ||
+    lifecycleStatus.statusName === 'transactionPending' ||
+    isLoading;
   const isMissingProps = !transactions || !address;
   const isWaitingForReceipt = !!transactionId || !!transactionHash;
 

--- a/src/transaction/components/TransactionProvider.test.tsx
+++ b/src/transaction/components/TransactionProvider.test.tsx
@@ -83,7 +83,8 @@ const TestComponent = () => {
     });
   };
   const handleStatusTransactionLegacyExecutedMultipleContracts = async () => {
-    context.setLifecycleStatus({
+    await context.onSubmit();
+    await context.setLifecycleStatus({
       statusName: 'transactionLegacyExecuted',
       statusData: {
         transactionHashList: ['hash12345678', 'hash12345678'],
@@ -252,6 +253,29 @@ describe('TransactionProvider', () => {
       expect(onSuccessMock).toHaveBeenCalled();
       expect(onSuccessMock).toHaveBeenCalledWith({
         transactionReceipts: ['hash12345678', 'hash12345678'],
+      });
+    });
+  });
+
+  it('should emit onError when building transactions fails', async () => {
+    const sendWalletTransactionsMock = vi.fn();
+    (useSendWalletTransactions as ReturnType<typeof vi.fn>).mockReturnValue(
+      sendWalletTransactionsMock,
+    );
+    const onErrorMock = vi.fn();
+    const contracts = Promise.reject(new Error('error'));
+    render(
+      <TransactionProvider contracts={contracts} onError={onErrorMock}>
+        <TestComponent />
+      </TransactionProvider>,
+    );
+    const button = screen.getByText('Submit');
+    fireEvent.click(button);
+    await waitFor(() => {
+      expect(onErrorMock).toHaveBeenCalledWith({
+        code: 'TmTPc04',
+        error: '{}',
+        message: 'Error building transactions',
       });
     });
   });

--- a/src/transaction/components/TransactionProvider.tsx
+++ b/src/transaction/components/TransactionProvider.tsx
@@ -241,7 +241,7 @@ export function TransactionProvider({
       return;
     }
     getTransactionLegacyReceipts();
-  }, [transactions, transactionHashList]);
+  }, [transactions, transactionCount, transactionHashList]);
 
   const getTransactionLegacyReceipts = useCallback(async () => {
     const receipts = [];
@@ -300,7 +300,7 @@ export function TransactionProvider({
       });
       return undefined;
     }
-  }, []);
+  }, [transactions]);
 
   const handleSubmit = useCallback(async () => {
     setErrorMessage('');
@@ -323,7 +323,7 @@ export function TransactionProvider({
         },
       });
     }
-  }, [chainId, sendWalletTransactions, switchChain]);
+  }, [buildTransaction, chainId, sendWalletTransactions, switchChain]);
 
   const value = useValue({
     chainId,

--- a/src/transaction/hooks/useGetTransactionStatusLabel.test.tsx
+++ b/src/transaction/hooks/useGetTransactionStatusLabel.test.tsx
@@ -40,6 +40,14 @@ describe('useGetTransactionStatusLabel', () => {
     expect(result.current.label).toBe('Confirm in wallet.');
   });
 
+  it('should return status when transaction is building', () => {
+    (useTransactionContext as Mock).mockReturnValue({
+      lifecycleStatus: { statusName: 'buildingTransaction', statusData: null },
+    });
+    const { result } = renderHook(() => useGetTransactionStatusLabel());
+    expect(result.current.label).toBe('Building transaction...');
+  });
+
   it('should return status when transaction hash exists', () => {
     (useTransactionContext as Mock).mockReturnValue({
       lifecycleStatus: { statusName: 'init', statusData: null },

--- a/src/transaction/hooks/useGetTransactionStatusLabel.tsx
+++ b/src/transaction/hooks/useGetTransactionStatusLabel.tsx
@@ -17,9 +17,17 @@ export function useGetTransactionStatusLabel() {
   // user started txn and needs to confirm in wallet
   const isPending = lifecycleStatus.statusName === 'transactionPending';
 
+  // waiting for calls or contracts promise to resolve
+  const isBuildingTransaction =
+    lifecycleStatus.statusName === 'buildingTransaction';
+
   return useMemo(() => {
     let label = '';
     let labelClassName: string = color.foregroundMuted;
+
+    if (isBuildingTransaction) {
+      label = 'Building transaction...';
+    }
 
     if (isPending) {
       label = 'Confirm in wallet.';
@@ -39,5 +47,5 @@ export function useGetTransactionStatusLabel() {
     }
 
     return { label, labelClassName };
-  }, [errorMessage, isInProgress, isPending, receipt]);
+  }, [errorMessage, isBuildingTransaction, isInProgress, isPending, receipt]);
 }

--- a/src/transaction/hooks/useGetTransactionToastLabel.test.tsx
+++ b/src/transaction/hooks/useGetTransactionToastLabel.test.tsx
@@ -35,6 +35,7 @@ describe('useGetTransactionToastLabel', () => {
   it('should return correct toast and actionElement when transaction is loading', () => {
     (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
+      lifecycleStatus: { statusName: 'init' },
     });
 
     const { result } = renderHook(() => useGetTransactionToastLabel());
@@ -45,6 +46,7 @@ describe('useGetTransactionToastLabel', () => {
   it('should return status when transaction hash exists', () => {
     (useTransactionContext as Mock).mockReturnValue({
       transactionHash: '0x123',
+      lifecycleStatus: { statusName: 'init' },
     });
 
     const { result } = renderHook(() => useGetTransactionToastLabel());
@@ -55,6 +57,7 @@ describe('useGetTransactionToastLabel', () => {
   it('should return status when transaction id exists', () => {
     (useTransactionContext as Mock).mockReturnValue({
       transactionId: 'ab123',
+      lifecycleStatus: { statusName: 'init' },
       onSubmit: vi.fn(),
     });
 
@@ -66,10 +69,21 @@ describe('useGetTransactionToastLabel', () => {
     expect(result.current.label).toBe('Transaction in progress');
   });
 
+  it('should return status when building transaction', () => {
+    (useTransactionContext as Mock).mockReturnValue({
+      lifecycleStatus: { statusName: 'buildingTransaction' },
+    });
+
+    const { result } = renderHook(() => useGetTransactionToastLabel());
+
+    expect(result.current.label).toBe('Building transaction');
+  });
+
   it('should return status when receipt exists', () => {
     (useTransactionContext as Mock).mockReturnValue({
       receipt: 'receipt',
       transactionHash: '0x123',
+      lifecycleStatus: { statusName: 'init' },
     });
 
     const { result } = renderHook(() => useGetTransactionToastLabel());
@@ -81,6 +95,7 @@ describe('useGetTransactionToastLabel', () => {
     const onSubmitMock = vi.fn();
     (useTransactionContext as Mock).mockReturnValue({
       errorMessage: 'error',
+      lifecycleStatus: { statusName: 'init' },
       onSubmit: onSubmitMock,
     });
 
@@ -92,6 +107,7 @@ describe('useGetTransactionToastLabel', () => {
   it('should return status when no status available', () => {
     (useTransactionContext as Mock).mockReturnValue({
       errorMessage: '',
+      lifecycleStatus: { statusName: 'init' },
     });
 
     const { result } = renderHook(() => useGetTransactionToastLabel());

--- a/src/transaction/hooks/useGetTransactionToastLabel.tsx
+++ b/src/transaction/hooks/useGetTransactionToastLabel.tsx
@@ -41,5 +41,5 @@ export function useGetTransactionToastLabel() {
     }
 
     return { label, labelClassName };
-  }, [errorMessage, isInProgress, receipt]);
+  }, [errorMessage, isBuildingTransaction, isInProgress, receipt]);
 }

--- a/src/transaction/hooks/useGetTransactionToastLabel.tsx
+++ b/src/transaction/hooks/useGetTransactionToastLabel.tsx
@@ -3,15 +3,29 @@ import { color } from '../../styles/theme';
 import { useTransactionContext } from '../components/TransactionProvider';
 
 export function useGetTransactionToastLabel() {
-  const { errorMessage, isLoading, receipt, transactionHash, transactionId } =
-    useTransactionContext();
+  const {
+    errorMessage,
+    isLoading,
+    lifecycleStatus,
+    receipt,
+    transactionHash,
+    transactionId,
+  } = useTransactionContext();
 
   // user confirmed in wallet, txn in progress
   const isInProgress = isLoading || !!transactionId || !!transactionHash;
 
+  // waiting for calls or contracts promise to resolve
+  const isBuildingTransaction =
+    lifecycleStatus.statusName === 'buildingTransaction';
+
   return useMemo(() => {
     let label = '';
     let labelClassName: string = color.foregroundMuted;
+
+    if (isBuildingTransaction) {
+      label = 'Building transaction';
+    }
 
     if (isInProgress) {
       label = 'Transaction in progress';

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -95,7 +95,7 @@ export type TransactionContextType = {
     | Call[]
     | ContractFunctionParameters[]
     | Promise<Call[]>
-    | Promise<ContractFunctionParameters[]>; // An array of transactions for the component.
+    | Promise<ContractFunctionParameters[]>; // An array of transactions for the component or a promise that resolves to an array of transactions.
   transactionId?: string; // An optional string representing the ID of the transaction.
   transactionHash?: string; // An optional string representing the hash of the transaction.
 };
@@ -270,22 +270,6 @@ export type UseSendWalletTransactionsParams = {
   // biome-ignore lint: cannot find module 'wagmi/experimental/query'
   writeContractsAsync: any;
   writeContractAsync: WriteContractMutateAsync<Config, unknown> | (() => void);
-};
-
-export type UseTransactionTypeParams = {
-  calls?: Call[];
-  contracts?: ContractFunctionParameters[];
-  transactionStatuses: {
-    [TRANSACTION_TYPE_CALLS]: {
-      single: string;
-      batch: string;
-    };
-    [TRANSACTION_TYPE_CONTRACTS]: {
-      single: string;
-      batch: string;
-    };
-  };
-  walletCapabilities: ViemWalletCapabilities;
 };
 
 /**

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -12,11 +12,6 @@ import type {
   SendTransactionMutateAsync,
   WriteContractMutateAsync,
 } from 'wagmi/query';
-// 🌲☀🌲
-import {
-  TRANSACTION_TYPE_CALLS,
-  TRANSACTION_TYPE_CONTRACTS,
-} from './constants';
 
 export type Call = { to: Hex; data?: Hex; value?: bigint };
 

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -40,6 +40,10 @@ export type LifecycleStatus =
       statusData: null;
     }
   | {
+      statusName: 'buildingTransaction';
+      statusData: null;
+    }
+  | {
       statusName: 'transactionPending'; // if the mutation is currently executing
       statusData: null;
     }
@@ -87,7 +91,11 @@ export type TransactionContextType = {
   setIsToastVisible: (isVisible: boolean) => void; // A function to set the visibility of the transaction toast.
   setLifecycleStatus: (state: LifecycleStatus) => void; // A function to set the lifecycle status of the component
   setTransactionId: (id: string) => void; // A function to set the transaction ID.
-  transactions?: Call[] | ContractFunctionParameters[]; // An array of transactions for the component.
+  transactions?:
+    | Call[]
+    | ContractFunctionParameters[]
+    | Promise<Call[]>
+    | Promise<ContractFunctionParameters[]>; // An array of transactions for the component.
   transactionId?: string; // An optional string representing the ID of the transaction.
   transactionHash?: string; // An optional string representing the hash of the transaction.
 };
@@ -131,11 +139,13 @@ export type TransactionError = {
 };
 
 export type TransactionProviderReact = {
-  calls?: Call[]; // An array of calls for the transaction. Mutually exclusive with the `contracts` prop.
+  calls?: Call[] | Promise<Call[]>; // An array of calls for the transaction. Mutually exclusive with the `contracts` prop.
   capabilities?: WalletCapabilities; // Capabilities that a wallet supports (e.g. paymasters, session keys, etc).
   chainId: number; // The chainId for the transaction.
   children: ReactNode; // The child components to be rendered within the provider component.
-  contracts?: ContractFunctionParameters[]; // An array of contract function parameters provided to the child components. Mutually exclusive with the `calls` prop.
+  contracts?:
+    | ContractFunctionParameters[]
+    | Promise<ContractFunctionParameters[]>; // An array of contract function parameters provided to the child components. Mutually exclusive with the `calls` prop.
   onError?: (e: TransactionError) => void; // An optional callback function that handles errors within the provider.
   onStatus?: (lifecycleStatus: LifecycleStatus) => void; // An optional callback function that exposes the component lifecycle state
   onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes the transaction receipts
@@ -145,12 +155,14 @@ export type TransactionProviderReact = {
  * Note: exported as public Type
  */
 export type TransactionReact = {
-  calls?: Call[]; // An array of calls to be made in the transaction. Mutually exclusive with the `contracts` prop.
+  calls?: Call[] | Promise<Call[]>; // An array of calls to be made in the transaction. Mutually exclusive with the `contracts` prop.
   capabilities?: WalletCapabilities; // Capabilities that a wallet supports (e.g. paymasters, session keys, etc).
   chainId?: number; // The chainId for the transaction.
   children: ReactNode; // The child components to be rendered within the transaction component.
   className?: string; // An optional CSS class name for styling the component.
-  contracts?: ContractFunctionParameters[]; // An array of contract function parameters for the transaction. Mutually exclusive with the `calls` prop.
+  contracts?:
+    | ContractFunctionParameters[]
+    | Promise<ContractFunctionParameters[]>; // An array of contract function parameters for the transaction. Mutually exclusive with the `calls` prop.
   onError?: (e: TransactionError) => void; // An optional callback function that handles transaction errors.
   onStatus?: (lifecycleStatus: LifecycleStatus) => void; // An optional callback function that exposes the component lifecycle state
   onSuccess?: (response: TransactionResponse) => void; // An optional callback function that exposes the transaction receipts
@@ -253,7 +265,6 @@ export type UseSendWalletTransactionsParams = {
   // biome-ignore lint: cannot find module 'wagmi/experimental/query'
   sendCallsAsync: any;
   sendCallAsync: SendTransactionMutateAsync<Config, unknown> | (() => void);
-  transactions?: Call[] | ContractFunctionParameters[];
   transactionType: string;
   walletCapabilities: ViemWalletCapabilities;
   // biome-ignore lint: cannot find module 'wagmi/experimental/query'

--- a/src/transaction/utils/isSpinnerDisplayed.test.ts
+++ b/src/transaction/utils/isSpinnerDisplayed.test.ts
@@ -43,6 +43,22 @@ describe('isSpinnerDisplayed', () => {
     expect(result).toEqual(true);
   });
 
+  it('should return true if status is building', () => {
+    transactionHash = '';
+    errorMessage = '';
+    lifecycleStatus = { statusName: 'buildingTransaction', statusData: null };
+    transactionId = '';
+    isLoading = false;
+    const result = isSpinnerDisplayed({
+      errorMessage,
+      isLoading,
+      lifecycleStatus,
+      transactionHash,
+      transactionId,
+    });
+    expect(result).toEqual(true);
+  });
+
   it('should return true if status is pending', () => {
     transactionHash = '';
     errorMessage = '';

--- a/src/transaction/utils/isSpinnerDisplayed.ts
+++ b/src/transaction/utils/isSpinnerDisplayed.ts
@@ -8,7 +8,9 @@ export function isSpinnerDisplayed({
   transactionHash,
   transactionId,
 }: IsSpinnerDisplayedProps) {
-  const isPending = lifecycleStatus.statusName === 'transactionPending';
+  const isPending =
+    lifecycleStatus.statusName === 'transactionPending' ||
+    lifecycleStatus.statusName === 'buildingTransaction';
   const isInProgress = transactionId || transactionHash;
 
   if (hasReceipt || errorMessage) {


### PR DESCRIPTION
**What changed? Why?**
* Add ability to pass a promise into the transaction component that resolves to calls or contracts
* Added new building transaction status
* Added new onError state when promise is rejected

**Notes to reviewers**

**How has it been tested?**
