### PR TITLE
chore: export `getPortfolios`

### DIFF
--- a/src/api/getPortfolios.test.ts
+++ b/src/api/getPortfolios.test.ts
@@ -1,12 +1,9 @@
-import type {
-  PortfolioTokenBalances,
-  PortfolioTokenWithFiatValue,
-} from '@/api/types';
+import type { Portfolio, PortfolioTokenWithFiatValue } from '@/api/types';
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
 import type { Address } from 'viem';
 import { type Mock, describe, expect, it, vi } from 'vitest';
 import { sendRequest } from '../core/network/request';
-import { getPortfolioTokenBalances } from './getPortfolioTokenBalances';
+import { getPortfolios } from './getPortfolios';
 
 vi.mock('@/core/network/request', () => ({
   sendRequest: vi.fn(),
@@ -25,7 +22,7 @@ const mockTokens: PortfolioTokenWithFiatValue[] = [
     fiatBalance: 100,
   },
 ];
-const mockPortfolioTokenBalances: PortfolioTokenBalances[] = [
+const mockPortfolioTokenBalances: Portfolio[] = [
   {
     address: mockAddresses[0],
     portfolioBalanceInUsd: 100,
@@ -33,7 +30,7 @@ const mockPortfolioTokenBalances: PortfolioTokenBalances[] = [
   },
 ];
 
-describe('getPortfolioTokenBalances', () => {
+describe('getPortfolios', () => {
   const mockSendRequest = sendRequest as Mock;
 
   const mockSuccessResponse = {
@@ -45,7 +42,7 @@ describe('getPortfolioTokenBalances', () => {
       result: mockSuccessResponse,
     });
 
-    const result = await getPortfolioTokenBalances({
+    const result = await getPortfolios({
       addresses: mockAddresses,
     });
 
@@ -67,7 +64,7 @@ describe('getPortfolioTokenBalances', () => {
       error: mockError,
     });
 
-    const result = await getPortfolioTokenBalances({
+    const result = await getPortfolios({
       addresses: mockAddresses,
     });
 
@@ -82,7 +79,7 @@ describe('getPortfolioTokenBalances', () => {
     const errorMessage = 'Network Error';
     mockSendRequest.mockRejectedValueOnce(new Error(errorMessage));
 
-    const result = await getPortfolioTokenBalances({
+    const result = await getPortfolios({
       addresses: mockAddresses,
     });
 

--- a/src/api/getPortfolios.ts
+++ b/src/api/getPortfolios.ts
@@ -1,18 +1,16 @@
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
 import { sendRequest } from '@/core/network/request';
-import type {
-  GetPortfolioTokenBalancesParams,
-  GetPortfoliosAPIResponse,
-} from './types';
+import type { GetPortfoliosParams, GetPortfoliosResponse } from './types';
 
-export async function getPortfolioTokenBalances({
-  addresses,
-}: GetPortfolioTokenBalancesParams) {
+/**
+ * Retrieves the portfolios for the provided addresses
+ */
+export async function getPortfolios({ addresses }: GetPortfoliosParams) {
   try {
-    const res = await sendRequest<
-      GetPortfolioTokenBalancesParams,
-      GetPortfoliosAPIResponse
-    >(CDP_GET_PORTFOLIO_TOKEN_BALANCES, [{ addresses }]);
+    const res = await sendRequest<GetPortfoliosParams, GetPortfoliosResponse>(
+      CDP_GET_PORTFOLIO_TOKEN_BALANCES,
+      [{ addresses }],
+    );
     if (res.error) {
       return {
         code: `${res.error.code}`,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,6 +6,7 @@ export { getMintDetails } from './getMintDetails';
 export { getSwapQuote } from './getSwapQuote';
 export { getTokenDetails } from './getTokenDetails';
 export { getTokens } from './getTokens';
+export { getPortfolios } from './getPortfolios';
 export type {
   APIError,
   BuildMintTransactionParams,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -23,4 +23,6 @@ export type {
   GetTokenDetailsResponse,
   GetTokensOptions,
   GetTokensResponse,
+  GetPortfoliosParams,
+  GetPortfoliosResponse,
 } from './types';

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -338,30 +338,31 @@ export type BuildMintTransactionResponse = MintTransaction | APIError;
 /**
  * Note: exported as public Type
  */
-export type GetPortfolioTokenBalancesParams = {
+export type GetPortfoliosParams = {
+  /** The addresses of the wallets to get the portfolio for */
   addresses: Address[] | null | undefined;
 };
 
-/**
- * Note: exported as public Type
- */
-export type PortfolioTokenBalances = {
+export type Portfolio = {
+  /** The address of the wallet */
   address: Address;
+  /** The balance of the wallet in USD */
   portfolioBalanceInUsd: number;
+  /** The tokens in the wallet */
   tokenBalances: PortfolioTokenWithFiatValue[];
 };
 
-/**
- * Note: exported as public Type
- */
 export type PortfolioTokenWithFiatValue = Token & {
+  /** The crypto balance of the token in the wallet */
   cryptoBalance: number;
+  /** The USD balance of the token in the wallet */
   fiatBalance: number;
 };
 
 /**
  * Note: exported as public Type
  */
-export type GetPortfoliosAPIResponse = {
-  portfolios: PortfolioTokenBalances[];
+export type GetPortfoliosResponse = {
+  /** The portfolios for the provided addresses */
+  portfolios: Portfolio[];
 };

--- a/src/wallet/components/WalletAdvancedProvider.test.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.test.tsx
@@ -1,4 +1,4 @@
-import { usePortfolioTokenBalances } from '@/wallet/hooks/usePortfolioTokenBalances';
+import { usePortfolio } from '@/wallet/hooks/usePortfolio';
 import { render, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
@@ -12,8 +12,8 @@ vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
 }));
 
-vi.mock('@/wallet/hooks/usePortfolioTokenBalances', () => ({
-  usePortfolioTokenBalances: vi.fn(),
+vi.mock('@/wallet/hooks/usePortfolio', () => ({
+  usePortfolio: vi.fn(),
 }));
 
 vi.mock('./WalletProvider', () => ({
@@ -31,16 +31,14 @@ describe('useWalletAdvancedContext', () => {
     isSubComponentClosing: false,
   };
 
-  const mockUsePortfolioTokenBalances = usePortfolioTokenBalances as ReturnType<
-    typeof vi.fn
-  >;
+  const mockUsePortfolio = usePortfolio as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     mockUseAccount.mockReturnValue({
       address: '0x123',
     });
     mockUseWalletContext.mockReturnValue(defaultWalletContext);
-    mockUsePortfolioTokenBalances.mockReturnValue({
+    mockUsePortfolio.mockReturnValue({
       data: {
         address: '0x123',
         tokenBalances: [],
@@ -95,7 +93,7 @@ describe('useWalletAdvancedContext', () => {
     console.error = originalError;
   });
 
-  it('should call usePortfolioTokenBalances with the correct address', () => {
+  it('should call usePortfolio with the correct address', () => {
     mockUseWalletContext.mockReturnValue({
       address: null,
       isSubComponentClosing: false,
@@ -105,7 +103,7 @@ describe('useWalletAdvancedContext', () => {
       wrapper: WalletAdvancedProvider,
     });
 
-    expect(mockUsePortfolioTokenBalances).toHaveBeenCalledWith({
+    expect(mockUsePortfolio).toHaveBeenCalledWith({
       address: null,
     });
 
@@ -116,7 +114,7 @@ describe('useWalletAdvancedContext', () => {
 
     rerender();
 
-    expect(mockUsePortfolioTokenBalances).toHaveBeenCalledWith({
+    expect(mockUsePortfolio).toHaveBeenCalledWith({
       address: '0x123',
     });
   });

--- a/src/wallet/components/WalletAdvancedProvider.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.tsx
@@ -1,5 +1,5 @@
 import { useValue } from '@/core-react/internal/hooks/useValue';
-import { usePortfolioTokenBalances } from '@/wallet/hooks/usePortfolioTokenBalances';
+import { usePortfolio } from '@/wallet/hooks/usePortfolio';
 import { type ReactNode, createContext, useContext, useState } from 'react';
 import type { WalletAdvancedContextType } from '../types';
 import { useWalletContext } from './WalletProvider';
@@ -37,7 +37,7 @@ export function WalletAdvancedProvider({
     refetch: refetchPortfolioData,
     isFetching: isFetchingPortfolioData,
     dataUpdatedAt: portfolioDataUpdatedAt,
-  } = usePortfolioTokenBalances({ address });
+  } = usePortfolio({ address });
 
   const portfolioFiatValue = portfolioData?.portfolioBalanceInUsd;
   const tokenBalances = portfolioData?.tokenBalances;

--- a/src/wallet/hooks/usePortfolio.test.tsx
+++ b/src/wallet/hooks/usePortfolio.test.tsx
@@ -1,14 +1,11 @@
-import { getPortfolioTokenBalances } from '@/api/getPortfolioTokenBalances';
-import type {
-  PortfolioTokenBalances,
-  PortfolioTokenWithFiatValue,
-} from '@/api/types';
+import { getPortfolios } from '@/api/getPortfolios';
+import type { Portfolio, PortfolioTokenWithFiatValue } from '@/api/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { usePortfolioTokenBalances } from './usePortfolioTokenBalances';
+import { usePortfolio } from './usePortfolio';
 
-vi.mock('@/api/getPortfolioTokenBalances');
+vi.mock('@/api/getPortfolios');
 
 const mockAddress: `0x${string}` = '0x123';
 const mockTokens: PortfolioTokenWithFiatValue[] = [
@@ -23,7 +20,7 @@ const mockTokens: PortfolioTokenWithFiatValue[] = [
     fiatBalance: 100,
   },
 ];
-const mockPortfolioTokenBalances: PortfolioTokenBalances = {
+const mockPortfolio: Portfolio = {
   address: mockAddress,
   portfolioBalanceInUsd: 100,
   tokenBalances: mockTokens,
@@ -42,18 +39,18 @@ const createWrapper = () => {
   );
 };
 
-describe('usePortfolioTokenBalances', () => {
+describe('usePortfolio', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('should fetch token balances successfully', async () => {
-    vi.mocked(getPortfolioTokenBalances).mockResolvedValueOnce({
-      portfolios: [mockPortfolioTokenBalances],
+    vi.mocked(getPortfolios).mockResolvedValueOnce({
+      portfolios: [mockPortfolio],
     });
 
     const { result } = renderHook(
-      () => usePortfolioTokenBalances({ address: mockAddress }),
+      () => usePortfolio({ address: mockAddress }),
       { wrapper: createWrapper() },
     );
 
@@ -61,22 +58,22 @@ describe('usePortfolioTokenBalances', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getPortfolioTokenBalances).toHaveBeenCalledWith({
+    expect(getPortfolios).toHaveBeenCalledWith({
       addresses: [mockAddress],
     });
 
-    expect(result.current.data).toEqual(mockPortfolioTokenBalances);
+    expect(result.current.data).toEqual(mockPortfolio);
   });
 
   it('should handle API errors', async () => {
-    vi.mocked(getPortfolioTokenBalances).mockResolvedValueOnce({
+    vi.mocked(getPortfolios).mockResolvedValueOnce({
       code: 'API Error',
       error: 'API Error',
       message: 'API Error',
     });
 
     const { result } = renderHook(
-      () => usePortfolioTokenBalances({ address: mockAddress }),
+      () => usePortfolio({ address: mockAddress }),
       { wrapper: createWrapper() },
     );
 
@@ -87,31 +84,28 @@ describe('usePortfolioTokenBalances', () => {
   });
 
   it('should not fetch when address is empty', () => {
-    renderHook(
-      () => usePortfolioTokenBalances({ address: '' as `0x${string}` }),
-      {
-        wrapper: createWrapper(),
-      },
-    );
-
-    expect(getPortfolioTokenBalances).not.toHaveBeenCalled();
-  });
-
-  it('should not fetch when address is undefined', () => {
-    renderHook(() => usePortfolioTokenBalances({ address: undefined }), {
+    renderHook(() => usePortfolio({ address: '' as `0x${string}` }), {
       wrapper: createWrapper(),
     });
 
-    expect(getPortfolioTokenBalances).not.toHaveBeenCalled();
+    expect(getPortfolios).not.toHaveBeenCalled();
+  });
+
+  it('should not fetch when address is undefined', () => {
+    renderHook(() => usePortfolio({ address: undefined }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(getPortfolios).not.toHaveBeenCalled();
   });
 
   it('should return empty data when portfolios is empty', async () => {
-    vi.mocked(getPortfolioTokenBalances).mockResolvedValueOnce({
+    vi.mocked(getPortfolios).mockResolvedValueOnce({
       portfolios: [],
     });
 
     const { result } = renderHook(
-      () => usePortfolioTokenBalances({ address: mockAddress }),
+      () => usePortfolio({ address: mockAddress }),
       { wrapper: createWrapper() },
     );
 

--- a/src/wallet/hooks/usePortfolio.ts
+++ b/src/wallet/hooks/usePortfolio.ts
@@ -1,18 +1,22 @@
-import { getPortfolioTokenBalances } from '@/api/getPortfolioTokenBalances';
-import type { PortfolioTokenBalances } from '@/api/types';
+import { getPortfolios } from '@/api/getPortfolios';
+import type { Portfolio } from '@/api/types';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { Address } from 'viem';
 
-export function usePortfolioTokenBalances({
+/**
+ * Retrieves the portfolio for the provided address
+ * portfolio includes the address, the balance of the address in USD, and the tokens in the address
+ */
+export function usePortfolio({
   address,
 }: {
   address: Address | undefined | null;
-}): UseQueryResult<PortfolioTokenBalances> {
+}): UseQueryResult<Portfolio> {
   return useQuery({
-    queryKey: ['usePortfolioTokenBalances', address],
+    queryKey: ['usePortfolio', address],
     queryFn: async () => {
-      const response = await getPortfolioTokenBalances({
+      const response = await getPortfolios({
         addresses: [address as Address], // Safe to coerce to Address because useQuery's enabled flag will prevent the query from running if address is undefined
       });
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -1,7 +1,4 @@
-import type {
-  PortfolioTokenBalances,
-  PortfolioTokenWithFiatValue,
-} from '@/api/types';
+import type { Portfolio, PortfolioTokenWithFiatValue } from '@/api/types';
 import type { SwapError } from '@/swap';
 import type { Token } from '@/token';
 import type { QueryObserverResult } from '@tanstack/react-query';
@@ -223,9 +220,7 @@ export type WalletAdvancedContextType = {
   portfolioFiatValue: number | undefined;
   isFetchingPortfolioData: boolean;
   portfolioDataUpdatedAt: number | undefined;
-  refetchPortfolioData: () => Promise<
-    QueryObserverResult<PortfolioTokenBalances, Error>
-  >;
+  refetchPortfolioData: () => Promise<QueryObserverResult<Portfolio, Error>>;
   animations: {
     container: string;
     content: string;


### PR DESCRIPTION
**What changed? Why?**
* updated endpoint name to `getPortfolios` for clarity and accuracy
* exported `getPortfolios` in `src/api`
* updated hook name to `usePortfolio` for clarity and accuracy
* updated response type to conform to convention

**Notes to reviewers**

**How has it been tested?**
