### PR TITLE
fix: `isSponsored` in `Checkout` component

### DIFF
--- a/.changeset/weak-coats-fetch.md
+++ b/.changeset/weak-coats-fetch.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+**fix**: `isSponsored` in `Checkout` component. by @0xAlec #1458

--- a/src/checkout/components/CheckoutProvider.test.tsx
+++ b/src/checkout/components/CheckoutProvider.test.tsx
@@ -478,9 +478,7 @@ describe('CheckoutProvider', () => {
           id: 'test-contract',
         },
       ],
-      capabilities: {
-        paymaster: null,
-      },
+      capabilities: undefined,
     });
   });
 
@@ -516,7 +514,9 @@ describe('CheckoutProvider', () => {
         },
       ],
       capabilities: {
-        paymaster: 'http://example.com',
+        paymasterService: {
+          url: 'http://example.com',
+        },
       },
     });
   });

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -55,7 +55,7 @@ export function CheckoutProvider({
 }: CheckoutProviderReact) {
   // Core hooks
   const {
-    config: { paymaster } = { paymaster: null },
+    config: { paymaster } = { paymaster: undefined },
   } = useOnchainKit();
   const { address, chainId, isConnected } = useAccount();
   const { connectAsync } = useConnect();
@@ -306,9 +306,13 @@ export function CheckoutProvider({
       // Open keys.coinbase.com for payment
       await writeContractsAsync({
         contracts: contractsRef.current,
-        capabilities: {
-          paymaster: isSponsored ? paymaster : null,
-        },
+        capabilities: isSponsored
+          ? {
+              paymasterService: {
+                url: paymaster,
+              },
+            }
+          : undefined,
       });
     } catch (error) {
       const isUserRejectedError =


### PR DESCRIPTION
**What changed? Why?**
- was not passing in the proper paymaster field for `capabilities` previously

**Notes to reviewers**

**How has it been tested?**
cherry picked to https://github.com/coinbase/onchainkit/pull/1428 and tested locally
