### PR TITLE
feat: export nft hooks

### DIFF
--- a/.changeset/perfect-knives-draw.md
+++ b/.changeset/perfect-knives-draw.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+***feat*** Added NFT data hooks. By @alessey #1838

--- a/src/core-react/nft/hooks/useMintDetails.ts
+++ b/src/core-react/nft/hooks/useMintDetails.ts
@@ -1,16 +1,17 @@
 import { getMintDetails } from '@/core/api/getMintDetails';
-import type { GetMintDetailsParams, MintDetails } from '@/core/api/types';
+import type { MintDetails } from '@/core/api/types';
 import { isNFTError } from '@/core/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
+import type { UseMintDetailsParams } from '../types';
 
 export function useMintDetails({
   contractAddress,
   takerAddress,
   tokenId,
-}: GetMintDetailsParams): UseQueryResult<MintDetails> {
-  const actionKey = `useMintDetails-${contractAddress}-${takerAddress}-${tokenId}`;
+  queryOptions,
+}: UseMintDetailsParams<MintDetails>): UseQueryResult<MintDetails> {
   return useQuery({
-    queryKey: ['useMintDetails', actionKey],
+    queryKey: ['useMintDetails', contractAddress, takerAddress, tokenId],
     queryFn: async () => {
       const mintDetails = await getMintDetails({
         contractAddress,
@@ -26,5 +27,6 @@ export function useMintDetails({
     },
     retry: false,
     refetchOnWindowFocus: false,
+    ...queryOptions,
   });
 }

--- a/src/core-react/nft/hooks/useTokenDetails.ts
+++ b/src/core-react/nft/hooks/useTokenDetails.ts
@@ -1,15 +1,16 @@
 import { getTokenDetails } from '@/core/api/getTokenDetails';
-import type { GetTokenDetailsParams, TokenDetails } from '@/core/api/types';
+import type { TokenDetails } from '@/core/api/types';
 import { isNFTError } from '@/core/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
+import type { UseTokenDetailsParams } from '../types';
 
 export function useTokenDetails({
   contractAddress,
   tokenId,
-}: GetTokenDetailsParams): UseQueryResult<TokenDetails> {
-  const actionKey = `useTokenDetails-${contractAddress}-${tokenId}`;
+  queryOptions,
+}: UseTokenDetailsParams<TokenDetails>): UseQueryResult<TokenDetails> {
   return useQuery({
-    queryKey: ['useTokenDetails', actionKey],
+    queryKey: ['useTokenDetails', contractAddress, tokenId],
     queryFn: async () => {
       const tokenDetails = await getTokenDetails({
         contractAddress,
@@ -24,5 +25,6 @@ export function useTokenDetails({
     },
     retry: false,
     refetchOnWindowFocus: false,
+    ...queryOptions,
   });
 }

--- a/src/core-react/nft/types.ts
+++ b/src/core-react/nft/types.ts
@@ -1,5 +1,12 @@
 import type { LifecycleStatusUpdate } from '@/core-react/internal/types';
-import type { ContractType, NFTError, NFTPrice } from '@/core/api/types';
+import type {
+  ContractType,
+  GetMintDetailsParams,
+  GetTokenDetailsParams,
+  NFTError,
+  NFTPrice,
+} from '@/core/api/types';
+import type { UseQueryOptions } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import type { Address, Hex, TransactionReceipt } from 'viem';
 import type { Call } from '../../transaction/types';
@@ -106,6 +113,20 @@ export type BuildMintTransactionDataProps = {
   tokenId?: string; // Token ID of the NFT
   quantity: number; // Quantity of the NFT to mint
   network?: string; // Network of the NFT
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type UseTokenDetailsParams<T> = GetTokenDetailsParams & {
+  queryOptions?: Omit<UseQueryOptions<T>, 'queryKey' | 'queryFn'>;
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type UseMintDetailsParams<T> = GetMintDetailsParams & {
+  queryOptions?: Omit<UseQueryOptions<T>, 'queryKey' | 'queryFn'>;
 };
 
 export type NFTReact = {

--- a/src/ui/react/nft/index.ts
+++ b/src/ui/react/nft/index.ts
@@ -17,3 +17,11 @@ export type {
   UseNFTData,
 } from '@/core-react/nft/types';
 export type { NFTError } from '@/core/api/types';
+
+// Hooks
+export { useTokenDetails } from '@/core-react/nft/hooks/useTokenDetails';
+export { useMintDetails } from '@/core-react/nft/hooks/useMintDetails';
+export type {
+  UseTokenDetailsParams,
+  UseMintDetailsParams,
+} from '@/core-react/nft/types';


### PR DESCRIPTION
**What changed? Why?**
Export nft hooks for useTokenDetails and useMintDetails, passthrough react-query options.

**Notes to reviewers**

**How has it been tested?**
