### PR TITLE
docs: Move Troubleshooting section to the Introduction

### DIFF
--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -3,7 +3,10 @@ import type { Sidebar } from 'vocs';
 export const sidebar = [
   {
     text: 'Introduction',
-    items: [{ text: 'Getting Started', link: '/getting-started' }],
+    items: [
+      { text: 'Getting Started', link: '/getting-started' },
+      { text: 'Troubleshooting', link: '/guides/troubleshooting' },
+    ],
   },
   {
     text: 'Installation',
@@ -50,10 +53,6 @@ export const sidebar = [
       {
         text: 'Theme Customization',
         link: '/guides/themes',
-      },
-      {
-        text: 'Troubleshooting',
-        link: '/guides/troubleshooting',
       },
       {
         text: 'Use Basename',


### PR DESCRIPTION
**What changed? Why?**
Initially under `Guides` we found that the Troubleshooting section was difficult to find. The `Introduction` section seems more appropriate. 

<img width="908" alt="Screenshot 2025-01-17 at 12 14 20 PM" src="https://github.com/user-attachments/assets/e8f2770a-3107-400e-ab33-4c681fac1af2" />

**Notes to reviewers**

**How has it been tested?**
