### PR TITLE
chore: export getPortfolios

### DIFF
--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.36.5",
+  "version": "0.36.6",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",

--- a/src/core-react/wallet/hooks/useSinglePortfolio.test.tsx
+++ b/src/core-react/wallet/hooks/useSinglePortfolio.test.tsx
@@ -1,4 +1,4 @@
-import { getPortfolioTokenBalances } from '@/core/api/getPortfolioTokenBalances';
+import { getPortfolios } from '@/core/api/getPortfolios';
 import type {
   PortfolioTokenBalances,
   PortfolioTokenWithFiatValue,
@@ -6,9 +6,9 @@ import type {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { usePortfolioTokenBalances } from './usePortfolioTokenBalances';
+import { useSinglePortfolio } from './useSinglePortfolio';
 
-vi.mock('@/core/api/getPortfolioTokenBalances');
+vi.mock('@/core/api/getPortfolios');
 
 const mockAddress: `0x${string}` = '0x123';
 const mockTokens: PortfolioTokenWithFiatValue[] = [
@@ -48,12 +48,12 @@ describe('usePortfolioTokenBalances', () => {
   });
 
   it('should fetch token balances successfully', async () => {
-    vi.mocked(getPortfolioTokenBalances).mockResolvedValueOnce({
+    vi.mocked(getPortfolios).mockResolvedValueOnce({
       portfolios: [mockPortfolioTokenBalances],
     });
 
     const { result } = renderHook(
-      () => usePortfolioTokenBalances({ address: mockAddress }),
+      () => useSinglePortfolio({ address: mockAddress }),
       { wrapper: createWrapper() },
     );
 
@@ -61,7 +61,7 @@ describe('usePortfolioTokenBalances', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getPortfolioTokenBalances).toHaveBeenCalledWith({
+    expect(getPortfolios).toHaveBeenCalledWith({
       addresses: [mockAddress],
     });
 
@@ -69,14 +69,14 @@ describe('usePortfolioTokenBalances', () => {
   });
 
   it('should handle API errors', async () => {
-    vi.mocked(getPortfolioTokenBalances).mockResolvedValueOnce({
+    vi.mocked(getPortfolios).mockResolvedValueOnce({
       code: 'API Error',
       error: 'API Error',
       message: 'API Error',
     });
 
     const { result } = renderHook(
-      () => usePortfolioTokenBalances({ address: mockAddress }),
+      () => useSinglePortfolio({ address: mockAddress }),
       { wrapper: createWrapper() },
     );
 
@@ -87,31 +87,28 @@ describe('usePortfolioTokenBalances', () => {
   });
 
   it('should not fetch when address is empty', () => {
-    renderHook(
-      () => usePortfolioTokenBalances({ address: '' as `0x${string}` }),
-      {
-        wrapper: createWrapper(),
-      },
-    );
-
-    expect(getPortfolioTokenBalances).not.toHaveBeenCalled();
-  });
-
-  it('should not fetch when address is undefined', () => {
-    renderHook(() => usePortfolioTokenBalances({ address: undefined }), {
+    renderHook(() => useSinglePortfolio({ address: '' as `0x${string}` }), {
       wrapper: createWrapper(),
     });
 
-    expect(getPortfolioTokenBalances).not.toHaveBeenCalled();
+    expect(getPortfolios).not.toHaveBeenCalled();
+  });
+
+  it('should not fetch when address is undefined', () => {
+    renderHook(() => useSinglePortfolio({ address: undefined }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(getPortfolios).not.toHaveBeenCalled();
   });
 
   it('should return empty data when portfolios is empty', async () => {
-    vi.mocked(getPortfolioTokenBalances).mockResolvedValueOnce({
+    vi.mocked(getPortfolios).mockResolvedValueOnce({
       portfolios: [],
     });
 
     const { result } = renderHook(
-      () => usePortfolioTokenBalances({ address: mockAddress }),
+      () => useSinglePortfolio({ address: mockAddress }),
       { wrapper: createWrapper() },
     );
 

--- a/src/core-react/wallet/hooks/useSinglePortfolio.ts
+++ b/src/core-react/wallet/hooks/useSinglePortfolio.ts
@@ -1,10 +1,10 @@
-import { getPortfolioTokenBalances } from '@/core/api/getPortfolioTokenBalances';
+import { getPortfolios } from '@/core/api/getPortfolios';
 import type { PortfolioTokenBalances } from '@/core/api/types';
 import { isApiError } from '@/core/utils/isApiResponseError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { Address } from 'viem';
 
-export function usePortfolioTokenBalances({
+export function useSinglePortfolio({
   address,
 }: {
   address: Address | undefined | null;
@@ -12,7 +12,7 @@ export function usePortfolioTokenBalances({
   return useQuery({
     queryKey: ['usePortfolioTokenBalances', address],
     queryFn: async () => {
-      const response = await getPortfolioTokenBalances({
+      const response = await getPortfolios({
         addresses: [address as Address], // Safe to coerce to Address because useQuery's enabled flag will prevent the query from running if address is undefined
       });
 

--- a/src/core-react/wallet/hooks/useSinglePortfolio.ts
+++ b/src/core-react/wallet/hooks/useSinglePortfolio.ts
@@ -10,7 +10,7 @@ export function useSinglePortfolio({
   address: Address | undefined | null;
 }): UseQueryResult<PortfolioTokenBalances> {
   return useQuery({
-    queryKey: ['usePortfolioTokenBalances', address],
+    queryKey: ['useSinglePortfolio', address],
     queryFn: async () => {
       const response = await getPortfolios({
         addresses: [address as Address], // Safe to coerce to Address because useQuery's enabled flag will prevent the query from running if address is undefined

--- a/src/core/api/getPortfolioTokenBalances.ts
+++ b/src/core/api/getPortfolioTokenBalances.ts
@@ -2,7 +2,7 @@ import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '../network/definitions/wallet'
 import { sendRequest } from '../network/request';
 import type {
   GetPortfolioTokenBalancesParams,
-  GetPortfoliosAPIResponse,
+  GetPortfolioTokenBalancesResponse,
 } from './types';
 
 export async function getPortfolioTokenBalances({
@@ -11,7 +11,7 @@ export async function getPortfolioTokenBalances({
   try {
     const res = await sendRequest<
       GetPortfolioTokenBalancesParams,
-      GetPortfoliosAPIResponse
+      GetPortfolioTokenBalancesResponse
     >(CDP_GET_PORTFOLIO_TOKEN_BALANCES, [{ addresses }]);
     if (res.error) {
       return {

--- a/src/core/api/getPortfolios.test.ts
+++ b/src/core/api/getPortfolios.test.ts
@@ -6,7 +6,7 @@ import type { Address } from 'viem';
 import { type Mock, describe, expect, it, vi } from 'vitest';
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '../network/definitions/wallet';
 import { sendRequest } from '../network/request';
-import { getPortfolioTokenBalances } from './getPortfolioTokenBalances';
+import { getPortfolios } from './getPortfolios';
 
 vi.mock('../network/request', () => ({
   sendRequest: vi.fn(),
@@ -45,7 +45,7 @@ describe('getPortfolioTokenBalances', () => {
       result: mockSuccessResponse,
     });
 
-    const result = await getPortfolioTokenBalances({
+    const result = await getPortfolios({
       addresses: mockAddresses,
     });
 
@@ -67,7 +67,7 @@ describe('getPortfolioTokenBalances', () => {
       error: mockError,
     });
 
-    const result = await getPortfolioTokenBalances({
+    const result = await getPortfolios({
       addresses: mockAddresses,
     });
 
@@ -82,7 +82,7 @@ describe('getPortfolioTokenBalances', () => {
     const errorMessage = 'Network Error';
     mockSendRequest.mockRejectedValueOnce(new Error(errorMessage));
 
-    const result = await getPortfolioTokenBalances({
+    const result = await getPortfolios({
       addresses: mockAddresses,
     });
 

--- a/src/core/api/getPortfolios.ts
+++ b/src/core/api/getPortfolios.ts
@@ -1,18 +1,13 @@
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '../network/definitions/wallet';
 import { sendRequest } from '../network/request';
-import type {
-  GetPortfolioTokenBalancesParams,
-  GetPortfolioTokenBalancesResponse,
-} from './types';
+import type { GetPortfoliosParams, GetPortfoliosResponse } from './types';
 
-export async function getPortfolioTokenBalances({
-  addresses,
-}: GetPortfolioTokenBalancesParams) {
+export async function getPortfolios({ addresses }: GetPortfoliosParams) {
   try {
-    const res = await sendRequest<
-      GetPortfolioTokenBalancesParams,
-      GetPortfolioTokenBalancesResponse
-    >(CDP_GET_PORTFOLIO_TOKEN_BALANCES, [{ addresses }]);
+    const res = await sendRequest<GetPortfoliosParams, GetPortfoliosResponse>(
+      CDP_GET_PORTFOLIO_TOKEN_BALANCES,
+      [{ addresses }],
+    );
     if (res.error) {
       return {
         code: `${res.error.code}`,

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -5,6 +5,7 @@ export { buildPayTransaction } from './buildPayTransaction';
 export { getMintDetails } from './getMintDetails';
 export { getSwapQuote } from './getSwapQuote';
 export { getTokenDetails } from './getTokenDetails';
+export { getPortfolioTokenBalances } from './getPortfolioTokenBalances';
 export { getTokens } from './getTokens';
 export type {
   APIError,
@@ -23,4 +24,6 @@ export type {
   GetTokenDetailsResponse,
   GetTokensOptions,
   GetTokensResponse,
+  GetPortfolioTokenBalancesParams,
+  GetPortfolioTokenBalancesResponse,
 } from './types';

--- a/src/core/api/index.ts
+++ b/src/core/api/index.ts
@@ -5,7 +5,7 @@ export { buildPayTransaction } from './buildPayTransaction';
 export { getMintDetails } from './getMintDetails';
 export { getSwapQuote } from './getSwapQuote';
 export { getTokenDetails } from './getTokenDetails';
-export { getPortfolioTokenBalances } from './getPortfolioTokenBalances';
+export { getPortfolios } from './getPortfolios';
 export { getTokens } from './getTokens';
 export type {
   APIError,
@@ -24,6 +24,6 @@ export type {
   GetTokenDetailsResponse,
   GetTokensOptions,
   GetTokensResponse,
-  GetPortfolioTokenBalancesParams,
-  GetPortfolioTokenBalancesResponse,
+  GetPortfoliosParams,
+  GetPortfoliosResponse,
 } from './types';

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -258,23 +258,17 @@ export type GetPortfolioTokenBalancesParams = {
 /**
  * Note: exported as public Type
  */
+export type GetPortfolioTokenBalancesResponse = {
+  portfolios: PortfolioTokenBalances[];
+};
+
 export type PortfolioTokenBalances = {
   address: Address;
   portfolioBalanceInUsd: number;
   tokenBalances: PortfolioTokenWithFiatValue[];
 };
 
-/**
- * Note: exported as public Type
- */
 export type PortfolioTokenWithFiatValue = Token & {
   cryptoBalance: number;
   fiatBalance: number;
-};
-
-/**
- * Note: exported as public Type
- */
-export type GetPortfoliosAPIResponse = {
-  portfolios: PortfolioTokenBalances[];
 };

--- a/src/core/api/types.ts
+++ b/src/core/api/types.ts
@@ -251,14 +251,14 @@ export type BuildMintTransactionResponse = MintTransaction | APIError;
 /**
  * Note: exported as public Type
  */
-export type GetPortfolioTokenBalancesParams = {
+export type GetPortfoliosParams = {
   addresses: Address[] | null | undefined;
 };
 
 /**
  * Note: exported as public Type
  */
-export type GetPortfolioTokenBalancesResponse = {
+export type GetPortfoliosResponse = {
   portfolios: PortfolioTokenBalances[];
 };
 

--- a/src/wallet/components/WalletAdvancedProvider.test.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.test.tsx
@@ -1,4 +1,4 @@
-import { usePortfolioTokenBalances } from '@/core-react/wallet/hooks/usePortfolioTokenBalances';
+import { useSinglePortfolio } from '@/core-react/wallet/hooks/useSinglePortfolio';
 import { render, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
@@ -12,8 +12,8 @@ vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
 }));
 
-vi.mock('../../core-react/wallet/hooks/usePortfolioTokenBalances', () => ({
-  usePortfolioTokenBalances: vi.fn(),
+vi.mock('../../core-react/wallet/hooks/useSinglePortfolio', () => ({
+  useSinglePortfolio: vi.fn(),
 }));
 
 vi.mock('./WalletProvider', () => ({
@@ -31,7 +31,7 @@ describe('useWalletAdvancedContext', () => {
     isSubComponentClosing: false,
   };
 
-  const mockUsePortfolioTokenBalances = usePortfolioTokenBalances as ReturnType<
+  const mockUseSinglePortfolio = useSinglePortfolio as ReturnType<
     typeof vi.fn
   >;
 
@@ -40,7 +40,7 @@ describe('useWalletAdvancedContext', () => {
       address: '0x123',
     });
     mockUseWalletContext.mockReturnValue(defaultWalletContext);
-    mockUsePortfolioTokenBalances.mockReturnValue({
+    mockUseSinglePortfolio.mockReturnValue({
       data: {
         address: '0x123',
         tokenBalances: [],
@@ -105,7 +105,7 @@ describe('useWalletAdvancedContext', () => {
       wrapper: WalletAdvancedProvider,
     });
 
-    expect(mockUsePortfolioTokenBalances).toHaveBeenCalledWith({
+    expect(mockUseSinglePortfolio).toHaveBeenCalledWith({
       address: null,
     });
 
@@ -116,7 +116,7 @@ describe('useWalletAdvancedContext', () => {
 
     rerender();
 
-    expect(mockUsePortfolioTokenBalances).toHaveBeenCalledWith({
+    expect(mockUseSinglePortfolio).toHaveBeenCalledWith({
       address: '0x123',
     });
   });

--- a/src/wallet/components/WalletAdvancedProvider.test.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.test.tsx
@@ -31,9 +31,7 @@ describe('useWalletAdvancedContext', () => {
     isSubComponentClosing: false,
   };
 
-  const mockUseSinglePortfolio = useSinglePortfolio as ReturnType<
-    typeof vi.fn
-  >;
+  const mockUseSinglePortfolio = useSinglePortfolio as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockUseAccount.mockReturnValue({

--- a/src/wallet/components/WalletAdvancedProvider.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.tsx
@@ -1,5 +1,5 @@
 import { useValue } from '@/core-react/internal/hooks/useValue';
-import { usePortfolioTokenBalances } from '@/core-react/wallet/hooks/usePortfolioTokenBalances';
+import { useSinglePortfolio } from '@/core-react/wallet/hooks/useSinglePortfolio';
 import { type ReactNode, createContext, useContext, useState } from 'react';
 import type { WalletAdvancedContextType } from '../types';
 import { useWalletContext } from './WalletProvider';
@@ -37,7 +37,7 @@ export function WalletAdvancedProvider({
     refetch: refetchPortfolioData,
     isFetching: isFetchingPortfolioData,
     dataUpdatedAt: portfolioDataUpdatedAt,
-  } = usePortfolioTokenBalances({ address });
+  } = useSinglePortfolio({ address });
 
   const portfolioFiatValue = portfolioData?.portfolioBalanceInUsd;
   const tokenBalances = portfolioData?.tokenBalances;


### PR DESCRIPTION
**What changed? Why?**
* updated endpoint name to `getPortfolios` for clarity and accuracy
* updated hook name to `useSinglePortfolio` for clarity and accuracy
* updated response type to conform to convention
* exported endpoint with `src/core/api`

**Notes to reviewers**

**How has it been tested?**
* full test coverage