### PR TITLE
[Fix] Import WalletDefault as used by democode

### DIFF
--- a/site/docs/components/landing/WalletDemo.tsx
+++ b/site/docs/components/landing/WalletDemo.tsx
@@ -20,6 +20,7 @@ export const walletDemoCode = `
   import {
     ConnectWallet,
     Wallet,
+    WalletDefault,
     WalletDropdown,
     WalletDropdownBasename,
     WalletDropdownLink,


### PR DESCRIPTION
**What changed? Why?**
On the component demo for onchainkit.xyz, we used `<WalletDefault />` without actually importing it. So copy-pasting the code in would fail. Added to fix 
(another option would be to use `<Wallet />`, but since `WalletDefault` is easier to get started with, left as-is)

**Notes to reviewers**

**How has it been tested?**
Ran locally
Before:
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/c4b5125d-90e8-4e81-8f43-54b58a9b240b">

After:
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/f9375bb4-57ed-4cb1-ab0e-1eb5e9c9c9b4">
