### PR TITLE
docs: Update Identity landing page preview

### DIFF
--- a/site/docs/components/landing/ComponentPreview.tsx
+++ b/site/docs/components/landing/ComponentPreview.tsx
@@ -68,7 +68,7 @@ const components: Component[] = [
     description: 'Fund wallets with a debit card or a coinbase account.',
   },
   {
-    name: 'Identity Card',
+    name: 'Identity',
     component: IdentityCardDemo,
     code: identityCardDemoCode,
     description:


### PR DESCRIPTION
**What changed? Why?**
Identity Card copy on the left back to Identity to remain consistent with the other previews. 
**Notes to reviewers**

<img width="1189" alt="Screenshot 2025-01-13 at 11 29 05 AM" src="https://github.com/user-attachments/assets/e72bba96-00c1-4a79-b4cb-3a258d3c3278" />

**How has it been tested?**
