### PR TITLE
docs: add different package manager installations to `Getting Started`

### DIFF
--- a/site/docs/pages/getting-started.mdx
+++ b/site/docs/pages/getting-started.mdx
@@ -40,9 +40,25 @@ Add OnchainKit to your existing project manually.
 
 Install OnchainKit in your project.
 
-```bash
-npm i @coinbase/onchainkit@latest
+:::code-group
+
+```bash [npm]
+npm install @coinbase/onchainkit
 ```
+
+```bash [yarn]
+yarn add @coinbase/onchainkit
+```
+
+```bash [pnpm]
+pnpm add @coinbase/onchainkit
+```
+
+```bash [bun]
+bun add @coinbase/onchainkit
+```
+
+:::
 
 ## Get Your Client API Key
 


### PR DESCRIPTION
**What changed? Why?**

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/aef39699-1243-478b-afae-aaeed943dae6">


**Notes to reviewers**

**How has it been tested?**
