### PR TITLE
Fix/transaction toast success

### DIFF
--- a/src/internal/components/Toast.test.tsx
+++ b/src/internal/components/Toast.test.tsx
@@ -273,6 +273,7 @@ describe('Toast component', () => {
         position="bottom-right"
         onClose={handleClose}
         durationMs={durationMs}
+        startTimeout={false}
       >
         <div>Test Child</div>
       </Toast>,
@@ -286,6 +287,7 @@ describe('Toast component', () => {
         position="bottom-right"
         onClose={handleClose}
         durationMs={durationMs}
+        startTimeout={true}
       >
         <div>Updated Child</div>
       </Toast>,

--- a/src/internal/components/Toast.test.tsx
+++ b/src/internal/components/Toast.test.tsx
@@ -262,6 +262,44 @@ describe('Toast component', () => {
     vi.useRealTimers();
   });
 
+  it('should reset the timer when re-triggered while already visible', async () => {
+    vi.useFakeTimers();
+    const handleClose = vi.fn();
+    const durationMs = 5000;
+
+    const { rerender } = render(
+      <Toast
+        isVisible={true}
+        position="bottom-right"
+        onClose={handleClose}
+        durationMs={durationMs}
+      >
+        <div>Test Child</div>
+      </Toast>,
+    );
+    vi.advanceTimersByTime(2000);
+    expect(handleClose).not.toHaveBeenCalled();
+
+    rerender(
+      <Toast
+        isVisible={true}
+        position="bottom-right"
+        onClose={handleClose}
+        durationMs={durationMs}
+      >
+        <div>Updated Child</div>
+      </Toast>,
+    );
+
+    vi.advanceTimersByTime(4000);
+    expect(handleClose).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2000);
+    expect(handleClose).toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
   it('should not fire timer after manual close', () => {
     vi.useFakeTimers();
     const handleClose = vi.fn();

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -11,7 +11,6 @@ type ToastProps = {
   isVisible: boolean;
   onClose: () => void;
   children: React.ReactNode;
-  parentComponentLifecycleStatus?: string;
 };
 
 const defaultAnimationByPosition = {
@@ -29,12 +28,11 @@ export function Toast({
   isVisible,
   onClose,
   children,
-  parentComponentLifecycleStatus,
 }: ToastProps) {
   const positionClass = getToastPosition(position);
   const animationClass = animation ?? defaultAnimationByPosition[position];
 
-  /* biome-ignore lint/correctness/useExhaustiveDependencies: retrigger durationMs on updates to children or lifecycleStatus  */
+  /* biome-ignore lint/correctness/useExhaustiveDependencies: retrigger durationMs on updates to children  */
   useEffect(() => {
     const timer = setTimeout(() => {
       if (isVisible) {
@@ -47,13 +45,7 @@ export function Toast({
         clearTimeout(timer);
       }
     };
-  }, [
-    durationMs,
-    isVisible,
-    onClose,
-    children,
-    parentComponentLifecycleStatus,
-  ]);
+  }, [durationMs, isVisible, onClose, children]);
 
   if (!isVisible) {
     return null;

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -32,6 +32,7 @@ export function Toast({
   const positionClass = getToastPosition(position);
   const animationClass = animation ?? defaultAnimationByPosition[position];
 
+  /* biome-ignore lint/correctness/useExhaustiveDependencies: retrigger durationMs on updates to children  */
   useEffect(() => {
     const timer = setTimeout(() => {
       if (isVisible) {
@@ -61,7 +62,7 @@ export function Toast({
           'flex items-center justify-between rounded-lg',
           'p-2 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.12)]',
           animationClass,
-          className,
+          className
         )}
         data-testid="ockToast"
       >

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -47,7 +47,13 @@ export function Toast({
         clearTimeout(timer);
       }
     };
-  }, [durationMs, isVisible, onClose, children, parentComponentLifecycleStatus]);
+  }, [
+    durationMs,
+    isVisible,
+    onClose,
+    children,
+    parentComponentLifecycleStatus,
+  ]);
 
   if (!isVisible) {
     return null;

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -6,6 +6,7 @@ import { getToastPosition } from '../utils/getToastPosition';
 type ToastProps = {
   className?: string;
   durationMs?: number;
+  startTimeout?: boolean;
   position: 'top-center' | 'top-right' | 'bottom-center' | 'bottom-right';
   animation?: 'animate-enterRight' | 'animate-enterUp' | 'animate-enterDown';
   isVisible: boolean;
@@ -23,6 +24,7 @@ const defaultAnimationByPosition = {
 export function Toast({
   className,
   durationMs = 5000,
+  startTimeout = true,
   position = 'bottom-center',
   animation,
   isVisible,
@@ -32,20 +34,21 @@ export function Toast({
   const positionClass = getToastPosition(position);
   const animationClass = animation ?? defaultAnimationByPosition[position];
 
-  /* biome-ignore lint/correctness/useExhaustiveDependencies: retrigger durationMs on updates to children  */
   useEffect(() => {
-    const timer = setTimeout(() => {
-      if (isVisible) {
-        onClose();
-      }
-    }, durationMs);
+    if (startTimeout) {
+      const timer = setTimeout(() => {
+        if (isVisible) {
+          onClose();
+        }
+      }, durationMs);
 
-    return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-    };
-  }, [durationMs, isVisible, onClose, children]);
+      return () => {
+        if (timer) {
+          clearTimeout(timer);
+        }
+      };
+    }
+  }, [durationMs, isVisible, onClose, startTimeout]);
 
   if (!isVisible) {
     return null;

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -62,7 +62,7 @@ export function Toast({
           'flex items-center justify-between rounded-lg',
           'p-2 shadow-[0px_8px_24px_0px_rgba(0,0,0,0.12)]',
           animationClass,
-          className
+          className,
         )}
         data-testid="ockToast"
       >

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -11,6 +11,7 @@ type ToastProps = {
   isVisible: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  parentComponentLifecycleStatus?: string;
 };
 
 const defaultAnimationByPosition = {
@@ -28,11 +29,12 @@ export function Toast({
   isVisible,
   onClose,
   children,
+  parentComponentLifecycleStatus,
 }: ToastProps) {
   const positionClass = getToastPosition(position);
   const animationClass = animation ?? defaultAnimationByPosition[position];
 
-  /* biome-ignore lint/correctness/useExhaustiveDependencies: retrigger durationMs on updates to children  */
+  /* biome-ignore lint/correctness/useExhaustiveDependencies: retrigger durationMs on updates to children or lifecycleStatus  */
   useEffect(() => {
     const timer = setTimeout(() => {
       if (isVisible) {
@@ -45,7 +47,7 @@ export function Toast({
         clearTimeout(timer);
       }
     };
-  }, [durationMs, isVisible, onClose, children]);
+  }, [durationMs, isVisible, onClose, children, parentComponentLifecycleStatus]);
 
   if (!isVisible) {
     return null;

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -22,7 +22,7 @@ const defaultAnimationByPosition = {
 
 export function Toast({
   className,
-  durationMs = 3000,
+  durationMs = 5000,
   position = 'bottom-center',
   animation,
   isVisible,

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -44,7 +44,7 @@ export function Toast({
         clearTimeout(timer);
       }
     };
-  }, [durationMs, isVisible, onClose]);
+  }, [durationMs, isVisible, onClose, children]);
 
   if (!isVisible) {
     return null;

--- a/src/transaction/components/TransactionToast.test.tsx
+++ b/src/transaction/components/TransactionToast.test.tsx
@@ -16,6 +16,9 @@ describe('TransactionToast', () => {
     (useTransactionContext as Mock).mockReturnValue({
       isLoading: true,
       isToastVisible: true,
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(
@@ -37,6 +40,9 @@ describe('TransactionToast', () => {
       setIsToastVisible: vi.fn(),
       transactionHash: '',
       transactionId: '',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(<TransactionToast>Test Message</TransactionToast>);
@@ -53,6 +59,9 @@ describe('TransactionToast', () => {
       setIsToastVisible,
       transactionHash: '0x123',
       transactionId: '',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(<TransactionToast>Test Message</TransactionToast>);
@@ -67,6 +76,9 @@ describe('TransactionToast', () => {
       isToastVisible: true,
       transactionHash: '',
       errorMessage: '',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(<TransactionToast>Transaction in progress</TransactionToast>);
@@ -81,6 +93,9 @@ describe('TransactionToast', () => {
       isToastVisible: true,
       transactionHash: mockTransactionHash,
       errorMessage: '',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(<TransactionToast>Transaction completed</TransactionToast>);
@@ -97,6 +112,9 @@ describe('TransactionToast', () => {
       transactionHash: '',
       errorMessage: mockErrorMessage,
       setIsToastVisible,
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(<TransactionToast>Error occurred</TransactionToast>);
@@ -112,6 +130,9 @@ describe('TransactionToast', () => {
       errorMessage: '',
       receipt: null,
       transactionId: '',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(<TransactionToast>In Progress</TransactionToast>);
@@ -127,6 +148,9 @@ describe('TransactionToast', () => {
       errorMessage: '',
       receipt: null,
       transactionId: 'test-id',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     const { container } = render(
@@ -145,6 +169,9 @@ describe('TransactionToast', () => {
       errorMessage: '',
       receipt: null,
       transactionId: 'test-id',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     const { container } = render(
@@ -163,6 +190,9 @@ describe('TransactionToast', () => {
       errorMessage: '',
       receipt: null,
       transactionId: 'test-id',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     const { container } = render(
@@ -181,6 +211,9 @@ describe('TransactionToast', () => {
       errorMessage: '',
       receipt: null,
       transactionId: 'test-id',
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     const { container } = render(<TransactionToast>Test</TransactionToast>);
@@ -199,6 +232,9 @@ describe('TransactionToast', () => {
       errorMessage: '',
       receipt: {},
       setIsToastVisible,
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(<TransactionToast durationMs={2000}>Test</TransactionToast>);
@@ -218,6 +254,9 @@ describe('TransactionToast', () => {
       errorMessage: 'Error',
       receipt: null,
       setIsToastVisible,
+      lifecycleStatus: {
+        statusName: 'test-status',
+      },
     });
 
     render(<TransactionToast durationMs={2000}>Test</TransactionToast>);

--- a/src/transaction/components/TransactionToast.test.tsx
+++ b/src/transaction/components/TransactionToast.test.tsx
@@ -89,12 +89,14 @@ describe('TransactionToast', () => {
   });
 
   it('displays error message when present', () => {
+    const setIsToastVisible = vi.fn();
     const mockErrorMessage = 'Transaction failed';
     (useTransactionContext as Mock).mockReturnValue({
       isLoading: false,
       isToastVisible: true,
       transactionHash: '',
       errorMessage: mockErrorMessage,
+      setIsToastVisible,
     });
 
     render(<TransactionToast>Error occurred</TransactionToast>);

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -17,6 +17,7 @@ export function TransactionToast({
     setIsToastVisible,
     transactionHash,
     transactionId,
+    lifecycleStatus,
   } = useTransactionContext();
 
   const closeToast = useCallback(() => {
@@ -47,6 +48,7 @@ export function TransactionToast({
       durationMs={durationMs}
       isVisible={isToastVisible}
       onClose={closeToast}
+      parentComponentLifecycleStatus={lifecycleStatus.statusName}
     >
       {children}
     </Toast>

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -48,7 +48,7 @@ export function TransactionToast({
       durationMs={durationMs}
       isVisible={isToastVisible}
       onClose={closeToast}
-      parentComponentLifecycleStatus={lifecycleStatus.statusName}
+      parentComponentLifecycleStatus={lifecycleStatus?.statusName}
     >
       {children}
     </Toast>

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -48,7 +48,7 @@ export function TransactionToast({
       durationMs={durationMs}
       isVisible={isToastVisible}
       onClose={closeToast}
-      parentComponentLifecycleStatus={lifecycleStatus?.statusName}
+      parentComponentLifecycleStatus={lifecycleStatus.statusName}
     >
       {children}
     </Toast>

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect } from 'react';
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useEffect,
+} from 'react';
 import { Toast } from '../../internal/components/Toast';
 import type { TransactionToastReact } from '../types';
 import { useTransactionContext } from './TransactionProvider';
@@ -48,9 +54,13 @@ export function TransactionToast({
       durationMs={durationMs}
       isVisible={isToastVisible}
       onClose={closeToast}
-      parentComponentLifecycleStatus={lifecycleStatus.statusName}
     >
-      {children}
+      {Children.map(children, (child) => {
+        if (isValidElement(child)) {
+          return cloneElement(child, { key: lifecycleStatus.statusName });
+        }
+        return child;
+      })}
     </Toast>
   );
 }

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Toast } from '../../internal/components/Toast';
 import type { TransactionToastReact } from '../types';
 import { useTransactionContext } from './TransactionProvider';
@@ -29,6 +29,12 @@ export function TransactionToast({
     !transactionHash &&
     !errorMessage &&
     !transactionId;
+
+  useEffect(() => {
+    if (receipt || errorMessage) {
+      setIsToastVisible(true);
+    }
+  }, [receipt, errorMessage, setIsToastVisible]);
 
   if (!isToastVisible || isInProgress) {
     return null;

--- a/src/transaction/components/TransactionToast.tsx
+++ b/src/transaction/components/TransactionToast.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  cloneElement,
-  isValidElement,
-  useCallback,
-  useEffect,
-} from 'react';
+import { useCallback } from 'react';
 import { Toast } from '../../internal/components/Toast';
 import type { TransactionToastReact } from '../types';
 import { useTransactionContext } from './TransactionProvider';
@@ -23,7 +17,6 @@ export function TransactionToast({
     setIsToastVisible,
     transactionHash,
     transactionId,
-    lifecycleStatus,
   } = useTransactionContext();
 
   const closeToast = useCallback(() => {
@@ -37,12 +30,6 @@ export function TransactionToast({
     !errorMessage &&
     !transactionId;
 
-  useEffect(() => {
-    if (receipt || errorMessage) {
-      setIsToastVisible(true);
-    }
-  }, [receipt, errorMessage, setIsToastVisible]);
-
   if (!isToastVisible || isInProgress) {
     return null;
   }
@@ -54,13 +41,9 @@ export function TransactionToast({
       durationMs={durationMs}
       isVisible={isToastVisible}
       onClose={closeToast}
+      startTimeout={!!receipt || !!errorMessage}
     >
-      {Children.map(children, (child) => {
-        if (isValidElement(child)) {
-          return cloneElement(child, { key: lifecycleStatus.statusName });
-        }
-        return child;
-      })}
+      {children}
     </Toast>
   );
 }


### PR DESCRIPTION
**What changed? Why?**
* added logic to TransactionToast to re-trigger on updates to `receipt` or `errorMessage`
* added logic to Toast to re-start timeout when Toast children are updated (eg. when children change based on inProgress --> success)
* updated Toast tests

**Notes to reviewers**

**How has it been tested?**
locally, and with test coverage