### PR TITLE
feat: Add UI Primitives - FocusTrap, DismissableLayer, and Dialog. 

### DIFF
--- a/.changeset/dull-shirts-confess.md
+++ b/.changeset/dull-shirts-confess.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: Add UI Primitives - FocusTrap, DismissableLayer, and Dialog. By @cpcramer #1822

--- a/src/internal/primitives/Dialog.test.tsx
+++ b/src/internal/primitives/Dialog.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Dialog } from './Dialog';
+
+vi.mock('react-dom', () => ({
+  createPortal: (node: React.ReactNode) => node,
+}));
+
+describe('Dialog', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    onClose.mockClear();
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it('renders nothing when isOpen is false', () => {
+    render(
+      <Dialog isOpen={false} onClose={onClose}>
+        <div>Dialog content</div>
+      </Dialog>,
+    );
+
+    expect(screen.queryByTestId('ockDialog')).not.toBeInTheDocument();
+  });
+
+  it('renders content when isOpen is true', () => {
+    render(
+      <Dialog isOpen={true} onClose={onClose}>
+        <div data-testid="content">Dialog content</div>
+      </Dialog>,
+    );
+
+    expect(screen.getByTestId('ockDialog')).toBeInTheDocument();
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+  });
+
+  it('sets correct ARIA attributes', () => {
+    render(
+      <Dialog
+        isOpen={true}
+        ariaLabel="Test Dialog"
+        ariaDescribedby="dialog-desc"
+        ariaLabelledby="dialog-title"
+        onClose={() => {}}
+      >
+        <div>Dialog content</div>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByTestId('ockDialog');
+    expect(dialog).toHaveAttribute('aria-label', 'Test Dialog');
+    expect(dialog).toHaveAttribute('aria-describedby', 'dialog-desc');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'dialog-title');
+  });
+
+  it('sets modal attribute correctly', () => {
+    render(
+      <Dialog isOpen={true} modal={false}>
+        <div>Dialog content</div>
+      </Dialog>,
+    );
+
+    expect(screen.getByTestId('ockDialog')).toHaveAttribute(
+      'aria-modal',
+      'false',
+    );
+  });
+
+  it('stops event propagation on dialog click', () => {
+    render(
+      <Dialog isOpen={true} onClose={onClose}>
+        <div>Dialog content</div>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByTestId('ockDialog');
+    const clickEvent = new MouseEvent('click', { bubbles: true });
+    const stopPropagationSpy = vi.spyOn(clickEvent, 'stopPropagation');
+
+    fireEvent(dialog, clickEvent);
+    expect(stopPropagationSpy).toHaveBeenCalled();
+  });
+
+  it('stops propagation of Enter and Space key events', () => {
+    render(
+      <Dialog isOpen={true} onClose={onClose}>
+        <div>Dialog content</div>
+      </Dialog>,
+    );
+
+    const dialog = screen.getByTestId('ockDialog');
+
+    const enterEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+    });
+    const spaceEvent = new KeyboardEvent('keydown', {
+      key: ' ',
+      bubbles: true,
+    });
+
+    const enterSpy = vi.spyOn(enterEvent, 'stopPropagation');
+    const spaceSpy = vi.spyOn(spaceEvent, 'stopPropagation');
+
+    fireEvent(dialog, enterEvent);
+    fireEvent(dialog, spaceEvent);
+
+    expect(enterSpy).toHaveBeenCalled();
+    expect(spaceSpy).toHaveBeenCalled();
+  });
+
+  it('calls onClose when clicking outside or pressing Escape', () => {
+    render(
+      <Dialog isOpen={true} onClose={onClose}>
+        <div>Dialog content</div>
+      </Dialog>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    fireEvent.pointerDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/internal/primitives/Dialog.test.tsx
+++ b/src/internal/primitives/Dialog.test.tsx
@@ -10,8 +10,7 @@ describe('Dialog', () => {
   const onClose = vi.fn();
 
   beforeEach(() => {
-    onClose.mockClear();
-
+    vi.clearAllMocks();
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
       value: vi.fn().mockImplementation((query) => ({
@@ -27,113 +26,196 @@ describe('Dialog', () => {
     });
   });
 
-  it('renders nothing when isOpen is false', () => {
-    render(
-      <Dialog isOpen={false} onClose={onClose}>
-        <div>Dialog content</div>
-      </Dialog>,
-    );
-
-    expect(screen.queryByTestId('ockDialog')).not.toBeInTheDocument();
-  });
-
-  it('renders content when isOpen is true', () => {
-    render(
-      <Dialog isOpen={true} onClose={onClose}>
-        <div data-testid="content">Dialog content</div>
-      </Dialog>,
-    );
-
-    expect(screen.getByTestId('ockDialog')).toBeInTheDocument();
-    expect(screen.getByTestId('content')).toBeInTheDocument();
-  });
-
-  it('sets correct ARIA attributes', () => {
-    render(
-      <Dialog
-        isOpen={true}
-        ariaLabel="Test Dialog"
-        ariaDescribedby="dialog-desc"
-        ariaLabelledby="dialog-title"
-        onClose={() => {}}
-      >
-        <div>Dialog content</div>
-      </Dialog>,
-    );
-
-    const dialog = screen.getByTestId('ockDialog');
-    expect(dialog).toHaveAttribute('aria-label', 'Test Dialog');
-    expect(dialog).toHaveAttribute('aria-describedby', 'dialog-desc');
-    expect(dialog).toHaveAttribute('aria-labelledby', 'dialog-title');
-  });
-
-  it('sets modal attribute correctly', () => {
-    render(
-      <Dialog isOpen={true} modal={false}>
-        <div>Dialog content</div>
-      </Dialog>,
-    );
-
-    expect(screen.getByTestId('ockDialog')).toHaveAttribute(
-      'aria-modal',
-      'false',
-    );
-  });
-
-  it('stops event propagation on dialog click', () => {
-    render(
-      <Dialog isOpen={true} onClose={onClose}>
-        <div>Dialog content</div>
-      </Dialog>,
-    );
-
-    const dialog = screen.getByTestId('ockDialog');
-    const clickEvent = new MouseEvent('click', { bubbles: true });
-    const stopPropagationSpy = vi.spyOn(clickEvent, 'stopPropagation');
-
-    fireEvent(dialog, clickEvent);
-    expect(stopPropagationSpy).toHaveBeenCalled();
-  });
-
-  it('stops propagation of Enter and Space key events', () => {
-    render(
-      <Dialog isOpen={true} onClose={onClose}>
-        <div>Dialog content</div>
-      </Dialog>,
-    );
-
-    const dialog = screen.getByTestId('ockDialog');
-
-    const enterEvent = new KeyboardEvent('keydown', {
-      key: 'Enter',
-      bubbles: true,
-    });
-    const spaceEvent = new KeyboardEvent('keydown', {
-      key: ' ',
-      bubbles: true,
+  describe('rendering', () => {
+    it('renders nothing when isOpen is false', () => {
+      render(
+        <Dialog isOpen={false} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+      expect(screen.queryByTestId('ockDialog')).not.toBeInTheDocument();
     });
 
-    const enterSpy = vi.spyOn(enterEvent, 'stopPropagation');
-    const spaceSpy = vi.spyOn(spaceEvent, 'stopPropagation');
-
-    fireEvent(dialog, enterEvent);
-    fireEvent(dialog, spaceEvent);
-
-    expect(enterSpy).toHaveBeenCalled();
-    expect(spaceSpy).toHaveBeenCalled();
+    it('renders content when isOpen is true', () => {
+      render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div data-testid="content">Content</div>
+        </Dialog>,
+      );
+      expect(screen.getByTestId('ockDialog')).toBeInTheDocument();
+      expect(screen.getByTestId('content')).toBeInTheDocument();
+    });
   });
 
-  it('calls onClose when clicking outside or pressing Escape', () => {
-    render(
-      <Dialog isOpen={true} onClose={onClose}>
-        <div>Dialog content</div>
-      </Dialog>,
-    );
+  describe('accessibility', () => {
+    it('sets all ARIA attributes correctly', () => {
+      render(
+        <Dialog
+          isOpen={true}
+          aria-label="Test Dialog"
+          aria-describedby="desc"
+          aria-labelledby="title"
+          modal={false}
+          onClose={onClose}
+        >
+          <div>Content</div>
+        </Dialog>,
+      );
 
-    fireEvent.keyDown(document, { key: 'Escape' });
-    expect(onClose).toHaveBeenCalledTimes(1);
+      const dialog = screen.getByTestId('ockDialog');
+      expect(dialog).toHaveAttribute('role', 'dialog');
+      expect(dialog).toHaveAttribute('aria-label', 'Test Dialog');
+      expect(dialog).toHaveAttribute('aria-describedby', 'desc');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'title');
+      expect(dialog).toHaveAttribute('aria-modal', 'false');
+    });
 
-    fireEvent.pointerDown(document.body);
-    expect(onClose).toHaveBeenCalledTimes(2);
+    it('uses default modal=true when not specified', () => {
+      render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+      expect(screen.getByTestId('ockDialog')).toHaveAttribute(
+        'aria-modal',
+        'true',
+      );
+    });
+  });
+
+  describe('event handling', () => {
+    it('stops propagation of click events on dialog', () => {
+      render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      const dialog = screen.getByTestId('ockDialog');
+      const clickEvent = new MouseEvent('click', { bubbles: true });
+      const stopPropagationSpy = vi.spyOn(clickEvent, 'stopPropagation');
+
+      fireEvent(dialog, clickEvent);
+      expect(stopPropagationSpy).toHaveBeenCalled();
+    });
+
+    it('stops propagation of Enter and Space key events', () => {
+      render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      const dialog = screen.getByTestId('ockDialog');
+      for (const key of ['Enter', ' ']) {
+        const event = new KeyboardEvent('keydown', { key, bubbles: true });
+        const spy = vi.spyOn(event, 'stopPropagation');
+        fireEvent(dialog, event);
+        expect(spy).toHaveBeenCalled();
+      }
+    });
+
+    it('does not stop propagation of other key events', () => {
+      render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      const dialog = screen.getByTestId('ockDialog');
+      const event = new KeyboardEvent('keydown', { key: 'A', bubbles: true });
+      const spy = vi.spyOn(event, 'stopPropagation');
+      fireEvent(dialog, event);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dismissal behavior', () => {
+    it('calls onClose when clicking outside', () => {
+      render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      fireEvent.pointerDown(document.body);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when pressing Escape', () => {
+      render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles undefined onClose prop gracefully', () => {
+      render(
+        <Dialog isOpen={true}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      fireEvent.pointerDown(document.body);
+      fireEvent.keyDown(document, { key: 'Escape' });
+    });
+  });
+
+  describe('theme and styling', () => {
+    it('applies correct theme classes to outer container', () => {
+      const { container } = render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      const outerContainer = container.querySelector('[class*="fixed"]');
+      const expectedClasses = [
+        'fixed',
+        'inset-0',
+        'z-50',
+        'flex',
+        'items-center',
+        'justify-center',
+        'bg-black/50',
+        'transition-opacity',
+        'duration-200',
+        'fade-in',
+        'animate-in',
+      ];
+
+      for (const className of expectedClasses) {
+        expect(outerContainer).toHaveClass(className);
+      }
+    });
+
+    it('applies animation classes to dialog container', () => {
+      render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      const dialog = screen.getByTestId('ockDialog');
+      expect(dialog).toHaveClass('zoom-in-95');
+      expect(dialog).toHaveClass('animate-in');
+      expect(dialog).toHaveClass('duration-200');
+    });
+  });
+
+  describe('portal rendering', () => {
+    it('renders in portal', () => {
+      const { baseElement } = render(
+        <Dialog isOpen={true} onClose={onClose}>
+          <div>Content</div>
+        </Dialog>,
+      );
+
+      expect(baseElement.contains(screen.getByTestId('ockDialog'))).toBe(true);
+    });
   });
 });

--- a/src/internal/primitives/Dialog.tsx
+++ b/src/internal/primitives/Dialog.tsx
@@ -1,0 +1,77 @@
+import type React from 'react';
+import { useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { useTheme } from '../../core-react/internal/hooks/useTheme';
+import { cn } from '../../styles/theme';
+import { DismissableLayer } from './DismissableLayer';
+import { FocusTrap } from './FocusTrap';
+
+type DialogProps = {
+  children?: React.ReactNode;
+  isOpen?: boolean;
+  onClose?: () => void;
+  modal?: boolean;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+  ariaDescribedby?: string;
+};
+
+/**
+ * Dialog primitive that handles:
+ * Portaling to document.body
+ * Focus management (trapping focus within dialog)
+ * Click outside and escape key dismissal
+ * Proper ARIA attributes for accessibility
+ */
+export function Dialog({
+  children,
+  isOpen,
+  modal = true,
+  onClose,
+  ariaLabel,
+  ariaLabelledby,
+  ariaDescribedby,
+}: DialogProps) {
+  const componentTheme = useTheme();
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const dialog = (
+    <div
+      className={cn(
+        componentTheme,
+        'fixed inset-0 z-50 flex items-center justify-center',
+        'bg-black/50 transition-opacity duration-200',
+        'fade-in animate-in duration-200',
+      )}
+    >
+      <FocusTrap active={isOpen}>
+        <DismissableLayer onDismiss={onClose}>
+          <div
+            aria-modal={modal}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+            aria-describedby={ariaDescribedby}
+            data-testid="ockDialog"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.stopPropagation();
+              }
+            }}
+            ref={dialogRef}
+            role="dialog"
+            className="zoom-in-95 animate-in duration-200"
+          >
+            {children}
+          </div>
+        </DismissableLayer>
+      </FocusTrap>
+    </div>
+  );
+
+  return createPortal(dialog, document.body);
+}

--- a/src/internal/primitives/Dialog.tsx
+++ b/src/internal/primitives/Dialog.tsx
@@ -11,9 +11,9 @@ type DialogProps = {
   isOpen?: boolean;
   onClose?: () => void;
   modal?: boolean;
-  ariaLabel?: string;
-  ariaLabelledby?: string;
-  ariaDescribedby?: string;
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+  'aria-describedby'?: string;
 };
 
 /**
@@ -28,9 +28,9 @@ export function Dialog({
   isOpen,
   modal = true,
   onClose,
-  ariaLabel,
-  ariaLabelledby,
-  ariaDescribedby,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledby,
+  'aria-describedby': ariaDescribedby,
 }: DialogProps) {
   const componentTheme = useTheme();
   const dialogRef = useRef<HTMLDivElement>(null);

--- a/src/internal/primitives/DismissableLayer.test.tsx
+++ b/src/internal/primitives/DismissableLayer.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DismissableLayer } from './DismissableLayer';
+
+describe('DismissableLayer', () => {
+  const onDismiss = vi.fn();
+
+  beforeEach(() => {
+    onDismiss.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <DismissableLayer>
+        <div data-testid="child">Test Content</div>
+      </DismissableLayer>,
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('calls onDismiss when Escape key is pressed', () => {
+    render(
+      <DismissableLayer onDismiss={onDismiss}>
+        <div>Test Content</div>
+      </DismissableLayer>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onDismiss when Escape key is pressed and disableEscapeKey is true', () => {
+    render(
+      <DismissableLayer onDismiss={onDismiss} disableEscapeKey={true}>
+        <div>Test Content</div>
+      </DismissableLayer>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('calls onDismiss when clicking outside', () => {
+    render(
+      <DismissableLayer onDismiss={onDismiss}>
+        <div>Test Content</div>
+      </DismissableLayer>,
+    );
+
+    fireEvent.pointerDown(document.body);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onDismiss when clicking inside', () => {
+    render(
+      <DismissableLayer onDismiss={onDismiss}>
+        <div data-testid="inner">Test Content</div>
+      </DismissableLayer>,
+    );
+
+    const innerElement = screen.getByTestId('inner');
+    fireEvent.pointerDown(innerElement);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('does not call onDismiss when clicking outside and disableOutsideClick is true', () => {
+    render(
+      <DismissableLayer onDismiss={onDismiss} disableOutsideClick={true}>
+        <div>Test Content</div>
+      </DismissableLayer>,
+    );
+
+    fireEvent.pointerDown(document.body);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('handles case when both disableEscapeKey and disableOutsideClick are true', () => {
+    render(
+      <DismissableLayer
+        onDismiss={onDismiss}
+        disableEscapeKey={true}
+        disableOutsideClick={true}
+      >
+        <div>Test Content</div>
+      </DismissableLayer>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.pointerDown(document.body);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('handles undefined onDismiss prop gracefully', () => {
+    render(
+      <DismissableLayer>
+        <div>Test Content</div>
+      </DismissableLayer>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    fireEvent.pointerDown(document.body);
+  });
+});

--- a/src/internal/primitives/DismissableLayer.tsx
+++ b/src/internal/primitives/DismissableLayer.tsx
@@ -1,0 +1,75 @@
+import type React from 'react';
+import { useEffect, useRef } from 'react';
+
+type DismissableLayerProps = {
+  children?: React.ReactNode;
+  disableEscapeKey?: boolean;
+  disableOutsideClick?: boolean;
+  onDismiss?: () => void;
+};
+
+// DismissableLayer handles dismissal using outside clicks and escape key events
+export function DismissableLayer({
+  children,
+  disableEscapeKey = false,
+  disableOutsideClick = false,
+  onDismiss,
+}: DismissableLayerProps) {
+  const layerRef = useRef<HTMLDivElement>(null);
+  // Tracks whether the pointer event originated inside the React component tree
+  const isPointerInsideReactTreeRef = useRef(false);
+
+  useEffect(() => {
+    if (disableOutsideClick && disableEscapeKey) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!disableEscapeKey && event.key === 'Escape') {
+        onDismiss?.();
+      }
+    };
+
+    const shouldDismiss = (target: Node) => {
+      return layerRef.current && !layerRef.current.contains(target);
+    };
+
+    // Handle clicks outside the layer
+    const handlePointerDown = (event: PointerEvent) => {
+      // Skip if outside clicks are disabled or if the click started inside the component
+      if (disableOutsideClick || isPointerInsideReactTreeRef.current) {
+        isPointerInsideReactTreeRef.current = false;
+        return;
+      }
+
+      // Dismiss if click is outside the layer
+      if (shouldDismiss(event.target as Node)) {
+        onDismiss?.();
+      }
+      // Reset the flag after handling the event
+      isPointerInsideReactTreeRef.current = false;
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('pointerdown', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [disableOutsideClick, disableEscapeKey, onDismiss]);
+
+  return (
+    <div
+      data-testid="ockDismissableLayer"
+      // Set flag when pointer event starts inside the component
+      // This prevents dismissal when dragging from inside to outside
+      onPointerDownCapture={() => {
+        isPointerInsideReactTreeRef.current = true;
+      }}
+      ref={layerRef}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/internal/primitives/FocusTrap.test.tsx
+++ b/src/internal/primitives/FocusTrap.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { FocusTrap } from './FocusTrap';
+
+describe('FocusTrap', () => {
+  beforeEach(() => {
+    document.body.focus();
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <FocusTrap>
+        <div data-testid="child">Test Content</div>
+      </FocusTrap>,
+    );
+
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('focuses first focusable element when mounted', () => {
+    render(
+      <FocusTrap>
+        <div>
+          <button type="button" data-testid="first">
+            First
+          </button>
+          <button type="button">Second</button>
+        </div>
+      </FocusTrap>,
+    );
+
+    expect(screen.getByTestId('first')).toHaveFocus();
+  });
+
+  it('does not trap focus when active is false', () => {
+    render(
+      <FocusTrap active={false}>
+        <div>
+          <button type="button" data-testid="first">
+            First
+          </button>
+          <button type="button">Second</button>
+        </div>
+      </FocusTrap>,
+    );
+
+    expect(screen.getByTestId('first')).not.toHaveFocus();
+  });
+
+  it('cycles focus forward with Tab key', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FocusTrap>
+        <div>
+          <button type="button" data-testid="first">
+            First
+          </button>
+          <button type="button" data-testid="second">
+            Second
+          </button>
+          <button type="button" data-testid="third">
+            Third
+          </button>
+        </div>
+      </FocusTrap>,
+    );
+
+    const first = screen.getByTestId('first');
+    const second = screen.getByTestId('second');
+    const third = screen.getByTestId('third');
+
+    expect(first).toHaveFocus();
+
+    await user.tab();
+    expect(second).toHaveFocus();
+
+    await user.tab();
+    expect(third).toHaveFocus();
+
+    await user.tab();
+    expect(first).toHaveFocus();
+  });
+
+  it('cycles focus backward with Shift+Tab', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FocusTrap>
+        <div>
+          <button type="button" data-testid="first">
+            First
+          </button>
+          <button type="button" data-testid="second">
+            Second
+          </button>
+          <button type="button" data-testid="third">
+            Third
+          </button>
+        </div>
+      </FocusTrap>,
+    );
+
+    const first = screen.getByTestId('first');
+    const second = screen.getByTestId('second');
+    const third = screen.getByTestId('third');
+
+    expect(first).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(third).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(second).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(first).toHaveFocus();
+  });
+
+  it('handles container with no focusable elements', () => {
+    render(
+      <FocusTrap>
+        <div data-testid="no-focusable">
+          <p>No focusable elements here</p>
+        </div>
+      </FocusTrap>,
+    );
+
+    const container = screen.getByTestId('no-focusable');
+    fireEvent.keyDown(container, { key: 'Tab' });
+  });
+
+  it('ignores non-Tab key events', () => {
+    render(
+      <FocusTrap>
+        <div>
+          <button type="button" data-testid="first">
+            First
+          </button>
+          <button type="button" data-testid="second">
+            Second
+          </button>
+        </div>
+      </FocusTrap>,
+    );
+
+    const first = screen.getByTestId('first');
+
+    fireEvent.keyDown(first, { key: 'Enter' });
+    expect(first).toHaveFocus();
+
+    fireEvent.keyDown(first, { key: ' ' });
+    expect(first).toHaveFocus();
+  });
+});

--- a/src/internal/primitives/FocusTrap.tsx
+++ b/src/internal/primitives/FocusTrap.tsx
@@ -2,7 +2,7 @@ import type React from 'react';
 import { useEffect, useRef } from 'react';
 
 const FOCUSABLE_ELEMENTS_SELECTOR =
-  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 interface FocusTrapProps {
   active?: boolean;

--- a/src/internal/primitives/FocusTrap.tsx
+++ b/src/internal/primitives/FocusTrap.tsx
@@ -1,0 +1,83 @@
+import type React from 'react';
+import { useEffect, useRef } from 'react';
+
+const FOCUSABLE_ELEMENTS_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+interface FocusTrapProps {
+  active?: boolean;
+  children?: React.ReactNode;
+}
+
+// FocusTrap ensures keyboard focus remains within a contained area for accessibility
+export function FocusTrap({ active = true, children }: FocusTrapProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    // Store currently focused element to restore later
+    previousFocusRef.current = document.activeElement as HTMLElement;
+
+    if (containerRef.current) {
+      // Query all interactive elements that can receive focus
+      const firstFocusable = containerRef.current.querySelector<HTMLElement>(
+        FOCUSABLE_ELEMENTS_SELECTOR,
+      );
+      firstFocusable?.focus();
+    }
+
+    return () => {
+      // Restore focus to previous element when trap is destroyed
+      previousFocusRef.current?.focus();
+    };
+  }, [active]);
+
+  const getFocusableElements = () =>
+    containerRef.current?.querySelectorAll<HTMLElement>(
+      FOCUSABLE_ELEMENTS_SELECTOR,
+    );
+
+  const handleTabNavigation = (
+    event: React.KeyboardEvent,
+    elements: NodeListOf<HTMLElement>,
+  ) => {
+    const firstElement = elements[0];
+    const lastElement = elements[elements.length - 1];
+    const isFirstElement = document.activeElement === firstElement;
+    const isLastElement = document.activeElement === lastElement;
+
+    if (event.shiftKey && isFirstElement) {
+      event.preventDefault();
+      lastElement.focus();
+    } else if (!event.shiftKey && isLastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (!active || event.key !== 'Tab') {
+      return;
+    }
+
+    const focusableElements = getFocusableElements();
+    if (!focusableElements?.length) {
+      return;
+    }
+
+    handleTabNavigation(event, focusableElements);
+  };
+
+  return (
+    <div
+      data-testid="ockFocusTrap"
+      onKeyDown={handleKeyDown}
+      ref={containerRef}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/wallet/components/ConnectWallet.test.tsx
+++ b/src/wallet/components/ConnectWallet.test.tsx
@@ -45,6 +45,20 @@ vi.mock('../../core-react/useOnchainKit', () => ({
 
 describe('ConnectWallet', () => {
   beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
     vi.mocked(useAccount).mockReturnValue({
       address: '',
       status: 'disconnected',
@@ -341,32 +355,6 @@ describe('ConnectWallet', () => {
   });
 
   describe('modal handling', () => {
-    it('should close modal when clicking overlay', () => {
-      vi.mocked(useOnchainKit).mockReturnValue({
-        config: { wallet: { display: 'modal' } },
-      });
-      vi.mocked(useAccount).mockReturnValue({
-        address: '',
-        status: 'disconnected',
-      });
-
-      const setIsConnectModalOpenMock = vi.fn();
-      vi.mocked(useWalletContext).mockReturnValue({
-        isConnectModalOpen: true,
-        setIsConnectModalOpen: setIsConnectModalOpenMock,
-      });
-
-      render(<ConnectWallet text="Connect Wallet" />);
-
-      const connectButton = screen.getByTestId('ockConnectButton');
-      fireEvent.click(connectButton);
-
-      const modalOverlay = screen.getByTestId('ockModalOverlay');
-      fireEvent.click(modalOverlay);
-
-      expect(setIsConnectModalOpenMock).toHaveBeenCalledWith(false);
-    });
-
     it('should close modal when clicking close button', () => {
       vi.mocked(useOnchainKit).mockReturnValue({
         config: { wallet: { display: 'modal' } },

--- a/src/wallet/components/ConnectWallet.tsx
+++ b/src/wallet/components/ConnectWallet.tsx
@@ -109,9 +109,7 @@ export function ConnectWallet({
             }}
             text={text}
           />
-          {isModalOpen && (
-            <WalletModal isOpen={true} onClose={handleCloseConnectModal} />
-          )}
+          <WalletModal isOpen={isModalOpen} onClose={handleCloseConnectModal} />
         </div>
       );
     }

--- a/src/wallet/components/WalletModal.tsx
+++ b/src/wallet/components/WalletModal.tsx
@@ -120,6 +120,7 @@ export function WalletModal({
             border.default,
             'absolute top-4 right-4',
             'flex items-center justify-center p-1',
+            'bg-current',
             'transition-colors duration-200',
           )}
           aria-label="Close modal"


### PR DESCRIPTION
**What changed? Why?**
Introduces new UI primitive components - `FocusTrap`, `DismissableLayer`, and `Dialog`.

`FocusTrap`:

- Ensures keyboard focus remains within a contained area for accessibility

`DismissableLayer`:

- Handles dismissal using outside clicks and escape key events

`Dialog`:
 * Portaling to document.body
 * Focus management (trapping focus within dialog)
 * Click outside and escape key dismissal
 * Proper ARIA attributes for accessibility

Design Principles: 
- Limited styling 
- ARIA Accessibility built in
- Optional props by default 
- Stand-alone primitive components

Updated `WalletModal` to use the primitives for:
- Proper modal dialog behavior with ARIA attributes
- Focus trapping for keyboard navigation
- Click outside and escape key dismissal
- Portal-based rendering

**Notes to reviewers**

**How has it been tested?**
