### PR TITLE
fix: fix minimum playground sidebar width

### DIFF
--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -11,6 +11,7 @@ import TransactionDemo from './demo/Transaction';
 import TransactionDefaultDemo from './demo/TransactionDefault';
 import WalletDemo from './demo/Wallet';
 import WalletDefaultDemo from './demo/WalletDefault';
+import { cn } from '@/lib/utils';
 
 function Demo() {
   const { activeComponent } = useContext(AppContext);
@@ -83,9 +84,10 @@ function Demo() {
   return (
     <>
       <div
-        className={`absolute top-0 right-0 bottom-0 left-0 z-20 flex w-full min-w-120 flex-col border-r bg-background p-6 transition-[height] sm:static sm:z-0 sm:w-1/4 ${
-          sideBarVisible ? 'h-full min-h-screen' : 'h-[5rem] overflow-hidden'
-        }`}
+        className={cn(
+          'absolute top-0 right-0 bottom-0 left-0 z-20 flex w-full min-w-80 flex-col border-r bg-background p-6 transition-[height] sm:static sm:z-0 sm:w-1/4',
+          sideBarVisible ? 'h-full min-h-screen' : 'h-[5rem] overflow-hidden',
+        )}
       >
         <div className="mb-12 flex justify-between">
           <div className="self-center font-semibold text-xl">
@@ -94,9 +96,7 @@ function Demo() {
           <button
             type="button"
             onClick={toggleSidebar}
-            className={`${buttonStyles} px-1 transition-transform sm:hidden ${
-              sideBarVisible ? '-rotate-90' : 'rotate-90'
-            }`}
+            className={cn(buttonStyles, 'px-1 transition-transform sm:hidden', sideBarVisible ? '-rotate-90' : 'rotate-90')}
           >
             <span className="pl-2">&rang;</span>
           </button>

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -86,7 +86,7 @@ function Demo() {
       <div
         className={cn(
           'absolute top-0 right-0 bottom-0 left-0 z-20 flex w-full min-w-80 flex-col border-r bg-background p-6 transition-[height] sm:static sm:z-0 sm:w-1/4',
-          sideBarVisible ? 'h-full min-h-screen' : 'h-[5rem] overflow-hidden',
+          sideBarVisible ? 'h-full min-h-screen' : 'h-20 overflow-hidden',
         )}
       >
         <div className="mb-12 flex justify-between">

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { AppContext, OnchainKitComponent } from '@/components/AppProvider';
+import { cn } from '@/lib/utils';
 import { useContext, useEffect, useState } from 'react';
 import DemoOptions from './DemoOptions';
 import CheckoutDemo from './demo/Checkout';
@@ -11,7 +12,6 @@ import TransactionDemo from './demo/Transaction';
 import TransactionDefaultDemo from './demo/TransactionDefault';
 import WalletDemo from './demo/Wallet';
 import WalletDefaultDemo from './demo/WalletDefault';
-import { cn } from '@/lib/utils';
 
 function Demo() {
   const { activeComponent } = useContext(AppContext);
@@ -96,7 +96,11 @@ function Demo() {
           <button
             type="button"
             onClick={toggleSidebar}
-            className={cn(buttonStyles, 'px-1 transition-transform sm:hidden', sideBarVisible ? '-rotate-90' : 'rotate-90')}
+            className={cn(
+              buttonStyles,
+              'px-1 transition-transform sm:hidden',
+              sideBarVisible ? '-rotate-90' : 'rotate-90',
+            )}
           >
             <span className="pl-2">&rang;</span>
           </button>


### PR DESCRIPTION
**What changed? Why?**

- Playground sidebar collapses on smaller screens (and sometimes on larger screens) because the class we're using, `min-w-120` does not actually exist. This PR updates that class to a a css class that _does_ exist.
- Remove unnecessary arbitrary Tailwind classes in favor of built in values

Before:
![CleanShot 2024-10-24 at 14 36 56@2x](https://github.com/user-attachments/assets/fdef9336-37b1-492b-a1af-30ae477df5f7)


After:
![CleanShot 2024-10-24 at 14 45 51@2x](https://github.com/user-attachments/assets/24519f73-94b6-4de2-91be-9af833bd44f3)


**Notes to reviewers**

- I've also switched to using the `cn` utility function that was already defined in the playground utils dir. This will improve readability and performance.

**How has it been tested?**
