### PR TITLE
fix: fix changelog formatting

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "coinbase/onchainkit" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
**What changed? Why?**
In the release process, our changelog is malformatted. This PR updates our `.changeset/config.json` to use the proper formatter. This will make it easier to read changelogs on our [Releases page](https://github.com/coinbase/onchainkit/releases) and anywhere else they appear, plus it will make the release process easier.

Before:
![CleanShot 2024-11-13 at 13 54 07@2x](https://github.com/user-attachments/assets/ca65c50a-6b31-4363-8e81-2573a7d0dc72)

After this PR, each change will be formatted on separate lines.

**Notes to reviewers**

**How has it been tested?**
- Created mock changeset`.md` file resembling one that happens during our releases
- Ran `bun: release version`, output is as expected.
