### PR TITLE
fix: typos in documentation files

### DIFF
--- a/site/docs/pages/wallet/is-wallet-a-coinbase-smart-wallet.mdx
+++ b/site/docs/pages/wallet/is-wallet-a-coinbase-smart-wallet.mdx
@@ -1,6 +1,6 @@
-# `isWalletASmartCoinbaseWallet`
+# `isWalletACoinbaseSmartWallet`
 
-The `isWalletASmartCoinbaseWallet` utility is designed to verify if a given sender address is a Smart Wallet proxy with the expected implementation before sponsoring a transaction.
+The `isWalletACoinbaseSmartWallet` utility is designed to verify if a given sender address is a Smart Wallet proxy with the expected implementation before sponsoring a transaction.
 
 ## Usage
 


### PR DESCRIPTION
The utility name `isWalletASmartCoinbaseWallet` should be changed to `isWalletACoinbaseSmartWallet`, which matches the correct function name specified in the import and code example.