### PR TITLE
chore: reorder sidebar elements in playground

### DIFF
--- a/playground/nextjs-app-router/components/DemoOptions.tsx
+++ b/playground/nextjs-app-router/components/DemoOptions.tsx
@@ -18,9 +18,9 @@ export default function DemoOptions({
 }) {
   const commonOptions = (
     <>
+      <ActiveComponent />
       <ComponentMode />
       <ComponentTheme />
-      <ActiveComponent />
       <WalletType />
     </>
   );


### PR DESCRIPTION
**What changed? Why?**

Moved the "Component" option above options for Component Mode and Component Theme to match natural flow

Before:

![CleanShot 2024-10-29 at 17 55 09@2x](https://github.com/user-attachments/assets/9e3d843c-4314-419a-8499-5d5bce91670d)


After:
![CleanShot 2024-10-29 at 17 54 45@2x](https://github.com/user-attachments/assets/3f3b2d29-13f2-4b3c-9d0d-26f978e6fe88)


**Notes to reviewers**

**How has it been tested?**
