### PR TITLE
Fix: Standardize Nomenclature on Providers

### DIFF
--- a/site/docs/pages/installation/astro.mdx
+++ b/site/docs/pages/installation/astro.mdx
@@ -120,10 +120,10 @@ export function Providers(props: { children: ReactNode }) {
 }
 ```
 
-## Wrap your OnchainKit components with `<AppProviders />`
+## Wrap your OnchainKit components with `<Providers />`
 
 After configuring the providers in step 4, you will need to wrap your OnchainKit components
-with the `<AppProviders />` component.
+with the `<Providers />` component.
 
 There are two options for this:
 
@@ -133,26 +133,26 @@ There are two options for this:
 :::code-group
 
 ```tsx [ReactIsland]
-import { AppProviders } from '../AppProviders';
+import { Providers } from '../Providers';
 
 export default function ReactIsland() {
   return (
-    <AppProviders>
+    <Providers>
       <YourReactAppContainingOnchainKitComponents />
-    </AppProviders>
+    </Providers>
   );
 }
 ```
 
 ```tsx [OnchainKit Wrappers]
-import { AppProviders } from '../AppProviders';
+import { Providers } from '../Providers';
 import { OnchainKitComponent } from '@coinbase/onchainkit';
 
 export default function OnchainKitComponentWrapper() {
   return (
-    <AppProviders>
+    <Providers>
       <OnchainKitComponent />
-    </AppProviders>
+    </Providers>
   );
 }
 ```

--- a/site/docs/pages/installation/remix.mdx
+++ b/site/docs/pages/installation/remix.mdx
@@ -158,19 +158,19 @@ export function Providers(props: { children: ReactNode }) {
 }
 ```
 
-## Wrap your app with `<AppProviders />`
+## Wrap your app with `<Providers />`
 
 After configuring the providers in step 4, wrap your app with
-the `<AppProviders />` component.
+the `<Providers />` component.
 
 ```tsx
-import { AppProviders } from 'src/AppProviders';
+import { Providers } from 'src/Providers';
 
 export default function App() {
   return (
-    <AppProviders>
+    <Providers>
       <Outlet />
-    </AppProviders>
+    </Providers>
   );
 }
 ```
@@ -179,17 +179,17 @@ export default function App() {
 
 OnchainKit components come with pre-configured styles.
 To include these styles in your project, add the following import
-statement at the top of the file where imported `<AppProviders />`:
+statement at the top of the file where imported `<Providers />`:
 
 ```tsx
-import { AppProviders } from 'src/AppProviders';
+import { Providers } from 'src/Providers';
 import '@coinbase/onchainkit/styles.css'; // [!code ++]
 
 export default function App() {
   return (
-    <AppProviders>
+    <Providers>
       <Outlet />
-    </AppProviders>
+    </Providers>
   );
 }
 ```

--- a/site/docs/pages/installation/vite.mdx
+++ b/site/docs/pages/installation/vite.mdx
@@ -118,19 +118,19 @@ export function Providers(props: { children: ReactNode }) {
 }
 ```
 
-## Wrap your app with `<AppProviders />`
+## Wrap your app with `<Providers />`
 
 After configuring the providers in step 4, wrap your app with
-the `<AppProviders />` component.
+the `<Providers />` component.
 
 ```tsx
-import { AppProviders } from 'src/AppProviders';
+import { Providers } from 'src/Providers';
 
 export default function App() {
   return (
-    <AppProviders>
+    <Providers>
       <YourApp />
-    </AppProviders>
+    </Providers>
   );
 }
 ```
@@ -139,17 +139,17 @@ export default function App() {
 
 OnchainKit components come with pre-configured styles.
 To include these styles in your project, add the following import
-statement at the top of the file where imported `<AppProviders />`:
+statement at the top of the file where imported `<Providers />`:
 
 ```tsx
-import { AppProviders } from 'src/AppProviders';
+import { Providers } from 'src/Providers';
 import '@coinbase/onchainkit/styles.css'; // [!code ++]
 
 export default function App() {
   return (
-    <AppProviders>
+    <Providers>
       <YourApp />
-    </AppProviders>
+    </Providers>
   );
 }
 ```


### PR DESCRIPTION
**What changed? Why?**
* use Providers everywhere instead of AppProviders

**Notes to reviewers**

**How has it been tested?**
