### PR TITLE
chore: update installation provider docs

### DIFF
--- a/site/docs/pages/config/supplemental-providers.mdx
+++ b/site/docs/pages/config/supplemental-providers.mdx
@@ -1,0 +1,88 @@
+---
+title: Supplemental Providers · OnchainKit
+description: Customize the Wagmi and QueryClient providers
+---
+
+import StartBuilding from '../../components/StartBuilding';
+
+# Custom Supplemental Providers
+
+Under the hood, OnchainKit will create our recommended Wagmi and QueryClient
+providers. If you wish to customize the providers, you can do so by creating
+these providers with your own configuration.
+
+For example, the following code creates custom Wagmi and QueryClient providers:
+
+:::code-group
+
+```tsx twoslash [wagmi.ts]
+import { http, cookieStorage, createConfig, createStorage } from 'wagmi';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
+import { coinbaseWallet } from 'wagmi/connectors';
+
+export function getConfig() {
+  return createConfig({
+    chains: [base], // add baseSepolia for testing // [!code ++]
+    connectors: [
+      coinbaseWallet({
+        appName: 'OnchainKit',
+        preference: 'smartWalletOnly',
+        version: '4',
+      }),
+    ],
+    storage: createStorage({
+      storage: cookieStorage,
+    }),
+    ssr: true,
+    transports: {
+      [base.id]: http(), // add baseSepolia for testing // [!code ++]
+    },
+  });
+}
+
+declare module 'wagmi' {
+  interface Register {
+    config: ReturnType<typeof getConfig>;
+  }
+}
+```
+
+```tsx twoslash [providers.tsx]
+// @noErrors: 2307 2580 2339 - cannot find 'process', cannot find './wagmi', cannot find 'import.meta'
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing// [!code ++]
+import { type ReactNode, useState } from 'react';
+import { type State, WagmiProvider } from 'wagmi';
+
+import { getConfig } from '@/wagmi'; // your import path may vary // [!code ++]
+
+export function Providers(props: {
+  children: ReactNode;
+  initialState?: State;
+}) {
+  const [config] = useState(() => getConfig());
+  const [queryClient] = useState(() => new QueryClient());
+  const apiKey = // [!code ++]
+    typeof window !== 'undefined' // [!code ++]
+      ? window.ENV?.PUBLIC_ONCHAINKIT_API_KEY // [!code ++]
+      : undefined; // [!code ++]
+
+  return (
+    <WagmiProvider config={config} initialState={props.initialState}>
+      <QueryClientProvider client={queryClient}>
+        <OnchainKitProvider
+          apiKey={apiKey} // [!code ++]
+          chain={base} // add baseSepolia for testing // [!code ++]
+        >
+          {props.children}
+        </OnchainKitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+}
+```
+
+:::
+
+<StartBuilding />

--- a/site/docs/pages/installation/astro.mdx
+++ b/site/docs/pages/installation/astro.mdx
@@ -92,87 +92,33 @@ Add your Client API Key to the `.env` file:
 PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY
 ```
 
-## Configure Providers
+## Add Providers
 
-In order to use OnchainKit, you need to wrap your app with three providers:
+Create a `providers.tsx` file. Add `OnchainKitProvider` with your desired config.
 
-1. `<WagmiProvider />`
-2. `<QueryClientProvider />`
-3. `<OnchainKitProvider />`
-
-To accomplish this, we recommend creating a `wagmi.ts` file
-and an `AppProviders.tsx` file within the `src` directory.
-
-You must add `base` as a supported chain in the Wagmi configuration file `wagmi.ts`.
-You can use `baseSepolia` for testing.
-
-:::code-group
-
-```tsx twoslash [wagmi.ts]
-import { http, cookieStorage, createConfig, createStorage } from 'wagmi';
-import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
-import { coinbaseWallet } from 'wagmi/connectors';
-
-export function getConfig() {
-  return createConfig({
-    chains: [base], // add baseSepolia for testing // [!code ++]
-    connectors: [
-      coinbaseWallet({
-        appName: 'OnchainKit',
-        preference: 'smartWalletOnly',
-        version: '4',
-      }),
-    ],
-    storage: createStorage({
-      storage: cookieStorage,
-    }),
-    ssr: true,
-    transports: {
-      [base.id]: http(), // add baseSepolia for testing // [!code ++]
-    },
-  });
-}
-
-declare module 'wagmi' {
-  interface Register {
-    config: ReturnType<typeof getConfig>;
-  }
-}
-```
+Under the hood, OnchainKit will create our recommended Wagmi and QueryClient
+providers. If you wish to customize these providers, check out [Custom
+Supplemental Providers](/config/supplemental-providers).
 
 ```tsx twoslash [providers.tsx]
 // @noErrors: 2307 2580 2339 - cannot find 'process', cannot find './wagmi', cannot find 'import.meta'
+'use client';
+
+import type { ReactNode } from 'react';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { base } from 'wagmi/chains'; // add baseSepolia for testing// [!code ++]
-import { type ReactNode, useState } from 'react';
-import { type State, WagmiProvider } from 'wagmi';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
 
-import { getConfig } from '@/wagmi'; // your import path may vary // [!code ++]
-
-export function Providers(props: {
-  children: ReactNode;
-  initialState?: State;
-}) {
-  const [config] = useState(() => getConfig());
-  const [queryClient] = useState(() => new QueryClient());
-
+export function Providers(props: { children: ReactNode }) {
   return (
-    <WagmiProvider config={config} initialState={props.initialState}>
-      <QueryClientProvider client={queryClient}>
-        <OnchainKitProvider
-          apiKey={import.meta.env.PUBLIC_ONCHAINKIT_API_KEY} // [!code ++]
-          chain={base} // add baseSepolia for testing // [!code ++]
-        >
-          {props.children}
-        </OnchainKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <OnchainKitProvider
+      apiKey={import.meta.env.PUBLIC_ONCHAINKIT_API_KEY} // [!code ++]
+      chain={base} // add baseSepolia for testing // [!code ++]
+    >
+      {props.children}
+    </OnchainKitProvider>
   );
 }
 ```
-
-:::
 
 ## Wrap your OnchainKit components with `<AppProviders />`
 

--- a/site/docs/pages/installation/nextjs.mdx
+++ b/site/docs/pages/installation/nextjs.mdx
@@ -18,7 +18,6 @@ skip to the [OnchainKit installation](#install-onchainkit).
 Create a new Next.js project by using the Next.js CLI.
 More information about Next.js can be found [here](https://nextjs.org/docs/getting-started/installation).
 
-
 ```bash [npm]
 npm create next-app@latest
 ```
@@ -54,101 +53,54 @@ bun add @coinbase/onchainkit
 
 Get your [Client API Key](https://portal.cdp.coinbase.com/projects/api-keys/client-key) from Coinbase Developer Platform.
 
-<img alt="OnchainKit copy Client API Key"
+<img
+  alt="OnchainKit copy Client API Key"
   src="https://onchainkit.xyz/assets/copy-api-key-guide.png"
-  height="364"/>
+  height="364"
+/>
 
 Create a `.env` file in your project's root directory.
-   <img
-     alt="OnchainKit define Client API Key"
-     src="https://onchainkit.xyz/assets/getting-started-create-env-file.png"
-     width="250"
-     loading="lazy"
-   />
+
+<img
+  alt="OnchainKit define Client API Key"
+  src="https://onchainkit.xyz/assets/getting-started-create-env-file.png"
+  width="250"
+  loading="lazy"
+/>
 
 Add your Client API Key to the `.env` file:
 
 ```tsx [.env]
-NEXT_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY
+NEXT_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY;
 ```
 
 ## Add Providers
 
-Create a `providers.tsx` file. Add `OnchainKitProvider` as a child of `WagmiProvider` and `QueryClientProvider`.
+Create a `providers.tsx` file. Add `OnchainKitProvider` with your desired config.
 
-Inside the `WagmiProvider`, wrap your app in a TanStack Query React Context Provider, e.g. `QueryClientProvider`, and pass a new `QueryClient` instance to the `client` property.
-
-Additionally, add Base as a supported chain in the Wagmi configuration file `wagmi.ts`.
-
-:::code-group
-
-```tsx twoslash [wagmi.ts]
-import { http, cookieStorage, createConfig, createStorage } from 'wagmi';
-import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
-import { coinbaseWallet } from 'wagmi/connectors';
-
-export function getConfig() {
-  return createConfig({
-    chains: [base], // add baseSepolia for testing// [!code ++]
-    connectors: [
-      coinbaseWallet({
-        appName: "OnchainKit",
-        preference: 'smartWalletOnly',
-        version: '4',
-      }),
-    ],
-    storage: createStorage({
-      storage: cookieStorage,
-    }),
-    ssr: true,
-    transports: {
-      [base.id]: http(), // add baseSepolia for testing // [!code ++]
-    },
-  });
-}
-
-declare module 'wagmi' {
-  interface Register {
-    config: ReturnType<typeof getConfig>;
-  }
-}
-```
+Under the hood, OnchainKit will create our recommended Wagmi and QueryClient
+providers. If you wish to customize these providers, check out [Custom
+Supplemental Providers](/config/supplemental-providers).
 
 ```tsx twoslash [providers.tsx]
 // @noErrors: 2307 2580 2339 - cannot find 'process', cannot find './wagmi', cannot find 'import.meta'
-"use client"
+'use client';
 
+import type { ReactNode } from 'react';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
-import { type ReactNode, useState } from 'react';
-import { type State, WagmiProvider } from 'wagmi';
 
-import { getConfig } from '@/wagmi'; // your import path may vary // [!code ++]
-
-export function Providers(props: {
-  children: ReactNode;
-  initialState?: State;
-}) {
-  const [config] = useState(() => getConfig());
-  const [queryClient] = useState(() => new QueryClient());
-
+export function Providers(props: { children: ReactNode }) {
   return (
-    <WagmiProvider config={config} initialState={props.initialState}>
-      <QueryClientProvider client={queryClient}>
-        <OnchainKitProvider
-          apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY} // [!code ++]
-          chain={base} // add baseSepolia for testing // [!code ++]
-        >
-          {props.children}
-        </OnchainKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <OnchainKitProvider
+      apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY} // [!code ++]
+      chain={base} // add baseSepolia for testing // [!code ++]
+    >
+      {props.children}
+    </OnchainKitProvider>
   );
 }
 ```
-
-:::
 
 ## Wrap your app with `<Providers />`
 
@@ -161,7 +113,7 @@ import { Providers } from './providers'; // [!code ++]
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode,
 }>) {
   return (
     <html lang="en">
@@ -215,7 +167,6 @@ export default function RootLayout(props: { children: ReactNode }) {
     </html>
   );
 }
-
 ```
 
 This ensures that the OnchainKit styles are loaded and applied to your entire application.
@@ -223,7 +174,7 @@ This ensures that the OnchainKit styles are loaded and applied to your entire ap
 - For Tailwind CSS users, check out our [Tailwind Integration Guide](/guides/tailwind).
 
 - Update the appearance of components by using our built-in themes or crafting your own custom theme.
-Explore the possibilities in our [Theming Guide](/guides/themes).
+  Explore the possibilities in our [Theming Guide](/guides/themes).
 
 ::::
 

--- a/site/docs/pages/installation/remix.mdx
+++ b/site/docs/pages/installation/remix.mdx
@@ -110,12 +110,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
         {children}
         <ScrollRestoration />
         <script // [!code ++]
-          dangerouslySetInnerHTML={{ // [!code ++]
-            __html: `window.ENV = ${JSON.stringify( // [!code ++]
+          dangerouslySetInnerHTML={{
+            // [!code ++]
+            __html: `window.ENV = ${JSON.stringify(
+              // [!code ++]
               data.ENV // [!code ++]
             )}`, // [!code ++]
           }} // [!code ++]
-        /> // [!code ++]
+        />{' '}
+        // [!code ++]
         <Scripts />
       </body>
     </html>
@@ -123,91 +126,37 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 ```
 
-## Configure Providers
+## Add Providers
 
-In order to use OnchainKit, you need to wrap your app with three providers:
+Create a `providers.tsx` file. Add `OnchainKitProvider` with your desired config.
 
-1. `<WagmiProvider />`
-2. `<QueryClientProvider />`
-3. `<OnchainKitProvider />`
-
-To accomplish this, we recommend creating a `wagmi.ts` file
-and an `AppProviders.tsx` file within the `src` directory.
-
-You must add `base` as a supported chain in the Wagmi configuration file `wagmi.ts`.
-You can use `baseSepolia` for testing.
-
-:::code-group
-
-```tsx twoslash [wagmi.ts]
-import { http, cookieStorage, createConfig, createStorage } from 'wagmi';
-import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
-import { coinbaseWallet } from 'wagmi/connectors';
-
-export function getConfig() {
-  return createConfig({
-    chains: [base], // add baseSepolia for testing // [!code ++]
-    connectors: [
-      coinbaseWallet({
-        appName: 'OnchainKit',
-        preference: 'smartWalletOnly',
-        version: '4',
-      }),
-    ],
-    storage: createStorage({
-      storage: cookieStorage,
-    }),
-    ssr: true,
-    transports: {
-      [base.id]: http(), // add baseSepolia for testing // [!code ++]
-    },
-  });
-}
-
-declare module 'wagmi' {
-  interface Register {
-    config: ReturnType<typeof getConfig>;
-  }
-}
-```
+Under the hood, OnchainKit will create our recommended Wagmi and QueryClient
+providers. If you wish to customize these providers, check out [Custom
+Supplemental Providers](/config/supplemental-providers).
 
 ```tsx twoslash [providers.tsx]
 // @noErrors: 2307 2580 2339 - cannot find 'process', cannot find './wagmi', cannot find 'import.meta'
+'use client';
+
+import type { ReactNode } from 'react';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { base } from 'wagmi/chains'; // add baseSepolia for testing// [!code ++]
-import { type ReactNode, useState } from 'react';
-import { type State, WagmiProvider } from 'wagmi';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
 
-import { getConfig } from '@/wagmi'; // your import path may vary // [!code ++]
-
-export function Providers(props: {
-  children: ReactNode;
-  initialState?: State;
-}) {
-  const [config] = useState(() => getConfig());
-  const [queryClient] = useState(() => new QueryClient());
-  const apiKey = // [!code ++]
-    typeof window !== 'undefined' // [!code ++]
-      ? window.ENV?.PUBLIC_ONCHAINKIT_API_KEY // [!code ++]
-      : undefined; // [!code ++]
-
+export function Providers(props: { children: ReactNode }) {
+  const apiKey =
+    typeof window !== 'undefined'
+      ? window.ENV?.PUBLIC_ONCHAINKIT_API_KEY
+      : undefined;
   return (
-    <WagmiProvider config={config} initialState={props.initialState}>
-      <QueryClientProvider client={queryClient}>
-        <OnchainKitProvider
-          apiKey={apiKey} // [!code ++]
-          chain={base} // add baseSepolia for testing // [!code ++]
-        >
-          {props.children}
-        </OnchainKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <OnchainKitProvider
+      apiKey={apiKey} // [!code ++]
+      chain={base} // add baseSepolia for testing // [!code ++]
+    >
+      {props.children}
+    </OnchainKitProvider>
   );
 }
 ```
-
-:::
 
 ## Wrap your app with `<AppProviders />`
 

--- a/site/docs/pages/installation/vite.mdx
+++ b/site/docs/pages/installation/vite.mdx
@@ -90,87 +90,33 @@ Add your Client API Key to the `.env` file:
 VITE_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY
 ```
 
-## Configure Providers
+## Add Providers
 
-In order to use OnchainKit, you need to wrap your app with three providers:
+Create a `providers.tsx` file. Add `OnchainKitProvider` with your desired config.
 
-1. `<WagmiProvider />`
-2. `<QueryClientProvider />`
-3. `<OnchainKitProvider />`
-
-To accomplish this, we recommend creating a `wagmi.ts` file
-and an `AppProviders.tsx` file within the `src` directory.
-
-You must add `base` as a supported chain in the Wagmi configuration file `wagmi.ts`.
-You can use `baseSepolia` for testing.
-
-:::code-group
-
-```tsx twoslash [wagmi.ts]
-import { http, cookieStorage, createConfig, createStorage } from 'wagmi';
-import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
-import { coinbaseWallet } from 'wagmi/connectors';
-
-export function getConfig() {
-  return createConfig({
-    chains: [base], // add baseSepolia for testing // [!code ++]
-    connectors: [
-      coinbaseWallet({
-        appName: 'OnchainKit',
-        preference: 'smartWalletOnly',
-        version: '4',
-      }),
-    ],
-    storage: createStorage({
-      storage: cookieStorage,
-    }),
-    ssr: true,
-    transports: {
-      [base.id]: http(), // add baseSepolia for testing // [!code ++]
-    },
-  });
-}
-
-declare module 'wagmi' {
-  interface Register {
-    config: ReturnType<typeof getConfig>;
-  }
-}
-```
+Under the hood, OnchainKit will create our recommended Wagmi and QueryClient
+providers. If you wish to customize these providers, check out [Custom
+Supplemental Providers](/config/supplemental-providers).
 
 ```tsx twoslash [providers.tsx]
 // @noErrors: 2307 2580 2339 - cannot find 'process', cannot find './wagmi', cannot find 'import.meta'
+'use client';
+
+import type { ReactNode } from 'react';
 import { OnchainKitProvider } from '@coinbase/onchainkit';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { base } from 'wagmi/chains'; // add baseSepolia for testing// [!code ++]
-import { type ReactNode, useState } from 'react';
-import { type State, WagmiProvider } from 'wagmi';
+import { base } from 'wagmi/chains'; // add baseSepolia for testing // [!code ++]
 
-import { getConfig } from '@/wagmi'; // your import path may vary // [!code ++]
-
-export function Providers(props: {
-  children: ReactNode;
-  initialState?: State;
-}) {
-  const [config] = useState(() => getConfig());
-  const [queryClient] = useState(() => new QueryClient());
-
+export function Providers(props: { children: ReactNode }) {
   return (
-    <WagmiProvider config={config} initialState={props.initialState}>
-      <QueryClientProvider client={queryClient}>
-        <OnchainKitProvider
-          apiKey={import.meta.env.VITE_PUBLIC_ONCHAINKIT_API_KEY} // [!code ++]
-          chain={base} // add baseSepolia for testing // [!code ++]
-        >
-          {props.children}
-        </OnchainKitProvider>
-      </QueryClientProvider>
-    </WagmiProvider>
+    <OnchainKitProvider
+      apiKey={import.meta.env.VITE_PUBLIC_ONCHAINKIT_API_KEY} // [!code ++]
+      chain={base} // add baseSepolia for testing // [!code ++]
+    >
+      {props.children}
+    </OnchainKitProvider>
   );
 }
 ```
-
-:::
 
 ## Wrap your app with `<AppProviders />`
 


### PR DESCRIPTION
**What changed? Why?**
* updated installation guides based on new recommended provider configuration
* created `/config/supplemental-providers` to illustrate how to create custom Wagmi and QueryClient providers

Updated Installation Guides:
* Next.js
<img width="745" alt="image" src="https://github.com/user-attachments/assets/5e7a2bbb-df0f-4ff5-a077-e8eb664491f2">

* Vite
<img width="776" alt="image" src="https://github.com/user-attachments/assets/1da1b7a7-da8d-4867-a505-90ef5742c11f">

* Remix
<img width="746" alt="image" src="https://github.com/user-attachments/assets/01399601-3889-4d92-9977-b018798e5acd">

* Astro
<img width="783" alt="image" src="https://github.com/user-attachments/assets/780fa49d-18e4-4b63-b8d4-96e017172d9c">


**Notes to reviewers**

**How has it been tested?**
locally