### PR TITLE
typo fix Update types.ts

### DIFF
--- a/src/fund/types.ts
+++ b/src/fund/types.ts
@@ -16,7 +16,7 @@ export type GetOnrampUrlWithProjectIdParams = {
    *
    * Each entry in the record represents a wallet address and the networks it is valid for. There should only be a
    * single address for each network your app supports. Users will be able to buy/send any asset supported by any of
-   * the networks you specify. See the assets param if you want to restrict the avaialable assets.
+   * the networks you specify. See the assets param if you want to restrict the available assets.
    *
    * Some common examples:
    *


### PR DESCRIPTION
**What changed? Why?**

A typo in the word "available," which was previously written as "avaialable".

Fixed.
