### PR TITLE
feat: automatically detect API keys in `~./onchainkit`

### DIFF
--- a/create-onchain/src/cli.ts
+++ b/create-onchain/src/cli.ts
@@ -69,7 +69,6 @@ async function init() {
   >;
 
   const storedKey = await getStoredApiKey();
-  console.log('hasStoredKey:', storedKey)
 
   try {
     result = await prompts(

--- a/create-onchain/src/cli.ts
+++ b/create-onchain/src/cli.ts
@@ -15,8 +15,7 @@ import {
 
 const sourceDir = path.resolve(
   fileURLToPath(import.meta.url), 
-  '../../templates/next'
-  // '../../../templates/next'
+'../../../templates/next'
 );
 
 const renameFiles: Record<string, string | undefined> = {

--- a/create-onchain/src/cli.ts
+++ b/create-onchain/src/cli.ts
@@ -14,8 +14,8 @@ import {
 } from './utils.js';
 
 const sourceDir = path.resolve(
-  fileURLToPath(import.meta.url), 
-'../../../templates/next'
+  fileURLToPath(import.meta.url),
+  '../../../templates/next'
 );
 
 const renameFiles: Record<string, string | undefined> = {
@@ -110,7 +110,7 @@ async function init() {
           message: 'Found an API key in ~/.onchainkit. Would you like to use it?',
           initial: true,
           active: 'yes',
-          inactive: 'no', 
+          inactive: 'no',
         },
         {
           type: (_, { useStoredKey }) => {
@@ -125,7 +125,7 @@ async function init() {
             )} (optional)`
           ),
         },
-{
+        {
           type: 'toggle',
           name: 'smartWallet',
           message: pc.reset('Use Coinbase Smart Wallet? (recommended)'),
@@ -163,8 +163,7 @@ async function init() {
   const envPath = path.join(root, '.env');
   await fs.promises.writeFile(
     envPath,
-    `NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME=${projectName}\nNEXT_PUBLIC_ONCHAINKIT_API_KEY=${apiKey}\nNEXT_PUBLIC_ONCHAINKIT_WALLET_CONFIG=${
-      smartWallet ? 'smartWalletOnly' : 'all'
+    `NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME=${projectName}\nNEXT_PUBLIC_ONCHAINKIT_API_KEY=${apiKey}\nNEXT_PUBLIC_ONCHAINKIT_WALLET_CONFIG=${smartWallet ? 'smartWalletOnly' : 'all'
     }`
   );
 

--- a/create-onchain/src/cli.ts
+++ b/create-onchain/src/cli.ts
@@ -112,10 +112,8 @@ async function init() {
           inactive: 'no',
         },
         {
-          type: (_, { useStoredKey }) => {
-            // If no stored key exists OR user declined to use stored key
-            return useStoredKey === false || !storedKey ? 'password' : null;
-          },
+          type: (_, { useStoredKey }) =>
+            useStoredKey === false || !storedKey ? 'password' : null,
           name: 'clientKey',
           message: pc.reset(
             `Enter your ${createClickableLink(

--- a/create-onchain/src/utils.ts
+++ b/create-onchain/src/utils.ts
@@ -75,11 +75,10 @@ export async function getStoredApiKey(): Promise<string | null> {
   try {
     const configPath = path.join(os.homedir(), '.onchainkit');
     const key = await fs.readFile(configPath, 'utf-8');
-    console.log('key:', key)
+
 
     // 32 characters long
     if (/^[A-Za-z0-9_-]{32,}$/.test(key.trim())) {
-      console.log("Stored API KEY matches!")
       return key.trim();
     }
   } catch (e) {}

--- a/create-onchain/src/utils.ts
+++ b/create-onchain/src/utils.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import os from 'os';
 
 async function copyFile(src: string, dest: string) {
   await fs.copyFile(src, dest);
@@ -67,4 +68,20 @@ export function detectPackageManager(): string {
     }
   }
   return 'npm'; // default to npm if unable to detect
+}
+
+
+export async function getStoredApiKey(): Promise<string | null> {
+  try {
+    const configPath = path.join(os.homedir(), '.onchainkit');
+    const key = await fs.readFile(configPath, 'utf-8');
+    console.log('key:', key)
+
+    // 32 characters long
+    if (/^[A-Za-z0-9_-]{32,}$/.test(key.trim())) {
+      console.log("Stored API KEY matches!")
+      return key.trim();
+    }
+  } catch (e) {}
+  return null;
 }

--- a/create-onchain/src/utils.ts
+++ b/create-onchain/src/utils.ts
@@ -76,7 +76,6 @@ export async function getStoredApiKey(): Promise<string | null> {
     const configPath = path.join(os.homedir(), '.onchainkit');
     const key = await fs.readFile(configPath, 'utf-8');
 
-
     // 32 characters long
     if (/^[A-Za-z0-9_-]{32,}$/.test(key.trim())) {
       return key.trim();


### PR DESCRIPTION
**What changed? Why?**
We've gotten feedback from developers that regularly use `create-onchain` that it's tedious to have to re-copy their API from CDP. This PR adds a feature that automatically detects an API key in `~/.onchainkit` and asks the developer whether or not they'd like to use it. If not, CLI behaves as normal.

**Notes to reviewers**

**How has it been tested?**
- Tested with valid API key in `.~/onchainkit`
- Tested with invalid API key in `~/.onchainkit`
- Tested with no `~/.onchainkit` file
- Tested with with pnpm, bun, and npm