### PR TITLE
fix: non-pressable tokenChip

### DIFF
--- a/src/token/components/TokenChip.stories.ts
+++ b/src/token/components/TokenChip.stories.ts
@@ -26,3 +26,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Basic: Story = {};
+
+export const NonPressable: Story = {
+  args: {
+    isPressable: false,
+  },
+};

--- a/src/token/components/TokenChip.test.tsx
+++ b/src/token/components/TokenChip.test.tsx
@@ -71,4 +71,36 @@ describe('TokenChip Component', () => {
 
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it('should render a button if pressable', async () => {
+    const token = {
+      address: '0x123' as Address,
+      chainId: 1,
+      decimals: 2,
+      image: 'imageURL',
+      name: 'Ether',
+      symbol: 'ETH',
+    };
+    const { getByTestId } = render(
+      <TokenChip token={token} onClick={vi.fn()} />,
+    );
+
+    expect(getByTestId('ockTokenChip_Button').tagName).toBe('BUTTON');
+  });
+
+  it('should render a div if non pressable', async () => {
+    const token = {
+      address: '0x123' as Address,
+      chainId: 1,
+      decimals: 2,
+      image: 'imageURL',
+      name: 'Ether',
+      symbol: 'ETH',
+    };
+    const { getByTestId } = render(
+      <TokenChip token={token} isPressable={false} />,
+    );
+
+    expect(getByTestId('ockTokenChip_Button').tagName).toBe('DIV');
+  });
 });

--- a/src/token/components/TokenChip.tsx
+++ b/src/token/components/TokenChip.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useTheme } from '../../core-react/internal/hooks/useTheme';
 import { background, cn, pressable, text } from '../../styles/theme';
 import type { TokenChipReact } from '../types';
@@ -6,8 +7,6 @@ import { TokenImage } from './TokenImage';
 /**
  * Small button that display a given token symbol and image.
  *
- * WARNING: This component is under development and
- *          may change in the next few weeks.
  */
 export function TokenChip({
   token,
@@ -17,22 +16,40 @@ export function TokenChip({
 }: TokenChipReact) {
   const componentTheme = useTheme();
 
+  const commonStyles = cn(
+    componentTheme,
+    background.secondary,
+    'flex w-fit shrink-0 items-center gap-2 rounded-lg py-1 pr-3 pl-1',
+  );
+
+  const tokenContent = useMemo(() => {
+    return (
+      <>
+        <TokenImage token={token} size={24} />
+        <span className={text.headline}>{token.symbol}</span>
+      </>
+    );
+  }, [token]);
+
+  if (!isPressable) {
+    return (
+      <div
+        data-testid="ockTokenChip_Button"
+        className={cn(commonStyles, 'cursor-default', className)}
+      >
+        {tokenContent}
+      </div>
+    );
+  }
+
   return (
     <button
       type="button"
       data-testid="ockTokenChip_Button"
-      className={cn(
-        componentTheme,
-        isPressable
-          ? [pressable.secondary, pressable.shadow]
-          : [background.secondary, 'cursor-default'],
-        'flex w-fit shrink-0 items-center gap-2 rounded-lg py-1 pr-3 pl-1 ',
-        className,
-      )}
+      className={cn(commonStyles, pressable.shadow, className)}
       onClick={() => onClick?.(token)}
     >
-      <TokenImage token={token} size={24} />
-      <span className={text.headline}>{token.symbol}</span>
+      {tokenContent}
     </button>
   );
 }


### PR DESCRIPTION
**What changed? Why?**
no style changes, rendering div instead of button when !pressable so its not focusable

| old | new |
|-------|------|
| ![image](https://github.com/user-attachments/assets/0252b896-0de4-4850-92a5-76ba9a1777ef) | ![image](https://github.com/user-attachments/assets/e6757499-3c16-4346-8f67-191eca7ba7e3) | 
| ![image](https://github.com/user-attachments/assets/cf09bd36-5037-45db-a909-f0d145343e78) | ![image](https://github.com/user-attachments/assets/5a03dfe5-eb68-4aa6-8d66-77ae587abdf3) |

**Notes to reviewers**

**How has it been tested?**
