### PR TITLE
fix: fix typos

### DIFF
--- a/src/core/api/buildMintTransaction.ts
+++ b/src/core/api/buildMintTransaction.ts
@@ -6,7 +6,7 @@ import type {
 } from './types';
 
 /**
- * Retrieves contract to mint a nft
+ * Retrieves contract to mint an NFT
  */
 export async function buildMintTransaction({
   mintAddress,

--- a/src/core/api/buildMintTransaction.ts
+++ b/src/core/api/buildMintTransaction.ts
@@ -6,7 +6,7 @@ import type {
 } from './types';
 
 /**
- * Retrieves contract to mint an nft
+ * Retrieves contract to mint a nft
  */
 export async function buildMintTransaction({
   mintAddress,

--- a/src/core/network/getRPCUrl.ts
+++ b/src/core/network/getRPCUrl.ts
@@ -2,7 +2,7 @@ import { ONCHAIN_KIT_CONFIG } from '../OnchainKitConfig';
 
 /**
  * Access the RPC URL for OnchainKit.
- * Defaults to using Coinbase Developer Platform if a RPC URL is not provided.
+ * Defaults to using Coinbase Developer Platform if an RPC URL is not provided.
  */
 export const getRPCUrl = () => {
   if (!ONCHAIN_KIT_CONFIG.rpcUrl && !ONCHAIN_KIT_CONFIG.apiKey) {


### PR DESCRIPTION
This pull request addresses minor typographical errors in the following files:

- In `buildMintTransaction.ts`, changed "mint a nft" to "mint an nft" for proper article usage.
- In `getRPCUrl.ts`, corrected the article "a" to "an" before "RPC" to follow grammar rules for words starting with a vowel sound.

### What changed? Why?
- The article "a" was replaced with "an" in both files to ensure correct grammar and improve readability.

### Notes to reviewers:
- This is a straightforward typo fix with no functional impact.

### How has it been tested?
- Changes have been reviewed manually for accuracy. No tests are required for this minor correction.
