### PR TITLE
fix: fix syntax error in .env file docs

### DIFF
--- a/site/docs/pages/installation/nextjs.mdx
+++ b/site/docs/pages/installation/nextjs.mdx
@@ -71,7 +71,7 @@ Create a `.env` file in your project's root directory.
 Add your Client API Key to the `.env` file:
 
 ```tsx [.env]
-NEXT_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY;
+NEXT_PUBLIC_ONCHAINKIT_API_KEY=YOUR_CLIENT_API_KEY
 ```
 
 ## Add Providers


### PR DESCRIPTION
**What changed? Why?**

This update corrects a typo in the `.env` file where a semicolon (`;`) was mistakenly added at the end of a line.  

The `.env` file follows a strict key-value format (`KEY=VALUE`) where semicolons are not valid syntax and may lead to misinterpretation of the variable or runtime errors during parsing. This change ensures compliance with the standard `.env` syntax and prevents potential issues when loading environment variables.  
