### PR TITLE
feat: improved funding flow in Checkout

### DIFF
--- a/.changeset/cold-clocks-sip.md
+++ b/.changeset/cold-clocks-sip.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+feat: improved funding flow in Checkout by @0xAlec #1692

--- a/src/checkout/components/CheckoutButton.test.tsx
+++ b/src/checkout/components/CheckoutButton.test.tsx
@@ -57,18 +57,6 @@ describe('CheckoutButton', () => {
     expect(screen.getByRole('button').textContent).toBe('View payment details');
   });
 
-  it('should render "Get USDC" when there is insufficient balance error', () => {
-    useCheckoutContextMock.mockReturnValue({
-      lifecycleStatus: {
-        statusName: CHECKOUT_LIFECYCLESTATUS.ERROR,
-        statusData: { error: 'User has insufficient balance' },
-      },
-      onSubmit: mockOnSubmit,
-    });
-    render(<CheckoutButton />);
-    expect(screen.getByRole('button').textContent).toBe('Get USDC');
-  });
-
   it('should call onSubmit when clicked', () => {
     render(<CheckoutButton />);
     fireEvent.click(screen.getByRole('button'));

--- a/src/checkout/components/CheckoutButton.tsx
+++ b/src/checkout/components/CheckoutButton.tsx
@@ -35,14 +35,8 @@ export function CheckoutButton({
     if (lifecycleStatus?.statusName === CHECKOUT_LIFECYCLESTATUS.SUCCESS) {
       return 'View payment details';
     }
-    if (
-      lifecycleStatus?.statusName === CHECKOUT_LIFECYCLESTATUS.ERROR &&
-      lifecycleStatus?.statusData.error === 'User has insufficient balance'
-    ) {
-      return 'Get USDC';
-    }
     return text;
-  }, [lifecycleStatus?.statusName, lifecycleStatus?.statusData, text]);
+  }, [lifecycleStatus?.statusName, text]);
   const shouldRenderIcon = buttonText === text && iconSvg;
 
   return (

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -269,6 +269,9 @@ export function CheckoutProvider({
           height,
           width,
         });
+        // Reset state
+        insufficientBalanceRef.current = false;
+        priceInUSDCRef.current = undefined;
         return;
       }
 

--- a/src/checkout/components/CheckoutProvider.tsx
+++ b/src/checkout/components/CheckoutProvider.tsx
@@ -272,6 +272,7 @@ export function CheckoutProvider({
         // Reset state
         insufficientBalanceRef.current = false;
         priceInUSDCRef.current = undefined;
+        fetchedDataUseEffect.current = false;
         return;
       }
 

--- a/src/checkout/constants.ts
+++ b/src/checkout/constants.ts
@@ -8,11 +8,6 @@ export const CHECKOUT_TOO_MANY_REQUESTS_ERROR_MESSAGE =
 
 export const CHECKOUT_INSUFFICIENT_BALANCE_ERROR =
   'User has insufficient balance';
-export const CHECKOUT_INSUFFICIENT_BALANCE_ERROR_MESSAGE = (
-  priceInUSD: string,
-) => {
-  return `You need at least ${priceInUSD} USDC to continue with payment`;
-};
 export const CHECKOUT_INVALID_CHARGE_ERROR_MESSAGE =
   'CHECKOUT_INVALID_CHARGE_ERROR';
 export const CHECKOUT_INVALID_PARAMETER_ERROR_MESSAGE =


### PR DESCRIPTION
**What changed? Why?**
- do not render `Get USDC` if insufficient funds
- instead, have original initial click bring user to keys.coinbase.com/fund
- open funding link in popup instead of new tab

**Notes to reviewers**

**How has it been tested?**
unit tests and playground