### PR TITLE
chore: Improve <Socials /> Farcaster URL processing 

### DIFF
--- a/src/identity/components/Socials.test.tsx
+++ b/src/identity/components/Socials.test.tsx
@@ -133,7 +133,7 @@ describe('Socials', () => {
     );
     expect(screen.getByTestId('ockSocials_Farcaster')).toHaveAttribute(
       'href',
-      'farcasteruser',
+      'https://warpcast.com/farcasteruser',
     );
     expect(screen.getByTestId('ockSocials_Website')).toHaveAttribute(
       'href',

--- a/src/identity/utils/getSocialPlatformDetails.test.tsx
+++ b/src/identity/utils/getSocialPlatformDetails.test.tsx
@@ -19,7 +19,7 @@ describe('PLATFORM_CONFIG', () => {
 
   it('should generate correct Farcaster URL', () => {
     const url = PLATFORM_CONFIG.farcaster.href('username');
-    expect(url).toBe('username');
+    expect(url).toBe('https://warpcast.com/username');
   });
 
   it('should return website URL as-is', () => {

--- a/src/identity/utils/getSocialPlatformDetails.tsx
+++ b/src/identity/utils/getSocialPlatformDetails.tsx
@@ -19,7 +19,10 @@ export const PLATFORM_CONFIG: Record<
     icon: githubSvg,
   },
   farcaster: {
-    href: (value) => value,
+    href: (value) => {
+      const username = value.split('/').pop();
+      return `https://warpcast.com/${username}`;
+    },
     icon: warpcastSvg,
   },
   website: {


### PR DESCRIPTION
**What changed? Why?**
This bug comes from when setting your Social URL in [base.org](http://base.org/), there is no enforcement on how to enter your profile. One user could have their entire Farcaster url hardcoded where another user could only have his Farcaster name.

I've updated how we process the Farcaster URLs to be more flexible. 

![image](https://github.com/user-attachments/assets/ec42902c-701f-4472-9d59-6f2157572fe3)

**Notes to reviewers**

**How has it been tested?**
