### PR TITLE
fix: set client boundary in `Buy`, `Checkout`, `Fund`, and `OnchainkitProvider`

### DIFF
--- a/packemon.config.ts
+++ b/packemon.config.ts
@@ -24,7 +24,11 @@ const config = {
           // Remove the original directive and split into lines
           const lines = code.replace("'use client';", '').split('\n');
           // Filter out any empty lines and reconstruct
-          return `'use client';\n${lines.filter((line) => line.trim()).join('\n')}`;
+
+          return {
+            code: `'use client';\n${lines.filter((line) => line.trim()).join('\n')}`,
+            map: null,
+          };
         }
         return null; // Return null to keep the original code (https://rollupjs.org/plugin-development/#renderchunk)
       },

--- a/src/buy/components/Buy.tsx
+++ b/src/buy/components/Buy.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useOutsideClick } from '@/ui-react/internal/hooks/useOutsideClick';
 import { useRef } from 'react';
 import { useTheme } from '../../core-react/internal/hooks/useTheme';
@@ -35,6 +37,7 @@ function BuyContent({ className }: { className?: string }) {
     </div>
   );
 }
+
 export function Buy({
   config = {
     maxSlippage: FALLBACK_DEFAULT_MAX_SLIPPAGE,

--- a/src/checkout/components/Checkout.tsx
+++ b/src/checkout/components/Checkout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useIsMounted } from '../../core-react/internal/hooks/useIsMounted';
 import { useTheme } from '../../core-react/internal/hooks/useTheme';
 import { cn } from '../../styles/theme';

--- a/src/checkout/components/CheckoutButton.tsx
+++ b/src/checkout/components/CheckoutButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useMemo } from 'react';
-import { Spinner } from '../../internal/components/Spinner';
 import { useIcon } from '../../core-react/internal/hooks/useIcon';
+import { Spinner } from '../../internal/components/Spinner';
 import {
   border,
   cn,

--- a/src/checkout/components/CheckoutButton.tsx
+++ b/src/checkout/components/CheckoutButton.tsx
@@ -1,6 +1,7 @@
+'use client';
+
 import { useMemo } from 'react';
 import { Spinner } from '../../internal/components/Spinner';
-
 import { useIcon } from '../../core-react/internal/hooks/useIcon';
 import {
   border,

--- a/src/checkout/components/CheckoutStatus.tsx
+++ b/src/checkout/components/CheckoutStatus.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn, text } from '../../styles/theme';
 import { useGetCheckoutStatus } from '../hooks/useGetCheckoutStatus';
 import type { CheckoutStatusReact } from '../types';

--- a/src/core-react/OnchainKitProvider.tsx
+++ b/src/core-react/OnchainKitProvider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createContext, useMemo } from 'react';
 import { WagmiProvider } from 'wagmi';

--- a/src/fund/components/FundButton.tsx
+++ b/src/fund/components/FundButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useCallback } from 'react';
 import { useTheme } from '../../core-react/internal/hooks/useTheme';
 import { addSvg } from '../../internal/svg/addSvg';

--- a/src/fund/index.ts
+++ b/src/fund/index.ts
@@ -1,4 +1,8 @@
+// 🌲☀🌲
+// Components
 export { FundButton } from './components/FundButton';
+
+// Utils
 export { getCoinbaseSmartWalletFundUrl } from './utils/getCoinbaseSmartWalletFundUrl';
 export { getOnrampBuyUrl } from './utils/getOnrampBuyUrl';
 export { setupOnrampEventListeners } from './utils/setupOnrampEventListeners';
@@ -7,6 +11,7 @@ export { fetchOnrampConfig } from './utils/fetchOnrampConfig';
 export { fetchOnrampOptions } from './utils/fetchOnrampOptions';
 export { fetchOnrampQuote } from './utils/fetchOnrampQuote';
 
+// Types
 export type {
   GetOnrampUrlWithProjectIdParams,
   GetOnrampUrlWithSessionTokenParams,


### PR DESCRIPTION
**What changed? Why?**
Continuing #1771 with support for `Buy` and `OnchainkitProvider`

**Notes to reviewers**
- Consumers will still need to set a client boundary manually with `OnchainkitProvider` because of the way that the `chain` prop from `viem` is handled.
- Only setting directive on `Buy` since it's the only exported Buy component (no subcomponents)

**How has it been tested?**
- Locally with Next 15 and Vite
