### PR TITLE
docs: add compatibility to nft mint card

### DIFF
--- a/site/docs/pages/mint/nft-mint-card.mdx
+++ b/site/docs/pages/mint/nft-mint-card.mdx
@@ -194,6 +194,10 @@ export default function NFTComponent() {
 
 <MintCardOverrideStyles/>
 
+## Compatibility
+
+The mint component uses a custom buildMintTransaction implementation which supports Coinbase mints as well as  [`these supported platforms on reservoir`](https://docs.reservoir.tools/docs/minting#platform-support).  If your contract is not supported, please follow the [`bring your own data instructions`](#bring-your-own-data) below.
+
 ## Advanced Usage
 
 ### Bring your own data


### PR DESCRIPTION
**What changed? Why?**
Added compatibility section to NFT Mint card, pointing users to reservoir platform support docs

<img width="784" alt="image" src="https://github.com/user-attachments/assets/5be26436-22b8-4b35-9519-e9f4fb737d94">


**Notes to reviewers**

**How has it been tested?**
