### PR TITLE
fix: deprecate v1 swap amountReference to

### DIFF
--- a/src/api/buildSwapTransaction.test.ts
+++ b/src/api/buildSwapTransaction.test.ts
@@ -9,12 +9,14 @@ import type { BuildSwapTransaction } from './types';
  */
 import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
 import { getSwapTransaction } from './utils/getSwapTransaction';
+import { SwapMessage } from '@/swap/constants';
+import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 
 vi.mock('@/core/network/request');
 
 const testFromAddress = '0x6Cd01c0F55ce9E0Bf78f5E90f72b4345b16d515d';
 const testAmount = '3305894409732200';
-const testAmountReference = 'from';
+const testAmountReference = 'from' as const;
 
 describe('buildSwapTransaction', () => {
   beforeEach(() => {
@@ -197,6 +199,23 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_TRADE, [
       mockApiParams,
     ]);
+  });
+
+  it('should return an error for an unsupported amount reference', async () => {
+    const mockParams = {
+      useAggregator: true,
+      fromAddress: testFromAddress as `0x${string}`,
+      amountReference: 'to' as const,
+      from: ETH_TOKEN,
+      to: DEGEN_TOKEN,
+      amount: testAmount,
+    };
+    const error = await buildSwapTransaction(mockParams);
+    expect(error).toEqual({
+      code: UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE,
+      error: SwapMessage.UNSUPPORTED_AMOUNT_REFERENCE,
+      message: '',
+    });
   });
 
   it('should return a swap with an approve transaction', async () => {

--- a/src/api/buildSwapTransaction.test.ts
+++ b/src/api/buildSwapTransaction.test.ts
@@ -3,6 +3,7 @@ import { sendRequest } from '@/core/network/request';
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { DEGEN_TOKEN, ETH_TOKEN } from '@/swap/mocks';
+import type { Address } from 'viem';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildSwapTransaction } from './buildSwapTransaction';
 import type { BuildSwapTransaction } from './types';
@@ -11,7 +12,6 @@ import type { BuildSwapTransaction } from './types';
  */
 import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
 import { getSwapTransaction } from './utils/getSwapTransaction';
-import type { Address } from 'viem';
 
 vi.mock('@/core/network/request');
 
@@ -27,7 +27,7 @@ describe('buildSwapTransaction', () => {
   it('should return a swap', async () => {
     const mockParams = {
       useAggregator: true,
-      fromAddress: testFromAddress ,
+      fromAddress: testFromAddress,
       amountReference: testAmountReference,
       from: ETH_TOKEN,
       to: DEGEN_TOKEN,

--- a/src/api/buildSwapTransaction.test.ts
+++ b/src/api/buildSwapTransaction.test.ts
@@ -1,5 +1,7 @@
 import { CDP_GET_SWAP_TRADE } from '@/core/network/definitions/swap';
 import { sendRequest } from '@/core/network/request';
+import { SwapMessage } from '@/swap/constants';
+import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { DEGEN_TOKEN, ETH_TOKEN } from '@/swap/mocks';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildSwapTransaction } from './buildSwapTransaction';
@@ -9,8 +11,6 @@ import type { BuildSwapTransaction } from './types';
  */
 import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
 import { getSwapTransaction } from './utils/getSwapTransaction';
-import { SwapMessage } from '@/swap/constants';
-import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 
 vi.mock('@/core/network/request');
 

--- a/src/api/buildSwapTransaction.test.ts
+++ b/src/api/buildSwapTransaction.test.ts
@@ -11,10 +11,11 @@ import type { BuildSwapTransaction } from './types';
  */
 import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
 import { getSwapTransaction } from './utils/getSwapTransaction';
+import type { Address } from 'viem';
 
 vi.mock('@/core/network/request');
 
-const testFromAddress = '0x6Cd01c0F55ce9E0Bf78f5E90f72b4345b16d515d';
+const testFromAddress: Address = '0x6Cd01c0F55ce9E0Bf78f5E90f72b4345b16d515d';
 const testAmount = '3305894409732200';
 const testAmountReference = 'from' as const;
 
@@ -26,7 +27,7 @@ describe('buildSwapTransaction', () => {
   it('should return a swap', async () => {
     const mockParams = {
       useAggregator: true,
-      fromAddress: testFromAddress as `0x${string}`,
+      fromAddress: testFromAddress ,
       amountReference: testAmountReference,
       from: ETH_TOKEN,
       to: DEGEN_TOKEN,
@@ -122,7 +123,7 @@ describe('buildSwapTransaction', () => {
   it('should return a swap with useAggregator=false', async () => {
     const mockParams = {
       useAggregator: false,
-      fromAddress: testFromAddress as `0x${string}`,
+      fromAddress: testFromAddress,
       amountReference: testAmountReference,
       from: ETH_TOKEN,
       to: DEGEN_TOKEN,
@@ -204,7 +205,7 @@ describe('buildSwapTransaction', () => {
   it('should return an error for an unsupported amount reference', async () => {
     const mockParams = {
       useAggregator: true,
-      fromAddress: testFromAddress as `0x${string}`,
+      fromAddress: testFromAddress,
       amountReference: 'to' as const,
       from: ETH_TOKEN,
       to: DEGEN_TOKEN,
@@ -222,7 +223,7 @@ describe('buildSwapTransaction', () => {
     const mockParams = {
       useAggregator: true,
       maxSlippage: '3',
-      fromAddress: testFromAddress as `0x${string}`,
+      fromAddress: testFromAddress,
       amountReference: testAmountReference,
       from: DEGEN_TOKEN,
       to: ETH_TOKEN,
@@ -311,7 +312,7 @@ describe('buildSwapTransaction', () => {
   it('should return an error if sendRequest fails', async () => {
     const mockParams = {
       useAggregator: true,
-      fromAddress: testFromAddress as `0x${string}`,
+      fromAddress: testFromAddress,
       amountReference: testAmountReference,
       from: ETH_TOKEN,
       to: DEGEN_TOKEN,
@@ -337,7 +338,7 @@ describe('buildSwapTransaction', () => {
   it('should return an error object from buildSwapTransaction', async () => {
     const mockParams = {
       useAggregator: true,
-      fromAddress: testFromAddress as `0x${string}`,
+      fromAddress: testFromAddress,
       amountReference: testAmountReference,
       from: ETH_TOKEN,
       to: DEGEN_TOKEN,
@@ -368,7 +369,7 @@ describe('buildSwapTransaction', () => {
   it('should return an error object from buildSwapTransaction for invalid `amount` input', async () => {
     const mockParams = {
       useAggregator: true,
-      fromAddress: testFromAddress as `0x${string}`,
+      fromAddress: testFromAddress,
       amountReference: testAmountReference,
       from: ETH_TOKEN,
       to: DEGEN_TOKEN,
@@ -387,7 +388,7 @@ describe('buildSwapTransaction', () => {
     const mockParams = {
       useAggregator: true,
       maxSlippage: '3',
-      fromAddress: testFromAddress as `0x${string}`,
+      fromAddress: testFromAddress,
       amountReference: testAmountReference,
       from: ETH_TOKEN,
       to: DEGEN_TOKEN,

--- a/src/api/buildSwapTransaction.ts
+++ b/src/api/buildSwapTransaction.ts
@@ -1,3 +1,5 @@
+import { SwapMessage } from '@/swap/constants';
+import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_TRADE } from '../core/network/definitions/swap';
 import { sendRequest } from '../core/network/request';
 import type { SwapAPIResponse } from '../swap/types';
@@ -18,7 +20,7 @@ export async function buildSwapTransaction(
 ): Promise<BuildSwapTransactionResponse> {
   // Default parameters
   const defaultParams = {
-    amountReference: 'from',
+    amountReference: 'from' as const,
     isAmountInDecimals: false,
   };
 
@@ -28,6 +30,15 @@ export async function buildSwapTransaction(
   });
   if ('error' in apiParams) {
     return apiParams;
+  }
+
+  if (params.useAggregator && params.amountReference === 'to') {
+    console.error(SwapMessage.UNSUPPORTED_AMOUNT_REFERENCE);
+    return {
+      code: UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE,
+      error: SwapMessage.UNSUPPORTED_AMOUNT_REFERENCE,
+      message: '',
+    };
   }
 
   if (!params.useAggregator) {

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -1,5 +1,7 @@
 import { CDP_GET_SWAP_QUOTE } from '@/core/network/definitions/swap';
 import { sendRequest } from '@/core/network/request';
+import { SwapMessage } from '@/swap/constants';
+import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { type Mock, afterEach, describe, expect, it, vi } from 'vitest';
 import { DEGEN_TOKEN, ETH_TOKEN } from '../swap/mocks';
 /**
@@ -7,8 +9,6 @@ import { DEGEN_TOKEN, ETH_TOKEN } from '../swap/mocks';
  */
 import { getSwapQuote } from './getSwapQuote';
 import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
-import { SwapMessage } from '@/swap/constants';
-import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 
 vi.mock('@/core/network/request');
 

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -7,11 +7,13 @@ import { DEGEN_TOKEN, ETH_TOKEN } from '../swap/mocks';
  */
 import { getSwapQuote } from './getSwapQuote';
 import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
+import { SwapMessage } from '@/swap/constants';
+import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 
 vi.mock('@/core/network/request');
 
 const testAmount = '3305894409732200';
-const testAmountReference = 'from';
+const testAmountReference = 'from' as const;
 
 describe('getSwapQuote', () => {
   afterEach(() => {
@@ -89,6 +91,22 @@ describe('getSwapQuote', () => {
         ...mockApiParams,
       },
     ]);
+  });
+
+  it('should return an error for an unsupported amount reference', async () => {
+    const mockParams = {
+      useAggregator: true,
+      amountReference: 'to' as const,
+      from: ETH_TOKEN,
+      to: DEGEN_TOKEN,
+      amount: testAmount,
+    };
+    const error = await getSwapQuote(mockParams);
+    expect(error).toEqual({
+      code: UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE,
+      error: SwapMessage.UNSUPPORTED_AMOUNT_REFERENCE,
+      message: '',
+    });
   });
 
   it('should return an error if sendRequest fails', async () => {

--- a/src/api/getSwapQuote.ts
+++ b/src/api/getSwapQuote.ts
@@ -1,3 +1,5 @@
+import { SwapMessage } from '@/swap/constants';
+import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_QUOTE } from '../core/network/definitions/swap';
 import { sendRequest } from '../core/network/request';
 import type { SwapQuote } from '../swap/types';
@@ -17,7 +19,7 @@ export async function getSwapQuote(
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {
-    amountReference: 'from',
+    amountReference: 'from' as const,
     isAmountInDecimals: false,
   };
   let apiParams = getAPIParamsForToken({
@@ -26,6 +28,15 @@ export async function getSwapQuote(
   });
   if ('error' in apiParams) {
     return apiParams;
+  }
+
+  if (params.useAggregator && params.amountReference === 'to') {
+    console.error(SwapMessage.UNSUPPORTED_AMOUNT_REFERENCE);
+    return {
+      code: UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE,
+      error: SwapMessage.UNSUPPORTED_AMOUNT_REFERENCE,
+      message: '',
+    };
   }
 
   if (!params.useAggregator) {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -72,7 +72,7 @@ export type GetAPIParamsForToken =
 
 export type GetQuoteAPIParams = {
   amount: string; // The amount to be swapped
-  amountReference?: string; // The reference amount for the swap
+  amountReference?: 'to' | 'from'; // The reference amount for the swap, 'to' is only supported with v2Enabled: false
   from: AddressOrETH | ''; // The source address or 'ETH' for Ethereum
   to: AddressOrETH | ''; // The destination address or 'ETH' for Ethereum
   v2Enabled?: boolean; // Whether to use V2 of the API (default: false)
@@ -88,7 +88,7 @@ export type GetSwapAPIParams = GetQuoteAPIParams & {
  */
 export type GetSwapQuoteParams = {
   amount: string; // The amount to be swapped
-  amountReference?: string; // The reference amount for the swap
+  amountReference?: 'to' | 'from'; // The reference amount for the swap, 'to' is only supported with v2Enabled: false
   from: Token; // The source token for the swap
   isAmountInDecimals?: boolean; // Whether the amount is in decimals
   maxSlippage?: string; // The slippage of the swap

--- a/src/buy/components/BuyAmountInput.tsx
+++ b/src/buy/components/BuyAmountInput.tsx
@@ -30,6 +30,7 @@ export function BuyAmountInput() {
         )}
         placeholder="0.0"
         delayMs={1000}
+        inputMode="decimal"
         value={formatAmount(to.amount)}
         setValue={to.setAmount}
         disabled={to.loading}

--- a/src/buy/components/BuyProvider.test.tsx
+++ b/src/buy/components/BuyProvider.test.tsx
@@ -693,7 +693,6 @@ describe('BuyProvider', () => {
       expect.objectContaining({
         maxSlippage: '10',
         amount: '5',
-        amountReference: 'to',
         from: ethToken,
         to: degenToken,
         useAggregator: true,
@@ -718,33 +717,6 @@ describe('BuyProvider', () => {
         isMissingRequiredField: true,
       }),
     });
-  });
-
-  it('should pass the correct amountReference to get', async () => {
-    const TestComponent = () => {
-      const { handleAmountChange } = useBuyContext();
-      // biome-ignore lint: hello
-      React.useEffect(() => {
-        const initializeSwap = () => {
-          handleAmountChange('100');
-        };
-        initializeSwap();
-      }, []);
-      return null;
-    };
-    await act(async () => {
-      renderWithProviders({ Component: TestComponent });
-    });
-    expect(getBuyQuote).toHaveBeenCalledWith(
-      expect.objectContaining({
-        maxSlippage: '10',
-        amount: '100',
-        amountReference: 'to',
-        from: ethToken,
-        to: degenToken,
-        useAggregator: true,
-      }),
-    );
   });
 
   it('should handle undefined in input', async () => {

--- a/src/buy/components/BuyProvider.tsx
+++ b/src/buy/components/BuyProvider.tsx
@@ -256,7 +256,6 @@ export function BuyProvider({
           formattedFromAmount: formattedAmountETH,
         } = await getBuyQuote({
           amount,
-          amountReference: 'to',
           from: fromETH.token,
           maxSlippage: String(maxSlippage),
           to: to.token,
@@ -269,7 +268,6 @@ export function BuyProvider({
           formattedFromAmount: formattedAmountUSDC,
         } = await getBuyQuote({
           amount,
-          amountReference: 'to',
           from: fromUSDC.token,
           maxSlippage: String(maxSlippage),
           to: to.token,
@@ -282,7 +280,6 @@ export function BuyProvider({
           formattedFromAmount: formattedAmountFrom,
         } = await getBuyQuote({
           amount,
-          amountReference: 'to',
           from: from?.token,
           maxSlippage: String(maxSlippage),
           to: to.token,

--- a/src/buy/utils/getBuyQuote.test.ts
+++ b/src/buy/utils/getBuyQuote.test.ts
@@ -33,27 +33,26 @@ const fromToken: Token = {
 const mockResponse = {
   from: fromToken,
   to: toToken,
-  fromAmount: '100000000000000000',
-  toAmount: '16732157880511600003860',
+  fromAmount: '16732157880511600003860',
+  toAmount: '100000000000000000',
   amountReference: 'from',
   priceImpact: '0.07',
   chainId: 8453,
   hasHighPriceImpact: false,
   slippage: '3',
-  fromAmountUSD: '100',
+  toAmountUSD: '100',
 };
 
 const mockEmptyResponse = {
   from: fromToken,
   to: toToken,
-  fromAmount: '',
-  toAmount: '16732157880511600003860',
-  amountReference: 'from',
+  toAmount: '',
+  fromAmount: '16732157880511600003860',
   priceImpact: '0.07',
   chainId: 8453,
   hasHighPriceImpact: false,
   slippage: '3',
-  fromAmountUSD: '',
+  toAmountUSD: '',
 };
 
 const mockFromSwapUnit = {
@@ -74,7 +73,6 @@ describe('getBuyQuote', () => {
   it('should return default values if `from` token is not provided', async () => {
     const result = await getBuyQuote({
       amount: '1',
-      amountReference: 'exactIn',
       maxSlippage: '0.5',
       to: toToken,
       useAggregator: true,
@@ -95,7 +93,6 @@ describe('getBuyQuote', () => {
 
     const result = await getBuyQuote({
       amount: '1',
-      amountReference: 'exactIn',
       from: fromToken,
       maxSlippage: '0.5',
       to: toToken,
@@ -105,10 +102,10 @@ describe('getBuyQuote', () => {
 
     expect(getSwapQuote).toHaveBeenCalledWith({
       amount: '1',
-      amountReference: 'exactIn',
-      from: fromToken,
+      amountReference: 'from',
+      from: toToken,
       maxSlippage: '0.5',
-      to: toToken,
+      to: fromToken,
       useAggregator: true,
     });
 
@@ -130,7 +127,6 @@ describe('getBuyQuote', () => {
 
     const result = await getBuyQuote({
       amount: '1',
-      amountReference: 'exactIn',
       from: fromToken,
       maxSlippage: '0.5',
       to: toToken,
@@ -140,10 +136,10 @@ describe('getBuyQuote', () => {
 
     expect(getSwapQuote).toHaveBeenCalledWith({
       amount: '1',
-      amountReference: 'exactIn',
-      from: fromToken,
+      amountReference: 'from',
+      from: toToken,
       maxSlippage: '0.5',
-      to: toToken,
+      to: fromToken,
       useAggregator: true,
     });
 
@@ -170,7 +166,6 @@ describe('getBuyQuote', () => {
 
     const result = await getBuyQuote({
       amount: '1',
-      amountReference: 'exactIn',
       from: fromToken,
       maxSlippage: '0.5',
       to: toToken,
@@ -189,7 +184,7 @@ describe('getBuyQuote', () => {
   it('should not call `getSwapQuote` if `from` and `to` tokens are the same', async () => {
     const result = await getBuyQuote({
       amount: '1',
-      amountReference: 'exactIn',
+      amountReference: 'from' as const,
       from: fromToken,
       maxSlippage: '0.5',
       to: fromToken,

--- a/src/buy/utils/getBuyQuote.ts
+++ b/src/buy/utils/getBuyQuote.ts
@@ -31,9 +31,9 @@ export async function getBuyQuote({
   let response: GetSwapQuoteResponse | undefined;
   // only fetch quote if the from and to tokens are different
   if (to?.symbol !== from?.symbol) {
-    // we are trying to swap from the token we are buying "to" the token we are selling
-    // instead of using amountRefence: 'to', we can use amountRefence: 'from'
-    // and then swap to and from to get the quote
+    // switching to and from here
+    // instead of getting a quote for how much of X do we need to sell to get the input token amount
+    // we can get a quote for how much of X we will recieve if we sell the input token amount
     response = await getSwapQuote({
       amount,
       amountReference: 'from',

--- a/src/buy/utils/getBuyQuote.ts
+++ b/src/buy/utils/getBuyQuote.ts
@@ -17,7 +17,6 @@ type GetBuyQuoteParams = Omit<GetSwapQuoteParams, 'from'> & {
 
 export async function getBuyQuote({
   amount,
-  amountReference,
   from,
   maxSlippage,
   to,
@@ -32,23 +31,26 @@ export async function getBuyQuote({
   let response: GetSwapQuoteResponse | undefined;
   // only fetch quote if the from and to tokens are different
   if (to?.symbol !== from?.symbol) {
+    // we are trying to swap from the token we are buying "to" the token we are selling
+    // instead of using amountRefence: 'to', we can use amountRefence: 'from'
+    // and then swap to and from to get the quote
     response = await getSwapQuote({
       amount,
-      amountReference,
-      from,
+      amountReference: 'from',
+      from: to,
       maxSlippage,
-      to,
+      to: from,
       useAggregator,
     });
   }
 
   let formattedFromAmount = '';
   if (response && !isSwapError(response)) {
-    formattedFromAmount = response?.fromAmount
-      ? formatTokenAmount(response.fromAmount, response.from.decimals)
+    formattedFromAmount = response?.toAmount
+      ? formatTokenAmount(response.toAmount, response.to.decimals)
       : '';
 
-    fromSwapUnit?.setAmountUSD(response?.fromAmountUSD || '');
+    fromSwapUnit?.setAmountUSD(response?.toAmountUSD || '');
     fromSwapUnit?.setAmount(formattedFromAmount || '');
   }
 

--- a/src/swap/constants.ts
+++ b/src/swap/constants.ts
@@ -11,6 +11,8 @@ export const UNCAUGHT_SWAP_ERROR_CODE = 'UNCAUGHT_SWAP_ERROR';
 export const UNIVERSALROUTER_CONTRACT_ADDRESS =
   '0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD';
 export const USER_REJECTED_ERROR_CODE = 'USER_REJECTED';
+export const UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE =
+  'UNSUPPORTED_AMOUNT_REFERENCE_ERROR';
 export enum SwapMessage {
   BALANCE_ERROR = 'Error fetching token balance',
   CONFIRM_IN_WALLET = 'Confirm in wallet',
@@ -22,6 +24,7 @@ export enum SwapMessage {
   SWAP_IN_PROGRESS = 'Swap in progress...',
   TOO_MANY_REQUESTS = 'Too many requests. Please try again later.',
   USER_REJECTED = 'User rejected the transaction',
+  UNSUPPORTED_AMOUNT_REFERENCE = 'useAggregator does not support amountReference: to, please use useAggregator: false',
 }
 
 export const ONRAMP_PAYMENT_METHODS = [


### PR DESCRIPTION
**What changed? Why?**
* Added error if amountReference: 'to' is used with the useAggregator: true param
* Updated Buy component to use amountReference: 'from' (default value) for quotes
* Update Buy component input to show numeric keyboard on mobile devices
* Fixed AmountReference type

**Notes to reviewers**

**How has it been tested?**
