### PR TITLE
feat: Client Analytics

### DIFF
--- a/.changeset/friendly-cougars-fly.md
+++ b/.changeset/friendly-cougars-fly.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+**feat** add analytics by @0xAlec #1869

--- a/src/OnchainKitProvider.test.tsx
+++ b/src/OnchainKitProvider.test.tsx
@@ -5,7 +5,15 @@ import type { EASSchemaUid } from '@/identity/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { base } from 'viem/chains';
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { http, WagmiProvider, createConfig } from 'wagmi';
 import { useConfig } from 'wagmi';
 import { mock } from 'wagmi/connectors';
@@ -187,6 +195,7 @@ describe('OnchainKitProvider', () => {
       rpcUrl: null,
       schemaId,
       projectId: null,
+      interactionId: null,
     });
   });
 
@@ -311,5 +320,34 @@ describe('OnchainKitProvider', () => {
         }),
       );
     });
+  });
+
+  it('should handle null interactionId', async () => {
+    vi.mock('./internal/hooks/useAnalytics', () => ({
+      useAnalytics: () => ({
+        generateInteractionId: () => null,
+        sendAnalytics: vi.fn(),
+      }),
+    }));
+
+    render(
+      <WagmiProvider config={mockConfig}>
+        <QueryClientProvider client={queryClient}>
+          <OnchainKitProvider chain={base} schemaId={schemaId} apiKey={apiKey}>
+            <TestComponent />
+          </OnchainKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    expect(setOnchainKitConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interactionId: null,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.resetModules();
   });
 });

--- a/src/OnchainKitProvider.test.tsx
+++ b/src/OnchainKitProvider.test.tsx
@@ -196,7 +196,7 @@ describe('OnchainKitProvider', () => {
       rpcUrl: null,
       schemaId,
       projectId: null,
-      interactionId: null,
+      interactionId: expect.any(String),
     });
   });
 
@@ -324,31 +324,6 @@ describe('OnchainKitProvider', () => {
         }),
       );
     });
-  });
-
-  it('should handle null interactionId', async () => {
-    vi.mock('./internal/hooks/useAnalytics', () => ({
-      useAnalytics: () => ({
-        generateInteractionId: () => null,
-        sendAnalytics: vi.fn(),
-      }),
-    }));
-
-    render(
-      <WagmiProvider config={mockConfig}>
-        <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider chain={base} schemaId={schemaId} apiKey={apiKey}>
-            <TestComponent />
-          </OnchainKitProvider>
-        </QueryClientProvider>
-      </WagmiProvider>,
-    );
-
-    expect(setOnchainKitConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        interactionId: null,
-      }),
-    );
   });
 
   afterEach(() => {

--- a/src/OnchainKitProvider.test.tsx
+++ b/src/OnchainKitProvider.test.tsx
@@ -178,6 +178,7 @@ describe('OnchainKitProvider', () => {
       address: null,
       apiKey,
       config: {
+        analyticsUrl: null,
         appearance: {
           logo: appLogo,
           name: appName,
@@ -214,6 +215,7 @@ describe('OnchainKitProvider', () => {
       expect(setOnchainKitConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           config: {
+            analyticsUrl: null,
             appearance: {
               logo: appLogo,
               name: appName,
@@ -234,6 +236,7 @@ describe('OnchainKitProvider', () => {
 
   it('should use custom values when override in config is provided', async () => {
     const customConfig = {
+      analyticsUrl: 'https://example.com',
       appearance: {
         name: 'custom name',
         logo: 'https://example.com/logo.png',
@@ -263,6 +266,7 @@ describe('OnchainKitProvider', () => {
           apiKey: apiKey,
           chain: base,
           config: {
+            analyticsUrl: 'https://example.com',
             appearance: {
               name: 'custom name',
               logo: 'https://example.com/logo.png',

--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -54,6 +54,7 @@ export function OnchainKitProvider({
       apiKey: apiKey ?? null,
       chain: chain,
       config: {
+        analyticsUrl: config?.analyticsUrl ?? null,
         appearance: {
           name: config?.appearance?.name ?? 'Dapp',
           logo: config?.appearance?.logo ?? '',

--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -7,7 +7,6 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createContext, useMemo } from 'react';
 import { WagmiProvider } from 'wagmi';
-import { useAnalytics } from './core-react/internal/hooks/useAnalytics';
 import { useProviderDependencies } from './core-react/internal/hooks/useProviderDependencies';
 import { DEFAULT_PRIVACY_URL, DEFAULT_TERMS_URL } from './core/constants';
 import { createWagmiConfig } from './core/createWagmiConfig';
@@ -36,11 +35,7 @@ export function OnchainKitProvider({
     throw Error('EAS schemaId must be 64 characters prefixed with "0x"');
   }
 
-  const { generateInteractionId } = useAnalytics();
-  const interactionId = useMemo(
-    () => generateInteractionId(),
-    [generateInteractionId],
-  );
+  const interactionId = useMemo(() => crypto.randomUUID(), []);
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: ignore
   const value = useMemo(() => {
@@ -71,7 +66,7 @@ export function OnchainKitProvider({
       projectId: projectId ?? null,
       rpcUrl: rpcUrl ?? null,
       schemaId: schemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
-      interactionId: interactionId ?? null,
+      interactionId,
     };
     setOnchainKitConfig(onchainKitConfig);
     return onchainKitConfig;

--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -13,6 +13,7 @@ import { createWagmiConfig } from './core/createWagmiConfig';
 import type { OnchainKitContextType } from './core/types';
 import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from './identity/constants';
 import { checkHashLength } from './internal/utils/checkHashLength';
+import { useAnalytics } from './core-react/internal/hooks/useAnalytics';
 import type { OnchainKitProviderReact } from './types';
 
 export const OnchainKitContext =
@@ -34,6 +35,12 @@ export function OnchainKitProvider({
   if (schemaId && !checkHashLength(schemaId, 64)) {
     throw Error('EAS schemaId must be 64 characters prefixed with "0x"');
   }
+
+  const { generateInteractionId } = useAnalytics();
+  const interactionId = useMemo(
+    () => generateInteractionId(),
+    [generateInteractionId],
+  );
 
   // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: ignore
   const value = useMemo(() => {
@@ -63,10 +70,20 @@ export function OnchainKitProvider({
       projectId: projectId ?? null,
       rpcUrl: rpcUrl ?? null,
       schemaId: schemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
+      interactionId: interactionId ?? null,
     };
     setOnchainKitConfig(onchainKitConfig);
     return onchainKitConfig;
-  }, [address, apiKey, chain, config, projectId, rpcUrl, schemaId]);
+  }, [
+    address,
+    apiKey,
+    chain,
+    config,
+    projectId,
+    rpcUrl,
+    schemaId,
+    interactionId,
+  ]);
 
   // Check the React context for WagmiProvider and QueryClientProvider
   const { providedWagmiConfig, providedQueryClient } =

--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -7,13 +7,13 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createContext, useMemo } from 'react';
 import { WagmiProvider } from 'wagmi';
+import { useAnalytics } from './core-react/internal/hooks/useAnalytics';
 import { useProviderDependencies } from './core-react/internal/hooks/useProviderDependencies';
 import { DEFAULT_PRIVACY_URL, DEFAULT_TERMS_URL } from './core/constants';
 import { createWagmiConfig } from './core/createWagmiConfig';
 import type { OnchainKitContextType } from './core/types';
 import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from './identity/constants';
 import { checkHashLength } from './internal/utils/checkHashLength';
-import { useAnalytics } from './core-react/internal/hooks/useAnalytics';
 import type { OnchainKitProviderReact } from './types';
 
 export const OnchainKitContext =

--- a/src/core-react/internal/hooks/useAnalytics.test.ts
+++ b/src/core-react/internal/hooks/useAnalytics.test.ts
@@ -1,8 +1,8 @@
-import { useOnchainKit } from '@/core-react/useOnchainKit';
 import { sendAnalytics } from '@/core/network/sendAnalytics';
+import { AnalyticsEvent } from '@/internal/types';
+import { useOnchainKit } from '@/useOnchainKit';
 import { cleanup, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AnalyticsEvent } from '../types';
 import { useAnalytics } from './useAnalytics';
 
 vi.mock('@/core-react/useOnchainKit', () => ({

--- a/src/core-react/internal/hooks/useAnalytics.test.ts
+++ b/src/core-react/internal/hooks/useAnalytics.test.ts
@@ -1,0 +1,100 @@
+import { useOnchainKit } from '@/core-react/useOnchainKit';
+import { sendAnalytics } from '@/core/network/sendAnalytics';
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnalyticsEvent } from '../types';
+import { useAnalytics } from './useAnalytics';
+
+vi.mock('@/core-react/useOnchainKit', () => ({
+  useOnchainKit: vi.fn(),
+}));
+
+vi.mock('@/core/network/sendAnalytics', () => ({
+  sendAnalytics: vi.fn(),
+}));
+
+describe('useAnalytics', () => {
+  const mockApiKey = 'test-api-key';
+  const mockInteractionId = 'test-interaction-id';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (useOnchainKit as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      apiKey: mockApiKey,
+      interactionId: mockInteractionId,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('should return sendAnalytics function and generateInteractionId', () => {
+    const { result } = renderHook(() => useAnalytics());
+
+    expect(result.current.sendAnalytics).toBeDefined();
+    expect(result.current.generateInteractionId).toBeDefined();
+  });
+
+  it('should call sendAnalytics with correct parameters', () => {
+    const { result } = renderHook(() => useAnalytics());
+    const event = AnalyticsEvent.WALLET_CONNECTED;
+    const data = { address: '0x0000000000000000000000000000000000000000' };
+
+    result.current.sendAnalytics(event as any, data);
+
+    expect(sendAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event,
+        data,
+        appName: expect.any(String),
+        apiKey: mockApiKey,
+        interactionId: mockInteractionId,
+      }),
+    );
+  });
+
+  it('should use document.title as appName in browser environment', () => {
+    const mockTitle = 'Test App';
+    Object.defineProperty(global.document, 'title', {
+      value: mockTitle,
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useAnalytics());
+    const event = AnalyticsEvent.WALLET_CONNECTED;
+    const data = { address: '0x0000000000000000000000000000000000000000' };
+
+    result.current.sendAnalytics(event as any, data);
+
+    expect(sendAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event,
+        data,
+        appName: mockTitle,
+        apiKey: mockApiKey,
+        interactionId: mockInteractionId,
+      }),
+    );
+  });
+
+  it('should generate a valid UUID', () => {
+    const mockUUID = 'test-uuid';
+    const mockCrypto = {
+      randomUUID: vi.fn().mockReturnValue(mockUUID),
+    };
+    Object.defineProperty(global, 'crypto', {
+      value: mockCrypto,
+      writable: true,
+      configurable: true,
+    });
+
+    const { result } = renderHook(() => useAnalytics());
+    const generatedId = result.current.generateInteractionId();
+
+    expect(generatedId).toBe(mockUUID);
+    expect(mockCrypto.randomUUID).toHaveBeenCalled();
+  });
+});

--- a/src/core-react/internal/hooks/useAnalytics.test.ts
+++ b/src/core-react/internal/hooks/useAnalytics.test.ts
@@ -5,7 +5,7 @@ import { cleanup, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAnalytics } from './useAnalytics';
 
-vi.mock('@/core-react/useOnchainKit', () => ({
+vi.mock('@/useOnchainKit', () => ({
   useOnchainKit: vi.fn(),
 }));
 

--- a/src/core-react/internal/hooks/useAnalytics.test.ts
+++ b/src/core-react/internal/hooks/useAnalytics.test.ts
@@ -31,11 +31,9 @@ describe('useAnalytics', () => {
     vi.restoreAllMocks();
   });
 
-  it('should return sendAnalytics function and generateInteractionId', () => {
+  it('should return sendAnalytics function', () => {
     const { result } = renderHook(() => useAnalytics());
-
     expect(result.current.sendAnalytics).toBeDefined();
-    expect(result.current.generateInteractionId).toBeDefined();
   });
 
   it('should call sendAnalytics with correct parameters', () => {
@@ -78,24 +76,6 @@ describe('useAnalytics', () => {
         interactionId: mockInteractionId,
       }),
     );
-  });
-
-  it('should generate a valid UUID', () => {
-    const mockUUID = 'test-uuid';
-    const mockCrypto = {
-      randomUUID: vi.fn().mockReturnValue(mockUUID),
-    };
-    Object.defineProperty(global, 'crypto', {
-      value: mockCrypto,
-      writable: true,
-      configurable: true,
-    });
-
-    const { result } = renderHook(() => useAnalytics());
-    const generatedId = result.current.generateInteractionId();
-
-    expect(generatedId).toBe(mockUUID);
-    expect(mockCrypto.randomUUID).toHaveBeenCalled();
   });
 
   it('should handle analyticsUrl from config correctly', () => {

--- a/src/core-react/internal/hooks/useAnalytics.test.ts
+++ b/src/core-react/internal/hooks/useAnalytics.test.ts
@@ -43,7 +43,7 @@ describe('useAnalytics', () => {
     const event = AnalyticsEvent.WALLET_CONNECTED;
     const data = { address: '0x0000000000000000000000000000000000000000' };
 
-    result.current.sendAnalytics(event as any, data);
+    result.current.sendAnalytics(event, data);
 
     expect(sendAnalytics).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -67,7 +67,7 @@ describe('useAnalytics', () => {
     const event = AnalyticsEvent.WALLET_CONNECTED;
     const data = { address: '0x0000000000000000000000000000000000000000' };
 
-    result.current.sendAnalytics(event as any, data);
+    result.current.sendAnalytics(event, data);
 
     expect(sendAnalytics).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/core-react/internal/hooks/useAnalytics.ts
+++ b/src/core-react/internal/hooks/useAnalytics.ts
@@ -1,6 +1,6 @@
+import { sendAnalytics } from '@/core/network/sendAnalytics';
 import type { AnalyticsEvent, AnalyticsEventData } from '@/internal/types';
 import { useOnchainKit } from '@/useOnchainKit';
-import { sendAnalytics } from '@/core/network/sendAnalytics';
 import { useEffect, useState } from 'react';
 
 export const useAnalytics = () => {

--- a/src/core-react/internal/hooks/useAnalytics.ts
+++ b/src/core-react/internal/hooks/useAnalytics.ts
@@ -1,0 +1,26 @@
+import type {
+  AnalyticsEvent,
+  AnalyticsEventData,
+} from '@/core-react/internal/types';
+import { useOnchainKit } from '@/core-react/useOnchainKit';
+import { sendAnalytics } from '@/core/network/sendAnalytics';
+import { useMemo } from 'react';
+
+export const useAnalytics = () => {
+  const { apiKey, interactionId } = useOnchainKit();
+  const appName = useMemo(() => {
+    return document.title;
+  }, []);
+
+  return {
+    sendAnalytics: (
+      event: AnalyticsEvent,
+      data: AnalyticsEventData[AnalyticsEvent],
+    ) => {
+      sendAnalytics({ event, data, appName, apiKey, interactionId });
+    },
+    generateInteractionId: () => {
+      return crypto.randomUUID();
+    },
+  };
+};

--- a/src/core-react/internal/hooks/useAnalytics.ts
+++ b/src/core-react/internal/hooks/useAnalytics.ts
@@ -1,8 +1,5 @@
-import type {
-  AnalyticsEvent,
-  AnalyticsEventData,
-} from '@/core-react/internal/types';
-import { useOnchainKit } from '@/core-react/useOnchainKit';
+import type { AnalyticsEvent, AnalyticsEventData } from '@/internal/types';
+import { useOnchainKit } from '@/useOnchainKit';
 import { sendAnalytics } from '@/core/network/sendAnalytics';
 import { useEffect, useState } from 'react';
 

--- a/src/core-react/internal/hooks/useAnalytics.ts
+++ b/src/core-react/internal/hooks/useAnalytics.ts
@@ -4,12 +4,14 @@ import type {
 } from '@/core-react/internal/types';
 import { useOnchainKit } from '@/core-react/useOnchainKit';
 import { sendAnalytics } from '@/core/network/sendAnalytics';
-import { useMemo } from 'react';
+import { useEffect, useState } from 'react';
 
 export const useAnalytics = () => {
   const { apiKey, interactionId } = useOnchainKit();
-  const appName = useMemo(() => {
-    return document.title;
+  const [appName, setAppName] = useState('');
+
+  useEffect(() => {
+    setAppName(document.title);
   }, []);
 
   return {

--- a/src/core-react/internal/hooks/useAnalytics.ts
+++ b/src/core-react/internal/hooks/useAnalytics.ts
@@ -25,8 +25,5 @@ export const useAnalytics = () => {
         interactionId,
       });
     },
-    generateInteractionId: () => {
-      return crypto.randomUUID();
-    },
   };
 };

--- a/src/core-react/internal/hooks/useAnalytics.ts
+++ b/src/core-react/internal/hooks/useAnalytics.ts
@@ -7,7 +7,7 @@ import { sendAnalytics } from '@/core/network/sendAnalytics';
 import { useEffect, useState } from 'react';
 
 export const useAnalytics = () => {
-  const { apiKey, interactionId } = useOnchainKit();
+  const { apiKey, interactionId, config } = useOnchainKit();
   const [appName, setAppName] = useState('');
 
   useEffect(() => {
@@ -19,7 +19,14 @@ export const useAnalytics = () => {
       event: AnalyticsEvent,
       data: AnalyticsEventData[AnalyticsEvent],
     ) => {
-      sendAnalytics({ event, data, appName, apiKey, interactionId });
+      sendAnalytics({
+        analyticsUrl: config?.analyticsUrl ?? undefined,
+        appName,
+        apiKey,
+        data,
+        event,
+        interactionId,
+      });
     },
     generateInteractionId: () => {
       return crypto.randomUUID();

--- a/src/core/OnchainKitConfig.ts
+++ b/src/core/OnchainKitConfig.ts
@@ -26,6 +26,7 @@ export const ONCHAIN_KIT_CONFIG: OnchainKitConfig = {
   rpcUrl: null,
   schemaId: null,
   projectId: null,
+  interactionId: null,
 };
 
 /**

--- a/src/core/OnchainKitConfig.ts
+++ b/src/core/OnchainKitConfig.ts
@@ -10,6 +10,7 @@ export const ONCHAIN_KIT_CONFIG: OnchainKitConfig = {
   apiKey: null,
   chain: baseSepolia,
   config: {
+    analyticsUrl: null,
     appearance: {
       name: null,
       logo: null,

--- a/src/core/network/constants.ts
+++ b/src/core/network/constants.ts
@@ -6,3 +6,4 @@ export const JSON_HEADERS = {
   'OnchainKit-Version': version,
 };
 export const JSON_RPC_VERSION = '2.0';
+export const ANALYTICS_API_URL = 'https://api.developer.coinbase.com/analytics';

--- a/src/core/network/sendAnalytics.test.ts
+++ b/src/core/network/sendAnalytics.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ANALYTICS_API_URL, JSON_HEADERS } from './constants';
+import { sendAnalytics } from './sendAnalytics';
+
+describe('sendAnalytics', () => {
+  const mockFetch = vi.fn();
+  const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch;
+  });
+
+  it('should send analytics data with correct parameters', async () => {
+    const params = {
+      appName: 'TestApp',
+      apiKey: 'test-api-key',
+      data: { foo: 'bar' },
+      event: 'test-event',
+      interactionId: 'test-interaction-id',
+    };
+
+    mockFetch.mockResolvedValueOnce({});
+
+    await sendAnalytics(params);
+
+    expect(mockFetch).toHaveBeenCalledWith(ANALYTICS_API_URL, {
+      method: 'POST',
+      headers: {
+        ...JSON_HEADERS,
+        'OnchainKit-App-Name': params.appName,
+      },
+      body: JSON.stringify({
+        apiKey: params.apiKey,
+        interactionId: params.interactionId,
+        eventType: params.event,
+        data: params.data,
+      }),
+    });
+  });
+
+  it('should handle null apiKey by using "undefined" string', async () => {
+    const params = {
+      appName: 'TestApp',
+      apiKey: null,
+      data: { foo: 'bar' },
+      event: 'test-event',
+      interactionId: 'test-interaction-id',
+    };
+
+    mockFetch.mockResolvedValueOnce({});
+
+    await sendAnalytics(params);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"apiKey":"undefined"'),
+      }),
+    );
+  });
+
+  it('should handle null apiKey by using "undefined" string', async () => {
+    const params = {
+      appName: 'TestApp',
+      apiKey: null,
+      data: { foo: 'bar' },
+      event: 'test-event',
+      interactionId: null,
+    };
+
+    mockFetch.mockResolvedValueOnce({});
+
+    await sendAnalytics(params);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"interactionId":"undefined"'),
+      }),
+    );
+  });
+
+  it('should silently fail and log error when fetch fails', async () => {
+    const error = new Error('Network error');
+    mockFetch.mockRejectedValueOnce(error);
+
+    const params = {
+      appName: 'TestApp',
+      apiKey: 'test-api-key',
+      data: { foo: 'bar' },
+      event: 'test-event',
+      interactionId: 'test-interaction-id',
+    };
+
+    await sendAnalytics(params);
+
+    expect(consoleSpy).toHaveBeenCalledWith('Error sending analytics:', error);
+  });
+});

--- a/src/core/network/sendAnalytics.test.ts
+++ b/src/core/network/sendAnalytics.test.ts
@@ -97,4 +97,41 @@ describe('sendAnalytics', () => {
 
     expect(consoleSpy).toHaveBeenCalledWith('Error sending analytics:', error);
   });
+
+  it('should use provided analyticsUrl when specified', async () => {
+    const customUrl = 'https://custom-analytics.example.com';
+    const params = {
+      analyticsUrl: customUrl,
+      appName: 'TestApp',
+      apiKey: 'test-api-key',
+      data: { foo: 'bar' },
+      event: 'test-event',
+      interactionId: 'test-interaction-id',
+    };
+
+    mockFetch.mockResolvedValueOnce({});
+
+    await sendAnalytics(params);
+
+    expect(mockFetch).toHaveBeenCalledWith(customUrl, expect.any(Object));
+  });
+
+  it('should use default ANALYTICS_API_URL when analyticsUrl is not provided', async () => {
+    const params = {
+      appName: 'TestApp',
+      apiKey: 'test-api-key',
+      data: { foo: 'bar' },
+      event: 'test-event',
+      interactionId: 'test-interaction-id',
+    };
+
+    mockFetch.mockResolvedValueOnce({});
+
+    await sendAnalytics(params);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      ANALYTICS_API_URL,
+      expect.any(Object),
+    );
+  });
 });

--- a/src/core/network/sendAnalytics.ts
+++ b/src/core/network/sendAnalytics.ts
@@ -1,6 +1,7 @@
 import { ANALYTICS_API_URL, JSON_HEADERS } from '@/core/network/constants';
 
 interface AnalyticsParams {
+  analyticsUrl?: string;
   appName: string;
   apiKey: string | null;
   data: Record<string, unknown>;
@@ -9,6 +10,7 @@ interface AnalyticsParams {
 }
 
 export const sendAnalytics = async ({
+  analyticsUrl = ANALYTICS_API_URL,
   appName,
   apiKey,
   data,
@@ -16,7 +18,7 @@ export const sendAnalytics = async ({
   interactionId,
 }: AnalyticsParams) => {
   try {
-    await fetch(ANALYTICS_API_URL, {
+    await fetch(analyticsUrl, {
       method: 'POST',
       headers: {
         ...JSON_HEADERS,

--- a/src/core/network/sendAnalytics.ts
+++ b/src/core/network/sendAnalytics.ts
@@ -3,7 +3,7 @@ import { ANALYTICS_API_URL, JSON_HEADERS } from '@/core/network/constants';
 interface AnalyticsParams {
   appName: string;
   apiKey: string | null;
-  data: any;
+  data: Record<string, unknown>;
   event: string;
   interactionId: string | null;
 }

--- a/src/core/network/sendAnalytics.ts
+++ b/src/core/network/sendAnalytics.ts
@@ -1,0 +1,36 @@
+import { ANALYTICS_API_URL, JSON_HEADERS } from '@/core/network/constants';
+
+interface AnalyticsParams {
+  appName: string;
+  apiKey: string | null;
+  data: any;
+  event: string;
+  interactionId: string | null;
+}
+
+export const sendAnalytics = async ({
+  appName,
+  apiKey,
+  data,
+  event,
+  interactionId,
+}: AnalyticsParams) => {
+  try {
+    await fetch(ANALYTICS_API_URL, {
+      method: 'POST',
+      headers: {
+        ...JSON_HEADERS,
+        'OnchainKit-App-Name': appName,
+      },
+      body: JSON.stringify({
+        apiKey: apiKey ?? 'undefined',
+        interactionId: interactionId ?? 'undefined',
+        eventType: event,
+        data,
+      }),
+    });
+  } catch (error) {
+    // Silently fail
+    console.error('Error sending analytics:', error);
+  }
+};

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -98,6 +98,8 @@ export type OnchainKitConfig = {
   schemaId: EASSchemaUid | null;
   /** ProjectId from Coinbase Developer Platform, only required for Coinbase Onramp support */
   projectId: string | null;
+  /** InteractionId, used for analytics */
+  interactionId: string | null;
 };
 
 export type SetOnchainKitConfig = Partial<OnchainKitConfig>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,8 @@ import type { Address, Chain } from 'viem';
  * Note: exported as public Type
  */
 export type AppConfig = {
+  /** Optional analytics URL for analytics data, defaults to Coinbase */
+  analyticsUrl?: string | null;
   appearance?: {
     /** The name of your application */
     name?: string | null;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -10,6 +10,16 @@ type GenericStatus<T> = {
   statusData: T;
 };
 
+export enum AnalyticsEvent {
+  WALLET_CONNECTED = 'walletConnected',
+}
+
+export type AnalyticsEventData = {
+  [AnalyticsEvent.WALLET_CONNECTED]: {
+    address: string;
+  };
+};
+
 // biome-ignore lint/suspicious/noExplicitAny: generic status can be any type
 export type AbstractLifecycleStatus = ErrorStatus | GenericStatus<any>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,8 @@ export type OnchainKitProviderReact = {
   chain: Chain;
   children: ReactNode;
   config?: AppConfig;
+  interactionId?: string;
+  projectId?: string;
   rpcUrl?: string;
   schemaId?: EASSchemaUid;
-  projectId?: string;
 };


### PR DESCRIPTION
**What changed? Why?**
- add `interactionId` on every `OnchainKitProvider` render (user session)
- add `analyticsURL` as a `config` parameter on `OnchainKitProvider` (users can override where analytics are sent)
- add `useAnalytics` hook
- add `sendAnalytics` API

**Notes to reviewers**

**How has it been tested?**
locally
