### PR TITLE
fix: update broken link docs README.md

### DIFF
--- a/create-onchain/templates/next/README.md
+++ b/create-onchain/templates/next/README.md
@@ -34,6 +34,6 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 ## Learn More
 
-To learn more about OnchainKit, see our [documentation](https://docs.onchainkit.com).
+To learn more about OnchainKit, see our [documentation](https://onchainkit.xyz/getting-started).
 
 To learn more about Next.js, see the [Next.js documentation](https://nextjs.org/docs).


### PR DESCRIPTION
Hi! In this PR, I fixed a broken link in the `README.md`. The link to the OnchainKit documentation now points to the correct URL (`https://onchainkit.xyz/getting-started`).

## Why is this needed?
The old link was no longer working, which could confuse users. This fix ensures access to the correct and up-to-date documentation.