### PR TITLE
chore: only run CLI github workflow on changes to `create-onchain` directory

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'create-onchain/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'create-onchain/**'
 
 jobs:
   test:


### PR DESCRIPTION
**What changed? Why?**
title

**Notes to reviewers**

**How has it been tested?**
no CLI workflow ran on this PR
