### PR TITLE
fix: add client boundaries for `WalletAdvanced*` components

### DIFF
--- a/src/wallet/components/WalletAdvanced.tsx
+++ b/src/wallet/components/WalletAdvanced.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { WalletAdvancedReact } from '../types';
 import { WalletAdvancedContent } from './WalletAdvancedContent';
 import { WalletAdvancedProvider } from './WalletAdvancedProvider';

--- a/src/wallet/components/WalletAdvancedAddressDetails.tsx
+++ b/src/wallet/components/WalletAdvancedAddressDetails.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Spinner } from '@/internal/components/Spinner';
 import { border, cn, color, pressable, text } from '@/styles/theme';
 import { Avatar, Badge, Name } from '@/ui/react/identity';

--- a/src/wallet/components/WalletAdvancedDefault.tsx
+++ b/src/wallet/components/WalletAdvancedDefault.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Avatar, Name } from '@/ui/react/identity';
 import { ConnectWallet } from './ConnectWallet';
 import { ConnectWalletText } from './ConnectWalletText';

--- a/src/wallet/components/WalletAdvancedQrReceive.tsx
+++ b/src/wallet/components/WalletAdvancedQrReceive.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { PressableIcon } from '@/internal/components/PressableIcon';
 import { QrCodeSvg } from '@/internal/components/QrCode/QrCodeSvg';
 import { backArrowSvg } from '@/internal/svg/backArrowSvg';

--- a/src/wallet/components/WalletAdvancedSwap.tsx
+++ b/src/wallet/components/WalletAdvancedSwap.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { PressableIcon } from '@/internal/components/PressableIcon';
 import { backArrowSvg } from '@/internal/svg/backArrowSvg';
 import { cn } from '@/styles/theme';

--- a/src/wallet/components/WalletAdvancedTokenHoldings.tsx
+++ b/src/wallet/components/WalletAdvancedTokenHoldings.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { cn, color, text } from '@/styles/theme';
 import { type Token, TokenImage } from '@/token';
 import { useWalletAdvancedContext } from './WalletAdvancedProvider';


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
