### PR TITLE
chore: add `viem` and `wagmi` as dependencies to `create-onchain` starter

### DIFF
--- a/create-onchain/templates/next/package.json
+++ b/create-onchain/templates/next/package.json
@@ -12,7 +12,9 @@
     "@coinbase/onchainkit": "latest",
     "next": "14.2.15",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "wagmi": "^2.12.25",
+    "viem": "^2.21.40"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
**What changed? Why?**
This PR adds `viem` and `wagmi` to the CLI starter template's `package.json`. This will allow auto-importing to work correctly, plus most devs will likely need to use both packages in their onchain app directly at some point anyway.

**Notes to reviewers**

**How has it been tested?**
