### PR TITLE
fix: fix CLI builds for yarn and pnpm

### DIFF
--- a/create-onchain/src/cli.ts
+++ b/create-onchain/src/cli.ts
@@ -15,7 +15,7 @@ import {
 
 const sourceDir = path.resolve(
   fileURLToPath(import.meta.url),
-'../../../templates/next'
+  '../../../templates/next'
 );
 
 const renameFiles: Record<string, string | undefined> = {

--- a/create-onchain/src/cli.ts
+++ b/create-onchain/src/cli.ts
@@ -15,7 +15,7 @@ import {
 
 const sourceDir = path.resolve(
   fileURLToPath(import.meta.url),
-  '../../../templates/next'
+'../../../templates/next'
 );
 
 const renameFiles: Record<string, string | undefined> = {

--- a/create-onchain/templates/next/.yarnrc.yml
+++ b/create-onchain/templates/next/.yarnrc.yml
@@ -1,0 +1,2 @@
+# You can remove this file if you don't want to use Yarn package manager.
+nodeLinker: node-modules

--- a/create-onchain/templates/next/package.json
+++ b/create-onchain/templates/next/package.json
@@ -13,6 +13,7 @@
     "next": "14.2.15",
     "react": "^18",
     "react-dom": "^18",
+    "@tanstack/react-query": "^5",
     "wagmi": "^2.12.25",
     "viem": "^2.21.40"
   },


### PR DESCRIPTION
**What changed? Why?**
Our CLI starter currently builds fine with `bun` and `npm`, but has errors when building with `yarn` and `pnpm` (after installing deps) due to the way that `pnpm` and `yarn` handle peer dependencies. This PR adds necessary peer dependencies to `package.json` so that devs won't have errors on their first build with `pnpm` and `yarn`

**Notes to reviewers**

**How has it been tested?**
Ran multiple installations from CLI with bun, yarn, pnpm, and npm
