### PR TITLE
docs: fix minor grammar issues

### DIFF
--- a/site/docs/pages/fund/types.mdx
+++ b/site/docs/pages/fund/types.mdx
@@ -41,7 +41,7 @@ type GetOnrampUrlWithProjectIdParams = {
   projectId: string;
   sessionToken?: never; // You cannot provide sessionToken when using projectId
   /**
-   * The address that the customer's funds should be delivered to.
+   * The addresses to which the customer's funds should be delivered.
    *
    * Each entry in the record represents a wallet address and the networks it is valid for. There should only be a
    * single address for each network your app supports. Users will be able to buy/send any asset supported by any of

--- a/site/docs/pages/fund/types.mdx
+++ b/site/docs/pages/fund/types.mdx
@@ -10,7 +10,7 @@ description: Glossary of Types.
 ```ts
 type FundButtonReact = {
   className?: string; // An optional CSS class name for styling the button component
-  disabled?: boolean; // A optional prop to disable the fund button
+  disabled?: boolean; // An optional prop to disable the fund button
   text?: string; // An optional text to be displayed in the button component
   hideText?: boolean; // An optional prop to hide the text in the button component
   hideIcon?: boolean; // An optional prop to hide the icon in the button component
@@ -41,7 +41,7 @@ type GetOnrampUrlWithProjectIdParams = {
   projectId: string;
   sessionToken?: never; // You cannot provide sessionToken when using projectId
   /**
-   * The addresses that the customer's funds should be delivered to.
+   * The address that the customer's funds should be delivered to.
    *
    * Each entry in the record represents a wallet address and the networks it is valid for. There should only be a
    * single address for each network your app supports. Users will be able to buy/send any asset supported by any of


### PR DESCRIPTION
**What changed? Why?**

I made some small corrections to the documentation to improve clarity and accuracy:

1. The phrase "A optional prop" was changed to "An optional prop" to follow the correct usage of the article. Since "optional" starts with a vowel sound, it should be preceded by "an" instead of "a."

2. The phrase "The addresses that the customer's funds should be delivered to" was adjusted to "The address that the customer's funds should be delivered to" to reflect proper grammar. Although multiple addresses might be implied, it's more grammatically appropriate to use the singular "address" in this context.

**Notes to reviewers**

These changes should help ensure that the documentation is more grammatically correct and easier to understand.
