### PR TITLE
docs: Update OnchainKitProvider with Config param in Getting Started guide

### DIFF
--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -70,6 +70,14 @@ Additionally, add Base as a supported chain in the Wagmi configuration file `wag
 
 ```tsx twoslash [providers.tsx]
 // @noErrors: 2307 2580 2322 - cannot find 'process', cannot find './wagmi'
+export type ComponentTheme =
+  | 'default'
+  | 'base'
+  | 'cyberpunk'
+  | 'hacker'
+
+export type Mode = 'auto' | 'light' | 'dark';
+// ---cut-before---
 import { OnchainKitProvider } from '@coinbase/onchainkit'; // [!code ++]
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { base } from 'wagmi/chains'; // [!code ++]
@@ -94,8 +102,8 @@ export function Providers(props: {
           config={{ // [!code ++]
             appearance: { // [!code ++]
               theme: { // [!code ++]
-                mode: 'auto', // [!code ++]
-                theme: 'default' // [!code ++]
+                mode: 'auto' as Mode, // [!code ++]
+                theme: 'default' as ComponentTheme // [!code ++]
               } // [!code ++]
             } // [!code ++]
           }} // [!code ++]

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -69,7 +69,7 @@ Additionally, add Base as a supported chain in the Wagmi configuration file `wag
 :::code-group
 
 ```tsx twoslash [providers.tsx]
-// @noErrors: 2307 2580 - cannot find 'process', cannot find './wagmi'
+// @noErrors: 2307 2580 2322 - cannot find 'process', cannot find './wagmi'
 import { OnchainKitProvider } from '@coinbase/onchainkit'; // [!code ++]
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { base } from 'wagmi/chains'; // [!code ++]
@@ -91,6 +91,14 @@ export function Providers(props: {
         <OnchainKitProvider // [!code ++]
           apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY} // [!code ++]
           chain={base} // [!code ++]
+          config={{ // [!code ++]
+            appearance: { // [!code ++]
+              theme: { // [!code ++]
+                mode: 'auto', // [!code ++]
+                theme: 'default' // [!code ++]
+              } // [!code ++]
+            } // [!code ++]
+          }} // [!code ++]
         > // [!code ++]
           {props.children}
         </OnchainKitProvider> // [!code ++]

--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -70,13 +70,13 @@ Additionally, add Base as a supported chain in the Wagmi configuration file `wag
 
 ```tsx twoslash [providers.tsx]
 // @noErrors: 2307 2580 2322 - cannot find 'process', cannot find './wagmi'
-export type ComponentTheme =
+type ComponentTheme =
   | 'default'
   | 'base'
   | 'cyberpunk'
   | 'hacker'
 
-export type Mode = 'auto' | 'light' | 'dark';
+type Mode = 'auto' | 'light' | 'dark';
 // ---cut-before---
 import { OnchainKitProvider } from '@coinbase/onchainkit'; // [!code ++]
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';


### PR DESCRIPTION
**What changed? Why?**
Add new `Config` parameter to the `OnchainKitProvider` example in the `Getting Started` guide. 

<img width="676" alt="Screenshot 2024-10-18 at 10 34 57 AM" src="https://github.com/user-attachments/assets/f219123d-f1de-41e9-a909-5b26c060dc24">

**Notes to reviewers**

**How has it been tested?**
