### PR TITLE
docs: correct grammar issue in text output Update types.mdx

### DIFF
--- a/site/docs/pages/fund/types.mdx
+++ b/site/docs/pages/fund/types.mdx
@@ -80,7 +80,7 @@ See https://docs.cdp.coinbase.com/onramp/docs/api-initializing#getting-an-coinba
 ```ts
 type GetOnrampUrlWithSessionTokenParams = {
   /**
-   * A session token create using the Onramp session token API. The token will 
+   * A session token created using the Onramp session token API. The token will 
    * be linked to the project ID, addresses, and assets params provided in the 
    */
   sessionToken: string;


### PR DESCRIPTION
**What changed? Why?**

This change fixes a grammatical error in the text output, where "create" was incorrectly used instead of "created."
The adjustment ensures the text is grammatically correct and aligns with proper English usage.  

**Notes to reviewers**

A small but important improvement to maintain clarity and professionalism in messaging.

