### PR TITLE
refactor: refactor `DemoOptions` component

### DIFF
--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -18,6 +18,23 @@ import TransactionDefaultDemo from './demo/TransactionDefault';
 import WalletDemo from './demo/Wallet';
 import WalletDefaultDemo from './demo/WalletDefault';
 
+const activeComponentMapping = {
+  [OnchainKitComponent.Fund]: FundDemo,
+  [OnchainKitComponent.Identity]: IdentityDemo,
+  [OnchainKitComponent.Transaction]: TransactionDemo,
+  [OnchainKitComponent.Checkout]: CheckoutDemo,
+  [OnchainKitComponent.Swap]: SwapDemo,
+  [OnchainKitComponent.SwapDefault]: SwapDefaultDemo,
+  [OnchainKitComponent.Wallet]: WalletDemo,
+  [OnchainKitComponent.WalletDefault]: WalletDefaultDemo,
+  [OnchainKitComponent.TransactionDefault]: TransactionDefaultDemo,
+  [OnchainKitComponent.NFTMintCard]: NFTMintCardDemo,
+  [OnchainKitComponent.NFTCard]: NFTCardDemo,
+  [OnchainKitComponent.NFTMintCardDefault]: NFTMintCardDefaultDemo,
+  [OnchainKitComponent.NFTCardDefault]: NFTCardDefaultDemo,
+  [OnchainKitComponent.IdentityCard]: IdentityCardDemo,
+};
+
 function Demo() {
   const { activeComponent } = useContext(AppContext);
   const [isDarkMode, setIsDarkMode] = useState(true);
@@ -47,12 +64,9 @@ function Demo() {
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO: refactor
   function renderActiveComponent() {
-    if (activeComponent === OnchainKitComponent.Fund) {
-      return <FundDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.Identity) {
-      return <IdentityDemo />;
+    if (activeComponent && activeComponentMapping[activeComponent]) {
+      const Component = activeComponentMapping[activeComponent];
+      return <Component />;
     }
 
     if (activeComponent === OnchainKitComponent.Transaction) {
@@ -136,25 +150,38 @@ function Demo() {
         <form className="mt-4 grid gap-8">
           <DemoOptions component={activeComponent} />
         </form>
-        <div className="mt-auto pt-6 text-sm">
-          <a
-            className="opacity-100 transition-opacity duration-200 hover:opacity-70"
-            href="https://github.com/coinbase/onchainkit/tree/main/playground"
-            rel="noreferrer"
-            target="_blank"
-            title="View OnchainKit Playground on GitHub"
-          >
-            Github ↗
-          </a>
-          <a
-            className="pl-4 opacity-100 transition-opacity duration-200 hover:opacity-70"
-            href="https://onchainkit.xyz"
-            rel="noreferrer"
-            target="_blank"
-            title="View OnchainKit"
-          >
-            OnchainKit ↗
-          </a>
+        <div className="mt-auto flex items-center justify-between pt-6 text-sm">
+          <div>
+            <a
+              className="opacity-100 transition-opacity duration-200 hover:opacity-70"
+              href="https://github.com/coinbase/onchainkit/tree/main/playground"
+              rel="noreferrer"
+              target="_blank"
+              title="View OnchainKit Playground on GitHub"
+            >
+              Github ↗
+            </a>
+            <a
+              className="pl-4 opacity-100 transition-opacity duration-200 hover:opacity-70"
+              href="https://onchainkit.xyz"
+              rel="noreferrer"
+              target="_blank"
+              title="View OnchainKit"
+            >
+              OnchainKit ↗
+            </a>
+          </div>
+          <div>
+            <button
+              type="button"
+              className=""
+              onClick={() => {
+                console.log('ok');
+              }}
+            >
+              Share
+            </button>
+          </div>
         </div>
       </div>
       <div className="linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] flex flex-1 flex-col bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px), bg-[size:6rem_4rem]">

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -18,7 +18,7 @@ import TransactionDefaultDemo from './demo/TransactionDefault';
 import WalletDemo from './demo/Wallet';
 import WalletDefaultDemo from './demo/WalletDefault';
 
-const activeComponentMapping = {
+const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
   [OnchainKitComponent.Fund]: FundDemo,
   [OnchainKitComponent.Identity]: IdentityDemo,
   [OnchainKitComponent.Transaction]: TransactionDemo,
@@ -62,63 +62,9 @@ function Demo() {
       : 'border-gray-300 bg-white text-black hover:bg-gray-100'
   }`;
 
-  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO: refactor
-  function renderActiveComponent() {
-    if (activeComponent && activeComponentMapping[activeComponent]) {
-      const Component = activeComponentMapping[activeComponent];
-      return <Component />;
-    }
-
-    if (activeComponent === OnchainKitComponent.Transaction) {
-      return <TransactionDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.Checkout) {
-      return <CheckoutDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.Swap) {
-      return <SwapDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.SwapDefault) {
-      return <SwapDefaultDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.Wallet) {
-      return <WalletDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.WalletDefault) {
-      return <WalletDefaultDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.TransactionDefault) {
-      return <TransactionDefaultDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.NFTMintCard) {
-      return <NFTMintCardDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.NFTCard) {
-      return <NFTCardDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.NFTMintCardDefault) {
-      return <NFTMintCardDefaultDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.NFTCardDefault) {
-      return <NFTCardDefaultDemo />;
-    }
-
-    if (activeComponent === OnchainKitComponent.IdentityCard) {
-      return <IdentityCardDemo />;
-    }
-
-    return <></>;
-  }
+  const ActiveComponent = activeComponent
+    ? activeComponentMapping[activeComponent]
+    : null;
 
   return (
     <>
@@ -150,43 +96,30 @@ function Demo() {
         <form className="mt-4 grid gap-8">
           <DemoOptions component={activeComponent} />
         </form>
-        <div className="mt-auto flex items-center justify-between pt-6 text-sm">
-          <div>
-            <a
-              className="opacity-100 transition-opacity duration-200 hover:opacity-70"
-              href="https://github.com/coinbase/onchainkit/tree/main/playground"
-              rel="noreferrer"
-              target="_blank"
-              title="View OnchainKit Playground on GitHub"
-            >
-              Github ↗
-            </a>
-            <a
-              className="pl-4 opacity-100 transition-opacity duration-200 hover:opacity-70"
-              href="https://onchainkit.xyz"
-              rel="noreferrer"
-              target="_blank"
-              title="View OnchainKit"
-            >
-              OnchainKit ↗
-            </a>
-          </div>
-          <div>
-            <button
-              type="button"
-              className=""
-              onClick={() => {
-                console.log('ok');
-              }}
-            >
-              Share
-            </button>
-          </div>
+        <div className="mt-auto pt-6 text-sm">
+          <a
+            className="opacity-100 transition-opacity duration-200 hover:opacity-70"
+            href="https://github.com/coinbase/onchainkit/tree/main/playground"
+            rel="noreferrer"
+            target="_blank"
+            title="View OnchainKit Playground on GitHub"
+          >
+            Github ↗
+          </a>
+          <a
+            className="pl-4 opacity-100 transition-opacity duration-200 hover:opacity-70"
+            href="https://onchainkit.xyz"
+            rel="noreferrer"
+            target="_blank"
+            title="View OnchainKit"
+          >
+            OnchainKit ↗
+          </a>
         </div>
       </div>
       <div className="linear-gradient(to_bottom,#f0f0f0_1px,transparent_1px)] flex flex-1 flex-col bg-[linear-gradient(to_right,#f0f0f0_1px,transparent_1px), bg-[size:6rem_4rem]">
         <div className="flex h-full w-full flex-col items-center justify-center">
-          {renderActiveComponent()}
+          {ActiveComponent && <ActiveComponent />}
         </div>
       </div>
     </>

--- a/playground/nextjs-app-router/components/DemoOptions.tsx
+++ b/playground/nextjs-app-router/components/DemoOptions.tsx
@@ -60,7 +60,7 @@ const COMPONENT_CONFIG: Partial<
     IsSponsored,
     NFTOptions,
   ],
-} as const;
+};
 
 export function getComponentQueryParams(
   component: OnchainKitComponent,

--- a/playground/nextjs-app-router/components/DemoOptions.tsx
+++ b/playground/nextjs-app-router/components/DemoOptions.tsx
@@ -11,74 +11,86 @@ import { SwapConfig } from './form/swap-config';
 import { TransactionOptions } from './form/transaction-options';
 import { WalletType } from './form/wallet-type';
 
+const COMMON_OPTIONS = [
+  ActiveComponent,
+  ComponentMode,
+  ComponentTheme,
+  WalletType,
+];
+
+const COMPONENT_CONFIG: Partial<
+  Record<OnchainKitComponent, (() => React.JSX.Element)[]>
+> = {
+  [OnchainKitComponent.Checkout]: [
+    Chain,
+    PaymasterUrl,
+    IsSponsored,
+    CheckoutOptions,
+  ],
+  [OnchainKitComponent.Swap]: [Chain, PaymasterUrl, IsSponsored, SwapConfig],
+  [OnchainKitComponent.SwapDefault]: [
+    Chain,
+    PaymasterUrl,
+    IsSponsored,
+    SwapConfig,
+  ],
+  [OnchainKitComponent.Transaction]: [
+    Chain,
+    PaymasterUrl,
+    IsSponsored,
+    TransactionOptions,
+  ],
+  [OnchainKitComponent.TransactionDefault]: [
+    Chain,
+    PaymasterUrl,
+    IsSponsored,
+    TransactionOptions,
+  ],
+  [OnchainKitComponent.NFTCard]: [Chain, NFTOptions],
+  [OnchainKitComponent.NFTCardDefault]: [Chain, NFTOptions],
+  [OnchainKitComponent.NFTMintCard]: [
+    Chain,
+    PaymasterUrl,
+    IsSponsored,
+    NFTOptions,
+  ],
+  [OnchainKitComponent.NFTMintCardDefault]: [
+    Chain,
+    PaymasterUrl,
+    IsSponsored,
+    NFTOptions,
+  ],
+} as const;
+
+export function getComponentQueryParams(
+  component: OnchainKitComponent,
+): string {
+  const options = COMPONENT_CONFIG[component] || [];
+  const paramKeys = [...COMMON_OPTIONS, ...options].map((Component) =>
+    Component.name.toLowerCase(),
+  );
+  return paramKeys.join('&');
+}
+
 export default function DemoOptions({
   component,
 }: {
   component?: OnchainKitComponent;
 }) {
-  const commonOptions = (
+  const commonElements = COMMON_OPTIONS.map((Component) => (
+    <Component key={Component.name} />
+  ));
+
+  const specificElements = component
+    ? (COMPONENT_CONFIG[component] || []).map((Component) => (
+        <Component key={Component.name} />
+      ))
+    : [];
+
+  return (
     <>
-      <ActiveComponent />
-      <ComponentMode />
-      <ComponentTheme />
-      <WalletType />
+      {commonElements}
+      {specificElements}
     </>
   );
-
-  switch (component) {
-    case OnchainKitComponent.Checkout:
-      return (
-        <>
-          {commonOptions}
-          <Chain />
-          <PaymasterUrl />
-          <IsSponsored />
-          <CheckoutOptions />
-        </>
-      );
-    case OnchainKitComponent.Swap:
-    case OnchainKitComponent.SwapDefault:
-      return (
-        <>
-          {commonOptions}
-          <Chain />
-          <PaymasterUrl />
-          <IsSponsored />
-          <SwapConfig />
-        </>
-      );
-    case OnchainKitComponent.Transaction:
-    case OnchainKitComponent.TransactionDefault:
-      return (
-        <>
-          {commonOptions}
-          <Chain />
-          <PaymasterUrl />
-          <IsSponsored />
-          <TransactionOptions />
-        </>
-      );
-    case OnchainKitComponent.NFTCard:
-    case OnchainKitComponent.NFTCardDefault:
-      return (
-        <>
-          {commonOptions}
-          <Chain />
-          <NFTOptions />
-        </>
-      );
-    case OnchainKitComponent.NFTMintCard:
-    case OnchainKitComponent.NFTMintCardDefault:
-      return (
-        <>
-          {commonOptions}
-          <Chain />
-          <PaymasterUrl />
-          <IsSponsored />
-          <NFTOptions />
-        </>
-      );
-    default:
-      return commonOptions;
-  }
 }

--- a/playground/nextjs-app-router/components/DemoOptions.tsx
+++ b/playground/nextjs-app-router/components/DemoOptions.tsx
@@ -62,16 +62,6 @@ const COMPONENT_CONFIG: Partial<
   ],
 };
 
-export function getComponentQueryParams(
-  component: OnchainKitComponent,
-): string {
-  const options = COMPONENT_CONFIG[component] || [];
-  const paramKeys = [...COMMON_OPTIONS, ...options].map((Component) =>
-    Component.name.toLowerCase(),
-  );
-  return paramKeys.join('&');
-}
-
 export default function DemoOptions({
   component,
 }: {

--- a/playground/nextjs-app-router/components/form/checkout-options.tsx
+++ b/playground/nextjs-app-router/components/form/checkout-options.tsx
@@ -3,11 +3,10 @@ import { Label } from '@/components/ui/label';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { useContext } from 'react';
 import { useState } from 'react';
-import { AppContext, CheckoutTypes, OnchainKitComponent } from '../AppProvider';
+import { AppContext, CheckoutTypes } from '../AppProvider';
 
 export function CheckoutOptions() {
   const {
-    activeComponent,
     checkoutTypes,
     setCheckoutTypes,
     checkoutOptions,
@@ -23,7 +22,7 @@ export function CheckoutOptions() {
     chargeId: '',
   });
 
-  return activeComponent === OnchainKitComponent.Checkout ? (
+  return (
     <div className="grid gap-2">
       <Label htmlFor="chain">Checkout Types</Label>
       <RadioGroup
@@ -94,7 +93,5 @@ export function CheckoutOptions() {
         </div>
       )}
     </div>
-  ) : (
-    <></>
   );
 }

--- a/playground/nextjs-app-router/components/form/checkout-options.tsx
+++ b/playground/nextjs-app-router/components/form/checkout-options.tsx
@@ -23,78 +23,78 @@ export function CheckoutOptions() {
     chargeId: '',
   });
 
-  return (
-    activeComponent === OnchainKitComponent.Checkout && (
-      <div className="grid gap-2">
-        <Label htmlFor="chain">Checkout Types</Label>
-        <RadioGroup
-          id="pay-type"
-          value={checkoutTypes}
-          className="flex items-center justify-between"
-          onValueChange={(value) => setCheckoutTypes?.(value as CheckoutTypes)}
-        >
-          <div className="flex items-center gap-2">
-            <Label
-              htmlFor="pay-type-product-id"
-              className="flex cursor-pointer items-center gap-2 rounded-md border p-2 [&:has(:checked)]:bg-muted"
-            >
-              <RadioGroupItem
-                id="pay-type-product-id"
-                value={CheckoutTypes.ProductID}
-              />
-              Product ID
-            </Label>
-            <Label
-              htmlFor="pay-type-charge-id"
-              className="flex cursor-pointer items-center gap-2 rounded-md border p-2 [&:has(:checked)]:bg-muted"
-            >
-              <RadioGroupItem
-                id="pay-type-charge-id"
-                value={CheckoutTypes.ChargeID}
-              />
-              Charge ID
-            </Label>
-          </div>
-        </RadioGroup>
+  return activeComponent === OnchainKitComponent.Checkout ? (
+    <div className="grid gap-2">
+      <Label htmlFor="chain">Checkout Types</Label>
+      <RadioGroup
+        id="pay-type"
+        value={checkoutTypes}
+        className="flex items-center justify-between"
+        onValueChange={(value) => setCheckoutTypes?.(value as CheckoutTypes)}
+      >
+        <div className="flex items-center gap-2">
+          <Label
+            htmlFor="pay-type-product-id"
+            className="flex cursor-pointer items-center gap-2 rounded-md border p-2 [&:has(:checked)]:bg-muted"
+          >
+            <RadioGroupItem
+              id="pay-type-product-id"
+              value={CheckoutTypes.ProductID}
+            />
+            Product ID
+          </Label>
+          <Label
+            htmlFor="pay-type-charge-id"
+            className="flex cursor-pointer items-center gap-2 rounded-md border p-2 [&:has(:checked)]:bg-muted"
+          >
+            <RadioGroupItem
+              id="pay-type-charge-id"
+              value={CheckoutTypes.ChargeID}
+            />
+            Charge ID
+          </Label>
+        </div>
+      </RadioGroup>
 
-        {checkoutTypes === CheckoutTypes.ChargeID && (
-          <div>
-            <Label htmlFor="charge-id">Charge ID</Label>
-            <Input
-              id="charge-id"
-              value={productOptions.chargeId}
-              placeholder="Enter Charge ID"
-              onChange={(e) => {
-                setProductOptions({
-                  ...productOptions,
-                  chargeId: e.target.value,
-                });
-                setCheckoutOptions?.({
-                  ...checkoutOptions,
-                  chargeId: e.target.value,
-                });
-              }}
-            />
-          </div>
-        )}
-        {checkoutTypes === CheckoutTypes.ProductID && (
-          <div>
-            <Label htmlFor="product-id">Product ID</Label>
-            <Input
-              id="product-id"
-              placeholder="Enter Product ID"
-              value={productId}
-              onChange={(e) => {
-                setProductId(e.target.value);
-                setCheckoutOptions?.({
-                  ...checkoutOptions,
-                  productId: e.target.value,
-                });
-              }}
-            />
-          </div>
-        )}
-      </div>
-    )
+      {checkoutTypes === CheckoutTypes.ChargeID && (
+        <div>
+          <Label htmlFor="charge-id">Charge ID</Label>
+          <Input
+            id="charge-id"
+            value={productOptions.chargeId}
+            placeholder="Enter Charge ID"
+            onChange={(e) => {
+              setProductOptions({
+                ...productOptions,
+                chargeId: e.target.value,
+              });
+              setCheckoutOptions?.({
+                ...checkoutOptions,
+                chargeId: e.target.value,
+              });
+            }}
+          />
+        </div>
+      )}
+      {checkoutTypes === CheckoutTypes.ProductID && (
+        <div>
+          <Label htmlFor="product-id">Product ID</Label>
+          <Input
+            id="product-id"
+            placeholder="Enter Product ID"
+            value={productId}
+            onChange={(e) => {
+              setProductId(e.target.value);
+              setCheckoutOptions?.({
+                ...checkoutOptions,
+                productId: e.target.value,
+              });
+            }}
+          />
+        </div>
+      )}
+    </div>
+  ) : (
+    <></>
   );
 }

--- a/playground/nextjs-app-router/components/form/transaction-options.tsx
+++ b/playground/nextjs-app-router/components/form/transaction-options.tsx
@@ -7,18 +7,12 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useContext } from 'react';
-import {
-  AppContext,
-  OnchainKitComponent,
-  TransactionTypes,
-} from '../AppProvider';
+import { AppContext, TransactionTypes } from '../AppProvider';
 
 export function TransactionOptions() {
-  const { activeComponent, transactionType, setTransactionType } =
-    useContext(AppContext);
+  const { transactionType, setTransactionType } = useContext(AppContext);
 
-  return activeComponent === OnchainKitComponent.Transaction ||
-    activeComponent === OnchainKitComponent.TransactionDefault ? (
+  return (
     <div className="grid gap-2">
       <Label htmlFor="chain">Transaction Options</Label>
       <Select
@@ -48,7 +42,5 @@ export function TransactionOptions() {
         </SelectContent>
       </Select>
     </div>
-  ) : (
-    <></>
   );
 }

--- a/playground/nextjs-app-router/components/form/transaction-options.tsx
+++ b/playground/nextjs-app-router/components/form/transaction-options.tsx
@@ -17,40 +17,38 @@ export function TransactionOptions() {
   const { activeComponent, transactionType, setTransactionType } =
     useContext(AppContext);
 
-  return (
-    (activeComponent === OnchainKitComponent.Transaction ||
-      activeComponent === OnchainKitComponent.TransactionDefault) && (
-      <div className="grid gap-2">
-        <Label htmlFor="chain">Transaction Options</Label>
-        <Select
-          value={transactionType}
-          onValueChange={(value) =>
-            value ? setTransactionType?.(value as TransactionTypes) : value
-          }
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Select transaction type" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={TransactionTypes.Calls}>Calls</SelectItem>
-            <SelectItem value={TransactionTypes.Contracts}>
-              Contracts
-            </SelectItem>
-            <SelectItem value={TransactionTypes.CallsPromise}>
-              Calls Promise
-            </SelectItem>
-            <SelectItem value={TransactionTypes.ContractsPromise}>
-              Contracts Promise
-            </SelectItem>
-            <SelectItem value={TransactionTypes.CallsCallback}>
-              Calls Callback
-            </SelectItem>
-            <SelectItem value={TransactionTypes.ContractsCallback}>
-              Contracts Callback
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-    )
+  return activeComponent === OnchainKitComponent.Transaction ||
+    activeComponent === OnchainKitComponent.TransactionDefault ? (
+    <div className="grid gap-2">
+      <Label htmlFor="chain">Transaction Options</Label>
+      <Select
+        value={transactionType}
+        onValueChange={(value) =>
+          value ? setTransactionType?.(value as TransactionTypes) : value
+        }
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="Select transaction type" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={TransactionTypes.Calls}>Calls</SelectItem>
+          <SelectItem value={TransactionTypes.Contracts}>Contracts</SelectItem>
+          <SelectItem value={TransactionTypes.CallsPromise}>
+            Calls Promise
+          </SelectItem>
+          <SelectItem value={TransactionTypes.ContractsPromise}>
+            Contracts Promise
+          </SelectItem>
+          <SelectItem value={TransactionTypes.CallsCallback}>
+            Calls Callback
+          </SelectItem>
+          <SelectItem value={TransactionTypes.ContractsCallback}>
+            Contracts Callback
+          </SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  ) : (
+    <></>
   );
 }


### PR DESCRIPTION
**What changed? Why?**
This PR refactors the `DemoOptions` component away from a switch/case and to a mapping pattern. I think this is appropriate for 2 reasons:
1. Mapping is easier to read and maintain without stepping through nested logic.
2. (more importantly) it will enable the next playground feature, the ability to copy "share links". This requires us to know _which options_ are associated with _which components_, and this is much easier to do with an accessible mapping available.

**Notes to reviewers**

**How has it been tested?**
