### PR TITLE
fix: typos in documentation files

### DIFF
--- a/site/docs/pages/fund/types.mdx
+++ b/site/docs/pages/fund/types.mdx
@@ -45,7 +45,7 @@ type GetOnrampUrlWithProjectIdParams = {
    *
    * Each entry in the record represents a wallet address and the networks it is valid for. There should only be a
    * single address for each network your app supports. Users will be able to buy/send any asset supported by any of
-   * the networks you specify. See the assets param if you want to restrict the avaialable assets.
+   * the networks you specify. See the assets param if you want to restrict the available assets.
    *
    * Some common examples:
    *


### PR DESCRIPTION
**What changed? Why?**
The word "avaialable" should be spelled as "available". 

Corrected.

