### PR TITLE
fix: remove unnecessary `actionKey`s in `useQuery`

### DIFF
--- a/src/identity/hooks/useAddress.ts
+++ b/src/identity/hooks/useAddress.ts
@@ -12,9 +12,8 @@ export const useAddress = (
   queryOptions?: UseQueryOptions,
 ) => {
   const { enabled = true, cacheTime } = queryOptions ?? {};
-  const actionKey = `useAddress-${name}-${chain.id}`;
   return useQuery<GetAddressReturnType>({
-    queryKey: ['useAddress', actionKey],
+    queryKey: ['useAddress', name, chain.id],
     queryFn: async () => {
       return await getAddress({ name, chain });
     },

--- a/src/identity/hooks/useAvatar.ts
+++ b/src/identity/hooks/useAvatar.ts
@@ -15,9 +15,8 @@ export const useAvatar = (
   queryOptions?: UseQueryOptions,
 ) => {
   const { enabled = true, cacheTime } = queryOptions ?? {};
-  const ensActionKey = `ens-avatar-${ensName}-${chain.id}`;
   return useQuery<GetAvatarReturnType>({
-    queryKey: ['useAvatar', ensActionKey],
+    queryKey: ['useAvatar', ensName, chain.id],
     queryFn: async () => {
       return getAvatar({ ensName, chain });
     },

--- a/src/identity/hooks/useName.ts
+++ b/src/identity/hooks/useName.ts
@@ -18,9 +18,8 @@ export const useName = (
   queryOptions?: UseQueryOptions,
 ) => {
   const { enabled = true, cacheTime } = queryOptions ?? {};
-  const ensActionKey = `ens-name-${address}-${chain.id}`;
   return useQuery<GetNameReturnType>({
-    queryKey: ['useName', ensActionKey],
+    queryKey: ['useName', address, chain.id],
     queryFn: async () => {
       return await getName({ address, chain });
     },

--- a/src/identity/hooks/useSocials.tsx
+++ b/src/identity/hooks/useSocials.tsx
@@ -14,9 +14,8 @@ export const useSocials = (
   queryOptions?: UseQueryOptions,
 ) => {
   const { enabled = true, cacheTime } = queryOptions ?? {};
-  const ensActionKey = `ens-socials-${ensName}-${chain.id}`;
   return useQuery<GetSocialsReturnType>({
-    queryKey: ['useSocials', ensActionKey],
+    queryKey: ['useSocials', ensName, chain.id],
     queryFn: async () => {
       return getSocials({ ensName, chain });
     },


### PR DESCRIPTION
**What changed? Why?**
We are defining unnecessary strings as `actionKey` and using that for our `queryKey`. We don't need to do this, Tanstack takes care of this under the hood by default.

**Notes to reviewers**

**How has it been tested?**
