### PR TITLE
docs: Enable auto logged in components on landing page

### DIFF
--- a/.changeset/slow-bats-obey.md
+++ b/.changeset/slow-bats-obey.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+-**docs**: Auto logged in components on landing page. @cpcramer #1754

--- a/site/docs/components/AppDemo.tsx
+++ b/site/docs/components/AppDemo.tsx
@@ -16,10 +16,10 @@ const queryClient = new QueryClient();
 // WARNING: This is a publicly exposed private key used only for documentation demos.
 // Do not use this key for any real transactions or store any assets in this account.
 const DUMMY_PK =
-  '0xa67bdd8a49324aa36cb3f7f7064b9b560e3aa653b774be9793415c0a6fc62cf8';
+  '0xa67bdd8a49324aa36cb3f7f7064b9b560e3aa653b774be9793415c0a6fc62cf8' as const;
 
 const demoWalletConnector = (_config: Config) => {
-  const account = privateKeyToAccount(DUMMY_PK as `0x${string}`);
+  const account = privateKeyToAccount(DUMMY_PK);
 
   const client = createWalletClient({
     account,

--- a/site/docs/components/AppDemo.tsx
+++ b/site/docs/components/AppDemo.tsx
@@ -8,6 +8,7 @@ import { coinbaseWallet } from 'wagmi/connectors';
 import '@coinbase/onchainkit/styles.css';
 import { createWalletClient } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import type { Config } from 'wagmi';
 import { useTheme } from '../contexts/Theme.tsx';
 
 const queryClient = new QueryClient();
@@ -17,7 +18,7 @@ const queryClient = new QueryClient();
 const DUMMY_PK =
   '0xa67bdd8a49324aa36cb3f7f7064b9b560e3aa653b774be9793415c0a6fc62cf8';
 
-const demoWalletConnector = (_config: any) => {
+const demoWalletConnector = (_config: Config) => {
   const account = privateKeyToAccount(DUMMY_PK as `0x${string}`);
 
   const client = createWalletClient({

--- a/site/docs/components/AppDemo.tsx
+++ b/site/docs/components/AppDemo.tsx
@@ -1,0 +1,118 @@
+'use client';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { http, WagmiProvider, createConfig } from 'wagmi';
+import { base, baseSepolia } from 'wagmi/chains';
+import { coinbaseWallet } from 'wagmi/connectors';
+import '@coinbase/onchainkit/styles.css';
+import { createWalletClient } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { useTheme } from '../contexts/Theme.tsx';
+
+const queryClient = new QueryClient();
+
+// WARNING: This is a publicly exposed private key used only for documentation demos.
+// Do not use this key for any real transactions or store any assets in this account.
+const DUMMY_PK =
+  '0xa67bdd8a49324aa36cb3f7f7064b9b560e3aa653b774be9793415c0a6fc62cf8';
+
+const demoWalletConnector = (_config: any) => {
+  const account = privateKeyToAccount(DUMMY_PK as `0x${string}`);
+
+  const client = createWalletClient({
+    account,
+    chain: baseSepolia,
+    transport: http(),
+  });
+
+  return {
+    id: 'testWallet',
+    name: 'Test Wallet',
+    type: 'injected' as const,
+    async connect() {
+      return {
+        accounts: [account.address],
+        chainId: baseSepolia.id,
+      };
+    },
+    async switchChain({ chainId }: { chainId: number }) {
+      if (chainId === baseSepolia.id) {
+        return baseSepolia;
+      }
+      if (chainId === base.id) {
+        return base;
+      }
+      throw new Error('Unsupported chain');
+    },
+    async disconnect() {},
+    async getAccount() {
+      return account.address;
+    },
+    async getChainId() {
+      return baseSepolia.id;
+    },
+    async isAuthorized() {
+      return true;
+    },
+    onAccountsChanged() {},
+    onChainChanged() {},
+    onDisconnect() {},
+    async getAccounts() {
+      return [account.address];
+    },
+    async getProvider() {
+      return client;
+    },
+  };
+};
+
+const wagmiConfig = createConfig({
+  chains: [base, baseSepolia],
+  connectors: [
+    demoWalletConnector,
+    coinbaseWallet({
+      appName: 'OnchainKit',
+    }),
+  ],
+  ssr: true,
+  transports: {
+    [base.id]: http(),
+    [baseSepolia.id]: http(),
+  },
+});
+
+export default function AppDemo({ children }: { children: ReactNode }) {
+  const isServer = typeof window === 'undefined';
+  if (isServer) {
+    return null;
+  }
+  const viteCdpApiKey = import.meta.env.VITE_CDP_API_KEY;
+  const viteProjectId = import.meta.env.VITE_CDP_PROJECT_ID;
+  const { theme } = useTheme();
+
+  return (
+    <WagmiProvider config={wagmiConfig}>
+      <QueryClientProvider client={queryClient}>
+        <OnchainKitProvider
+          apiKey={viteCdpApiKey}
+          chain={base}
+          projectId={viteProjectId}
+          schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
+          config={{
+            appearance: {
+              mode: 'auto',
+              theme: theme,
+            },
+            autoConnect: true,
+            chains: [base, baseSepolia],
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            {children}
+          </div>
+        </OnchainKitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
+  );
+}

--- a/site/docs/components/landing/SwapDemo.tsx
+++ b/site/docs/components/landing/SwapDemo.tsx
@@ -7,7 +7,7 @@ import {
   SwapToggleButton,
 } from '@coinbase/onchainkit/swap';
 import { ConnectWallet, Wallet } from '@coinbase/onchainkit/wallet';
-import App from '../App.tsx';
+import AppDemo from '../AppDemo.tsx';
 import SwapWrapper from '../SwapWrapper.tsx';
 
 export const swapDemoCode = `
@@ -48,7 +48,7 @@ export const swapDemoCode = `
 function SwapDemo() {
   return (
     <div className="mx-auto flex flex-col items-center justify-center">
-      <App>
+      <AppDemo>
         <SwapWrapper>
           {({ address, swappableTokens }) => {
             if (address) {
@@ -84,7 +84,7 @@ function SwapDemo() {
             );
           }}
         </SwapWrapper>
-      </App>
+      </AppDemo>
     </div>
   );
 }

--- a/site/docs/components/landing/WalletDemo.tsx
+++ b/site/docs/components/landing/WalletDemo.tsx
@@ -11,10 +11,9 @@ import {
   Wallet,
   WalletDropdown,
   WalletDropdownBasename,
-  WalletDropdownDisconnect,
   WalletDropdownLink,
 } from '@coinbase/onchainkit/wallet';
-import App from '../App.tsx';
+import AppDemo from '../AppDemo.tsx';
 
 export const walletDemoCode = `
   import {
@@ -24,7 +23,6 @@ export const walletDemoCode = `
     WalletDropdown,
     WalletDropdownBasename,
     WalletDropdownLink,
-    WalletDropdownDisconnect,
   } from '@coinbase/onchainkit/wallet';
   import {
     Address,
@@ -42,7 +40,7 @@ export const walletDemoCode = `
 
 function WalletDemo() {
   return (
-    <App>
+    <AppDemo>
       <Wallet>
         <ConnectWallet>
           <Avatar className="h-6 w-6" />
@@ -61,10 +59,9 @@ function WalletDemo() {
             Wallet
           </WalletDropdownLink>
           <WalletDropdownBasename />
-          <WalletDropdownDisconnect />
         </WalletDropdown>
       </Wallet>
-    </App>
+    </AppDemo>
   );
 }
 


### PR DESCRIPTION
**What changed? Why?**
Create new demo app provider which includes our auto logged in demo wallet. This is to achieve a "logged in" state for our components on the landing page, allowing users to see the intended components rather than a bunch of Connect Wallet buttons. 

For now, we are only auto logging in for the Wallet and Swap component. The Fund and Transaction component would have to be set to disabled. We've decided that it's better to leave these and allow the user to connect their own wallet to test out the functionality. 

<img width="1062" alt="Screenshot 2024-12-17 at 1 19 56 PM" src="https://github.com/user-attachments/assets/03fe0417-c718-47bc-a04f-1ac9599d5cb4" />

<img width="950" alt="Screenshot 2024-12-17 at 1 20 04 PM" src="https://github.com/user-attachments/assets/d1746cc2-f34c-42fe-98c1-0c01a421ea19" />

**Notes to reviewers**

**How has it been tested?**
