### PR TITLE
fix: modal state local to connect wallet

### DIFF
--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.36.4",
+  "version": "0.36.5",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",

--- a/src/wallet/components/ConnectWallet.tsx
+++ b/src/wallet/components/ConnectWallet.tsx
@@ -41,7 +41,7 @@ export function ConnectWallet({
 
   // State
   const [hasClickedConnect, setHasClickedConnect] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false); // duplicate modal state because ConnectWallet not always within WalletProvider
 
   // Get connectWalletText from children when present,
   // this is used to customize the connect wallet button text
@@ -69,20 +69,20 @@ export function ConnectWallet({
   // Handles
   const handleToggle = useCallback(() => {
     if (isSubComponentOpen) {
-      handleClose?.();
+      handleClose?.(); // optional because ConnectWallet not always within WalletProvider
     } else {
       setIsSubComponentOpen(true);
     }
   }, [isSubComponentOpen, handleClose, setIsSubComponentOpen]);
 
   const handleCloseConnectModal = useCallback(() => {
-    setIsModalOpen(false);
-    setIsConnectModalOpen?.(false);
+    setIsModalOpen(false); // duplicate state because ConnectWallet not always within WalletProvider
+    setIsConnectModalOpen?.(false); // optional because ConnectWallet not always within WalletProvider
   }, [setIsConnectModalOpen]);
 
   const handleOpenConnectModal = useCallback(() => {
-    setIsModalOpen(true);
-    setIsConnectModalOpen?.(true);
+    setIsModalOpen(true); // duplicate state because ConnectWallet not always within WalletProvider
+    setIsConnectModalOpen?.(true); // optional because ConnectWallet not always within WalletProvider
     setHasClickedConnect(true);
   }, [setIsConnectModalOpen]);
 

--- a/src/wallet/components/ConnectWallet.tsx
+++ b/src/wallet/components/ConnectWallet.tsx
@@ -31,7 +31,6 @@ export function ConnectWallet({
 
   // Core Hooks
   const {
-    isConnectModalOpen,
     setIsConnectModalOpen,
     isSubComponentOpen,
     setIsSubComponentOpen,
@@ -42,6 +41,7 @@ export function ConnectWallet({
 
   // State
   const [hasClickedConnect, setHasClickedConnect] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   // Get connectWalletText from children when present,
   // this is used to customize the connect wallet button text
@@ -69,18 +69,20 @@ export function ConnectWallet({
   // Handles
   const handleToggle = useCallback(() => {
     if (isSubComponentOpen) {
-      handleClose();
+      handleClose?.();
     } else {
       setIsSubComponentOpen(true);
     }
   }, [isSubComponentOpen, handleClose, setIsSubComponentOpen]);
 
   const handleCloseConnectModal = useCallback(() => {
-    setIsConnectModalOpen(false);
+    setIsModalOpen(false);
+    setIsConnectModalOpen?.(false);
   }, [setIsConnectModalOpen]);
 
   const handleOpenConnectModal = useCallback(() => {
-    setIsConnectModalOpen(true);
+    setIsModalOpen(true);
+    setIsConnectModalOpen?.(true);
     setHasClickedConnect(true);
   }, [setIsConnectModalOpen]);
 
@@ -105,7 +107,7 @@ export function ConnectWallet({
             }}
             text={text}
           />
-          {isConnectModalOpen && (
+          {isModalOpen && (
             <WalletModal isOpen={true} onClose={handleCloseConnectModal} />
           )}
         </div>


### PR DESCRIPTION
**What changed? Why?**
* duplicated connect modal state in ConnectWallet
  * fixes issue where ConnectWallet not always wrapped in WalletProvider. in these cases, modal is unable to be displayed because the handlers come from context
  * by adding state local to this component, we can use it in a disconnected state without wrapping in a a WalletProvider

**Notes to reviewers**

**How has it been tested?**
locally