### PR TITLE
docs: add 'use client' directive to Providers to prevent error

### DIFF
--- a/site/docs/pages/installation/nextjs.mdx
+++ b/site/docs/pages/installation/nextjs.mdx
@@ -116,6 +116,8 @@ declare module 'wagmi' {
 
 ```tsx twoslash [providers.tsx]
 // @noErrors: 2307 2580 2339 - cannot find 'process', cannot find './wagmi', cannot find 'import.meta'
+"use client"
+
 import { OnchainKitProvider } from '@coinbase/onchainkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]


### PR DESCRIPTION
**What changed? Why?**
Adding 'use client' directive to the providers file in order to prevent server component errors in Next 14+

**Notes to reviewers**

**How has it been tested?**
