### PR TITLE
fix: pass though logo and name to cb wallet

### DIFF
--- a/.changeset/eight-buttons-walk.md
+++ b/.changeset/eight-buttons-walk.md
@@ -1,0 +1,5 @@
+---
+'@coinbase/onchainkit': patch
+---
+
+***fix***: update wallet modal to pass through app name and logo. By @alessey #1808

--- a/src/wallet/components/WalletModal.tsx
+++ b/src/wallet/components/WalletModal.tsx
@@ -81,8 +81,8 @@ export function WalletModal({
     };
   }, [isOpen, onClose]);
 
-  const appLogo = config?.appearance?.logo;
-  const appName = config?.appearance?.name;
+  const appLogo = config?.appearance?.logo ?? undefined;
+  const appName = config?.appearance?.name ?? undefined;
   const privacyPolicyUrl = config?.wallet?.privacyUrl ?? undefined;
   const termsOfServiceUrl = config?.wallet?.termsUrl ?? undefined;
 
@@ -90,8 +90,9 @@ export function WalletModal({
     try {
       const cbConnector = coinbaseWallet({
         preference: 'all',
+        appName,
+        appLogoUrl: appLogo,
       });
-
       connect({ connector: cbConnector });
       onClose();
     } catch (error) {
@@ -104,7 +105,7 @@ export function WalletModal({
         );
       }
     }
-  }, [connect, onClose, onError]);
+  }, [appName, appLogo, connect, onClose, onError]);
 
   const handleMetaMaskConnection = useCallback(() => {
     try {
@@ -112,7 +113,7 @@ export function WalletModal({
         dappMetadata: {
           name: appName || 'OnchainKit App',
           url: window.location.origin,
-          iconUrl: appLogo || undefined,
+          iconUrl: appLogo,
         },
       });
 


### PR DESCRIPTION
**What changed? Why?**
Pass through appLogo and appName to cb smart wallet from wallet modal

fixes: https://github.com/coinbase/onchainkit/issues/1789

| before | after |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/13484a2a-da7e-4258-8cc4-062400a286f1) | ![image](https://github.com/user-attachments/assets/32bae768-5739-4aa9-a992-6f7f648d5ba4) |

**Notes to reviewers**

**How has it been tested?**
