### PR TITLE
feat: Implement Popover, DismissableLayer, and FocusTrap primitives in SwapSettings

### DIFF
--- a/.changeset/many-glasses-visit.md
+++ b/.changeset/many-glasses-visit.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: Implement Popover, DismissableLayer, and FocusTrap primitives in SwapSettings. @cpcramer #1856

--- a/src/internal/primitives/DismissableLayer.test.tsx
+++ b/src/internal/primitives/DismissableLayer.test.tsx
@@ -195,7 +195,7 @@ describe('DismissableLayer', () => {
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
-  it('handles null event target gracefully', () => {
+  it('handles non-Node event target gracefully', () => {
     render(
       <DismissableLayer onDismiss={onDismiss}>
         <div>Test Content</div>
@@ -203,7 +203,8 @@ describe('DismissableLayer', () => {
     );
 
     const event = new Event('pointerdown', { bubbles: true });
-    Object.defineProperty(event, 'target', { value: null });
+    // Create a non-Node object as target
+    Object.defineProperty(event, 'target', { value: {} });
     document.dispatchEvent(event);
 
     expect(onDismiss).not.toHaveBeenCalled();

--- a/src/internal/primitives/DismissableLayer.test.tsx
+++ b/src/internal/primitives/DismissableLayer.test.tsx
@@ -194,4 +194,18 @@ describe('DismissableLayer', () => {
     fireEvent.pointerDown(document.body);
     expect(onDismiss).not.toHaveBeenCalled();
   });
+
+  it('handles null event target gracefully', () => {
+    render(
+      <DismissableLayer onDismiss={onDismiss}>
+        <div>Test Content</div>
+      </DismissableLayer>,
+    );
+
+    const event = new Event('pointerdown', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: null });
+    document.dispatchEvent(event);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
 });

--- a/src/internal/primitives/DismissableLayer.test.tsx
+++ b/src/internal/primitives/DismissableLayer.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DismissableLayer } from './DismissableLayer';
 
@@ -63,23 +64,73 @@ describe('DismissableLayer', () => {
       </DismissableLayer>,
     );
 
-    const innerElement = screen.getByTestId('inner');
-    fireEvent.pointerDown(innerElement);
+    fireEvent.pointerDown(screen.getByTestId('inner'));
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
-  it('does not call onDismiss when clicking outside and disableOutsideClick is true', () => {
-    render(
-      <DismissableLayer onDismiss={onDismiss} disableOutsideClick={true}>
-        <div>Test Content</div>
-      </DismissableLayer>,
-    );
+  it('handles trigger clicks with preventTriggerBubbling', () => {
+    const TestComponent = () => {
+      const triggerRef = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button type="button" ref={triggerRef} data-testid="trigger">
+            Trigger
+          </button>
+          <DismissableLayer
+            onDismiss={onDismiss}
+            triggerRef={triggerRef}
+            preventTriggerEvents={true}
+          >
+            <div>Content</div>
+          </DismissableLayer>
+        </>
+      );
+    };
 
-    fireEvent.pointerDown(document.body);
+    render(<TestComponent />);
+
+    const event = new Event('pointerdown', { bubbles: true });
+    Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
+    Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
+
+    const trigger = screen.getByTestId('trigger');
+    trigger.dispatchEvent(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
-  it('handles case when both disableEscapeKey and disableOutsideClick are true', () => {
+  it('handles trigger clicks without preventTriggerBubbling', () => {
+    const TestComponent = () => {
+      const triggerRef = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button type="button" ref={triggerRef} data-testid="trigger">
+            Trigger
+          </button>
+          <DismissableLayer onDismiss={onDismiss} triggerRef={triggerRef}>
+            <div>Content</div>
+          </DismissableLayer>
+        </>
+      );
+    };
+
+    render(<TestComponent />);
+
+    const event = new Event('pointerdown', { bubbles: true });
+    Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
+    Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
+
+    const trigger = screen.getByTestId('trigger');
+    trigger.dispatchEvent(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('handles both disableEscapeKey and disableOutsideClick being true', () => {
     render(
       <DismissableLayer
         onDismiss={onDismiss}
@@ -108,19 +159,39 @@ describe('DismissableLayer', () => {
   });
 
   it('does not call onDismiss when clicking the trigger button', () => {
-    render(
-      <>
-        <button type="button" aria-label="Toggle swap settings">
-          Trigger
-        </button>
-        <DismissableLayer onDismiss={onDismiss}>
-          <div>Test Content</div>
-        </DismissableLayer>
-      </>,
-    );
+    const TestComponent = () => {
+      const triggerRef = useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button
+            type="button"
+            ref={triggerRef}
+            aria-label="Toggle swap settings"
+          >
+            Trigger
+          </button>
+          <DismissableLayer onDismiss={onDismiss} triggerRef={triggerRef}>
+            <div>Test Content</div>
+          </DismissableLayer>
+        </>
+      );
+    };
+
+    render(<TestComponent />);
 
     const triggerButton = screen.getByLabelText('Toggle swap settings');
     fireEvent.pointerDown(triggerButton);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('does not call onDismiss when clicking outside and disableOutsideClick is true', () => {
+    render(
+      <DismissableLayer onDismiss={onDismiss} disableOutsideClick={true}>
+        <div>Test Content</div>
+      </DismissableLayer>,
+    );
+
+    fireEvent.pointerDown(document.body);
     expect(onDismiss).not.toHaveBeenCalled();
   });
 });

--- a/src/internal/primitives/DismissableLayer.tsx
+++ b/src/internal/primitives/DismissableLayer.tsx
@@ -45,6 +45,7 @@ export function DismissableLayer({
       return layerRef.current?.contains(target);
     };
 
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: TODO Refactor this component
     const handlePointerDownCapture = (event: PointerEvent) => {
       if (disableOutsideClick) {
         return;

--- a/src/internal/primitives/DismissableLayer.tsx
+++ b/src/internal/primitives/DismissableLayer.tsx
@@ -50,11 +50,11 @@ export function DismissableLayer({
         return;
       }
 
-      if (!event.target) {
+      if (!(event.target instanceof Node)) {
         return;
       }
 
-      const target = event.target as Node;
+      const target = event.target;
 
       if (triggerRef?.current?.contains(target)) {
         handleTriggerClick(event);

--- a/src/internal/primitives/DismissableLayer.tsx
+++ b/src/internal/primitives/DismissableLayer.tsx
@@ -6,14 +6,26 @@ type DismissableLayerProps = {
   disableEscapeKey?: boolean;
   disableOutsideClick?: boolean;
   onDismiss?: () => void;
+  /**
+   * Reference to the trigger element (e.g., button) that opens this layer.
+   * Prevents the layer from being dismissed when the trigger is clicked, enabling proper toggle behavior.
+   */
+  triggerRef?: React.RefObject<HTMLElement>;
+  /**
+   * When `true`, prevents trigger click events from bubbling up.
+   * Useful for bottom sheets to prevent unwanted side effects.
+   */
+  preventTriggerEvents?: boolean;
 };
 
-// DismissableLayer handles dismissal using outside clicks and escape key events
+/** DismissableLayer handles dismissal using outside clicks and escape key events */
 export function DismissableLayer({
   children,
   disableEscapeKey = false,
   disableOutsideClick = false,
   onDismiss,
+  triggerRef,
+  preventTriggerEvents = false,
 }: DismissableLayerProps) {
   const layerRef = useRef<HTMLDivElement>(null);
 
@@ -22,46 +34,58 @@ export function DismissableLayer({
       return;
     }
 
+    const handleTriggerClick = (event: PointerEvent) => {
+      if (preventTriggerEvents) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    };
+
+    const isClickInsideLayer = (target: Node) => {
+      return layerRef.current?.contains(target);
+    };
+
+    const handlePointerDownCapture = (event: PointerEvent) => {
+      if (disableOutsideClick) {
+        return;
+      }
+
+      const target = event.target as Node;
+
+      if (triggerRef?.current?.contains(target)) {
+        handleTriggerClick(event);
+        return;
+      }
+
+      if (!isClickInsideLayer(target)) {
+        onDismiss?.();
+      }
+    };
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (!disableEscapeKey && event.key === 'Escape') {
         onDismiss?.();
       }
     };
 
-    const handlePointerDown = (event: PointerEvent) => {
-      if (disableOutsideClick) {
-        return;
-      }
-
-      // If the click is inside the dismissable layer content, don't dismiss
-      // This prevents the popover from closing when clicking inside it
-      if (layerRef.current?.contains(event.target as Node)) {
-        return;
-      }
-
-      // Handling for the trigger button (e.g., settings toggle)
-      // Without this, clicking the trigger would cause both:
-      // 1. The button's onClick to fire (toggling isOpen)
-      // 2. This dismissal logic to fire (forcing close)
-      // This would create a race condition where the popover rapidly closes and reopens
-      const isTriggerClick = (event.target as HTMLElement).closest(
-        '[aria-label="Toggle swap settings"]',
-      );
-      if (isTriggerClick) {
-        return;
-      }
-
-      onDismiss?.();
-    };
-
+    document.addEventListener('pointerdown', handlePointerDownCapture, true);
     document.addEventListener('keydown', handleKeyDown);
-    document.addEventListener('pointerdown', handlePointerDown);
 
     return () => {
+      document.removeEventListener(
+        'pointerdown',
+        handlePointerDownCapture,
+        true,
+      );
       document.removeEventListener('keydown', handleKeyDown);
-      document.removeEventListener('pointerdown', handlePointerDown);
     };
-  }, [disableOutsideClick, disableEscapeKey, onDismiss]);
+  }, [
+    disableOutsideClick,
+    disableEscapeKey,
+    onDismiss,
+    triggerRef,
+    preventTriggerEvents,
+  ]);
 
   return (
     <div data-testid="ockDismissableLayer" ref={layerRef}>

--- a/src/internal/primitives/DismissableLayer.tsx
+++ b/src/internal/primitives/DismissableLayer.tsx
@@ -50,6 +50,10 @@ export function DismissableLayer({
         return;
       }
 
+      if (!event.target) {
+        return;
+      }
+
       const target = event.target as Node;
 
       if (triggerRef?.current?.contains(target)) {

--- a/src/internal/primitives/FocusTrap.tsx
+++ b/src/internal/primitives/FocusTrap.tsx
@@ -9,7 +9,7 @@ interface FocusTrapProps {
   children?: React.ReactNode;
 }
 
-// FocusTrap ensures keyboard focus remains within a contained area for accessibility
+/** FocusTrap ensures keyboard focus remains within a contained area for accessibility */
 export function FocusTrap({ active = true, children }: FocusTrapProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);

--- a/src/internal/primitives/Popover.test.tsx
+++ b/src/internal/primitives/Popover.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Popover } from './Popover';
 
 describe('Popover', () => {
-  let anchorEl: HTMLElement;
+  let anchor: HTMLElement;
 
   beforeEach(() => {
     Object.defineProperty(window, 'matchMedia', {
@@ -21,9 +21,9 @@ describe('Popover', () => {
       })),
     });
 
-    anchorEl = document.createElement('button');
-    anchorEl.setAttribute('data-testid', 'anchor');
-    document.body.appendChild(anchorEl);
+    anchor = document.createElement('button');
+    anchor.setAttribute('data-testid', 'anchor');
+    document.body.appendChild(anchor);
   });
 
   afterEach(() => {
@@ -35,7 +35,7 @@ describe('Popover', () => {
   describe('rendering', () => {
     it('should not render when isOpen is false', () => {
       render(
-        <Popover anchorEl={anchorEl} isOpen={false}>
+        <Popover anchor={anchor} isOpen={false}>
           Content
         </Popover>,
       );
@@ -45,7 +45,7 @@ describe('Popover', () => {
 
     it('should render when isOpen is true', () => {
       render(
-        <Popover anchorEl={anchorEl} isOpen={true}>
+        <Popover anchor={anchor} isOpen={true}>
           Content
         </Popover>,
       );
@@ -54,9 +54,9 @@ describe('Popover', () => {
       expect(screen.getByText('Content')).toBeInTheDocument();
     });
 
-    it('should handle null anchorEl gracefully', () => {
+    it('should handle null anchor gracefully', () => {
       render(
-        <Popover anchorEl={null} isOpen={true}>
+        <Popover anchor={null} isOpen={true}>
           Content
         </Popover>,
       );
@@ -74,7 +74,7 @@ describe('Popover', () => {
         it(`should position correctly with position=${position} and align=${align}`, () => {
           render(
             <Popover
-              anchorEl={anchorEl}
+              anchor={anchor}
               isOpen={true}
               position={position}
               align={align}
@@ -95,7 +95,7 @@ describe('Popover', () => {
 
     it('should update position on window resize', async () => {
       render(
-        <Popover anchorEl={anchorEl} isOpen={true}>
+        <Popover anchor={anchor} isOpen={true}>
           Content
         </Popover>,
       );
@@ -107,7 +107,7 @@ describe('Popover', () => {
 
     it('should update position on scroll', async () => {
       render(
-        <Popover anchorEl={anchorEl} isOpen={true}>
+        <Popover anchor={anchor} isOpen={true}>
           Content
         </Popover>,
       );
@@ -125,7 +125,7 @@ describe('Popover', () => {
         .mockReturnValue(undefined);
 
       render(
-        <Popover anchorEl={anchorEl} isOpen={true}>
+        <Popover anchor={anchor} isOpen={true}>
           Content
         </Popover>,
       );
@@ -141,7 +141,7 @@ describe('Popover', () => {
     it('should not call onClose when clicking inside', async () => {
       const onClose = vi.fn();
       render(
-        <Popover anchorEl={anchorEl} isOpen={true} onClose={onClose}>
+        <Popover anchor={anchor} isOpen={true} onClose={onClose}>
           Content
         </Popover>,
       );
@@ -153,7 +153,7 @@ describe('Popover', () => {
     it('should call onClose when pressing Escape', async () => {
       const onClose = vi.fn();
       render(
-        <Popover anchorEl={anchorEl} isOpen={true} onClose={onClose}>
+        <Popover anchor={anchor} isOpen={true} onClose={onClose}>
           Content
         </Popover>,
       );
@@ -167,7 +167,7 @@ describe('Popover', () => {
     it('should have correct ARIA attributes', () => {
       render(
         <Popover
-          anchorEl={anchorEl}
+          anchor={anchor}
           isOpen={true}
           aria-label="Test Label"
           aria-labelledby="labelId"
@@ -187,7 +187,7 @@ describe('Popover', () => {
     it('should trap focus when open', async () => {
       const user = userEvent.setup();
       render(
-        <Popover anchorEl={anchorEl} isOpen={true}>
+        <Popover anchor={anchor} isOpen={true}>
           <button type="button">First</button>
           <button type="button">Second</button>
         </Popover>,
@@ -210,7 +210,7 @@ describe('Popover', () => {
   describe('cleanup', () => {
     it('should remove event listeners on unmount', () => {
       const { unmount } = render(
-        <Popover anchorEl={anchorEl} isOpen={true}>
+        <Popover anchor={anchor} isOpen={true}>
           Content
         </Popover>,
       );

--- a/src/internal/primitives/Popover.tsx
+++ b/src/internal/primitives/Popover.tsx
@@ -10,21 +10,25 @@ type Position = 'top' | 'right' | 'bottom' | 'left';
 type Alignment = 'start' | 'center' | 'end';
 
 type PopoverProps = {
-  align?: Alignment; // Determines how the popover aligns with the anchor
-  anchorEl: HTMLElement | null;
+  /** Determines how the popover aligns with the anchor */
+  align?: Alignment;
+  /** The element that the popover will be positioned relative to. */
+  anchor: HTMLElement | null;
   children?: React.ReactNode;
   onClose?: () => void;
-  offset?: number; // Spacing (in pixels) between the anchor element and the popover content.
-  position?: Position; // Determines which side of the anchor element the popover will appear.
+  /** Spacing (in pixels) between the anchor element and the popover content. */
+  offset?: number;
+  /** Determines which side of the anchor element the popover will appear. */
+  position?: Position;
   isOpen?: boolean;
+  /** Reference to the element that triggered the popover (e.g., a button that opened it). */
+  trigger?: React.RefObject<HTMLElement>;
   'aria-label'?: string;
   'aria-labelledby'?: string;
   'aria-describedby'?: string;
 };
 
-/**
- * Calculates the initial position of the popover based on the position prop.
- */
+/** Calculates the initial position of the popover based on the position prop. */
 function getInitialPosition(
   triggerRect: DOMRect,
   contentRect: DOMRect,
@@ -52,9 +56,7 @@ function getInitialPosition(
   return { top, left };
 }
 
-/**
- * Adjusts the initial position based on the alignment prop.
- */
+/** Adjusts the initial position based on the alignment prop. */
 function adjustAlignment(
   triggerRect: DOMRect,
   contentRect: DOMRect,
@@ -95,22 +97,21 @@ function adjustAlignment(
   return { top, left };
 }
 
-/**
- * Popover primitive that handles:
+/** Popover primitive that handles:
  * - Positioning relative to anchor element
  * - Focus management
  * - Click outside and escape key dismissal
  * - Portal rendering
- * - Proper ARIA attributes
- */
+ * - Proper ARIA attributes */
 export function Popover({
   children,
-  anchorEl,
+  anchor,
   isOpen,
   onClose,
   position = 'bottom',
   align = 'center',
   offset = 8,
+  trigger,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledby,
   'aria-describedby': ariaDescribedby,
@@ -119,11 +120,11 @@ export function Popover({
   const componentTheme = useTheme();
 
   const updatePosition = useCallback(() => {
-    if (!anchorEl || !contentRef.current) {
+    if (!anchor || !contentRef.current) {
       return;
     }
 
-    const triggerRect = anchorEl.getBoundingClientRect();
+    const triggerRect = anchor.getBoundingClientRect();
     const contentRect = contentRef.current?.getBoundingClientRect();
 
     if (!triggerRect || !contentRect) {
@@ -146,7 +147,7 @@ export function Popover({
 
     contentRef.current.style.top = `${finalPosition.top}px`;
     contentRef.current.style.left = `${finalPosition.left}px`;
-  }, [anchorEl, position, offset, align]);
+  }, [anchor, position, offset, align]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -170,7 +171,7 @@ export function Popover({
   const popover = (
     <div className={cn(componentTheme, 'fixed z-50', 'pointer-events-none')}>
       <FocusTrap active={isOpen}>
-        <DismissableLayer onDismiss={onClose}>
+        <DismissableLayer onDismiss={onClose} triggerRef={trigger}>
           <div
             aria-label={ariaLabel}
             aria-labelledby={ariaLabelledby}

--- a/src/swap/components/SwapSettings.tsx
+++ b/src/swap/components/SwapSettings.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useRef, useState } from 'react';
 import { useIcon } from '../../core-react/internal/hooks/useIcon';
+import { DismissableLayer } from '../../internal/primitives/DismissableLayer';
+import { FocusTrap } from '../../internal/primitives/FocusTrap';
+import { Popover } from '../../internal/primitives/Popover';
 import { background, border, cn, pressable, text } from '../../styles/theme';
 import { useBreakpoints } from '../../ui/react/internal/hooks/useBreakpoints';
-import { useOutsideClick } from '../../ui/react/internal/hooks/useOutsideClick';
 import type { SwapSettingsReact } from '../types';
 import { SwapSettingsSlippageLayout } from './SwapSettingsSlippageLayout';
 import { SwapSettingsSlippageLayoutBottomSheet } from './SwapSettingsSlippageLayoutBottomSheet';
@@ -16,14 +18,16 @@ export function SwapSettings({
   const breakpoint = useBreakpoints();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
-  const handleToggle = useCallback(() => {
+  const handleToggle = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
     setIsOpen((prev) => !prev);
   }, []);
 
-  useOutsideClick(dropdownRef, () => {
+  const handleClose = useCallback(() => {
     setIsOpen(false);
-  });
+  }, []);
 
   const iconSvg = useIcon({ icon });
 
@@ -38,6 +42,7 @@ export function SwapSettings({
       {buttonText && <span className={cn(text.body)}>{buttonText}</span>}
       <div className={cn('relative', isOpen && 'group')} ref={dropdownRef}>
         <button
+          ref={triggerRef}
           type="button"
           aria-label="Toggle swap settings"
           className={cn(
@@ -49,22 +54,38 @@ export function SwapSettings({
           <div className="h-[1.125rem] w-[1.125rem]">{iconSvg}</div>
         </button>
         {breakpoint === 'sm' ? (
-          <div
-            className={cn(
-              background.inverse,
-              pressable.shadow,
-              'fixed inset-x-0 z-50 transition-[bottom] duration-300 ease-in-out',
-              '-bottom-[12.875rem] h-[12.875rem] rounded-t-lg group-[]:bottom-0',
-              className,
-            )}
-            data-testid="ockSwapSettingsSlippageLayoutBottomSheet_container"
-          >
-            <SwapSettingsSlippageLayoutBottomSheet className={className}>
-              {children}
-            </SwapSettingsSlippageLayoutBottomSheet>
-          </div>
+          <FocusTrap active={isOpen}>
+            <DismissableLayer
+              onDismiss={handleClose}
+              triggerRef={triggerRef}
+              preventTriggerEvents={true}
+            >
+              <div
+                className={cn(
+                  background.inverse,
+                  pressable.shadow,
+                  'fixed inset-x-0 z-50 transition-[bottom] duration-300 ease-in-out',
+                  isOpen ? 'bottom-0' : '-bottom-[12.875rem]',
+                  'h-[12.875rem] rounded-t-lg',
+                  className,
+                )}
+                data-testid="ockSwapSettingsSlippageLayoutBottomSheet_container"
+              >
+                <SwapSettingsSlippageLayoutBottomSheet className={className}>
+                  {children}
+                </SwapSettingsSlippageLayoutBottomSheet>
+              </div>
+            </DismissableLayer>
+          </FocusTrap>
         ) : (
-          isOpen && (
+          <Popover
+            isOpen={isOpen}
+            onClose={handleClose}
+            anchor={dropdownRef.current}
+            position="bottom"
+            align="end"
+            trigger={triggerRef}
+          >
             <div
               className={cn(
                 border.radius,
@@ -78,7 +99,7 @@ export function SwapSettings({
                 {children}
               </SwapSettingsSlippageLayout>
             </div>
-          )
+          </Popover>
         )}
       </div>
     </div>


### PR DESCRIPTION
**What changed? Why?**
Implement `Popover`, `DismissableLayer`, and `FocusTrap` primitives in the `SwapSettings` component. 

**Notes to reviewers**

**How has it been tested?**
Tested SwapSettings (mobile and desktop view) and WalletModal in the playground.