### PR TITLE
chore: Update OnchainKitProvider to fallback to CB verified schemaId

### DIFF
--- a/.changeset/quick-fans-tease.md
+++ b/.changeset/quick-fans-tease.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+-**chore**: Updated `OnchainKitProvider` to fallback to CB verified schemaID. By @cpcramer #1575

--- a/src/OnchainKitProvider.test.tsx
+++ b/src/OnchainKitProvider.test.tsx
@@ -181,7 +181,6 @@ describe('OnchainKitProvider', () => {
         <QueryClientProvider client={queryClient}>
           <OnchainKitProvider
             chain={base}
-            schemaId={schemaId}
             apiKey={apiKey}
             config={customConfig}
           >
@@ -208,7 +207,7 @@ describe('OnchainKitProvider', () => {
           },
           projectId: null,
           rpcUrl: null,
-          schemaId: schemaId,
+          schemaId: COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
         }),
       );
     });
@@ -228,6 +227,7 @@ describe('OnchainKitProvider', () => {
         <QueryClientProvider client={queryClient}>
           <OnchainKitProvider
             chain={base}
+            schemaId={schemaId}
             apiKey={apiKey}
             config={customConfig}
           >
@@ -254,7 +254,7 @@ describe('OnchainKitProvider', () => {
           },
           projectId: null,
           rpcUrl: null,
-          schemaId: COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
+          schemaId: schemaId,
         }),
       );
     });

--- a/src/OnchainKitProvider.test.tsx
+++ b/src/OnchainKitProvider.test.tsx
@@ -7,6 +7,7 @@ import { http, WagmiProvider, createConfig } from 'wagmi';
 import { mock } from 'wagmi/connectors';
 import { setOnchainKitConfig } from './OnchainKitConfig';
 import { OnchainKitProvider } from './OnchainKitProvider';
+import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from './identity/constants';
 import type { EASSchemaUid } from './identity/types';
 import { useOnchainKit } from './useOnchainKit';
 
@@ -227,7 +228,6 @@ describe('OnchainKitProvider', () => {
         <QueryClientProvider client={queryClient}>
           <OnchainKitProvider
             chain={base}
-            schemaId={schemaId}
             apiKey={apiKey}
             config={customConfig}
           >
@@ -254,7 +254,7 @@ describe('OnchainKitProvider', () => {
           },
           projectId: null,
           rpcUrl: null,
-          schemaId: schemaId,
+          schemaId: COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
         }),
       );
     });

--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useMemo } from 'react';
 import { ONCHAIN_KIT_CONFIG, setOnchainKitConfig } from './OnchainKitConfig';
+import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from './identity/constants';
 import { checkHashLength } from './internal/utils/checkHashLength';
 import type { OnchainKitContextType, OnchainKitProviderReact } from './types';
 
@@ -44,7 +45,7 @@ export function OnchainKitProvider({
       },
       projectId: projectId ?? null,
       rpcUrl: rpcUrl ?? null,
-      schemaId: schemaId ?? null,
+      schemaId: schemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
     };
     setOnchainKitConfig(onchainKitConfig);
     return onchainKitConfig;

--- a/src/identity/constants.ts
+++ b/src/identity/constants.ts
@@ -1,5 +1,6 @@
 import { base, baseSepolia } from 'viem/chains';
 import type { ResolverAddressesByChainIdMap } from './types';
+import type { EASSchemaUid } from './types';
 
 export const RESOLVER_ADDRESSES_BY_CHAIN_ID: ResolverAddressesByChainIdMap = {
   [baseSepolia.id]: '0x6533C94869D28fAA8dF77cc63f9e2b2D6Cf77eBA',
@@ -24,3 +25,6 @@ export const BASE_DEFAULT_PROFILE_PICTURES = [
   BASE_DEFAULT_PROFILE_PICTURES6,
   BASE_DEFAULT_PROFILE_PICTURES7,
 ];
+
+export const COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID: EASSchemaUid =
+  '0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9';


### PR DESCRIPTION
**What changed? Why?**
Default to use the `COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID` in the `OnchainKitProvider` when the `schemaID` is missing. This is to prevent the `DisplayBadge` component from throwing an error. 
**Notes to reviewers**

**How has it been tested?**
