### PR TITLE
fix: improve dev server watching configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ci:format": "biome ci --linter-enabled=false --organize-imports-enabled=false",
     "ci:lint": "biome ci --formatter-enabled=false --organize-imports-enabled=false",
     "cp": "cp -R src site/docs/pages",
-    "dev:watch": "concurrently \"tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch\" \"tsup\"",
+    "dev:watch": "concurrently \"tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch\" \"tsup --watch ./src/**/*.tsx\"",
     "format": "biome format --write .",
     "lint": "biome lint --write .",
     "lint:unsafe": "biome lint --write --unsafe .",
@@ -41,10 +41,10 @@
     "clsx": "^2.1.1",
     "graphql": "^14 || ^15 || ^16",
     "graphql-request": "^6.1.0",
-    "permissionless": "^0.2.10",
+    "permissionless": "^0.1.29",
     "tailwind-merge": "^2.3.0",
-    "viem": "^2.21.33",
-    "wagmi": "^2.12.24"
+    "viem": "^2.17.4",
+    "wagmi": "^2.11.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
@@ -73,7 +73,7 @@
     "graphql-request": "^6.1.0",
     "jsdom": "^24.1.0",
     "packemon": "3.3.1",
-    "permissionless": "^0.2.10",
+    "permissionless": "^0.1.29",
     "react": "^18",
     "react-dom": "^18",
     "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ci:format": "biome ci --linter-enabled=false --organize-imports-enabled=false",
     "ci:lint": "biome ci --formatter-enabled=false --organize-imports-enabled=false",
     "cp": "cp -R src site/docs/pages",
-    "dev:watch": "concurrently \"tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch\" \"tsup --watch ./src/**/*.tsx\"",
+    "dev:watch": "concurrently \"tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch\" \"tsup\"",
     "format": "biome format --write .",
     "lint": "biome lint --write .",
     "lint:unsafe": "biome lint --write --unsafe .",
@@ -41,10 +41,10 @@
     "clsx": "^2.1.1",
     "graphql": "^14 || ^15 || ^16",
     "graphql-request": "^6.1.0",
-    "permissionless": "^0.1.29",
+    "permissionless": "^0.2.10",
     "tailwind-merge": "^2.3.0",
-    "viem": "^2.17.4",
-    "wagmi": "^2.11.0"
+    "viem": "^2.21.33",
+    "wagmi": "^2.12.24"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.3",
@@ -73,7 +73,7 @@
     "graphql-request": "^6.1.0",
     "jsdom": "^24.1.0",
     "packemon": "3.3.1",
-    "permissionless": "^0.1.29",
+    "permissionless": "^0.2.10",
     "react": "^18",
     "react-dom": "^18",
     "rimraf": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ci:format": "biome ci --linter-enabled=false --organize-imports-enabled=false",
     "ci:lint": "biome ci --formatter-enabled=false --organize-imports-enabled=false",
     "cp": "cp -R src site/docs/pages",
-    "dev:watch": "concurrently \"tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch\" \"tsup --watch ./src/**/*.tsx\"",
+    "dev:watch": "concurrently \"tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch\" \"tsup\"",
     "format": "biome format --write .",
     "lint": "biome lint --write .",
     "lint:unsafe": "biome lint --write --unsafe .",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,6 +4,9 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/**/index.ts', 'src/**/theme.ts', 'src/**/styles.css'],
+  ignoreWatch: ['**/*.test.ts', '**/*.test.tsx', '**/*.stories.tsx'],
+  // TODO: update this based on environment, once we switch to tsup for builds
+  watch: ['src/**/*.{ts,tsx}'],
   format: 'esm',
   minify: false, // Disable minification during development
   splitting: true, // Enable code splitting to properly handle React contexts


### PR DESCRIPTION
**What changed? Why?**
Dev server previously ignored some files like `src/createWagmiConfig.ts`. This PR moves watching logic to `tsup.config.ts` and ensures that all `ts,tsx` files are watched.

**Notes to reviewers**

**How has it been tested?**
