### PR TITLE
feat: Token Picker component

### DIFF
--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -19,6 +19,7 @@ import TransactionDemo from './demo/Transaction';
 import TransactionDefaultDemo from './demo/TransactionDefault';
 import WalletDemo from './demo/Wallet';
 import WalletDefaultDemo from './demo/WalletDefault';
+import TokenPickerDemo from './demo/TokenPicker';
 
 const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
   [OnchainKitComponent.Fund]: FundDemo,
@@ -35,6 +36,7 @@ const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
   [OnchainKitComponent.NFTMintCardDefault]: NFTMintCardDefaultDemo,
   [OnchainKitComponent.NFTCardDefault]: NFTCardDefaultDemo,
   [OnchainKitComponent.IdentityCard]: IdentityCardDemo,
+  [OnchainKitComponent.TokenPicker]: TokenPickerDemo,
 };
 
 function Demo() {

--- a/playground/nextjs-app-router/components/demo/TokenPicker.tsx
+++ b/playground/nextjs-app-router/components/demo/TokenPicker.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Token } from '../../../../src/token';
+import { TokenPicker } from '../../../../src/token/components/TokenPicker';
+import { useState } from 'react';
+
+export default function TokenPickerDemo() {
+  const [pickedToken, setPickedToken] = useState<Token>({
+    name: 'Ethereum',
+    symbol: 'ETH',
+    decimals: 18,
+    address: '0x0000000000000000000000000000000000000000',
+    chainId: 1,
+    image: 'https://assets.coingecko.com/coins/images/279/small/ethereum.png',
+  });
+
+  const defaultTokens: Token[] = [
+    {
+      name: 'Ethereum',
+      symbol: 'ETH',
+      decimals: 18,
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: 1,
+      image: 'https://assets.coingecko.com/coins/images/279/small/ethereum.png',
+    },
+    {
+      name: 'USDC',
+      symbol: 'USDC',
+      decimals: 6,
+      address: '0x833589fCD6eDb6E08B1Daf2d5eB29B519B68F139',
+      chainId: 8453,
+      image: 'https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png',
+    },
+    {
+      name: 'DEGEN',
+      symbol: 'DEGEN',
+      decimals: 18,
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: 8453,
+      image: 'https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png',
+    },
+  ];
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4">
+      <TokenPicker
+        pickedToken={pickedToken}
+        defaultTokens={defaultTokens}
+        onTokenPicked={setPickedToken}
+        onError={(error) => console.error(error)}
+      />
+    </div>
+  );
+}

--- a/playground/nextjs-app-router/components/form/active-component.tsx
+++ b/playground/nextjs-app-router/components/form/active-component.tsx
@@ -56,6 +56,9 @@ export function ActiveComponent() {
           <SelectItem value={OnchainKitComponent.NFTMintCardDefault}>
             NFT Mint Card Default
           </SelectItem>
+          <SelectItem value={OnchainKitComponent.TokenPicker}>
+            Token Picker
+          </SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.35.7",
+  "version": "0.35.8",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",

--- a/playground/nextjs-app-router/types/onchainkit.ts
+++ b/playground/nextjs-app-router/types/onchainkit.ts
@@ -13,6 +13,7 @@ export enum OnchainKitComponent {
   NFTCardDefault = 'nft-card-default',
   NFTMintCard = 'nft-mint-card',
   NFTMintCardDefault = 'nft-mint-card-default',
+  TokenPicker = 'token-picker',
 }
 
 export enum TransactionTypes {

--- a/src/token/components/TokenPicker.stories.tsx
+++ b/src/token/components/TokenPicker.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { TokenPicker } from './TokenPicker';
+import type { Token } from '../types';
+
+const defaultTokens: Token[] = [
+  {
+    name: 'Ethereum',
+    symbol: 'ETH',
+    decimals: 18,
+    address: '0x0000000000000000000000000000000000000000',
+    chainId: 1,
+    image: 'https://assets.coingecko.com/coins/images/279/small/ethereum.png',
+  },
+  {
+    name: 'USDC',
+    symbol: 'USDC',
+    decimals: 6,
+    address: '0x833589fCD6eDb6E08B1Daf2d5eB29B519B68F139',
+    chainId: 8453,
+    image: 'https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png',
+  },
+  {
+    name: 'DEGEN',
+    symbol: 'DEGEN',
+    decimals: 18,
+    address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+    chainId: 8453,
+    image: 'https://assets.coingecko.com/coins/images/6319/small/USD_Coin_icon.png',
+  },
+];
+
+const meta = {
+  title: 'Token/TokenPicker',
+  component: TokenPicker,
+  tags: ['autodocs'],
+  args: {
+    pickedToken: defaultTokens[0],
+    defaultTokens,
+    onTokenPicked: fn(),
+    onError: fn(),
+  },
+} satisfies Meta<typeof TokenPicker>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {};
+
+export const NoDefaultTokens: Story = {
+  args: {
+    defaultTokens: [],
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    onError: fn((error: Error) => console.error(error)),
+  },
+}; 

--- a/src/token/components/TokenPicker.test.tsx
+++ b/src/token/components/TokenPicker.test.tsx
@@ -1,0 +1,277 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Address } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TokenPicker } from './TokenPicker';
+import type { Token } from '../types';
+import React from 'react';
+import { getTokens } from '../../api/getTokens';
+
+// Mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // Deprecated
+    removeListener: vi.fn(), // Deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock scrollIntoView
+Element.prototype.scrollIntoView = vi.fn();
+
+// Mock the useOnchainKit hook
+vi.mock('../../useOnchainKit', () => ({
+  useOnchainKit: vi.fn(() => ({
+    config: {
+      appearance: {
+        logo: 'test-logo.png',
+        name: 'Test App'
+      }
+    }
+  }))
+}));
+
+// Mock the getTokens API
+vi.mock('../../api/getTokens', () => ({
+  getTokens: vi.fn(async ({ search }) => {
+    if (search === 'eth') {
+      return [
+        {
+          name: 'Ethereum',
+          address: '0x123' as Address,
+          symbol: 'ETH',
+          decimals: 18,
+          image: 'eth.png',
+          chainId: 8453,
+        }
+      ];
+    }
+    return [];
+  })
+}));
+
+describe('TokenPicker Component', () => {
+  const defaultToken: Token = {
+    name: 'Ethereum',
+    address: '0x123' as Address,
+    symbol: 'ETH',
+    decimals: 18,
+    image: 'eth.png',
+    chainId: 8453,
+  };
+
+  const defaultTokens: Token[] = [
+    defaultToken,
+    {
+      name: 'USD Coin',
+      address: '0x456' as Address,
+      symbol: 'USDC',
+      decimals: 6,
+      image: 'usdc.png',
+      chainId: 8453,
+    }
+  ];
+
+  const onTokenPicked = vi.fn();
+  const onError = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders TokenChip when modal is closed', () => {
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    expect(screen.getByTestId('ockTokenChip_Button')).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens modal when TokenChip is clicked', () => {
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ockTokenChip_Button'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes modal when clicking outside', () => {
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ockTokenChip_Button'));
+    fireEvent.click(screen.getByTestId('ockModalOverlay'));
+    
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('closes modal when clicking close button', () => {
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ockTokenChip_Button'));
+    const closeButton = screen.getByLabelText('Close modal');
+    fireEvent.click(closeButton);
+    
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('displays default tokens as chips', () => {
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ockTokenChip_Button'));
+    
+    defaultTokens.forEach((token) => {
+      expect(screen.getByTestId(`ockTokenChip_${token.address}`)).toBeInTheDocument();
+    });
+  });
+
+  it('searches for tokens and displays results', async () => {
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ockTokenChip_Button'));
+    const searchInput = screen.getByRole('textbox');
+    fireEvent.change(searchInput, { target: { value: 'eth' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument();
+    });
+  });
+
+  it('handles token selection', async () => {
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ockTokenChip_Button'));
+    const searchInput = screen.getByRole('textbox');
+    fireEvent.change(searchInput, { target: { value: 'eth' } });
+
+    await waitFor(() => {
+      const tokenRow = screen.getByTestId('ockTokenRow_Container');
+      fireEvent.click(tokenRow);
+    });
+
+    expect(onTokenPicked).toHaveBeenCalledWith(expect.objectContaining({
+      symbol: 'ETH',
+      address: '0x123'
+    }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('handles keyboard navigation', async () => {
+    const scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ockTokenChip_Button'));
+    const searchInput = screen.getByRole('textbox');
+    fireEvent.change(searchInput, { target: { value: 'eth' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ethereum')).toBeInTheDocument();
+    });
+
+    // Test arrow down navigation
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    
+    // Find the specific token row for Ethereum
+    const tokenRows = screen.getAllByTestId('ockTokenRow_Container');
+    const ethereumRow = tokenRows.find(row => row.textContent?.includes('Ethereum'));
+    expect(ethereumRow).toBeDefined();
+    expect(ethereumRow).toHaveClass('border-2');
+
+    // Verify scrollIntoView was called with correct options
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'nearest'
+    });
+
+    // Test selection with Enter
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(onTokenPicked).toHaveBeenCalledWith(expect.objectContaining({
+      symbol: 'ETH',
+      address: '0x123'
+    }));
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('handles API errors', async () => {
+    const mockGetTokens = vi.fn().mockRejectedValue(new Error('API Error'));
+    vi.mocked(getTokens).mockImplementation(mockGetTokens);
+
+    render(
+      <TokenPicker
+        pickedToken={defaultToken}
+        onTokenPicked={onTokenPicked}
+        defaultTokens={defaultTokens}
+        onError={onError}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('ockTokenChip_Button'));
+    const searchInput = screen.getByRole('textbox');
+    fireEvent.change(searchInput, { target: { value: 'eth' } });
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
+}); 

--- a/src/token/components/TokenPicker.tsx
+++ b/src/token/components/TokenPicker.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { closeSvg } from '../../internal/svg/closeSvg';
+import {
+  background,
+  border,
+  cn,
+  color,
+  text,
+} from '../../styles/theme';
+import { useOnchainKit } from '../../useOnchainKit';
+import { Token, TokenChip, TokenRow, TokenSearch } from '..';
+import { getTokens } from '../../api/getTokens';
+
+type TokenPickerProps = {
+  pickedToken: Token;
+  onTokenPicked: (token: Token) => void;
+  defaultTokens?: Token[];
+  className?: string;
+  onError?: (error: Error) => void;
+};
+
+export function TokenPicker({
+  pickedToken,
+  onTokenPicked,
+  defaultTokens,
+  className,
+  onError,
+}: TokenPickerProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const tokenListRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const { config } = useOnchainKit();
+  const [tokenOptions, setTokenOptions] = useState<Token[]>(defaultTokens || []);
+  const [focusedIndex, setFocusedIndex] = useState<number>(-1);
+
+  const handleChange = useCallback((q: string) => {
+    async function getData(q: string) {
+      try {
+        const tokens = await getTokens({ search: q }); 
+        if (tokens instanceof Array) {
+          setTokenOptions(tokens);
+          setFocusedIndex(-1);
+        }
+      } catch (error) {
+        onError?.(error as Error);
+      }
+    }
+    void getData(q)
+  }, []);
+
+  const onClose = useCallback(() => {
+    setIsOpen(false);
+    handleChange('');
+    setFocusedIndex(-1);
+  }, []);
+
+  const handleSelectToken = useCallback((token: Token) => {
+    onTokenPicked(token);
+    onClose();
+  }, [onTokenPicked]);
+
+
+  // Handle focus trap and keyboard interactions
+  useEffect(() => {
+    if (!isOpen || !modalRef.current) {
+      return;
+    }
+
+    const modal = modalRef.current;
+    const focusableElements = modal.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'Tab') {
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (!e.shiftKey && document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement?.focus();
+        } else if (e.shiftKey && document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement?.focus();
+        }
+      } else if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setFocusedIndex(prev => 
+          prev < tokenOptions.length - 1 ? prev + 1 : prev
+        );
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setFocusedIndex(prev => prev > 0 ? prev - 1 : prev);
+      } else if (e.key === 'Enter' && focusedIndex >= 0) {
+        e.preventDefault();
+        handleSelectToken(tokenOptions[focusedIndex]);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose, focusedIndex, tokenOptions, handleSelectToken]);
+
+  // Handle scrolling focused item into view. useful if scrolling with arrow keys
+  useEffect(() => {
+    if (focusedIndex >= 0 && tokenListRef.current) {
+      const tokenElements = tokenListRef.current.children;
+      const focusedElement = tokenElements[focusedIndex] as HTMLElement;
+      if (focusedElement) {
+        focusedElement.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
+      }
+    }
+  }, [focusedIndex]);
+
+  if (!isOpen) {
+    return (
+      <TokenChip 
+        onClick={() => setIsOpen(true)}
+        token={pickedToken}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-50 flex items-center justify-center',
+        'bg-black/70 transition-opacity duration-200',
+        isOpen ? 'opacity-100' : 'opacity-0',
+      )}
+      onClick={onClose}
+      onKeyDown={(e) => e.key === 'Enter' && onClose()}
+      role="presentation"
+      data-testid="ockModalOverlay"
+    >
+      <div
+        ref={modalRef}
+        className={cn(
+          border.lineDefault,
+          border.radius,
+          background.default,
+          'w-[323px] p-6 pb-4',
+          'flex flex-col gap-4',
+          'relative',
+          '-translate-x-1/2 -translate-y-1/2 fixed top-1/2 left-1/2',
+          'transition-opacity duration-200',
+          isOpen ? 'opacity-100' : 'opacity-0',
+        )}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.key === 'Enter' && e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className={cn(
+            'absolute top-4 right-4',
+            'flex items-center justify-center',
+            'h-3 w-3',
+          )}
+          aria-label="Close modal"
+        >
+          <div
+            className={cn(
+              'relative h-full w-full transition-colors',
+              '[&>svg>path]:hover:fill-[var(--ock-icon-color-foreground-muted)]',
+            )}
+          >
+            {closeSvg}
+          </div>
+        </button>
+
+        {(config?.appearance?.logo || config?.appearance?.name) && (
+          <div className="mt-3 flex w-[275px] flex-col items-center gap-3 self-stretch p-2">
+            {config?.appearance?.logo && (
+              <div className={cn(border.radius, 'h-14 w-14 overflow-hidden')}>
+                <img
+                  src={config?.appearance?.logo}
+                  alt={`${config?.appearance?.name || 'App'} icon`}
+                  className="h-full w-full object-cover"
+                />
+              </div>
+            )}
+            {config?.appearance?.name && (
+              <h2 className={cn(text.headline, color.foreground)}>{config?.appearance?.name}</h2>
+            )}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-2 bg-base-100">
+          <h3 className="text-lg font-bold">Select a token</h3>
+          <TokenSearch onChange={handleChange} delayMs={200} />
+          <div className="flex justify-between items-center gap-2 overflow-x-auto w-full [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
+            {defaultTokens?.map((token) => (
+              <div 
+                data-testid={`ockTokenChip_${token.address}`}
+                key={token.address}
+              >
+                <TokenChip 
+                  token={token} 
+                  onClick={handleSelectToken} 
+                  className="shadow-none"
+                />
+              </div>
+            ))}
+          </div>
+          <div 
+            ref={tokenListRef}
+            className="flex flex-col gap-2 mt-4 overflow-y-auto max-h-96 min-h-80"
+          >
+            {tokenOptions.map((token, index) => (
+              <TokenRow 
+                key={token.address}
+                onClick={handleSelectToken}
+                token={token} 
+                className={cn(
+                  index === focusedIndex ? 'border-2' : 'border-2 border-transparent'
+                )}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
**What changed? Why?**
Add a <TokenPicker /> component that composes the <TokenChip />, <TokenSearch /> and <TokenRow /> to give builders an easy way for users to pop a modal for finding and selecting a token

**Notes to reviewers**
This PR also adds the Token Picker to the playground. I noticed other Token components are not there so I am happy to remove if desired.

The token picker modal allows you to focus, scroll and select tokens with your keyboard.

To test this locally you may have to add this to the TokenPicker for search to work

```  
import { setOnchainKitConfig } from '../../OnchainKitConfig';
import { base } from 'viem/chains';

export function TokenPicker({
  pickedToken,
  onTokenPicked,
  defaultTokens,
  className,
  onError,
}: TokenPickerProps) {
setOnchainKitConfig({
    apiKey: "YOUR_KEY",
    chain: base,
  });
  ...
  ```

**How has it been tested?**
Added unit tests and tested in local playground

https://github.com/user-attachments/assets/e1ed8dc3-668a-427a-9532-ae7f1853f19e

