### PR TITLE
feat: add Earn amount inputs

### DIFF
--- a/src/earn/components/DepositAmountInput.test.tsx
+++ b/src/earn/components/DepositAmountInput.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type Mock, describe, expect, it, vi } from 'vitest';
+import { DepositAmountInput } from './DepositAmountInput';
+import { useEarnContext } from './EarnProvider';
+
+vi.mock('./EarnProvider', () => ({
+  useEarnContext: vi.fn(),
+}));
+
+describe('DepositAmountInput', () => {
+  it('renders the EarnAmountInput with the correct props', () => {
+    const mocksetDepositAmount = vi.fn();
+    (useEarnContext as Mock).mockReturnValue({
+      depositAmount: '100',
+      setDepositAmount: mocksetDepositAmount,
+    });
+
+    render(<DepositAmountInput className="custom-class" />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('100');
+
+    const container = input.parentElement;
+    expect(container).toHaveClass('custom-class');
+  });
+
+  it('updates the value when onChange is called', () => {
+    const mocksetDepositAmount = vi.fn();
+    (useEarnContext as Mock).mockReturnValue({
+      depositAmount: '100',
+      setDepositAmount: mocksetDepositAmount,
+    });
+
+    render(<DepositAmountInput />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    fireEvent.change(input, { target: { value: '200' } });
+
+    expect(mocksetDepositAmount).toHaveBeenCalledWith('200');
+  });
+});

--- a/src/earn/components/DepositAmountInput.tsx
+++ b/src/earn/components/DepositAmountInput.tsx
@@ -10,6 +10,7 @@ export function DepositAmountInput({ className }: DepositAmountInputReact) {
       className={className}
       value={depositAmount}
       onChange={setDepositAmount}
+      aria-label="Deposit Amount"
     />
   );
 }

--- a/src/earn/components/DepositAmountInput.tsx
+++ b/src/earn/components/DepositAmountInput.tsx
@@ -1,0 +1,15 @@
+import type { DepositAmountInputReact } from '../types';
+import { EarnAmountInput } from './EarnAmountInput';
+import { useEarnContext } from './EarnProvider';
+
+export function DepositAmountInput({ className }: DepositAmountInputReact) {
+  const { depositAmount, setDepositAmount } = useEarnContext();
+
+  return (
+    <EarnAmountInput
+      className={className}
+      value={depositAmount}
+      onChange={setDepositAmount}
+    />
+  );
+}

--- a/src/earn/components/EarnAmountInput.test.tsx
+++ b/src/earn/components/EarnAmountInput.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { EarnAmountInput } from './EarnAmountInput';
+import { isValidAmount } from '@/core/utils/isValidAmount';
+import { formatAmount } from '@/swap/utils/formatAmount';
+
+vi.mock('@/swap/utils/formatAmount', () => ({
+  formatAmount: vi.fn((value) => value),
+}));
+
+vi.mock('@/core/utils/isValidAmount', () => ({
+  isValidAmount: vi.fn((value) => /^\d*(\.\d{0,2})?$/.test(value)),
+}));
+
+describe('EarnAmountInput Component', () => {
+  it('renders the component correctly', () => {
+    render(<EarnAmountInput value="0" onChange={() => {}} />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('0');
+  });
+
+  it('formats the value using formatAmount', () => {
+    render(<EarnAmountInput value="1234.56" onChange={() => {}} />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    expect(formatAmount).toHaveBeenCalledWith('1234.56');
+    expect(input).toHaveValue('1234.56');
+  });
+
+  it('calls onChange when the value changes', () => {
+    const handleChange = vi.fn();
+    render(<EarnAmountInput value="0" onChange={handleChange} />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    fireEvent.change(input, { target: { value: '50' } });
+
+    expect(handleChange).toHaveBeenCalledWith('50');
+  });
+
+  it('validates input using inputValidator', () => {
+    render(<EarnAmountInput value="0" onChange={() => {}} />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    fireEvent.change(input, { target: { value: 'invalid' } });
+
+    expect(isValidAmount).toHaveBeenCalledWith('invalid');
+    expect(isValidAmount('invalid')).toBe(false);
+  });
+
+  it('disables the input when the disabled prop is true', () => {
+    render(<EarnAmountInput value="0" onChange={() => {}} disabled={true} />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    expect(input).toBeDisabled();
+  });
+
+  it('applies custom className', () => {
+    render(
+      <EarnAmountInput
+        value="0"
+        onChange={() => {}}
+        className="custom-class"
+      />,
+    );
+
+    const container = screen.getByPlaceholderText('0.0').parentElement;
+    expect(container).toHaveClass('custom-class');
+  });
+});

--- a/src/earn/components/EarnAmountInput.test.tsx
+++ b/src/earn/components/EarnAmountInput.test.tsx
@@ -1,4 +1,4 @@
-import { isValidAmount } from '@/core/utils/isValidAmount';
+import { isValidAmount } from '@/internal/utils/isValidAmount';
 import { formatAmount } from '@/swap/utils/formatAmount';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -8,7 +8,7 @@ vi.mock('@/swap/utils/formatAmount', () => ({
   formatAmount: vi.fn((value) => value),
 }));
 
-vi.mock('@/core/utils/isValidAmount', () => ({
+vi.mock('@/internal/utils/isValidAmount', () => ({
   isValidAmount: vi.fn((value) => /^\d*(\.\d{0,2})?$/.test(value)),
 }));
 

--- a/src/earn/components/EarnAmountInput.test.tsx
+++ b/src/earn/components/EarnAmountInput.test.tsx
@@ -1,8 +1,8 @@
+import { isValidAmount } from '@/core/utils/isValidAmount';
+import { formatAmount } from '@/swap/utils/formatAmount';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { EarnAmountInput } from './EarnAmountInput';
-import { isValidAmount } from '@/core/utils/isValidAmount';
-import { formatAmount } from '@/swap/utils/formatAmount';
 
 vi.mock('@/swap/utils/formatAmount', () => ({
   formatAmount: vi.fn((value) => value),

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -15,7 +15,7 @@ export function EarnAmountInput({
     <div className={cn('flex flex-col', className)}>
       <TextInput
         className={cn(
-          'w-full border-[none] bg-transparent font-display text-5xl',
+          'w-full border-none bg-transparent font-display text-5xl',
           'leading-none outline-none',
         )}
         placeholder="0.0"

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -15,7 +15,7 @@ export function EarnAmountInput({
     <div className={cn('flex flex-col', className)}>
       <TextInput
         className={cn(
-          'w-full border-[none] bg-transparent font-display text-[2.5rem]',
+          'w-full border-[none] bg-transparent font-display text-5xl',
           'leading-none outline-none',
         )}
         placeholder="0.0"

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -1,0 +1,28 @@
+import { cn } from '@/styles/theme';
+import { EarnAmountInputReact } from '../types';
+import { TextInput } from '@/internal/components/TextInput';
+import { isValidAmount } from '@/core/utils/isValidAmount';
+import { formatAmount } from '@/swap/utils/formatAmount';
+
+export function EarnAmountInput({
+  className,
+  disabled,
+  value,
+  onChange,
+}: EarnAmountInputReact) {
+  return (
+    <div className={cn('flex flex-col', className)}>
+      <TextInput
+        className={cn(
+          'w-full border-[none] bg-transparent font-display text-[2.5rem]',
+          'leading-none outline-none',
+        )}
+        placeholder="0.0"
+        value={formatAmount(value)}
+        onChange={onChange}
+        inputValidator={isValidAmount}
+        disabled={disabled}
+      />
+    </div>
+  );
+}

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -1,5 +1,5 @@
-import { isValidAmount } from '@/core/utils/isValidAmount';
 import { TextInput } from '@/internal/components/TextInput';
+import { isValidAmount } from '@/internal/utils/isValidAmount';
 import { cn } from '@/styles/theme';
 import { formatAmount } from '@/swap/utils/formatAmount';
 import type { EarnAmountInputReact } from '../types';

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -9,6 +9,7 @@ export function EarnAmountInput({
   disabled,
   value,
   onChange,
+  'aria-label': ariaLabel,
 }: EarnAmountInputReact) {
   return (
     <div className={cn('flex flex-col', className)}>
@@ -22,6 +23,7 @@ export function EarnAmountInput({
         onChange={onChange}
         inputValidator={isValidAmount}
         disabled={disabled}
+        aria-label={ariaLabel}
       />
     </div>
   );

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -1,8 +1,8 @@
-import { cn } from '@/styles/theme';
-import { EarnAmountInputReact } from '../types';
-import { TextInput } from '@/internal/components/TextInput';
 import { isValidAmount } from '@/core/utils/isValidAmount';
+import { TextInput } from '@/internal/components/TextInput';
+import { cn } from '@/styles/theme';
 import { formatAmount } from '@/swap/utils/formatAmount';
+import type { EarnAmountInputReact } from '../types';
 
 export function EarnAmountInput({
   className,

--- a/src/earn/components/EarnProvider.tsx
+++ b/src/earn/components/EarnProvider.tsx
@@ -1,21 +1,19 @@
 import { useValue } from '@/core-react/internal/hooks/useValue';
-import { type ReactNode, createContext, useContext } from 'react';
-import type { Address } from 'viem';
-
-interface EarnContextType {
-  vaultAddress: Address;
-}
+import { createContext, useContext, useState } from 'react';
+import type { EarnContextType, EarnProviderReact } from '../types';
 
 const EarnContext = createContext<EarnContextType | undefined>(undefined);
 
-interface EarnProviderProps {
-  vaultAddress: Address;
-  children: ReactNode;
-}
+export function EarnProvider({ vaultAddress, children }: EarnProviderReact) {
+  const [depositAmount, setDepositAmount] = useState('');
+  const [withdrawAmount, setWithdrawAmount] = useState('');
 
-export function EarnProvider({ vaultAddress, children }: EarnProviderProps) {
   const value = useValue({
     vaultAddress,
+    depositAmount,
+    setDepositAmount,
+    withdrawAmount,
+    setWithdrawAmount,
   });
 
   return <EarnContext.Provider value={value}>{children}</EarnContext.Provider>;

--- a/src/earn/components/WithdrawAmountInput.test.tsx
+++ b/src/earn/components/WithdrawAmountInput.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, describe, expect, it, vi } from 'vitest';
-import { WithdrawAmountInput } from './WithdrawAmountInput';
 import { useEarnContext } from './EarnProvider';
+import { WithdrawAmountInput } from './WithdrawAmountInput';
 
 vi.mock('./EarnProvider', () => ({
   useEarnContext: vi.fn(),

--- a/src/earn/components/WithdrawAmountInput.test.tsx
+++ b/src/earn/components/WithdrawAmountInput.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type Mock, describe, expect, it, vi } from 'vitest';
+import { WithdrawAmountInput } from './WithdrawAmountInput';
+import { useEarnContext } from './EarnProvider';
+
+vi.mock('./EarnProvider', () => ({
+  useEarnContext: vi.fn(),
+}));
+
+describe('WithdrawAmountInput', () => {
+  it('renders the EarnAmountInput with the correct props', () => {
+    const mockSetWithdrawAmount = vi.fn();
+    (useEarnContext as Mock).mockReturnValue({
+      withdrawAmount: '100',
+      setWithdrawAmount: mockSetWithdrawAmount,
+    });
+
+    render(<WithdrawAmountInput className="custom-class" />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveValue('100');
+
+    const container = input.parentElement;
+    expect(container).toHaveClass('custom-class');
+  });
+
+  it('updates the value when onChange is called', () => {
+    const mockSetWithdrawAmount = vi.fn();
+    (useEarnContext as Mock).mockReturnValue({
+      withdrawAmount: '100',
+      setWithdrawAmount: mockSetWithdrawAmount,
+    });
+
+    render(<WithdrawAmountInput />);
+
+    const input = screen.getByPlaceholderText('0.0');
+    fireEvent.change(input, { target: { value: '200' } });
+
+    expect(mockSetWithdrawAmount).toHaveBeenCalledWith('200');
+  });
+});

--- a/src/earn/components/WithdrawAmountInput.tsx
+++ b/src/earn/components/WithdrawAmountInput.tsx
@@ -10,6 +10,7 @@ export function WithdrawAmountInput({ className }: WithdrawAmountInputReact) {
       className={className}
       value={withdrawAmount}
       onChange={setWithdrawAmount}
+      aria-label="Withdraw Amount"
     />
   );
 }

--- a/src/earn/components/WithdrawAmountInput.tsx
+++ b/src/earn/components/WithdrawAmountInput.tsx
@@ -1,0 +1,15 @@
+import type { WithdrawAmountInputReact } from '../types';
+import { EarnAmountInput } from './EarnAmountInput';
+import { useEarnContext } from './EarnProvider';
+
+export function WithdrawAmountInput({ className }: WithdrawAmountInputReact) {
+  const { withdrawAmount, setWithdrawAmount } = useEarnContext();
+
+  return (
+    <EarnAmountInput
+      className={className}
+      value={withdrawAmount}
+      onChange={setWithdrawAmount}
+    />
+  );
+}

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -1,0 +1,29 @@
+import { Address } from 'viem';
+
+export type EarnProviderReact = {
+  children: React.ReactNode;
+  vaultAddress: Address;
+};
+
+export type EarnContextType = {
+  vaultAddress: Address;
+  depositAmount: string;
+  setDepositAmount: (amount: string) => void;
+  withdrawAmount: string;
+  setWithdrawAmount: (amount: string) => void;
+};
+
+export type EarnAmountInputReact = {
+  className?: string;
+  onChange: (value: string) => void;
+  value: string;
+  disabled?: boolean;
+};
+
+export type WithdrawAmountInputReact = {
+  className?: string;
+};
+
+export type DepositAmountInputReact = {
+  className?: string;
+};

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -18,6 +18,7 @@ export type EarnAmountInputReact = {
   onChange: (value: string) => void;
   value: string;
   disabled?: boolean;
+  'aria-label'?: string;
 };
 
 export type WithdrawAmountInputReact = {

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -1,4 +1,4 @@
-import { Address } from 'viem';
+import type { Address } from 'viem';
 
 export type EarnProviderReact = {
   children: React.ReactNode;


### PR DESCRIPTION
**What changed? Why?**
- add `EarnAmountInput` and wrappers for `Earn` component


```
<WithdrawAmountInput />
<DepositAmountInput />

```


**Notes to reviewers**

**How has it been tested?**
