### PR TITLE
fix: fix className and typo in components

### DIFF
--- a/site/docs/components/StartBuilding.tsx
+++ b/site/docs/components/StartBuilding.tsx
@@ -189,7 +189,7 @@ export default function StartBuilding() {
             >
               Mint
             </a>{' '}
-            NFTs in yoru app.
+            NFTs in your app.
           </span>
         </li>
         <li className="vocs_ListItem">

--- a/site/docs/components/landing/LandingFooter.tsx
+++ b/site/docs/components/landing/LandingFooter.tsx
@@ -12,7 +12,7 @@ const FooterColumn = ({
       <a
         key={link.href}
         href={link.href}
-        className="className='text-base text-zinc-600 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
+        className="text-base text-zinc-600 hover:text-zinc-800 dark:text-zinc-400 dark:hover:text-zinc-200"
       >
         {link.text}
       </a>


### PR DESCRIPTION
**What changed and why?**
- Fixed a typo in `StartBuilding.tsx` (replaced "yoru" with "your").
- Removed an extra `className=` in `LandingFooter.tsx`.
