### PR TITLE
fix: fix path resolution issue in cli.ts

### DIFF
--- a/create-onchain/src/cli.ts
+++ b/create-onchain/src/cli.ts
@@ -14,7 +14,7 @@ import {
 } from './utils.js';
 
 const sourceDir = path.resolve(
-  fileURLToPath(import.meta.url), 
+  path.dirname(fileURLToPath(import.meta.url)), 
   '../../../templates/next'
 );
 


### PR DESCRIPTION
### Description  

This update addresses an issue with path resolution in the following code snippet:  

#### Previous Code  
```typescript  
const sourceDir = path.resolve(  
  fileURLToPath(import.meta.url),   
  '../../../templates/next'  
);  
```  

#### Problem  
The `fileURLToPath(import.meta.url)` function returns the absolute path to the current file, but passing it directly into `path.resolve` without using `path.dirname` can cause problems. This is particularly an issue if the file's path contains special characters (e.g., `%20` for spaces), as it may not be decoded properly.  

#### Fix  
The code now explicitly extracts the directory name using `path.dirname`, ensuring robust path resolution:  

```typescript  
const sourceDir = path.resolve(  
  path.dirname(fileURLToPath(import.meta.url)),   
  '../../../templates/next'  
);  
```  

#### Why This Matters  
- `fileURLToPath(import.meta.url)` provides the file path, not the directory.  
- Using `path.dirname` ensures the proper resolution of relative paths, making the code more reliable and compatible with various environments.  
- The updated approach avoids potential issues with encoded characters in URLs.  

This change improves the overall resilience and compatibility of the file resolution logic.
