### PR TITLE
docs: Update WalletModal image size

### DIFF
--- a/site/docs/pages/wallet/wallet.mdx
+++ b/site/docs/pages/wallet/wallet.mdx
@@ -321,9 +321,13 @@ import { color } from '@coinbase/onchainkit/theme';
 
 ## Using Wallet Modal
 
-<img alt="Wallet Modal"
+<img 
+  alt="Wallet Modal"
   src="https://onchainkit.xyz/assets/wallet-modal.png"
-  height="364"/>
+  height="364"
+  width="364"
+  className="mx-auto"
+/>
 
 Wallet modal offers users multiple wallet connection options. The modal automatically appears when users click the `ConnectWallet` component and provides three distinct connection paths:
 


### PR DESCRIPTION
**What changed? Why?**
<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td>

<img width="1433" alt="Screenshot 2024-12-12 at 9 21 56 AM" src="https://github.com/user-attachments/assets/23945a93-c9cb-48ba-94a0-2c8866116815" />

</td>
    <td>

<img width="1452" alt="Screenshot 2024-12-12 at 9 22 05 AM" src="https://github.com/user-attachments/assets/fd9c283e-4729-470b-8435-f7a349ee3b4b" />

   </td>
  </tr>
</table>
**Notes to reviewers**

**How has it been tested?**
