### PR TITLE
feat: add `presetCryptoAmount` param to `Checkout`

### DIFF
--- a/.changeset/few-files-attack.md
+++ b/.changeset/few-files-attack.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+- **feat**: added presetCryptoAmount param to Checkout. by @0xAlec #1461

--- a/src/checkout/components/CheckoutProvider.test.tsx
+++ b/src/checkout/components/CheckoutProvider.test.tsx
@@ -404,7 +404,7 @@ describe('CheckoutProvider', () => {
     });
     fireEvent.click(screen.getByText('Submit'));
     expect(windowOpenMock).toHaveBeenCalledWith(
-      'https://keys.coinbase.com/fund?asset=USDC&chainId=8453&presentCryptoAmount=10',
+      'https://keys.coinbase.com/fund?asset=USDC&chainId=8453&presetCryptoAmount=10',
       '_blank',
       'noopener,noreferrer',
     );

--- a/src/checkout/components/CheckoutProvider.test.tsx
+++ b/src/checkout/components/CheckoutProvider.test.tsx
@@ -404,7 +404,7 @@ describe('CheckoutProvider', () => {
     });
     fireEvent.click(screen.getByText('Submit'));
     expect(windowOpenMock).toHaveBeenCalledWith(
-      'https://keys.coinbase.com/fund?asset=USDC&chainId=8453',
+      'https://keys.coinbase.com/fund?asset=USDC&chainId=8453&presentCryptoAmount=10',
       '_blank',
       'noopener,noreferrer',
     );

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -217,7 +217,7 @@ export function CheckoutProvider({
           CheckoutErrorCode.INSUFFICIENT_BALANCE
       ) {
         window.open(
-          'https://keys.coinbase.com/fund?asset=USDC&chainId=8453',
+          `https://keys.coinbase.com/fund?asset=USDC&chainId=8453&presentCryptoAmount=${priceInUSDCRef.current}`,
           '_blank',
           'noopener,noreferrer',
         );

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -217,7 +217,7 @@ export function CheckoutProvider({
           CheckoutErrorCode.INSUFFICIENT_BALANCE
       ) {
         window.open(
-          `https://keys.coinbase.com/fund?asset=USDC&chainId=8453&presentCryptoAmount=${priceInUSDCRef.current}`,
+          `https://keys.coinbase.com/fund?asset=USDC&chainId=8453&presetCryptoAmount=${priceInUSDCRef.current}`,
           '_blank',
           'noopener,noreferrer',
         );


### PR DESCRIPTION
**What changed? Why?**
- add a USDC fill amount to Checkout funding flow

**Notes to reviewers**

**How has it been tested?**
cherry picked to https://github.com/coinbase/onchainkit/pull/1428 and tested locally
