### PR TITLE
fix: fix CLI's `npm` build

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -19,24 +19,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
-  
+
       - name: Install dependencies
         working-directory: ./create-onchain
         run: bun install
-  
+
       - name: Build CLI
         working-directory: ./create-onchain
         run: bun run build
+
+      - name: Make CLI executable
+        run: chmod +x ./create-onchain/dist/esm/cli.js
 
       - name: Create test project
         run: |

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -40,9 +40,7 @@ jobs:
           mkdir test-project
           cd test-project
           yes "" | ../create-onchain/dist/esm/cli.js
-        env:
-          CI: true
-      
+
       - name: Install & Build test project
         working-directory: ./test-project/my-onchainkit-app
         run: |

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,0 +1,48 @@
+name: CLI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        working-directory: ./create-onchain
+        run: npm install
+
+      - name: Build CLI
+        working-directory: ./create-onchain
+        run: npm run build
+
+      - name: Create test project
+        run: |
+          mkdir test-project
+          cd test-project
+          ../create-onchain/dist/esm/cli.js
+        env:
+          CI: true
+
+      - name: Install & Build test project
+        working-directory: ./test-project/my-onchainkit-app
+        run: |
+          npm install
+          npm run build

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -1,4 +1,4 @@
-name: CLI
+name: "CLI: Build & Install"
 
 on:
   push:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -35,19 +35,15 @@ jobs:
       - name: Make CLI executable
         run: chmod +x ./create-onchain/dist/esm/cli.js
 
-      - name: Create test project
+      - name: Run CLI with automated responses
         run: |
-          mkdir test-project
-          cd test-project
-          yes "" | ../create-onchain/dist/esm/cli.js
-        env:
-          CI: true
+          yes "" | head -n 4 | ./create-onchain/dist/esm/cli.js
 
-      - name: List directories
-        run: ls -la test-project
+      # - name: List directories
+      #   run: ls -la test-project
 
       - name: Install & Build test project
-        working-directory: ./test-project/my-onchainkit-app
+        working-directory: ./my-onchainkit-app
         run: |
           bun install
           bun run build

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -25,13 +25,18 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+  
       - name: Install dependencies
         working-directory: ./create-onchain
-        run: npm install
-
+        run: bun install
+  
       - name: Build CLI
         working-directory: ./create-onchain
-        run: npm run build
+        run: bun run build
 
       - name: Create test project
         run: |

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -49,5 +49,5 @@ jobs:
       - name: Install & Build test project
         working-directory: ./test-project/my-onchainkit-app
         run: |
-          bun install
-          bun run build
+          npm install
+          npm run build

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -39,12 +39,12 @@ jobs:
         run: |
           mkdir test-project
           cd test-project
-          ../create-onchain/dist/esm/cli.js
+          echo -e "\ntest-project\n\n\ny\n" | ../create-onchain/dist/esm/cli.js
         env:
           CI: true
 
       - name: Install & Build test project
         working-directory: ./test-project/my-onchainkit-app
         run: |
-          npm install
-          npm run build
+          bun install
+          bun run build

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -39,12 +39,12 @@ jobs:
         run: |
           mkdir test-project
           cd test-project
-          echo -e "\ntest-project\n\n\ny\n" | ../create-onchain/dist/esm/cli.js
+          printf "test-project\n\n\ny\n" | ../create-onchain/dist/esm/cli.js
         env:
           CI: true
 
       - name: Install & Build test project
-        working-directory: ./test-project/my-onchainkit-app
+        working-directory: ./test-project/test-project
         run: |
           bun install
           bun run build

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           mkdir test-project
           cd test-project
-          printf "test-project\n\n\ny\n" | ../create-onchain/dist/esm/cli.js
+          yes "" | ../create-onchain/dist/esm/cli.js
         env:
           CI: true
 
@@ -47,7 +47,7 @@ jobs:
         run: ls -la test-project
 
       - name: Install & Build test project
-        working-directory: ./test-project/test-project
+        working-directory: ./test-project/my-onchainkit-app
         run: |
           bun install
           bun run build

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -42,10 +42,7 @@ jobs:
           yes "" | ../create-onchain/dist/esm/cli.js
         env:
           CI: true
-
-      - name: List directories
-        run: ls -la test-project
-
+      
       - name: Install & Build test project
         working-directory: ./test-project/my-onchainkit-app
         run: |

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -43,6 +43,9 @@ jobs:
         env:
           CI: true
 
+      - name: List directories
+        run: ls -la test-project
+
       - name: Install & Build test project
         working-directory: ./test-project/test-project
         run: |

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -36,15 +36,18 @@ jobs:
         run: chmod +x ./create-onchain/dist/esm/cli.js
 
       - name: Create test project
-        run: yes "" | ../create-onchain/dist/esm/cli.js
+        run: |
+          mkdir test-project
+          cd test-project
+          yes "" | ../create-onchain/dist/esm/cli.js
         env:
           CI: true
 
-      # - name: List directories
-      #   run: ls -la test-project
+      - name: List directories
+        run: ls -la test-project
 
       - name: Install & Build test project
-        working-directory: ./my-onchainkit-app
+        working-directory: ./test-project/my-onchainkit-app
         run: |
           bun install
           bun run build

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -35,9 +35,10 @@ jobs:
       - name: Make CLI executable
         run: chmod +x ./create-onchain/dist/esm/cli.js
 
-      - name: Run CLI with automated responses
-        run: |
-          yes "" | head -n 4 | ./create-onchain/dist/esm/cli.js
+      - name: Create test project
+        run: yes "" | ../create-onchain/dist/esm/cli.js
+        env:
+          CI: true
 
       # - name: List directories
       #   run: ls -la test-project

--- a/create-onchain/templates/next/package.json
+++ b/create-onchain/templates/next/package.json
@@ -14,8 +14,8 @@
     "react": "^18",
     "react-dom": "^18",
     "@tanstack/react-query": "^5",
-    "viem": "^2.17.4",
-    "wagmi": "^2.11.0"
+    "wagmi": "^2.12.25",
+    "viem": "^2.21.40"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/create-onchain/templates/next/package.json
+++ b/create-onchain/templates/next/package.json
@@ -14,8 +14,8 @@
     "react": "^18",
     "react-dom": "^18",
     "@tanstack/react-query": "^5",
-    "wagmi": "^2.12.25",
-    "viem": "^2.21.40"
+    "viem": "^2.17.4",
+    "wagmi": "^2.11.0"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
**What changed? Why?**
Our CLI template has mismatching versions of `viem` and `wagmi` from `onchainkit`, causing type errors and the build to fail. This PR updates the template's `package.json` to have versions of `viem` and `wagmi` that match `onchainkit`'s.

**Notes to reviewers**
- Also adds CI check that builds package, runs it, installs deps, and builds the project with npm

**How has it been tested?**
