### PR TITLE
fix: fix base URL in docs sidebar links

### DIFF
--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -11,9 +11,10 @@ const ONCHAINKIT_DESCRIPTION =
   'React components and TypeScript utilities for top-tier onchain apps.';
 
 export default defineConfig({
-  baseUrl: process.env.VERCEL_URL
-    ? `https://${process.env.VERCEL_URL}`
-    : 'https://onchainkit.xyz',
+  baseUrl:
+    process.env.VERCEL_ENV === 'preview'
+      ? `https://${process.env.VERCEL_BRANCH_URL}`
+      : 'https://onchainkit.xyz',
   title: ONCHAINKIT_TITLE,
   titleTemplate: '%s · OnchainKit',
   description: ONCHAINKIT_DESCRIPTION,

--- a/site/vocs.config.tsx
+++ b/site/vocs.config.tsx
@@ -11,7 +11,9 @@ const ONCHAINKIT_DESCRIPTION =
   'React components and TypeScript utilities for top-tier onchain apps.';
 
 export default defineConfig({
-  baseUrl: 'https://onchainkit.xyz',
+  baseUrl: process.env.VERCEL_URL
+    ? `https://${process.env.VERCEL_URL}`
+    : 'https://onchainkit.xyz',
   title: ONCHAINKIT_TITLE,
   titleTemplate: '%s · OnchainKit',
   description: ONCHAINKIT_DESCRIPTION,


### PR DESCRIPTION
**What changed? Why?**
In previews, docs site sidebar links are pointed at `https://onchainkit.xyz/...`. This PR makes use of Vercel environment variables to update the `baseUrl` correctly in preview environments.

**Notes to reviewers**

**How has it been tested?**
