### PR TITLE
fix: fix playground share link in production

### DIFF
--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -19,6 +19,7 @@ import TransactionDemo from './demo/Transaction';
 import TransactionDefaultDemo from './demo/TransactionDefault';
 import WalletDemo from './demo/Wallet';
 import WalletDefaultDemo from './demo/WalletDefault';
+import { usePathname } from 'next/navigation';
 
 const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
   [OnchainKitComponent.Fund]: FundDemo,
@@ -38,6 +39,8 @@ const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
 };
 
 function Demo() {
+  const pathname = usePathname();
+  console.log('pathname:', pathname);
   const { activeComponent } = useContext(AppContext);
   const [isDarkMode, setIsDarkMode] = useState(true);
   const [sideBarVisible, setSideBarVisible] = useState(true);

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -19,7 +19,6 @@ import TransactionDemo from './demo/Transaction';
 import TransactionDefaultDemo from './demo/TransactionDefault';
 import WalletDemo from './demo/Wallet';
 import WalletDefaultDemo from './demo/WalletDefault';
-import { usePathname } from 'next/navigation';
 
 const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
   [OnchainKitComponent.Fund]: FundDemo,
@@ -39,8 +38,6 @@ const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
 };
 
 function Demo() {
-  const pathname = usePathname();
-  console.log('pathname:', pathname);
   const { activeComponent } = useContext(AppContext);
   const [isDarkMode, setIsDarkMode] = useState(true);
   const [sideBarVisible, setSideBarVisible] = useState(true);

--- a/playground/nextjs-app-router/lib/url-params.ts
+++ b/playground/nextjs-app-router/lib/url-params.ts
@@ -33,7 +33,7 @@ const URL_PARAM_MAPPING: Partial<Record<OnchainKitComponent, string[]>> = {
 
 export function getShareableUrl(activeComponent?: OnchainKitComponent) {
   if (!activeComponent) {
-    return window.location.origin;
+    return `${window.location.origin}${window.location.pathname}`;
   }
 
   const relevantParams = getComponentQueryParams(activeComponent);
@@ -41,13 +41,12 @@ export function getShareableUrl(activeComponent?: OnchainKitComponent) {
 
   for (const param of [...relevantParams, ...commonOptions]) {
     const value = localStorage.getItem(getStorageKey(param));
-    // Only include the param if it's not the default value
     if (value && value !== defaultState[param as keyof typeof defaultState]) {
       params.set(param, value);
     }
   }
 
-  return `${window.location.origin}?${params.toString()}`;
+  return `${window.location.origin}${window.location.pathname}?${params.toString()}`;
 }
 
 export function getComponentQueryParams(component: OnchainKitComponent) {


### PR DESCRIPTION
**What changed? Why?**

Because our playground app is hosted at /playground, our logic for sharing links wasn't correct. This adds a `pathname` part to the URL so linking works as expected.

**Notes to reviewers**

**How has it been tested?**
