### PR TITLE
Fix: Enforce base as chain for name resolution

### DIFF
--- a/src/wallet/components/WalletDropdownBasename.test.tsx
+++ b/src/wallet/components/WalletDropdownBasename.test.tsx
@@ -1,7 +1,7 @@
 import type { UseQueryResult } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import type { GetAccountReturnType } from '@wagmi/core';
-import { base } from 'viem/chains';
+import { base, mainnet } from 'viem/chains';
 import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { useName } from '../../identity/hooks/useName';
@@ -100,5 +100,49 @@ describe('WalletDropdownBasename', () => {
 
     const { container } = render(<WalletDropdownBasename />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it('should render "Claim Basename" regardless of chain', () => {
+    (useAccount as Mock<() => Partial<GetAccountReturnType>>).mockReturnValue({
+      address: '0x1234' as `0x${string}`,
+      isConnected: true,
+    });
+    (useWalletContext as Mock).mockReturnValue({
+      chain: mainnet,
+    });
+    (
+      useName as Mock<() => Partial<UseQueryResult<string | null, Error>>>
+    ).mockReturnValue({
+      data: null,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<WalletDropdownBasename />);
+    expect(screen.getByText('Claim Basename')).toBeInTheDocument();
+    expect(screen.getByText('NEW')).toBeInTheDocument();
+  });
+
+  it('should render "Profile" when basename exists', () => {
+    (useAccount as Mock<() => Partial<GetAccountReturnType>>).mockReturnValue({
+      address: '0x1234' as `0x${string}`,
+      isConnected: true,
+    });
+    (useWalletContext as Mock).mockReturnValue({
+      chain: mainnet,
+    });
+    (
+      useName as Mock<() => Partial<UseQueryResult<string | null, Error>>>
+    ).mockReturnValue({
+      data: 'test.base',
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+
+    render(<WalletDropdownBasename />);
+    expect(screen.getByText('Profile')).toBeInTheDocument();
+    expect(screen.queryByText('NEW')).not.toBeInTheDocument();
   });
 });

--- a/src/wallet/components/WalletDropdownBasename.tsx
+++ b/src/wallet/components/WalletDropdownBasename.tsx
@@ -4,21 +4,20 @@ import { Spinner } from '../../internal/components/Spinner';
 import { basenameSvg } from '../../internal/svg/basenameSvg';
 import { cn, color, pressable, text } from '../../styles/theme';
 import type { WalletDropdownBasenameReact } from '../types';
-import { useWalletContext } from './WalletProvider';
+import { base } from 'viem/chains';
 
 export function WalletDropdownBasename({
   className,
 }: WalletDropdownBasenameReact) {
   const { address } = useAccount();
-  const { chain } = useWalletContext();
 
-  if (!address || !chain) {
+  if (!address) {
     return null;
   }
 
   const { data: basename, isLoading } = useName({
     address,
-    chain,
+    chain: base,
   });
 
   const hasBaseUserName = !!basename;
@@ -33,7 +32,7 @@ export function WalletDropdownBasename({
         pressable.default,
         color.foreground,
         'relative flex items-center px-4 py-3',
-        className,
+        className
       )}
       href={href}
       target="_blank"
@@ -51,7 +50,7 @@ export function WalletDropdownBasename({
             {!hasBaseUserName && (
               <span
                 className={cn(
-                  'ml-2 rounded-full bg-[#E0E7FF] px-2 py-0.5 text-center font-bold font-inter text-[#4F46E5] text-[0.6875rem] uppercase leading-none',
+                  'ml-2 rounded-full bg-[#E0E7FF] px-2 py-0.5 text-center font-bold font-inter text-[#4F46E5] text-[0.6875rem] uppercase leading-none'
                 )}
               >
                 NEW

--- a/src/wallet/components/WalletDropdownBasename.tsx
+++ b/src/wallet/components/WalletDropdownBasename.tsx
@@ -1,10 +1,10 @@
+import { base } from 'viem/chains';
 import { useAccount } from 'wagmi';
 import { useName } from '../../identity/hooks/useName';
 import { Spinner } from '../../internal/components/Spinner';
 import { basenameSvg } from '../../internal/svg/basenameSvg';
 import { cn, color, pressable, text } from '../../styles/theme';
 import type { WalletDropdownBasenameReact } from '../types';
-import { base } from 'viem/chains';
 
 export function WalletDropdownBasename({
   className,

--- a/src/wallet/components/WalletDropdownBasename.tsx
+++ b/src/wallet/components/WalletDropdownBasename.tsx
@@ -32,7 +32,7 @@ export function WalletDropdownBasename({
         pressable.default,
         color.foreground,
         'relative flex items-center px-4 py-3',
-        className
+        className,
       )}
       href={href}
       target="_blank"
@@ -50,7 +50,7 @@ export function WalletDropdownBasename({
             {!hasBaseUserName && (
               <span
                 className={cn(
-                  'ml-2 rounded-full bg-[#E0E7FF] px-2 py-0.5 text-center font-bold font-inter text-[#4F46E5] text-[0.6875rem] uppercase leading-none'
+                  'ml-2 rounded-full bg-[#E0E7FF] px-2 py-0.5 text-center font-bold font-inter text-[#4F46E5] text-[0.6875rem] uppercase leading-none',
                 )}
               >
                 NEW


### PR DESCRIPTION
`WalletDropdownBasename` should only use `base` as chain, otherwise it will try to redirect L1 ENS name: https://linear.app/coinbase/issue/BAPP-670/%5Bbug%5D-broken-profile-link-that-appends-ethbaseeth