### PR TITLE
dev: fix typo in playground README.md

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -18,7 +18,7 @@ Navigate to NextJS (app router) demo app
 cd nextjs-app-router
 ```
 
-Intall dependencies and run app
+Install dependencies and run app
 
 ```bash
 bun build:prepare && bun build:link && bun dev


### PR DESCRIPTION
**What changed? Why?**

While reviewing the documentation, I noticed a small typo in the "Getting Started" section. The word "Intall" was misspelled and has been corrected to "**Install**."

**Notes to reviewers**

**How has it been tested?**
