### PR TITLE
fix transaction demo code overflow

### DIFF
--- a/site/docs/components/landing/ComponentPreview.tsx
+++ b/site/docs/components/landing/ComponentPreview.tsx
@@ -171,7 +171,7 @@ function PreviewContainer({
   const ActiveComponent = components[activeTab].component;
 
   return (
-    <div className="h-[550px] w-[375px] overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 sm:w-[640px] md:h-[600px] md:w-[700px] dark:border-zinc-900 dark:bg-zinc-950">
+    <div className="h-[550px] w-[375px] overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50 sm:w-[600px] md:h-[670px] md:w-[700px] dark:border-zinc-900 dark:bg-zinc-950">
       <div className="mt-2 flex items-center justify-between border-zinc-200 border-b px-3 dark:border-zinc-900">
         <div className="flex">
           <TabButton
@@ -208,16 +208,12 @@ function PreviewContainer({
         <div
           className={`${
             activeSubTab === 'preview' ? 'flex' : 'hidden'
-          } h-[500px] w-full items-center justify-center md:h-[550px]`}
+          } h-[500px] w-full items-center justify-center md:h-[600px]`}
         >
           <ActiveComponent />
         </div>
-        <div
-          className={`${
-            activeSubTab === 'code' ? 'flex' : 'hidden'
-          } overflow-auto p-4`}
-        >
-          <pre className="overflow-autos h-[450px] whitespace-pre-wrap break-words text-sm md:h-[600px]">
+        <div className={`${activeSubTab === 'code' ? 'flex' : 'hidden'} p-4`}>
+          <pre className="h-[450px] whitespace-pre-wrap break-words text-sm md:h-[600px]">
             <code>{components[activeTab].code}</code>
           </pre>
         </div>


### PR DESCRIPTION
**What changed? Why?**
- Fixed the overflow + scroll behaviors for the code snippets

Before
<img width="729" alt="Screenshot 2024-10-24 at 3 51 50 PM" src="https://github.com/user-attachments/assets/2bad5d00-2191-4581-b584-ed9cf941660c">

After
<img width="731" alt="Screenshot 2024-10-24 at 3 51 46 PM" src="https://github.com/user-attachments/assets/d35082a5-dc35-49b9-893c-e64ecb86e826">

**Notes to reviewers**

**How has it been tested?**
- Check for all components
- Checked that it doesn't impact mobile responsiveness
