### PR TITLE
fix: add typesafety to morpho build functions

### DIFF
--- a/src/earn/utils/buildDepositToMorphoTx.test.ts
+++ b/src/earn/utils/buildDepositToMorphoTx.test.ts
@@ -5,15 +5,18 @@ import {
 } from '@/earn/constants';
 import { encodeFunctionData, parseUnits } from 'viem';
 import { describe, expect, it } from 'vitest';
-import { buildDepositToMorphoTx } from './buildDepositToMorphoTx';
+import {
+  type DepositToMorphoArgs,
+  buildDepositToMorphoTx,
+} from './buildDepositToMorphoTx';
 
 describe('buildDepositToMorphoTx', () => {
-  const mockArgs = {
+  const mockArgs: DepositToMorphoArgs = {
     vaultAddress: '0xd63070114470f685b75B74D60EEc7c1113d33a3D',
     tokenAddress: USDC_ADDRESS,
     amount: parseUnits('1000', USDC_DECIMALS),
     receiverAddress: '0x9E95f497a7663B70404496dB6481c890C4825fe1',
-  } as const;
+  };
 
   it('should return an array with two transactions', async () => {
     const result = buildDepositToMorphoTx(mockArgs);
@@ -90,4 +93,11 @@ describe('buildDepositToMorphoTx', () => {
       }),
     ).toBe(result[1].data);
   });
+});
+
+buildDepositToMorphoTx({
+  vaultAddress: '0x',
+  tokenAddress: '0x',
+  amount: 0n,
+  receiverAddress: '0x',
 });

--- a/src/earn/utils/buildDepositToMorphoTx.test.ts
+++ b/src/earn/utils/buildDepositToMorphoTx.test.ts
@@ -94,10 +94,3 @@ describe('buildDepositToMorphoTx', () => {
     ).toBe(result[1].data);
   });
 });
-
-buildDepositToMorphoTx({
-  vaultAddress: '0x',
-  tokenAddress: '0x',
-  amount: 0n,
-  receiverAddress: '0x',
-});

--- a/src/earn/utils/buildDepositToMorphoTx.ts
+++ b/src/earn/utils/buildDepositToMorphoTx.ts
@@ -2,7 +2,7 @@ import { MORPHO_VAULT_ABI } from '@/earn/constants';
 import type { Call } from '@/transaction/types';
 import { type Address, encodeFunctionData, erc20Abi } from 'viem';
 
-type DepositToMorphoArgs = {
+export type DepositToMorphoArgs = {
   /** The address of the Morpho vault */
   vaultAddress: Address;
   /** The address of the token to deposit */

--- a/src/earn/utils/buildWithdrawFromMorphoTx.test.ts
+++ b/src/earn/utils/buildWithdrawFromMorphoTx.test.ts
@@ -1,14 +1,17 @@
 import { MORPHO_VAULT_ABI, USDC_DECIMALS } from '@/earn/constants';
 import { encodeFunctionData, parseUnits } from 'viem';
 import { describe, expect, it } from 'vitest';
-import { buildWithdrawFromMorphoTx } from './buildWithdrawFromMorphoTx';
+import {
+  type WithdrawFromMorphoArgs,
+  buildWithdrawFromMorphoTx,
+} from './buildWithdrawFromMorphoTx';
 
 describe('buildWithdrawFromMorphoTx', () => {
-  const mockArgs = {
+  const mockArgs: WithdrawFromMorphoArgs = {
     vaultAddress: '0xd63070114470f685b75B74D60EEc7c1113d33a3D',
     amount: parseUnits('1000', USDC_DECIMALS),
     receiverAddress: '0x9E95f497a7663B70404496dB6481c890C4825fe1',
-  } as const;
+  };
 
   it('should return an array with one transaction', async () => {
     const result = await buildWithdrawFromMorphoTx(mockArgs);

--- a/src/earn/utils/buildWithdrawFromMorphoTx.ts
+++ b/src/earn/utils/buildWithdrawFromMorphoTx.ts
@@ -2,7 +2,7 @@ import { MORPHO_VAULT_ABI } from '@/earn/constants';
 import type { Call } from '@/transaction/types';
 import { type Address, encodeFunctionData } from 'viem';
 
-type WithdrawFromMorphoArgs = {
+export type WithdrawFromMorphoArgs = {
   /** The address of the Morpho vault */
   vaultAddress: Address;
   /** The amount of tokens to withdraw */


### PR DESCRIPTION
**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
