### PR TITLE
docs: add missing `ConnectWalletReact` prop to types page

### DIFF
--- a/site/docs/pages/wallet/types.mdx
+++ b/site/docs/pages/wallet/types.mdx
@@ -12,7 +12,7 @@ type ConnectWalletReact = {
   children?: React.ReactNode; // Children can be utilized to display customized content when the wallet is connected.
   className?: string; // Optional className override for button element
   text?: string; // Optional text override for button. Note: Prefer using `ConnectWalletText` component instead as this will be deprecated in a future version.
-  withWalletAggregator?: boolean; // Optional flag to enable wallet aggregators like RainbowKit
+  withWalletAggregator?: boolean; // Optional flag to enable the wallet aggregator like RainbowKit
 };
 ```
 

--- a/site/docs/pages/wallet/types.mdx
+++ b/site/docs/pages/wallet/types.mdx
@@ -12,6 +12,7 @@ type ConnectWalletReact = {
   children?: React.ReactNode; // Children can be utilized to display customized content when the wallet is connected.
   className?: string; // Optional className override for button element
   text?: string; // Optional text override for button
+  withWalletAggregator?: boolean; // Optional flag to enable wallet aggregators like RainbowKit
 };
 ```
 

--- a/site/docs/pages/wallet/types.mdx
+++ b/site/docs/pages/wallet/types.mdx
@@ -11,7 +11,7 @@ description: Glossary of Types.
 type ConnectWalletReact = {
   children?: React.ReactNode; // Children can be utilized to display customized content when the wallet is connected.
   className?: string; // Optional className override for button element
-  text?: string; // Optional text override for button
+  text?: string; // Optional text override for button. Note: Prefer using `ConnectWalletText` component instead as this will be deprecated in a future version.
   withWalletAggregator?: boolean; // Optional flag to enable wallet aggregators like RainbowKit
 };
 ```

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -19,7 +19,7 @@ export type ConnectWalletReact = {
   className?: string; // Optional className override for button element
   /** @deprecated Prefer `ConnectWalletText component` */
   text?: string; // Optional text override for button
-  withWalletAggregator?: boolean; // Optional flag to enable the wallet aggregator like RainbowKit
+  withWalletAggregator?: boolean; // Optional flag to enable wallet aggregators like RainbowKit
 };
 
 /**

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -19,7 +19,7 @@ export type ConnectWalletReact = {
   className?: string; // Optional className override for button element
   /** @deprecated Prefer `ConnectWalletText component` */
   text?: string; // Optional text override for button
-  withWalletAggregator?: boolean; // Optional flag to enable wallet aggregators like RainbowKit
+  withWalletAggregator?: boolean; // Optional flag to enable the wallet aggregator like RainbowKit
 };
 
 /**


### PR DESCRIPTION
**What changed? Why?**

Type for `ConnectWalletReact` in docs was missing the `withWalletAggregator` property.

**Notes to reviewers**

**How has it been tested?**
