### PR TITLE
Update to latest sdk and expose keysurl

### DIFF
--- a/create-onchain/templates/next/app/providers.tsx
+++ b/create-onchain/templates/next/app/providers.tsx
@@ -14,8 +14,9 @@ const config = createConfig({
     coinbaseWallet({
       appName: process.env.NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME,
       preference: process.env.NEXT_PUBLIC_ONCHAINKIT_WALLET_CONFIG as
-        | 'smartWalletOnly'
-        | 'all',
+        | "smartWalletOnly"
+        | "all",
+      keysUrl: "https://keys.coinbase.com/connect",
     }),
   ],
   storage: createStorage({

--- a/create-onchain/templates/next/package.json
+++ b/create-onchain/templates/next/package.json
@@ -14,7 +14,7 @@
     "react": "^18",
     "react-dom": "^18",
     "@tanstack/react-query": "^5",
-    "wagmi": "^2.12.25",
+    "wagmi": "^2.12.28",
     "viem": "^2.21.40"
   },
   "devDependencies": {


### PR DESCRIPTION
**What changed? Why?**
expose keysUrl in create onchain demo app

**Notes to reviewers**
See the wagmi version update here: https://github.com/wevm/wagmi/releases/tag/wagmi%402.12.28
See the SDK version update here: https://github.com/coinbase/coinbase-wallet-sdk/releases/tag/v4.2.1

**How has it been tested?**
