### PR TITLE
chore: Update Tweet on Landing Page

### DIFF
--- a/site/docs/components/landing/Tweets.tsx
+++ b/site/docs/components/landing/Tweets.tsx
@@ -73,24 +73,21 @@ const Tweets: React.FC = () => {
             </TweetCard>
             <TweetCard className="tweet2 md:flex-shrink-0">
               <p lang="en" dir="ltr">
-                Building with
-                <a href="https://twitter.com/OnchainKit?ref_src=twsrc%5Etfw">
-                  @OnchainKit
-                </a>{' '}
-                has been such a great experience so far. We&#39;re builders, and
-                we like to build things from scratch. But with{' '}
+                Rush absolutely recommends Base devs to try{' '}
                 <a href="https://twitter.com/OnchainKit?ref_src=twsrc%5Etfw">
                   @OnchainKit
                 </a>
-                , there was a real boost in productivity, allowing us to ship
-                dApps with seamless functionality in a matter of minutes. <br />
-                <br />
-                Onto the next…{' '}
-                <a href="https://t.co/QzlJ4RIKLG">https://t.co/QzlJ4RIKLG</a>
+                , which can make life much easier with their cool SwapWidget and
+                deep{' '}
+                <a href="https://twitter.com/CoinbaseWallet?ref_src=twsrc%5Etfw">
+                  @CoinbaseWallet
+                </a>{' '}
+                integration🥹{' '}
+                <a href="https://t.co/yJJFjTr4nN">https://t.co/yJJFjTr4nN</a>
               </p>
-              &mdash; Coinfever (@coinfeverapp){' '}
-              <a href="https://twitter.com/coinfeverapp/status/1842230362337915205?ref_src=twsrc%5Etfw">
-                October 4, 2024
+              &mdash; Rush (@rushtradingx){' '}
+              <a href="https://twitter.com/rushtradingx/status/1849197213702135863?ref_src=twsrc%5Etfw">
+                October 23, 2024
               </a>
             </TweetCard>
             <TweetCard className="tweet3 md:flex-shrink-0">

--- a/site/docs/styles.css
+++ b/site/docs/styles.css
@@ -265,12 +265,11 @@ footer a.vocs_Anchor {
 
 #twitter-widget-1 {
   width: 40.5rem !important;
-  height: 22.5rem !important
 }
 
 #twitter-widget-2 {
   width: 40.5rem !important;
-  height: 37rem !important
+  height: 39rem !important
 }
 
 @keyframes scroll {


### PR DESCRIPTION
**What changed? Why?**
New middle tweet. 
Tweak sizing. 

<img width="1382" alt="Screenshot 2024-10-24 at 9 19 35 AM" src="https://github.com/user-attachments/assets/e24c80a9-9a59-4f09-8604-b9c24075722d">

![image](https://github.com/user-attachments/assets/ed6186e4-d025-4cc6-8137-6feeabfb6dcd)

**Notes to reviewers**

**How has it been tested?**
