### PR TITLE
docs: IdentityCard and Socials components

### DIFF
--- a/site/docs/pages/identity/identity-card.mdx
+++ b/site/docs/pages/identity/identity-card.mdx
@@ -1,0 +1,104 @@
+---
+title: <IdentityCard /> · OnchainKit
+description: Display user identity information with ENS and chain-specific name resolution
+---
+
+import {
+  Address,
+  Avatar,
+  Identity,
+  IdentityCard,
+  Name,
+} from '../src/identity';
+import App from '../../components/App';
+import { base, mainnet } from 'viem/chains';
+
+# `<IdentityCard />`
+
+The `IdentityCard` component provides a comprehensive way to display user identity information, including ENS names, avatars, and chain-specific name resolution.
+
+## Features
+- **Name Resolution:** Resolves both Basenames and ENS names automatically
+- **Avatar Support:** Displays ENS and chain-specific avatars
+- **Flexible Display:** Customizable layout and styling options
+- **Chain-Aware:** Works across different EVM chains that support name resolution
+
+## Usage
+
+### Basic Usage
+
+```tsx twoslash
+// @errors: 2305
+import { IdentityCard } from '../src/identity'; // [!code focus]
+import { base } from 'viem/chains';
+
+<IdentityCard // [!code focus] 
+  address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF" // [!code focus]
+  chain={base} // [!code focus]
+/> // [!code focus]
+```
+<App>
+  <IdentityCard 
+    schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+    chain={base}
+    className="max-w-[300px]"
+  />
+</App>
+
+## Customization
+
+You can override styles using `className` or by setting a custom [OnchainKit theme](/guides/themes#custom-theme). You can also set the `mainnet` chain for ENS name resolution:
+
+```tsx twoslash
+// @errors: 2724
+import { IdentityCard } from '../src/identity';
+import { mainnet } from 'viem/chains'; // [!code focus]
+
+<IdentityCard 
+  address="0x123..."
+  chain={mainnet} // [!code focus]
+  className="bg-[#EA580C]" // [!code focus]
+/>
+
+```
+<App>
+  <IdentityCard 
+    schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+    chain={mainnet}
+    className="bg-[#EA580C] max-w-[300px]"
+  />
+</App>
+
+## Props
+
+The `IdentityCard` component accepts the following props:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `address` | `string` | The wallet address to display identity for |
+| `chain` | `Chain` | The chain to resolve the identity on |
+| `className` | `string` | Additional CSS classes to apply |
+
+## Error Handling
+
+The component handles various error states gracefully:
+
+- Invalid addresses display a shortened address format
+- Missing ENS names fallback to shortened addresses
+- Failed avatar fetches show a default avatar
+- Network errors maintain a degraded but functional display
+
+## Best Practices
+
+1. Always provide a valid chain object from viem/chains
+2. Handle loading states in parent components when address might be undefined
+4. Implement proper error boundaries in parent components
+5. Consider mobile responsiveness when styling
+
+## Related Components
+
+- [`<Avatar />`](/identity/avatar) - Displays user avatars
+- [`<Name />`](/identity/name) - Displays resolved names
+- [`<Identity />`](/identity/identity) - Simplified identity display

--- a/site/docs/pages/identity/identity-card.mdx
+++ b/site/docs/pages/identity/identity-card.mdx
@@ -9,7 +9,7 @@ import {
   Identity,
   IdentityCard,
   Name,
-} from '../src/identity';
+} from '@coinbase/onchainkit/identity';
 import App from '../../components/App';
 import { base, mainnet } from 'viem/chains';
 
@@ -29,7 +29,7 @@ The `IdentityCard` component provides a comprehensive way to display user identi
 
 ```tsx twoslash
 // @errors: 2305
-import { IdentityCard } from '../src/identity'; // [!code focus]
+import { IdentityCard } from '@coinbase/onchainkit/identity'; // [!code focus]
 import { base } from 'viem/chains';
 
 <IdentityCard // [!code focus] 
@@ -50,12 +50,20 @@ import { base } from 'viem/chains';
 
 You can override styles using `className` or by setting a custom [OnchainKit theme](/guides/themes#custom-theme). You can also set the `mainnet` chain for ENS name resolution:
 
-```tsx twoslash
-// @errors: 2724 
-import { IdentityCard } from '../src/identity';
+```tsx
+// @errors: 2305 2724 2304 2657
+import { IdentityCard } from '@coinbase/onchainkit/identity';
 import { mainnet } from 'viem/chains'; // [!code focus]
 
-// theme: "cyberpunk" // [!code focus]
+<OnchainKitProvider
+  config={{
+    appearance: {
+      mode: 'auto',
+      theme: 'cyberpunk', // [!code focus]
+    },
+  }}
+>
+</OnchainKitProvider>
 
 <IdentityCard 
   address="0x123..."

--- a/site/docs/pages/identity/identity-card.mdx
+++ b/site/docs/pages/identity/identity-card.mdx
@@ -51,14 +51,15 @@ import { base } from 'viem/chains';
 You can override styles using `className` or by setting a custom [OnchainKit theme](/guides/themes#custom-theme). You can also set the `mainnet` chain for ENS name resolution:
 
 ```tsx twoslash
-// @errors: 2724
+// @errors: 2724 
 import { IdentityCard } from '../src/identity';
 import { mainnet } from 'viem/chains'; // [!code focus]
+
+// theme: "cyberpunk" // [!code focus]
 
 <IdentityCard 
   address="0x123..."
   chain={mainnet} // [!code focus]
-  className="bg-[#EA580C]" // [!code focus]
 />
 
 ```
@@ -67,7 +68,7 @@ import { mainnet } from 'viem/chains'; // [!code focus]
     schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
     address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
     chain={mainnet}
-    className="bg-[#EA580C] max-w-[300px]"
+    className="cyberpunk max-w-[300px]"
   />
 </App>
 

--- a/site/docs/pages/identity/socials.mdx
+++ b/site/docs/pages/identity/socials.mdx
@@ -1,0 +1,184 @@
+---
+title: <Socials /> · OnchainKit
+description: Display social links for ENS names
+---
+import {
+  Address,
+  Avatar,
+  Badge,
+  Identity,
+  Name,
+  Socials,
+} from '../src/identity';
+import App from '../../components/App';
+import { base, mainnet } from 'viem/chains';
+
+# `<Socials />`
+
+The `Socials` component displays social media links associated with Basenames and ENS names. 
+It automatically fetches and renders social links stored in text records.
+
+## Features
+- **Name Resolution:** Resolves both Basenames and ENS names to fetch associated social links
+- **Multiple Platform Support:** Supports Twitter, GitHub, Discord, and other major platforms
+- **Customizable Display:** Flexible styling options to match your app's design
+- **Chain-Aware:** Works across different EVM chains that support ENS
+
+## Usage
+
+### Basic Usage
+
+```tsx twoslash
+// @errors: 2305
+import {
+  Address,
+  Avatar,
+  Badge,
+  Identity,
+  Name,
+  Socials, // [!code focus]
+} from '../src/identity';
+import { base } from 'viem/chains';
+
+<Identity
+  address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+  schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+  chain={base}
+>
+  <Avatar />
+  <Name>
+    <Badge />
+  </Name>
+  <Address />
+  <Socials /> // [!code focus]
+</Identity>
+```
+<App>
+  <Identity
+    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+    schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+    chain={base}
+  >
+    <Avatar />
+    <Name>
+      <Badge />
+    </Name>
+    <Address />
+    <Socials />
+  </Identity>
+</App>
+
+### Standalone Usage
+
+You can also use the `Socials` component independently by providing an address:
+
+```tsx twoslash
+// @errors: 2305
+import { Socials } from '../src/identity';
+import { base } from 'viem/chains';
+
+export default function StandaloneSocials() {
+  return (
+    <Socials // [!code focus]
+      address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF" // [!code focus]
+      chain={base} // [!code focus]
+    /> // [!code focus]
+  );
+}
+```
+<App>
+  <Socials 
+    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+    chain={base}
+  />
+</App>
+
+### Custom Chain
+
+Specify a different chain for ENS resolution:
+
+```tsx twoslash
+// @errors: 2305
+import {
+  Address,
+  Avatar,
+  Badge,
+  Identity,
+  Name,
+  Socials, // [!code focus]
+} from '../src/identity';
+import { mainnet } from 'viem/chains'; // [!code focus]
+
+<Identity
+  address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+  schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+  chain={mainnet}
+>
+  <Avatar />
+  <Name>
+    <Badge />
+  </Name>
+  <Address />
+  <Socials /> // [!code focus]
+</Identity>
+```
+<App>
+  <Identity
+    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+    schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+    chain={mainnet}
+  >
+    <Avatar />
+    <Name>
+      <Badge />
+    </Name>
+    <Address />
+    <Socials />
+  </Identity>
+</App>
+
+
+### Styling
+
+You can customize the appearance using the `className` prop:
+
+```tsx twoslash
+// @errors: 2305
+import { Socials } from '../src/identity';
+
+export default function StyledSocials() {
+  return (
+    <Socials 
+      address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+      className="bg-[#EA580C] p-4 rounded-lg"
+    />
+  );
+}
+```
+<App>
+  <Socials 
+    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
+    className="bg-[#EA580C] p-4 rounded-lg"
+  />
+</App>
+
+## Props
+
+The `Socials` component accepts the following props:
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `address` | `Address \| null` | The Ethereum address to resolve social links for |
+| `ensName` | `string` | Optional ENS name to resolve social links for |
+| `chain` | `Chain` | The chain to use for ENS resolution |
+| `className` | `string` | Custom CSS classes to apply to the component |
+
+
+## Error Handling
+
+The component handles various edge cases:
+
+- Returns `null` if no social links are found
+- Shows empty state while loading
+- Gracefully handles ENS resolution errors
+- Validates social links before display

--- a/site/docs/pages/identity/socials.mdx
+++ b/site/docs/pages/identity/socials.mdx
@@ -9,7 +9,7 @@ import {
   Identity,
   Name,
   Socials,
-} from '../src/identity';
+} from '@coinbase/onchainkit/identity';
 import App from '../../components/App';
 import { base, mainnet } from 'viem/chains';
 
@@ -37,7 +37,7 @@ import {
   Identity,
   Name,
   Socials, // [!code focus]
-} from '../src/identity';
+} from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 <Identity
@@ -74,7 +74,7 @@ You can also use the `Socials` component independently by providing an address:
 
 ```tsx twoslash
 // @errors: 2305
-import { Socials } from '../src/identity';
+import { Socials } from '@coinbase/onchainkit/identity';
 import { base } from 'viem/chains';
 
 export default function StandaloneSocials() {
@@ -106,7 +106,7 @@ import {
   Identity,
   Name,
   Socials, // [!code focus]
-} from '../src/identity';
+} from '@coinbase/onchainkit/identity';
 import { mainnet } from 'viem/chains'; // [!code focus]
 
 <Identity
@@ -135,36 +135,6 @@ import { mainnet } from 'viem/chains'; // [!code focus]
     <Address />
     <Socials />
   </Identity>
-</App>
-
-
-### Styling
-
-You can override styles using `className` or by setting a custom [OnchainKit theme](/guides/themes#custom-theme). 
-You can also set the `mainnet` chain for ENS name resolution:
-
-```tsx twoslash
-// @errors: 2305
-import { Socials } from '../src/identity';
-import { mainnet } from 'viem/chains'; // [!code focus]
-
-// theme: "cyberpunk" // [!code focus]
-
-export default function StyledSocials() {
-  return (
-    <Socials 
-      address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
-      chain={mainnet} // [!code focus]
-    />
-  );
-}
-```
-<App>
-  <Socials 
-    address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
-    chain={mainnet}
-    className="cyberpunk"
-  />
 </App>
 
 ## Props

--- a/site/docs/pages/identity/socials.mdx
+++ b/site/docs/pages/identity/socials.mdx
@@ -140,17 +140,21 @@ import { mainnet } from 'viem/chains'; // [!code focus]
 
 ### Styling
 
-You can customize the appearance using the `className` prop:
+You can override styles using `className` or by setting a custom [OnchainKit theme](/guides/themes#custom-theme). 
+You can also set the `mainnet` chain for ENS name resolution:
 
 ```tsx twoslash
 // @errors: 2305
 import { Socials } from '../src/identity';
+import { mainnet } from 'viem/chains'; // [!code focus]
+
+// theme: "cyberpunk" // [!code focus]
 
 export default function StyledSocials() {
   return (
     <Socials 
       address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
-      className="bg-[#EA580C] p-4 rounded-lg"
+      chain={mainnet} // [!code focus]
     />
   );
 }
@@ -158,7 +162,8 @@ export default function StyledSocials() {
 <App>
   <Socials 
     address="0x4bEf0221d6F7Dd0C969fe46a4e9b339a84F52FDF"
-    className="bg-[#EA580C] p-4 rounded-lg"
+    chain={mainnet}
+    className="cyberpunk"
   />
 </App>
 

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,7 @@
     "sitemap": "node createSitemap.js"
   },
   "dependencies": {
-    "@coinbase/onchainkit": "0.35.1",
+    "@coinbase/onchainkit": "0.35.2",
     "@types/react": "latest",
     "@vercel/edge": "^1.1.1",
     "express": "^4.21.1",

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -106,8 +106,16 @@ export const sidebar = [
             link: '/identity/badge',
           },
           {
+            text: 'IdentityCard',
+            link: '/identity/identity-card',
+          },
+          {
             text: 'Name',
             link: '/identity/name',
+          },
+          {
+            text: 'Socials',
+            link: '/identity/socials',
           },
         ],
       },

--- a/site/yarn.lock
+++ b/site/yarn.lock
@@ -479,9 +479,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@coinbase/onchainkit@npm:0.35.1":
-  version: 0.35.1
-  resolution: "@coinbase/onchainkit@npm:0.35.1"
+"@coinbase/onchainkit@npm:0.35.2":
+  version: 0.35.2
+  resolution: "@coinbase/onchainkit@npm:0.35.2"
   dependencies:
     "@rainbow-me/rainbowkit": "npm:^2.1.3"
     "@tanstack/react-query": "npm:^5"
@@ -496,7 +496,7 @@ __metadata:
     "@xmtp/frames-validator": ^0.6.0
     react: ^18
     react-dom: ^18
-  checksum: 051ce9ae63bf68f95a2aee634d07d5ff50a8dd8ee96e6967de60d2ab03b08baf175fc6c6a9a92dc6b09810b9940d752acbfccde62b63dd1f2401ad352e951f83
+  checksum: 209635cdece2e56f8d038c3cb3b94e76f9b1d6ce2db64b15839dcda81aeade85997b15a8c2022a316abb4e8cc76a49b64862b513731fe59b01091717c07c5325
   languageName: node
   linkType: hard
 
@@ -8528,7 +8528,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "onchainkit@workspace:."
   dependencies:
-    "@coinbase/onchainkit": "npm:0.35.1"
+    "@coinbase/onchainkit": "npm:0.35.2"
     "@types/express": "npm:^4"
     "@types/react": "npm:latest"
     "@types/sitemap-generator": "npm:^8"


### PR DESCRIPTION
**What changed? Why?**
`identity/identity-card`:
<img width="726" alt="Screenshot 2024-10-29 at 12 30 12 PM" src="https://github.com/user-attachments/assets/dcf3d998-a39d-4663-853a-0f8da771308b">

<img width="767" alt="Screenshot 2024-10-29 at 12 30 22 PM" src="https://github.com/user-attachments/assets/992d5564-1102-4555-9173-eca4b7adf489">


`identity/socials`:
[IdentityCard and Socials components](https://github.com/coinbase/onchainkit/pull/1489#top)

<img width="719" alt="Screenshot 2024-10-29 at 12 29 53 PM" src="https://github.com/user-attachments/assets/d3436619-0589-478f-8f6c-72d3b5315001">

**Notes to reviewers**

**How has it been tested?**
