### PR TITLE
 fix: fix incorrect documentation link for `getAvatar` function

### DIFF
--- a/site/docs/pages/checkout/checkout.mdx
+++ b/site/docs/pages/checkout/checkout.mdx
@@ -118,7 +118,7 @@ const chargeHandler = async () => {
 ```
 ::::
 
-That's it! Starting selling onchain with just a few lines of code. 
+That's it! Start selling onchain with just a few lines of code. 
 
 ## Usage
 

--- a/site/docs/pages/guides/use-basename-in-onchain-app.mdx
+++ b/site/docs/pages/guides/use-basename-in-onchain-app.mdx
@@ -76,7 +76,7 @@ const { data: name, isLoading: nameIsLoading } = await useName({ address, chain:
 
 ## Typescript utility with `getAvatar` and `getName`
 
-Use the [`getAvatar`](/identity/get-name) and [`getName`](/identity/get-name) functions to get Basenames associated with Ethereum addresses.
+Use the [`getAvatar`](/identity/get-avatar) and [`getName`](/identity/get-name) functions to get Basenames associated with Ethereum addresses.
 
 Being pure functions, it seamlessly integrates into any TypeScript project, including Vue, Angular, Svelte, or Node.js.
 


### PR DESCRIPTION

Fixed incorrect link path for getAvatar function documentation from `/identity/get-name` to `/identity/get-avatar` to ensure users are directed to the correct documentation page.