### PR TITLE
docs: Clarified Comment to Improve Readability BuyProvider.tsx

### DIFF
--- a/src/buy/components/BuyProvider.tsx
+++ b/src/buy/components/BuyProvider.tsx
@@ -142,7 +142,7 @@ export function BuyProvider({
   useEffect(() => {
     // Reset inputs after status reset. `resetInputs` is dependent
     // on 'from' and 'to' so moved to separate useEffect to
-    // prevents multiple calls to `onStatus`
+    // prevent multiple calls to `onStatus`
     if (lifecycleStatus.statusName === 'init' && hasHandledSuccess) {
       setHasHandledSuccess(false);
       resetInputs();


### PR DESCRIPTION
**What changed? Why?**

While reviewing the code, I noticed a minor inconsistency in a comment within the `useEffect` hook. The original text:  
```javascript
// prevents multiple calls to `onStatus`
```  
has been updated for grammatical correctness and clarity to:  
```javascript
// prevent multiple calls to `onStatus`
```  
**Notes to reviewers**

This small change aligns the comment's style with the rest of the codebase and avoids any potential confusion.

