### PR TITLE
docs: fix Tailwind CSS spelling

### DIFF
--- a/site/docs/pages/guides/tailwind.mdx
+++ b/site/docs/pages/guides/tailwind.mdx
@@ -1,9 +1,9 @@
 ---
-title: Tailwindcss Integration Guide · OnchainKit
-description: Learn how to integrate tailwindcss with OnchainKit
+title: Tailwind CSS Integration Guide · OnchainKit
+description: Learn how to integrate Tailwind CSS with OnchainKit
 ---
 
-# Tailwindcss Integration Guide
+# Tailwind CSS Integration Guide
 
 OnchainKit comes with first class support for `tailwindcss`.
 
@@ -18,9 +18,9 @@ Just place this at the top of your application's entry point to have the compone
 import '@coinbase/onchainkit/styles.css';
 ```
 
-### TailwindCSS Config
+### Tailwind CSS Config
 
-Depending on your dark mode setup, you may have to add `safelist: ['dark']` to your tailwind config.
+Depending on your dark mode setup, you may have to add `safelist: ['dark']` to your Tailwind config.
 
 ```javascript title="tailwind.config.js"
 /** @type {import('tailwindcss').Config} */
@@ -103,4 +103,3 @@ To override default colorscheme, you need to modify the following css variables:
 ```
 
 ::::
-

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -29,7 +29,7 @@ export const sidebar = [
         link: '/guides/reporting-bug',
       },
       {
-        text: 'Tailwindcss Integration',
+        text: 'Tailwind CSS Integration',
         link: '/guides/tailwind',
       },
       {


### PR DESCRIPTION
**What changed? Why?**
This PR fixes a few instances of "Tailwind CSS" spelling to match [Tailwind's](https://tailwindcss.com/) own spelling. 

**Notes to reviewers**

**How has it been tested?**
