### PR TITLE
fix: Fix SitemapGenerator instantiation to use new keyword in createS…

### DIFF
--- a/site/createSitemap.js
+++ b/site/createSitemap.js
@@ -2,7 +2,7 @@ import SitemapGenerator from 'sitemap-generator';
 
 let pagesInSitemap = 0;
 
-const generator = SitemapGenerator('https://onchainkit.xyz', {
+const generator = new SitemapGenerator('https://onchainkit.xyz', {
   changeFreq: 'daily',
   ignore: (url) => {
     // Ignore coverage pages


### PR DESCRIPTION
**What changed? Why?**

I noticed that the `SitemapGenerator` method was being called without the `new` keyword, which is incorrect since it's a class constructor.

I've updated the code to properly instantiate it using `new`. The correct usage should be:  

```javascript  
const generator = new SitemapGenerator('https://onchainkit.xyz', {  
```  


