### PR TITLE
fix: fix typo in token-image.mdx

### DIFF
--- a/site/docs/pages/token/token-image.mdx
+++ b/site/docs/pages/token/token-image.mdx
@@ -9,7 +9,7 @@ With `token` props has no image, render partial token symbol and deterministic d
 
 ## Usage
 
-`TokenImage` with an url
+`TokenImage` with a url
 
 ```tsx twoslash
 // @noErrors: 2739 - missing properties from Token


### PR DESCRIPTION
This pull request corrects a grammatical error in the `token-image.mdx` file, changing "with an url" to "with a url" to follow proper grammar rules. This update ensures the correct article "a" is used before a consonant sound.

**What changed? Why?**
- Fixed the usage of "an" to "a" in the context of "url."

**Notes to reviewers:**
- The change is grammatical and has no functional impact.

**How has it been tested?**
- Review of the file to confirm the fix.
