### PR TITLE
docs: add NFTCardDefault and NFTMintCardDefault

### DIFF
--- a/site/docs/components/NFTComponents.tsx
+++ b/site/docs/components/NFTComponents.tsx
@@ -41,7 +41,7 @@ export function MintCardMain() {
               currency: 'ETH',
               amountUSD: '0.2384455',
             },
-            maxMintsPerWallet: 1,
+            maxMintsPerWallet: 2,
             isEligibleToMint: true,
             creatorAddress: '0xb4e741b761d8b69103cc986f1b7cd71ed627f8cc',
             network: 'networks/base-mainnet',

--- a/site/docs/pages/mint/nft-card.mdx
+++ b/site/docs/pages/mint/nft-card.mdx
@@ -61,6 +61,19 @@ Wrap the `<OnchainKitProvider />` around your app, following the steps in [Getti
 
 ## Quickstart
 
+The `NFTCardDefault` component is a simplified version of the `NFTCard` component, designed to streamline the integration process for developers.  Instead of manually defining each subcomponent, developers can use this shorthand version which renders our suggested implementation of the component and includes `NFTTitle`, `NFTMedia`, `NFTOwner`, `NFTLastSoldPrice` and `NFTNetwork`.
+
+```tsx twoslash
+import { NFTCardDefault } from '@coinbase/onchainkit/nft'; // [!code focus]
+
+<NFTCardDefault // [!code focus]
+  contractAddress='0xb4703a3a73aec16e764cbd210b0fde9efdab8941'  // [!code focus]
+  tokenId='1' // [!code focus]
+/>  // [!code focus]
+```
+
+If you'd like more customization you can follow the steps below to customize which subcomponents are rendered.
+
 ::::steps
 
 ### Add the NFTCard
@@ -108,9 +121,9 @@ That's it! You've now created an NFT card.
 
 ## Customization
 
-### Add the NFTCard components in any order
+### Add the NFTCard subcomponents in any order
 
-If you prefer to have the title above the media, you can easily change the order of the children components and they will render in the new order.
+If you prefer to have the title above the media, you can easily change the order of the subcomponents and they will render in the new order.
 
 ```tsx twoslash
 import { NFTCard } from '@coinbase/onchainkit/nft';

--- a/site/docs/pages/mint/nft-mint-card.mdx
+++ b/site/docs/pages/mint/nft-mint-card.mdx
@@ -12,7 +12,7 @@ import {
 
 # `<NFTMintCard />`
 
-The `NFTMintCard` component provides an easy way to mint an NFT.  Just enter the NFT contract address and token Id (for ERC1155 contracts) and include the child components you want to render.
+The `NFTMintCard` component provides an easy way to mint an NFT.  Just enter the NFT contract address and token Id (for ERC1155 contracts) and include the subcomponents you want to render.
 
 <img alt="Checkout"
   src="../assets/NFTMintCard.gif"
@@ -60,6 +60,18 @@ bun add @coinbase/onchainkit
 Wrap the `<OnchainKitProvider />` around your app, following the steps in [Getting Started](/getting-started#add-providers).
 
 ## Quickstart
+
+The `NFTMintCardDefault` component is a simplified version of the `NFTMintCard` component, designed to streamline the integration process for developers.  Instead of manually defining each subcomponent, developers can use this shorthand version which renders our suggested implementation of the component and includes `NFTCreator`, `NFTMedia`, `NFTCollectionTitle`, `NFTQuantitySelector`, `NFTAssetCost` and `NFTMintButton`.
+
+```tsx twoslash
+import { NFTMintCardDefault } from '@coinbase/onchainkit/nft'; // [!code focus]
+
+<NFTMintCardDefault  // [!code focus]
+  contractAddress='0xb4703a3a73aec16e764cbd210b0fde9efdab8941'  // [!code focus]
+/>  // [!code focus]
+```
+
+If you'd like more customization you can follow the steps below to customize which subcomponents are rendered.
 
 ::::steps
 
@@ -115,7 +127,7 @@ You can create your own NFT to mint at [Coinbase Wallets create a Mint flow](htt
 
 ### Add the NFTMintCard components in any order
 
-If you prefer to have the collection title above the media, you can easily change the order of the children components and they will render in the new order.
+If you prefer to have the collection title above the media, you can easily change the order of the subcomponents and they will render in the new order.
 
 ```tsx twoslash
 import { NFTMintCard } from '@coinbase/onchainkit/nft';


### PR DESCRIPTION
**What changed? Why?**
* Update docs for `NFTCard` and `NFTMintCard` with information about NFTCardDefault and NFTMintCardDefault implementations.
* Update mock data for Mint NFT with higher quantity so quantity selector shows in example

**Notes to reviewers**

**How has it been tested?**

| NFT Card | Mint Card | Mint Demo NFT |
| --------- | -------- | --------| 
| ![image](https://github.com/user-attachments/assets/806d566d-e26c-4e7e-94c0-0ab28a2ebc11) | ![image](https://github.com/user-attachments/assets/5c4d8d88-0200-4800-b89b-befd40967589) | ![image](https://github.com/user-attachments/assets/0895fded-0ab8-4516-b7af-3856ecf52abb) |
