### PR TITLE
fix: clear error message in `CheckoutStatus` if a request is denied

### DIFF
--- a/.changeset/real-dolphins-drive.md
+++ b/.changeset/real-dolphins-drive.md
@@ -9,3 +9,4 @@
 - **docs**: Updated documentation. By @0xAlec @dschlabach @fakepixels @cpcramer #1465 #1470 #1477 #1478 #1486 #1487 #1490
 - **feat**: Updated playground with `Checkout` component and custom `Theming`. @0xAlec @cpcramer #1428 #1465
 - **feat**: Updated landing page. @mindapivessa #1482 #1496 
+- **fix**: clear error message in CheckoutStatus if a request is denied. by @0xAlec #1510

--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -22,7 +22,7 @@ export function OnchainKitProvider({
   if (schemaId && !checkHashLength(schemaId, 64)) {
     throw Error('EAS schemaId must be 64 characters prefixed with "0x"');
   }
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor the configurations
+
   const value = useMemo(() => {
     const defaultPaymasterUrl = apiKey
       ? `https://api.developer.coinbase.com/rpc/v1/${chain.name

--- a/src/checkout/components/CheckoutProvider.test.tsx
+++ b/src/checkout/components/CheckoutProvider.test.tsx
@@ -135,6 +135,39 @@ describe('CheckoutProvider', () => {
     });
   });
 
+  it('should clear user rejected request on next button press', async () => {
+    (useCommerceContracts as Mock).mockReturnValue(() =>
+      Promise.resolve({
+        insufficientBalance: false,
+        contracts: [{}],
+        priceInUSDC: '10',
+      }),
+    );
+    (useWriteContracts as Mock).mockImplementation(() => {
+      return {
+        status: 'error',
+        writeContractsAsync: vi
+          .fn()
+          .mockRejectedValue(new Error('User denied connection request.')),
+      };
+    });
+    render(
+      <CheckoutProvider>
+        <TestComponent />
+      </CheckoutProvider>,
+    );
+    fireEvent.click(screen.getByText('Submit'));
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message').textContent).toBe(
+        'Request denied.',
+      );
+    });
+    fireEvent.click(screen.getByText('Submit'));
+    await waitFor(() => {
+      expect(screen.getByTestId('error-message').textContent).toBe('');
+    });
+  });
+
   it('should handle other errors', async () => {
     (useCommerceContracts as Mock).mockReturnValue(() =>
       Promise.resolve({

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -358,6 +358,7 @@ export function CheckoutProvider({
     chainId,
     chargeId,
     connectAsync,
+    errorMessage,
     fetchData,
     isConnected,
     isSmartWallet,

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -232,7 +232,6 @@ export function CheckoutProvider({
         });
         return;
       }
-      /* v8 ignore next 4 */
       if (errorMessage === USER_REJECTED_ERROR) {
         // Reset status if previous request was a rejection
         setErrorMessage('');

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -232,6 +232,11 @@ export function CheckoutProvider({
         });
         return;
       }
+      /* v8 ignore next 4 */
+      if (errorMessage === USER_REJECTED_ERROR) {
+        // Reset status if previous request was a rejection
+        setErrorMessage('');
+      }
 
       let connectedAddress = address;
       let connectedChainId = chainId;


### PR DESCRIPTION
**What changed? Why?**
- reset `errorMessage` on subsequent button press

**Notes to reviewers**

**How has it been tested?**
playground
