### PR TITLE
feat: added custom border classes

### DIFF
--- a/site/docs/pages/guides/themes.mdx
+++ b/site/docs/pages/guides/themes.mdx
@@ -69,16 +69,16 @@ If no mode is specified, `auto` mode will be applied by default.
 
 ## CSS Overrides
 
-Fine-tune specific aspects of an existing theme. 
+Fine-tune specific aspects of an existing theme.
 This is useful when you want to make adjustments to the appearance of the components without creating an entirely new theme.
 
 ```css
 @layer base {
   :root
   .default-light,
-  .default-dark, 
+  .default-dark,
   .base,
-  .cyberpunk, 
+  .cyberpunk,
   .hacker {
     /* Override specific variables as needed */
     --ock-font-family: 'your-custom-value';
@@ -90,7 +90,7 @@ This is useful when you want to make adjustments to the appearance of the compon
 
 ## Custom Theme
 
-Define an entirely new look and feel for your application. 
+Define an entirely new look and feel for your application.
 This gives you complete control over all aspects of the design, including colors, fonts, and other visual properties.
 
 #### Usage Options:
@@ -125,13 +125,13 @@ This gives you complete control over all aspects of the design, including colors
       mode: 'light', // [!code focus]
       theme: 'custom', // [!code focus]
     },
-  }} 
+  }}
 >
 ```
 
 ##### Defining a custom theme
 
-Use CSS variables to define your custom theme. 
+Use CSS variables to define your custom theme.
 The class name definitions must include the `-light` or `-dark` suffix.
 
 ```css
@@ -184,11 +184,11 @@ The class name definitions must include the `-light` or `-dark` suffix.
     --ock-icon-color-success: 'your-custom-value';
     --ock-icon-color-warning: 'your-custom-value';
 
-    /* Line Colors */
-    --ock-line-primary: 'your-custom-value';
-    --ock-line-default: 'your-custom-value';
-    --ock-line-heavy: 'your-custom-value';
-    --ock-line-inverse: 'your-custom-value';
+    /* Border Colors */
+    --ock-border-line-primary: 'your-custom-value';
+    --ock-border-line-default: 'your-custom-value';
+    --ock-border-line-heavy: 'your-custom-value';
+    --ock-border-line-inverse: 'your-custom-value';
   }
 
   .custom-dark {

--- a/src/identity/components/IdentityCard.tsx
+++ b/src/identity/components/IdentityCard.tsx
@@ -6,7 +6,7 @@ import { Identity } from './Identity';
 import { Name } from './Name';
 import { Socials } from './Socials';
 
-import { background, border, cn, line } from '../../styles/theme';
+import { background, border, cn } from '../../styles/theme';
 
 type IdentityCardReact = {
   address?: Address;

--- a/src/identity/components/IdentityCard.tsx
+++ b/src/identity/components/IdentityCard.tsx
@@ -27,8 +27,8 @@ export function IdentityCard({
       chain={chain}
       className={cn(
         border.radius,
+        border.lineDefault,
         background.default,
-        line.default,
         'items-left flex min-w-[300px] p-4',
         className,
       )}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -12,6 +12,22 @@
   border-color: var(--ock-bg-default-active);
 }
 
+.ock-border-line-primary {
+  border-color: var(--ock-line-primary);
+}
+
+.ock-border-line-default {
+  border-color: var(--ock-line-default);
+}
+
+.ock-border-line-heavy {
+  border-color: var(--ock-line-heavy);
+}
+
+.ock-border-line-inverse {
+  border-color: var(--ock-line-inverse);
+}
+
 .ock-border-radius {
   border-radius: var(--ock-border-radius);
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -182,19 +182,3 @@
   background-color: var(--ock-bg-primary-disabled);
 }
 
-/* Line */
-.ock-line-primary {
-  border-color: var(--ock-line-primary);
-}
-
-.ock-line-default {
-  border-color: var(--ock-line-default);
-}
-
-.ock-line-heavy {
-  border-color: var(--ock-line-heavy);
-}
-
-.ock-line-inverse {
-  border-color: var(--ock-line-inverse);
-}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -68,10 +68,10 @@ export const fill = {
 export const border = {
   default: 'ock-border-default',
   defaultActive: 'ock-border-default-active',
-  linePrimary: 'ock-border-line-primary',
-  lineDefault: 'ock-border-line-default',
-  lineHeavy: 'ock-border-line-heavy',
-  lineInverse: 'ock-border-line-inverse',
+  linePrimary: 'ock-border-line-primary border',
+  lineDefault: 'ock-border-line-default border',
+  lineHeavy: 'ock-border-line-heavy border',
+  lineInverse: 'ock-border-line-inverse border',
   radius: 'ock-border-radius',
   radiusInner: 'ock-border-radius-inner',
 } as const;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -68,6 +68,10 @@ export const fill = {
 export const border = {
   default: 'ock-border-default',
   defaultActive: 'ock-border-default-active',
+  linePrimary: 'ock-border-line-primary',
+  lineDefault: 'ock-border-line-default',
+  lineHeavy: 'ock-border-line-heavy',
+  lineInverse: 'ock-border-line-inverse',
   radius: 'ock-border-radius',
   radiusInner: 'ock-border-radius-inner',
 } as const;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -89,10 +89,3 @@ export const icon = {
   success: 'ock-icon-color-success',
   warning: 'ock-icon-color-warning',
 } as const;
-
-export const line = {
-  primary: 'ock-line-primary border',
-  default: 'ock-line-default border',
-  heavy: 'ock-line-heavy border',
-  inverse: 'ock-line-inverse border',
-} as const;

--- a/src/swap/components/SwapSettingsSlippageLayout.tsx
+++ b/src/swap/components/SwapSettingsSlippageLayout.tsx
@@ -26,7 +26,7 @@ export function SwapSettingsSlippageLayout({
       className={cn(
         background.default,
         border.radius,
-        line.default,
+        border.lineDefault,
         'right-0 z-10 w-[21.75rem] px-3 py-3',
         className,
       )}

--- a/src/swap/components/SwapSettingsSlippageLayout.tsx
+++ b/src/swap/components/SwapSettingsSlippageLayout.tsx
@@ -1,6 +1,6 @@
 import { Children, useMemo } from 'react';
 import { findComponent } from '../../internal/utils/findComponent';
-import { background, border, cn, line } from '../../styles/theme';
+import { background, border, cn } from '../../styles/theme';
 import type { SwapSettingsSlippageLayoutReact } from '../types';
 import { SwapSettingsSlippageDescription } from './SwapSettingsSlippageDescription';
 import { SwapSettingsSlippageInput } from './SwapSettingsSlippageInput';

--- a/src/token/components/TokenSelectButton.tsx
+++ b/src/token/components/TokenSelectButton.tsx
@@ -1,7 +1,7 @@
 import { type ForwardedRef, forwardRef } from 'react';
 import { caretDownSvg } from '../../internal/svg/caretDownSvg';
 import { caretUpSvg } from '../../internal/svg/caretUpSvg';
-import { border, cn, color, line, pressable, text } from '../../styles/theme';
+import { border, cn, color, pressable, text } from '../../styles/theme';
 import type { TokenSelectButtonReact } from '../types';
 import { TokenImage } from './TokenImage';
 

--- a/src/token/components/TokenSelectButton.tsx
+++ b/src/token/components/TokenSelectButton.tsx
@@ -17,7 +17,7 @@ export const TokenSelectButton = forwardRef(function TokenSelectButton(
         pressable.default,
         pressable.shadow,
         border.radius,
-        line.default,
+        border.lineDefault,
         'flex w-fit items-center gap-2 px-3 py-1',
         className,
       )}

--- a/src/wallet/components/WalletModal.tsx
+++ b/src/wallet/components/WalletModal.tsx
@@ -158,10 +158,9 @@ export function WalletModal({
       <div
         ref={modalRef}
         className={cn(
-          border.default,
+          border.lineDefault,
           border.radius,
           background.default,
-          line.default,
           'w-[323px] p-6 pb-4',
           'flex flex-col gap-4',
           'relative',
@@ -217,7 +216,7 @@ export function WalletModal({
             onClick={handleCoinbaseWalletConnection}
             className={cn(
               border.radiusInner,
-              line.default,
+              border.lineDefault,
               text.label2,
               pressable.alternate,
               color.foreground,
@@ -231,7 +230,7 @@ export function WalletModal({
 
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
-              <div className={cn(line.default, 'w-full border-[0.5px]')} />
+              <div className={cn(border.lineDefault, 'w-full border-[0.5px]')} />
             </div>
             <div className="relative flex justify-center">
               <span
@@ -253,7 +252,7 @@ export function WalletModal({
             className={cn(
               border.default,
               border.radiusInner,
-              line.default,
+              border.lineDefault,
               text.label2,
               pressable.alternate,
               color.foreground,
@@ -269,9 +268,8 @@ export function WalletModal({
             type="button"
             onClick={handleWalletConnectConnector}
             className={cn(
-              border.default,
               border.radiusInner,
-              line.default,
+              border.lineDefault,
               text.label2,
               pressable.alternate,
               color.foreground,

--- a/src/wallet/components/WalletModal.tsx
+++ b/src/wallet/components/WalletModal.tsx
@@ -10,7 +10,6 @@ import {
   border,
   cn,
   color,
-  line,
   pressable,
   text,
 } from '../../styles/theme';
@@ -230,7 +229,9 @@ export function WalletModal({
 
           <div className="relative">
             <div className="absolute inset-0 flex items-center">
-              <div className={cn(border.lineDefault, 'w-full border-[0.5px]')} />
+              <div
+                className={cn(border.lineDefault, 'w-full border-[0.5px]')}
+              />
             </div>
             <div className="relative flex justify-center">
               <span


### PR DESCRIPTION
**What changed? Why?**
* added classes for border styles
  * preserved backwards compatibility: `ock-border-default` and `ock-border-default-active` unchanged
  * adds `ock-border-line-default`, `ock-border-line-primary`, `ock-border-line-heavy`, and `ock-border-line-inverse`

**Notes to reviewers**

**How has it been tested?**
locally