### PR TITLE
fix: nft network

### DIFF
--- a/src/nft/components/view/NFTNetwork.test.tsx
+++ b/src/nft/components/view/NFTNetwork.test.tsx
@@ -1,28 +1,28 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import { type Mock, describe, expect, it, vi } from 'vitest';
-import { useAccount } from 'wagmi';
+import { useChainId } from 'wagmi';
 import { NFTNetwork } from './NFTNetwork';
 
 vi.mock('wagmi', () => ({
-  useAccount: vi.fn(),
+  useChainId: vi.fn(),
 }));
 
 describe('NFTNetwork', () => {
   it('should render null if chain is not available', () => {
-    (useAccount as Mock).mockReturnValue({ chain: null });
+    (useChainId as Mock).mockReturnValue(undefined);
     const { container } = render(<NFTNetwork />);
     expect(container.firstChild).toBeNull();
   });
 
-  it('should render null if chain name is not in networkMap', () => {
-    (useAccount as Mock).mockReturnValue({ chain: { name: 'Unknown' } });
+  it('should render null if chain Id is not in networkMap', () => {
+    (useChainId as Mock).mockReturnValue(1);
     const { container } = render(<NFTNetwork />);
     expect(container.firstChild).toBeNull();
   });
 
   it('should render correctly with valid chain name', () => {
-    (useAccount as Mock).mockReturnValue({ chain: { name: 'Base' } });
+    (useChainId as Mock).mockReturnValue(8453);
     const { getByText, getByRole } = render(<NFTNetwork />);
     expect(getByText('Network')).toBeInTheDocument();
     expect(getByText('Base')).toBeInTheDocument();
@@ -30,13 +30,13 @@ describe('NFTNetwork', () => {
   });
 
   it('should apply custom className', () => {
-    (useAccount as Mock).mockReturnValue({ chain: { name: 'Base' } });
+    (useChainId as Mock).mockReturnValue(8453);
     const { container } = render(<NFTNetwork className="custom-class" />);
     expect(container.firstChild).toHaveClass('custom-class');
   });
 
   it('should render with custom label', () => {
-    (useAccount as Mock).mockReturnValue({ chain: { name: 'Base' } });
+    (useChainId as Mock).mockReturnValue(8453);
     const { getByText } = render(<NFTNetwork label="Custom Label" />);
     expect(getByText('Custom Label')).toBeInTheDocument();
   });

--- a/src/nft/components/view/NFTNetwork.tsx
+++ b/src/nft/components/view/NFTNetwork.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
-import { useAccount } from 'wagmi';
+import { type Chain, base } from 'viem/chains';
+import { useChainId } from 'wagmi';
 import { baseSvg } from '../../../internal/svg/baseSvg';
 import { cn, color, text } from '../../../styles/theme';
 
@@ -9,15 +10,20 @@ type NFTNetworkReact = {
 };
 
 const networkMap = {
-  Base: baseSvg,
-} as Record<string, ReactNode>;
+  8453: {
+    chain: base,
+    icon: baseSvg,
+  },
+} as Record<number, { chain: Chain; icon: ReactNode }>;
 
 export function NFTNetwork({ className, label = 'Network' }: NFTNetworkReact) {
-  const { chain } = useAccount();
+  const chainId = useChainId();
 
-  if (!chain || !networkMap[chain.name]) {
+  if (!chainId || !networkMap[chainId]) {
     return null;
   }
+
+  const { chain, icon } = networkMap[chainId];
 
   return (
     <div
@@ -29,7 +35,7 @@ export function NFTNetwork({ className, label = 'Network' }: NFTNetworkReact) {
     >
       <div className={cn(color.foregroundMuted)}>{label}</div>
       <div className="flex items-center gap-1">
-        <div className="h-4 w-4 object-cover">{networkMap[chain.name]}</div>
+        <div className="h-4 w-4 object-cover">{icon}</div>
         <div>{chain.name}</div>
       </div>
     </div>


### PR DESCRIPTION
**What changed? Why?**
Update NFT Network component to use wagmi's useChainId instead of getting chain off useAccount so Network still displays when no wallet is connected.

useChainId returns the last configured chainId when there is no active connection instead of undefined.

**Notes to reviewers**

**How has it been tested?**
