### PR TITLE
fix: nft responsiveness

### DIFF
--- a/.changeset/clever-days-compete.md
+++ b/.changeset/clever-days-compete.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+-**fix**: Update `NFTCard` and `NFTMintCard` to be more responsive. By @alessey #1590

--- a/src/nft/components/view/NFTImage.test.tsx
+++ b/src/nft/components/view/NFTImage.test.tsx
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { fireEvent, render, waitFor } from '@testing-library/react';
-import { act } from 'react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useNFTContext } from '../NFTProvider';
 import { NFTImage } from './NFTImage';
@@ -86,18 +85,6 @@ describe('NFTImage', () => {
         message: 'Error loading image',
       }),
     );
-  });
-
-  it('should hide the svg on transition end', async () => {
-    (useNFTContext as Mock).mockReturnValue({
-      imageUrl: 'transitionend',
-      description: 'Test NFT Image',
-    });
-    const { getByTestId, queryByTestId } = render(<NFTImage />);
-    await act(async () => {
-      fireEvent.transitionEnd(getByTestId('ockNFTImage'));
-    });
-    expect(queryByTestId('ock-defaultNFTSvg')).toBeNull();
   });
 
   it('should retry loading the image when retry button is clicked', async () => {

--- a/src/nft/components/view/NFTVideo.tsx
+++ b/src/nft/components/view/NFTVideo.tsx
@@ -49,7 +49,9 @@ export function NFTVideo({
   return (
     <div
       className={cn(
-        'relative flex h-[450px] max-h-screen items-center justify-center',
+        'grid aspect-square w-full',
+        '[&>*]:col-start-1 [&>*]:col-end-1 [&>*]:row-start-1 [&>*]:row-end-1',
+        { 'content-center justify-center': !square },
         className,
       )}
     >

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -13,7 +13,7 @@ export const text = {
   label1: 'ock-font-family font-semibold text-sm leading-5',
   label2: 'ock-font-family text-sm leading-5',
   legal: 'ock-font-family text-xs leading-4',
-  title1: 'ock-font-family font-semibold text-[1.75rem] leading-9',
+  title1: 'ock-font-family font-semibold text-2xl leading-9',
   title3: 'ock-font-family font-semibold text-xl leading-7',
 } as const;
 


### PR DESCRIPTION
**What changed? Why?**
* updated text1 style to 2xl (collection title)
* updated media to use grid vs. absolute positioning to render loading image

Test NFTs
Video (wide): 0x1f52841279fA4dE8B606a70373E9c84e84Ce9204
Video (square): 0xFE12c6d7555B4A94B352998f8e1E96aDFbE628e9
Image (tall): 0xc6A1F929B7cA5D76e0fA21EB44da1E48765990C5
Image (slightly wider than tall): 0x6d65115def07d25841891d0679189f2c42032f48

Mobile Video Card
| before | after |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/bcc86500-f30a-4582-b949-c049527297c5) | ![image](https://github.com/user-attachments/assets/6176e940-5728-4d05-b7d9-f392d74bb822) |

Mobile Video Mint Card
| before | after |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/6481db47-8d71-4b85-a78c-a09fb8976406) | ![image](https://github.com/user-attachments/assets/a8106323-b28c-4a84-b617-7075cd57381d) |

Mobile Image card
| before | after |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/66c75433-9052-49ac-bbe3-662ef61f1111) | ![image](https://github.com/user-attachments/assets/d8300f36-f74e-44e6-9fa8-c4add0fadeb3) |

Mobile Image Mint Card
| before | after |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/50c6a700-5b05-4ed8-9904-71ff4a8c4114) | ![image](https://github.com/user-attachments/assets/a9cfdb6a-74fe-4986-837a-bf702f53f1be) |

Desktop Image Card (unchanged)
| before | after |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/65e1930a-ad0f-4e0a-b67a-f0b6a82d3205) | ![image](https://github.com/user-attachments/assets/82e6c4a6-882c-4ad1-9cc7-8180051e9c89) |

Desktop Image Mint Card (unchanged)
| before | after |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/055ab3ec-01a6-48cd-9c2e-c0cdc6da0a2b) | ![image](https://github.com/user-attachments/assets/389e0cff-e785-4fb5-9a6c-ae6315db28b9) |

Square prop
| square false | square true |
| ------- | ------ |
| ![image](https://github.com/user-attachments/assets/07ac7e1a-5c1a-4225-a0ac-3b1ed96abd11) | ![image](https://github.com/user-attachments/assets/e0b6bada-f01d-4a70-a612-ae6307a45d44) |



**Notes to reviewers**

**How has it been tested?**
