### PR TITLE
Typo Update types.ts

### DIFF
--- a/src/fund/types.ts
+++ b/src/fund/types.ts
@@ -16,7 +16,7 @@ export type GetOnrampUrlWithProjectIdParams = {
    *
    * Each entry in the record represents a wallet address and the networks it is valid for. There should only be a
    * single address for each network your app supports. Users will be able to buy/send any asset supported by any of
-   * the networks you specify. See the assets param if you want to restrict the avaialable assets.
+   * the networks you specify. See the assets param if you want to restrict the available assets.
    *
    * Some common examples:
    *


### PR DESCRIPTION
**Description**:
This pull request addresses a minor typo in the comment for the `assets` field in the `GetOnrampUrlWithProjectIdParams` type. The word **"avaialable"** was corrected to **"available"**.

**Importance**:
While this is a small fix, correcting the typo improves the clarity and accuracy of the documentation. The incorrect spelling could lead to confusion, especially for non-native English speakers or new contributors reviewing the codebase. Ensuring correct spelling in comments helps maintain professional standards and enhances the overall readability of the project.
