### PR TITLE
fix: fix Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,8 @@
 /** @type {import('tailwindcss').Config} */
+
+import tailwindcssAnimate from 'tailwindcss-animate';
+
+
 export default {
   content: ['./src/**/*.{ts,tsx}'],
   darkMode: ['class'],
@@ -13,5 +17,5 @@ export default {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [tailwindcssAnimate],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,6 @@
 
 import tailwindcssAnimate from 'tailwindcss-animate';
 
-
 export default {
   content: ['./src/**/*.{ts,tsx}'],
   darkMode: ['class'],


### PR DESCRIPTION
**What changed? Why?**
We're getting an error breaking playground styling with the addition of `require('tailwindcss-animate')` in our Tailwind plugins. 

This switches import statement to ESModules to fix the config.

**Notes to reviewers**

**How has it been tested?**
