### PR TITLE
feat: add additional Earn components

### DIFF
--- a/src/earn/components/DepositBalance.test.tsx
+++ b/src/earn/components/DepositBalance.test.tsx
@@ -16,6 +16,8 @@ const baseContext = {
   depositedAmount: '0',
   withdrawAmount: '0',
   setWithdrawAmount: vi.fn(),
+  depositCalls: [],
+  withdrawCalls: [],
 };
 
 describe('DepositBalance', () => {

--- a/src/earn/components/DepositButton.test.tsx
+++ b/src/earn/components/DepositButton.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import type { Address } from 'viem';
+import { type Mock, describe, it, expect, vi } from 'vitest';
+import { DepositButton } from './DepositButton';
+import { useEarnContext } from './EarnProvider';
+import { Transaction, TransactionButton } from '@/transaction';
+import type { Call } from '@/transaction/types';
+
+vi.mock('./EarnProvider', () => ({
+  useEarnContext: vi.fn(),
+}));
+
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+  useConfig: vi.fn(),
+  useCapabilities: vi.fn(),
+}));
+
+const baseContext = {
+  convertedBalance: '1000',
+  setDepositAmount: vi.fn(),
+  vaultAddress: '0x123' as Address,
+  depositAmount: '0',
+  depositedAmount: '0',
+  withdrawAmount: '0',
+  setWithdrawAmount: vi.fn(),
+  depositCalls: [],
+  withdrawCalls: [],
+};
+
+vi.mock('@/transaction', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('@/transaction')>()),
+    TransactionLifecycleStatus: vi.fn(),
+    TransactionButton: ({
+      text,
+      disabled,
+    }: { text: string; disabled: boolean }) => (
+      <button type="button" disabled={disabled} data-testid="transactionButton">
+        {text}
+      </button>
+    ),
+    Transaction: ({
+      onStatus,
+      children,
+      capabilities,
+    }: {
+      onStatus: (status: { statusName: string }) => void;
+      children: React.ReactNode;
+      capabilities: { paymasterService: { url: string } };
+    }) => (
+      <>
+        <div data-testid="transaction">
+          <button
+            type="button"
+            data-testid="transaction-button"
+            onClick={() => onStatus({ statusName: 'transactionPending' })}
+          >
+            TransactionPending
+          </button>
+          <button
+            type="button"
+            data-testid="transaction-button"
+            onClick={() =>
+              onStatus({ statusName: 'transactionLegacyExecuted' })
+            }
+          >
+            TransactionLegacyExecuted
+          </button>
+          <button
+            type="button"
+            data-testid="transaction-button"
+            onClick={() => onStatus({ statusName: 'success' })}
+          >
+            Success
+          </button>
+          <button
+            type="button"
+            data-testid="transaction-button"
+            onClick={() => onStatus({ statusName: 'error' })}
+          >
+            Error
+          </button>
+          <div>{capabilities?.paymasterService?.url}</div>
+        </div>
+        {children}
+      </>
+    ),
+    TransactionSponsor: vi.fn(),
+    TransactionStatus: vi.fn(),
+    TransactionStatusAction: vi.fn(),
+    TransactionStatusLabel: vi.fn(),
+  };
+});
+
+vi.mock('@/internal/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+describe('DepositButton Component', () => {
+  it('renders Transaction with depositCalls from EarnProvider', () => {
+    const mockDepositCalls = [{ to: '0x123', data: '0x456' }] as Call[];
+    vi.mocked(useEarnContext).mockReturnValue({
+      ...baseContext,
+      depositCalls: mockDepositCalls,
+    });
+
+    render(<DepositButton />);
+
+    const transactionElement = screen.getByTestId('transaction');
+    expect(transactionElement).toBeInTheDocument();
+  });
+
+  it('renders TransactionButton with the correct text', () => {
+    vi.mocked(useEarnContext).mockReturnValue({
+      ...baseContext,
+      depositCalls: [],
+    });
+
+    const { container } = render(<DepositButton />);
+
+    expect(container).toHaveTextContent('Withdraw');
+  });
+});

--- a/src/earn/components/DepositButton.test.tsx
+++ b/src/earn/components/DepositButton.test.tsx
@@ -1,10 +1,9 @@
+import type { Call } from '@/transaction/types';
 import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
-import { type Mock, describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { DepositButton } from './DepositButton';
 import { useEarnContext } from './EarnProvider';
-import { Transaction, TransactionButton } from '@/transaction';
-import type { Call } from '@/transaction/types';
 
 vi.mock('./EarnProvider', () => ({
   useEarnContext: vi.fn(),

--- a/src/earn/components/DepositButton.test.tsx
+++ b/src/earn/components/DepositButton.test.tsx
@@ -118,6 +118,6 @@ describe('DepositButton Component', () => {
 
     const { container } = render(<DepositButton />);
 
-    expect(container).toHaveTextContent('Withdraw');
+    expect(container).toHaveTextContent('Deposit');
   });
 });

--- a/src/earn/components/DepositButton.tsx
+++ b/src/earn/components/DepositButton.tsx
@@ -2,7 +2,7 @@ import { Transaction, TransactionButton } from '@/transaction';
 import type { DepositButtonReact } from '../types';
 import { useEarnContext } from './EarnProvider';
 
-export function WithdrawButton({ className }: DepositButtonReact) {
+export function DepositButton({ className }: DepositButtonReact) {
   const { depositCalls } = useEarnContext();
 
   return (

--- a/src/earn/components/DepositButton.tsx
+++ b/src/earn/components/DepositButton.tsx
@@ -1,0 +1,13 @@
+import { Transaction, TransactionButton } from '@/transaction';
+import type { DepositButtonReact } from '../types';
+import { useEarnContext } from './EarnProvider';
+
+export function WithdrawButton({ className }: DepositButtonReact) {
+  const { depositCalls } = useEarnContext();
+
+  return (
+    <Transaction className={className} calls={depositCalls}>
+      <TransactionButton text="Withdraw" />
+    </Transaction>
+  );
+}

--- a/src/earn/components/DepositButton.tsx
+++ b/src/earn/components/DepositButton.tsx
@@ -7,7 +7,7 @@ export function DepositButton({ className }: DepositButtonReact) {
 
   return (
     <Transaction className={className} calls={depositCalls}>
-      <TransactionButton text="Withdraw" />
+      <TransactionButton text="Deposit" />
     </Transaction>
   );
 }

--- a/src/earn/components/DepositDetails.test.tsx
+++ b/src/earn/components/DepositDetails.test.tsx
@@ -9,7 +9,7 @@ vi.mock('./EarnProvider', () => ({
   useEarnContext: vi.fn(),
 }));
 
-vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+vi.mock('@/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));
 
@@ -21,6 +21,8 @@ const baseContext = {
   depositedAmount: '0',
   withdrawAmount: '0',
   setWithdrawAmount: vi.fn(),
+  depositCalls: [],
+  withdrawCalls: [],
 };
 
 describe('DepositDetails Component', () => {

--- a/src/earn/components/DepositDetails.test.tsx
+++ b/src/earn/components/DepositDetails.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { usdcToken } from '@/token/constants';
+import type { Address } from 'viem';
+import { type Mock, describe, it, expect, vi } from 'vitest';
+import { DepositDetails } from './DepositDetails';
+import { useEarnContext } from './EarnProvider';
+
+vi.mock('./EarnProvider', () => ({
+  useEarnContext: vi.fn(),
+}));
+
+vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+const baseContext = {
+  convertedBalance: '1000',
+  setDepositAmount: vi.fn(),
+  vaultAddress: '0x123' as Address,
+  depositAmount: '0',
+  depositedAmount: '0',
+  withdrawAmount: '0',
+  setWithdrawAmount: vi.fn(),
+};
+
+describe('DepositDetails Component', () => {
+  it('renders EarnDetails with default APY tag when APY is provided', () => {
+    const mockApy = '5.00%';
+    vi.mocked(useEarnContext).mockReturnValue({ ...baseContext, apy: mockApy });
+
+    const { container } = render(<DepositDetails />);
+
+    const tokenElement = screen.getByTestId('ockTokenChip_Button');
+    expect(tokenElement).toHaveTextContent(usdcToken.name);
+
+    // const tagElement = screen.getByTestId('tag');
+    expect(container).toHaveTextContent(`APY ${mockApy}`);
+  });
+
+  it('renders EarnDetails with an empty tag when APY is not provided', () => {
+    vi.mocked(useEarnContext).mockReturnValue({ ...baseContext, apy: '' });
+
+    render(<DepositDetails />);
+
+    const tokenElement = screen.getByTestId('ockTokenChip_Button');
+    expect(tokenElement).toHaveTextContent(usdcToken.name);
+  });
+
+  it('applies custom className to the EarnDetails container', () => {
+    const customClass = 'custom-class';
+    (useEarnContext as Mock).mockReturnValue({ apy: null });
+
+    render(<DepositDetails className={customClass} />);
+
+    const earnDetails = screen.getByTestId('ockEarnDetails');
+    expect(earnDetails).toHaveClass(customClass);
+  });
+});

--- a/src/earn/components/DepositDetails.test.tsx
+++ b/src/earn/components/DepositDetails.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
 import { usdcToken } from '@/token/constants';
+import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
-import { type Mock, describe, it, expect, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { DepositDetails } from './DepositDetails';
 import { useEarnContext } from './EarnProvider';
 

--- a/src/earn/components/DepositDetails.tsx
+++ b/src/earn/components/DepositDetails.tsx
@@ -1,9 +1,10 @@
 import { usdcToken } from '@/token/constants';
 import { useMemo } from 'react';
+import type { DepositDetailsReact } from '../types';
 import { EarnDetails } from './EarnDetails';
 import { useEarnContext } from './EarnProvider';
 
-export function DepositDetails() {
+export function DepositDetails({ className }: DepositDetailsReact) {
   const { apy } = useEarnContext();
 
   const tag = useMemo(() => {
@@ -14,5 +15,12 @@ export function DepositDetails() {
   }, [apy]);
 
   // TODO: update token when we have logic to fetch vault info
-  return <EarnDetails token={usdcToken} tag={tag} tagVariant="default" />;
+  return (
+    <EarnDetails
+      className={className}
+      token={usdcToken}
+      tag={tag}
+      tagVariant="default"
+    />
+  );
 }

--- a/src/earn/components/DepositDetails.tsx
+++ b/src/earn/components/DepositDetails.tsx
@@ -1,0 +1,18 @@
+import { usdcToken } from '@/token/constants';
+import { useMemo } from 'react';
+import { EarnDetails } from './EarnDetails';
+import { useEarnContext } from './EarnProvider';
+
+export function DepositDetails() {
+  const { apy } = useEarnContext();
+
+  const tag = useMemo(() => {
+    if (apy) {
+      return `APY ${apy}`;
+    }
+    return '';
+  }, [apy]);
+
+  // TODO: update token when we have logic to fetch vault info
+  return <EarnDetails token={usdcToken} tag={tag} tagVariant="default" />;
+}

--- a/src/earn/components/Earn.test.tsx
+++ b/src/earn/components/Earn.test.tsx
@@ -1,3 +1,4 @@
+import type { Call } from '@/transaction/types';
 import { useGetTokenBalance } from '@/wallet/hooks/useGetTokenBalance';
 import { render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -11,7 +12,11 @@ vi.mock('wagmi', () => ({
 }));
 
 vi.mock('@/transaction', () => ({
-  Transaction: ({ className, calls, children }: any) => (
+  Transaction: ({
+    className,
+    calls,
+    children,
+  }: { className: string; calls: Call[]; children: React.ReactNode }) => (
     <div
       data-testid="transaction"
       className={className}
@@ -21,7 +26,9 @@ vi.mock('@/transaction', () => ({
     </div>
   ),
   TransactionButton: ({ text }: { text: string }) => (
-    <button data-testid="transaction-button">{text}</button>
+    <button data-testid="transaction-button" type="button">
+      {text}
+    </button>
   ),
 }));
 

--- a/src/earn/components/Earn.test.tsx
+++ b/src/earn/components/Earn.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
 import { useGetTokenBalance } from '@/wallet/hooks/useGetTokenBalance';
-import { type Mock, beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { Earn } from './Earn';
 

--- a/src/earn/components/Earn.test.tsx
+++ b/src/earn/components/Earn.test.tsx
@@ -1,33 +1,28 @@
 import { useGetTokenBalance } from '@/wallet/hooks/useGetTokenBalance';
 import { render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useAccount } from 'wagmi';
+import { useAccount, useConfig } from 'wagmi';
 import { Earn } from './Earn';
 
-vi.mock('wagmi', async (importOriginal) => {
-  return {
-    ...(await importOriginal<typeof import('wagmi')>()),
-    useAccount: vi.fn(),
-  };
-});
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+  useConfig: vi.fn(),
+  useCapabilities: vi.fn(),
+}));
 
-vi.mock('@/internal', () => ({
-  Tabs: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="ockTabs">{children}</div>
+vi.mock('@/transaction', () => ({
+  Transaction: ({ className, calls, children }: any) => (
+    <div
+      data-testid="transaction"
+      className={className}
+      data-calls={JSON.stringify(calls)}
+    >
+      {children}
+    </div>
   ),
-  TabsList: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="tabs-list">{children}</div>
+  TransactionButton: ({ text }: { text: string }) => (
+    <button data-testid="transaction-button">{text}</button>
   ),
-  Tab: ({ value, children }: { value: string; children: React.ReactNode }) => (
-    <button data-testid={`tab-${value}`}>{children}</button>
-  ),
-  TabContent: ({
-    value,
-    children,
-  }: {
-    value: string;
-    children: React.ReactNode;
-  }) => <div data-testid={`tab-content-${value}`}>{children}</div>,
 }));
 
 vi.mock('@/wallet/hooks/useGetTokenBalance', () => ({
@@ -47,6 +42,7 @@ describe('Earn Component', () => {
       convertedBalance: '0.0',
       error: null,
     });
+    (useConfig as Mock).mockReturnValue({});
   });
 
   it('renders custom children when provided', () => {

--- a/src/earn/components/Earn.test.tsx
+++ b/src/earn/components/Earn.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/wallet/hooks/useGetTokenBalance', () => ({
   useGetTokenBalance: vi.fn(),
 }));
 
-vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+vi.mock('@/core-react/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));
 

--- a/src/earn/components/Earn.test.tsx
+++ b/src/earn/components/Earn.test.tsx
@@ -11,6 +11,25 @@ vi.mock('wagmi', async (importOriginal) => {
   };
 });
 
+vi.mock('@/internal', () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="ockTabs">{children}</div>
+  ),
+  TabsList: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tabs-list">{children}</div>
+  ),
+  Tab: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <button data-testid={`tab-${value}`}>{children}</button>
+  ),
+  TabContent: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => <div data-testid={`tab-content-${value}`}>{children}</div>,
+}));
+
 vi.mock('@/wallet/hooks/useGetTokenBalance', () => ({
   useGetTokenBalance: vi.fn(),
 }));

--- a/src/earn/components/Earn.test.tsx
+++ b/src/earn/components/Earn.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { useGetTokenBalance } from '@/wallet/hooks/useGetTokenBalance';
+import { type Mock, beforeEach, describe, it, expect, vi } from 'vitest';
+import { useAccount } from 'wagmi';
+import { Earn } from './Earn';
+
+vi.mock('wagmi', async (importOriginal) => {
+  return {
+    ...(await importOriginal<typeof import('wagmi')>()),
+    useAccount: vi.fn(),
+  };
+});
+
+vi.mock('@/wallet/hooks/useGetTokenBalance', () => ({
+  useGetTokenBalance: vi.fn(),
+}));
+
+vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+describe('Earn Component', () => {
+  beforeEach(() => {
+    (useAccount as Mock).mockReturnValue({
+      address: '0x123',
+    });
+    (useGetTokenBalance as Mock).mockReturnValue({
+      convertedBalance: '0.0',
+      error: null,
+    });
+  });
+
+  it('renders custom children when provided', () => {
+    const customChildren = <p>Custom Children</p>;
+    render(<Earn vaultAddress="0x123">{customChildren}</Earn>);
+
+    expect(screen.getByText('Custom Children')).toBeInTheDocument();
+    expect(screen.queryByTestId('tabs')).not.toBeInTheDocument();
+  });
+
+  it('renders default tabs and their contents when children are not provided', () => {
+    const { container } = render(<Earn vaultAddress="0x123" />);
+
+    const tabs = screen.getByTestId('ockTabs');
+    expect(tabs).toBeInTheDocument();
+
+    expect(container).toHaveTextContent('Deposit');
+    expect(container).toHaveTextContent('Withdraw');
+  });
+});

--- a/src/earn/components/Earn.test.tsx
+++ b/src/earn/components/Earn.test.tsx
@@ -34,7 +34,7 @@ vi.mock('@/wallet/hooks/useGetTokenBalance', () => ({
   useGetTokenBalance: vi.fn(),
 }));
 
-vi.mock('@/core-react/internal/hooks/useTheme', () => ({
+vi.mock('@/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));
 

--- a/src/earn/components/Earn.tsx
+++ b/src/earn/components/Earn.tsx
@@ -5,7 +5,11 @@ import { EarnDeposit } from './EarnDeposit';
 import { EarnProvider } from './EarnProvider';
 import { EarnWithdraw } from './EarnWithdraw';
 
-export function Earn({ children, className, vaultAddress }: EarnReact) {
+export function Earn({
+  children = <EarnDefaultContent />,
+  className,
+  vaultAddress,
+}: EarnReact) {
   return (
     <EarnProvider vaultAddress={vaultAddress}>
       <div
@@ -16,35 +20,37 @@ export function Earn({ children, className, vaultAddress }: EarnReact) {
           className,
         )}
       >
-        {children ? (
-          children
-        ) : (
-          <Tabs defaultValue="deposit">
-            <TabsList>
-              <Tab value="deposit">Deposit</Tab>
-              <Tab value="withdraw">Withdraw</Tab>
-            </TabsList>
-            <TabContent
-              value="deposit"
-              className={cn(
-                border.lineDefault,
-                '!border-l-0 !border-b-0 !border-r-0',
-              )}
-            >
-              <EarnDeposit />
-            </TabContent>
-            <TabContent
-              value="withdraw"
-              className={cn(
-                border.lineDefault,
-                '!border-l-0 !border-b-0 !border-r-0',
-              )}
-            >
-              <EarnWithdraw />
-            </TabContent>
-          </Tabs>
-        )}
+        {children}
       </div>
     </EarnProvider>
+  );
+}
+
+function EarnDefaultContent() {
+  return (
+    <Tabs defaultValue="deposit">
+      <TabsList>
+        <Tab value="deposit">Deposit</Tab>
+        <Tab value="withdraw">Withdraw</Tab>
+      </TabsList>
+      <TabContent
+        value="deposit"
+        className={cn(
+          border.lineDefault,
+          '!border-l-0 !border-b-0 !border-r-0',
+        )}
+      >
+        <EarnDeposit />
+      </TabContent>
+      <TabContent
+        value="withdraw"
+        className={cn(
+          border.lineDefault,
+          '!border-l-0 !border-b-0 !border-r-0',
+        )}
+      >
+        <EarnWithdraw />
+      </TabContent>
+    </Tabs>
   );
 }

--- a/src/earn/components/Earn.tsx
+++ b/src/earn/components/Earn.tsx
@@ -1,0 +1,50 @@
+import { EarnProvider } from './EarnProvider';
+import type { EarnReact } from '../types';
+import { border, cn } from '@/styles/theme';
+import { Tabs, TabsList, Tab, TabContent } from '@/internal';
+import { EarnWithdraw } from './EarnWithdraw';
+import { EarnDeposit } from './EarnDeposit';
+
+export function Earn({ children, className, vaultAddress }: EarnReact) {
+  return (
+    <EarnProvider vaultAddress={vaultAddress}>
+      <div
+        className={cn(
+          'flex flex-col overflow-hidden w-[375px]',
+          border.radius,
+          border.lineDefault,
+          className,
+        )}
+      >
+        {children ? (
+          children
+        ) : (
+          <Tabs defaultValue="deposit">
+            <TabsList>
+              <Tab value="deposit">Deposit</Tab>
+              <Tab value="withdraw">Withdraw</Tab>
+            </TabsList>
+            <TabContent
+              value="deposit"
+              className={cn(
+                border.lineDefault,
+                '!border-l-0 !border-b-0 !border-r-0',
+              )}
+            >
+              <EarnDeposit />
+            </TabContent>
+            <TabContent
+              value="withdraw"
+              className={cn(
+                border.lineDefault,
+                '!border-l-0 !border-b-0 !border-r-0',
+              )}
+            >
+              <EarnWithdraw />
+            </TabContent>
+          </Tabs>
+        )}
+      </div>
+    </EarnProvider>
+  );
+}

--- a/src/earn/components/Earn.tsx
+++ b/src/earn/components/Earn.tsx
@@ -1,4 +1,4 @@
-import { Tabs, TabsList, Tab, TabContent } from '@/internal';
+import { Tab, TabContent, Tabs, TabsList } from '@/internal';
 import { border, cn } from '@/styles/theme';
 import type { EarnReact } from '../types';
 import { EarnDeposit } from './EarnDeposit';

--- a/src/earn/components/Earn.tsx
+++ b/src/earn/components/Earn.tsx
@@ -1,16 +1,16 @@
-import { EarnProvider } from './EarnProvider';
-import type { EarnReact } from '../types';
-import { border, cn } from '@/styles/theme';
 import { Tabs, TabsList, Tab, TabContent } from '@/internal';
-import { EarnWithdraw } from './EarnWithdraw';
+import { border, cn } from '@/styles/theme';
+import type { EarnReact } from '../types';
 import { EarnDeposit } from './EarnDeposit';
+import { EarnProvider } from './EarnProvider';
+import { EarnWithdraw } from './EarnWithdraw';
 
 export function Earn({ children, className, vaultAddress }: EarnReact) {
   return (
     <EarnProvider vaultAddress={vaultAddress}>
       <div
         className={cn(
-          'flex flex-col overflow-hidden w-[375px]',
+          'flex w-[375px] flex-col overflow-hidden',
           border.radius,
           border.lineDefault,
           className,

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -12,7 +12,10 @@ export function EarnAmountInput({
   'aria-label': ariaLabel,
 }: EarnAmountInputReact) {
   return (
-    <div className={cn('flex flex-col', className)}>
+    <div
+      data-testid="ockEarnAmountInput"
+      className={cn('flex flex-col', className)}
+    >
       <TextInput
         className={cn(
           'w-full border-none bg-transparent font-display text-5xl',

--- a/src/earn/components/EarnCard.test.tsx
+++ b/src/earn/components/EarnCard.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { EarnCard } from './EarnCard';
 
 describe('EarnCard Component', () => {

--- a/src/earn/components/EarnCard.test.tsx
+++ b/src/earn/components/EarnCard.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { EarnCard } from './EarnCard';
+
+describe('EarnCard Component', () => {
+  it('renders children correctly', () => {
+    render(
+      <EarnCard>
+        <p>Test Child</p>
+      </EarnCard>,
+    );
+
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+  });
+
+  it('applies custom className', () => {
+    const customClass = 'custom-class';
+    render(
+      <EarnCard className={customClass}>
+        <div>earn</div>
+      </EarnCard>,
+    );
+
+    const cardElement = screen.getByTestId('ockEarnCard');
+    expect(cardElement).toHaveClass(customClass);
+  });
+
+  it('has default styles applied', () => {
+    render(
+      <EarnCard>
+        <div>earn</div>
+      </EarnCard>,
+    );
+
+    const cardElement = screen.getByTestId('ockEarnCard');
+    expect(cardElement).toHaveClass('border-t');
+    expect(cardElement).toHaveClass('flex');
+    expect(cardElement).toHaveClass('flex-col');
+    expect(cardElement).toHaveClass('p-4');
+    expect(cardElement).toHaveClass('gap-4');
+  });
+});

--- a/src/earn/components/EarnCard.tsx
+++ b/src/earn/components/EarnCard.tsx
@@ -1,0 +1,17 @@
+import { background, border, cn } from '@/styles/theme';
+import { EarnCardReact } from '../types';
+
+export function EarnCard({ children, className }: EarnCardReact) {
+  return (
+    <div
+      className={cn(
+        border.default,
+        'border-t flex flex-col p-4 gap-4',
+        background.default,
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/earn/components/EarnCard.tsx
+++ b/src/earn/components/EarnCard.tsx
@@ -1,5 +1,5 @@
 import { background, border, cn } from '@/styles/theme';
-import { EarnCardReact } from '../types';
+import type { EarnCardReact } from '../types';
 
 export function EarnCard({ children, className }: EarnCardReact) {
   return (

--- a/src/earn/components/EarnCard.tsx
+++ b/src/earn/components/EarnCard.tsx
@@ -4,6 +4,7 @@ import type { EarnCardReact } from '../types';
 export function EarnCard({ children, className }: EarnCardReact) {
   return (
     <div
+      data-testid="ockEarnCard"
       className={cn(
         border.default,
         'border-t flex flex-col p-4 gap-4',

--- a/src/earn/components/EarnCard.tsx
+++ b/src/earn/components/EarnCard.tsx
@@ -7,7 +7,7 @@ export function EarnCard({ children, className }: EarnCardReact) {
       data-testid="ockEarnCard"
       className={cn(
         border.default,
-        'border-t flex flex-col p-4 gap-4',
+        'flex flex-col gap-4 border-t p-4',
         background.default,
         className,
       )}

--- a/src/earn/components/EarnDeposit.test.tsx
+++ b/src/earn/components/EarnDeposit.test.tsx
@@ -1,3 +1,4 @@
+import type { Call } from '@/transaction/types';
 import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -27,7 +28,11 @@ const baseContext = {
 };
 
 vi.mock('@/transaction', () => ({
-  Transaction: ({ className, calls, children }: any) => (
+  Transaction: ({
+    className,
+    calls,
+    children,
+  }: { className: string; calls: Call[]; children: React.ReactNode }) => (
     <div
       data-testid="transaction"
       className={className}
@@ -37,7 +42,9 @@ vi.mock('@/transaction', () => ({
     </div>
   ),
   TransactionButton: ({ text }: { text: string }) => (
-    <button data-testid="transaction-button">{text}</button>
+    <button data-testid="transaction-button" type="button">
+      {text}
+    </button>
   ),
 }));
 

--- a/src/earn/components/EarnDeposit.test.tsx
+++ b/src/earn/components/EarnDeposit.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EarnDeposit } from './EarnDeposit';
 import { useEarnContext } from './EarnProvider';
 

--- a/src/earn/components/EarnDeposit.test.tsx
+++ b/src/earn/components/EarnDeposit.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EarnDeposit } from './EarnDeposit';
 import { useEarnContext } from './EarnProvider';
 
-vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+vi.mock('@/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));
 
@@ -22,6 +22,8 @@ const baseContext = {
   setWithdrawAmount: vi.fn(),
   interest: '1.2k',
   apy: '5%',
+  depositCalls: [],
+  withdrawCalls: [],
 };
 
 describe('EarnDeposit Component', () => {

--- a/src/earn/components/EarnDeposit.test.tsx
+++ b/src/earn/components/EarnDeposit.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { Address } from 'viem';
+import type { Address } from 'viem';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EarnDeposit } from './EarnDeposit';
 import { useEarnContext } from './EarnProvider';

--- a/src/earn/components/EarnDeposit.test.tsx
+++ b/src/earn/components/EarnDeposit.test.tsx
@@ -26,6 +26,21 @@ const baseContext = {
   withdrawCalls: [],
 };
 
+vi.mock('@/transaction', () => ({
+  Transaction: ({ className, calls, children }: any) => (
+    <div
+      data-testid="transaction"
+      className={className}
+      data-calls={JSON.stringify(calls)}
+    >
+      {children}
+    </div>
+  ),
+  TransactionButton: ({ text }: { text: string }) => (
+    <button data-testid="transaction-button">{text}</button>
+  ),
+}));
+
 describe('EarnDeposit Component', () => {
   beforeEach(() => {
     vi.mocked(useEarnContext).mockReturnValue(baseContext);

--- a/src/earn/components/EarnDeposit.test.tsx
+++ b/src/earn/components/EarnDeposit.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { Address } from 'viem';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EarnDeposit } from './EarnDeposit';
+import { useEarnContext } from './EarnProvider';
+
+vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+vi.mock('./EarnProvider', () => ({
+  useEarnContext: vi.fn(),
+}));
+
+const baseContext = {
+  convertedBalance: '1000',
+  setDepositAmount: vi.fn(),
+  vaultAddress: '0x123' as Address,
+  depositAmount: '0',
+  depositedAmount: '0',
+  withdrawAmount: '0',
+  setWithdrawAmount: vi.fn(),
+  interest: '1.2k',
+  apy: '5%',
+};
+
+describe('EarnDeposit Component', () => {
+  beforeEach(() => {
+    vi.mocked(useEarnContext).mockReturnValue(baseContext);
+  });
+
+  it('renders children when provided', () => {
+    const mockChildren = <p>Custom Children</p>;
+    render(<EarnDeposit>{mockChildren}</EarnDeposit>);
+
+    const earnCard = screen.getByTestId('ockEarnCard');
+    expect(earnCard).toBeInTheDocument();
+    expect(earnCard).toHaveTextContent('Custom Children');
+  });
+
+  it('renders default components when children are not provided', () => {
+    render(<EarnDeposit />);
+
+    const earnCard = screen.getByTestId('ockEarnCard');
+    expect(earnCard).toBeInTheDocument();
+
+    expect(screen.getByTestId('ockEarnDetails')).toBeInTheDocument();
+    expect(screen.getByTestId('ockEarnAmountInput')).toBeInTheDocument();
+    expect(screen.getByTestId('ockEarnBalance')).toBeInTheDocument();
+  });
+
+  it('applies custom className to the EarnCard', () => {
+    const customClass = 'custom-class';
+    render(<EarnDeposit className={customClass} />);
+
+    const earnCard = screen.getByTestId('ockEarnCard');
+    expect(earnCard).toHaveClass(customClass);
+  });
+});

--- a/src/earn/components/EarnDeposit.tsx
+++ b/src/earn/components/EarnDeposit.tsx
@@ -1,0 +1,20 @@
+import type { EarnDepositReact } from '../types';
+import { DepositAmountInput } from './DepositAmountInput';
+import { DepositBalance } from './DepositBalance';
+import { DepositDetails } from './DepositDetails';
+import { EarnCard } from './EarnCard';
+
+export function EarnDeposit({ children, className }: EarnDepositReact) {
+  if (children) {
+    return <EarnCard className={className}>{children}</EarnCard>;
+  }
+
+  return (
+    <EarnCard className={className}>
+      <DepositDetails />
+      <DepositAmountInput />
+      <DepositBalance />
+      {/* TODO: add remaining components */}
+    </EarnCard>
+  );
+}

--- a/src/earn/components/EarnDeposit.tsx
+++ b/src/earn/components/EarnDeposit.tsx
@@ -1,6 +1,7 @@
 import type { EarnDepositReact } from '../types';
 import { DepositAmountInput } from './DepositAmountInput';
 import { DepositBalance } from './DepositBalance';
+import { DepositButton } from './DepositButton';
 import { DepositDetails } from './DepositDetails';
 import { EarnCard } from './EarnCard';
 
@@ -14,7 +15,7 @@ export function EarnDeposit({ children, className }: EarnDepositReact) {
       <DepositDetails />
       <DepositAmountInput />
       <DepositBalance />
-      {/* TODO: add remaining components */}
+      <DepositButton />
     </EarnCard>
   );
 }

--- a/src/earn/components/EarnDeposit.tsx
+++ b/src/earn/components/EarnDeposit.tsx
@@ -5,17 +5,20 @@ import { DepositButton } from './DepositButton';
 import { DepositDetails } from './DepositDetails';
 import { EarnCard } from './EarnCard';
 
-export function EarnDeposit({ children, className }: EarnDepositReact) {
-  if (children) {
-    return <EarnCard className={className}>{children}</EarnCard>;
-  }
+export function EarnDeposit({
+  children = <EarnDepositDefaultContent />,
+  className,
+}: EarnDepositReact) {
+  return <EarnCard className={className}>{children}</EarnCard>;
+}
 
+function EarnDepositDefaultContent() {
   return (
-    <EarnCard className={className}>
+    <>
       <DepositDetails />
       <DepositAmountInput />
       <DepositBalance />
       <DepositButton />
-    </EarnCard>
+    </>
   );
 }

--- a/src/earn/components/EarnDetails.test.tsx
+++ b/src/earn/components/EarnDetails.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { EarnDetails } from './EarnDetails';
 
-vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+vi.mock('@/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));
 

--- a/src/earn/components/EarnDetails.test.tsx
+++ b/src/earn/components/EarnDetails.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
 import { usdcToken } from '@/token/constants';
-import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { EarnDetails } from './EarnDetails';
 
 vi.mock('../../core-react/internal/hooks/useTheme', () => ({

--- a/src/earn/components/EarnDetails.test.tsx
+++ b/src/earn/components/EarnDetails.test.tsx
@@ -19,7 +19,7 @@ describe('EarnDetails Component', () => {
     const tokenChip = screen.getByTestId('ockTokenChip_Button');
     expect(tokenChip).toBeInTheDocument();
     expect(tokenChip).toHaveTextContent('USDC');
-    expect(tokenChip).toHaveClass('!bg-[transparent]');
+    expect(tokenChip).toHaveClass('!bg-transparent');
   });
 
   it('renders tag with default styles when tagVariant is "default"', () => {

--- a/src/earn/components/EarnDetails.test.tsx
+++ b/src/earn/components/EarnDetails.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { usdcToken } from '@/token/constants';
+import { describe, it, expect, vi } from 'vitest';
+import { EarnDetails } from './EarnDetails';
+
+vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+describe('EarnDetails Component', () => {
+  it('renders nothing when token is not provided', () => {
+    const { container } = render(<EarnDetails />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders TokenChip with the correct props', () => {
+    render(<EarnDetails token={usdcToken} tag="test" />);
+
+    const tokenChip = screen.getByTestId('ockTokenChip_Button');
+    expect(tokenChip).toBeInTheDocument();
+    expect(tokenChip).toHaveTextContent('USDC');
+    expect(tokenChip).toHaveClass('!bg-[transparent]');
+  });
+
+  it('renders tag with default styles when tagVariant is "default"', () => {
+    const mockTag = 'Default Tag';
+    render(
+      <EarnDetails token={usdcToken} tag={mockTag} tagVariant="default" />,
+    );
+
+    const tagElement = screen.getByText(mockTag);
+    expect(tagElement).toBeInTheDocument();
+    expect(tagElement).toHaveClass('flex');
+    expect(tagElement).toHaveClass('items-center');
+    expect(tagElement).toHaveClass('justify-center');
+    expect(tagElement).toHaveClass('rounded-full');
+    expect(tagElement).toHaveClass('p-1');
+    expect(tagElement).toHaveClass('px-3');
+  });
+
+  it('applies custom className to the container', () => {
+    const customClass = 'custom-class';
+    render(<EarnDetails token={usdcToken} className={customClass} />);
+
+    const container = screen.getByTestId('ockTokenChip_Button').parentElement;
+    expect(container).toHaveClass(customClass);
+  });
+});

--- a/src/earn/components/EarnDetails.tsx
+++ b/src/earn/components/EarnDetails.tsx
@@ -13,6 +13,7 @@ export function EarnDetails({
   }
   return (
     <div
+      data-testid="ockEarnDetails"
       className={cn(
         border.radius,
         'flex w-full items-center justify-between gap-4',

--- a/src/earn/components/EarnDetails.tsx
+++ b/src/earn/components/EarnDetails.tsx
@@ -21,7 +21,7 @@ export function EarnDetails({
       )}
     >
       <TokenChip
-        className={'!bg-[transparent]'}
+        className={'!bg-transparent'}
         token={token}
         isPressable={false}
       />

--- a/src/earn/components/EarnDetails.tsx
+++ b/src/earn/components/EarnDetails.tsx
@@ -1,0 +1,41 @@
+import { background, border, cn, color, text } from '@/styles/theme';
+import { EarnDetailsReact } from '../types';
+import { TokenChip } from '@/token';
+
+export function EarnDetails({
+  className,
+  token,
+  tag,
+  tagVariant = 'default',
+}: EarnDetailsReact) {
+  if (!token) {
+    return null;
+  }
+  return (
+    <div
+      className={cn(
+        border.radius,
+        'flex items-center gap-4 w-full justify-between',
+        className,
+      )}
+    >
+      <TokenChip
+        className={'!bg-[transparent]'}
+        token={token}
+        isPressable={false}
+      />
+      {tag && (
+        <div
+          className={cn(
+            text.label1,
+            tagVariant === 'default' ? color.foregroundMuted : color.primary,
+            tagVariant === 'default' ? background.alternate : background.washed,
+            'p-1 px-3 rounded-full flex items-center justify-center',
+          )}
+        >
+          {tag}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/earn/components/EarnDetails.tsx
+++ b/src/earn/components/EarnDetails.tsx
@@ -1,6 +1,6 @@
-import { background, border, cn, color, text } from '@/styles/theme';
-import { EarnDetailsReact } from '../types';
 import { TokenChip } from '@/token';
+import { background, border, cn, color, text } from '@/styles/theme';
+import type { EarnDetailsReact } from '../types';
 
 export function EarnDetails({
   className,
@@ -15,7 +15,7 @@ export function EarnDetails({
     <div
       className={cn(
         border.radius,
-        'flex items-center gap-4 w-full justify-between',
+        'flex w-full items-center justify-between gap-4',
         className,
       )}
     >
@@ -30,7 +30,7 @@ export function EarnDetails({
             text.label1,
             tagVariant === 'default' ? color.foregroundMuted : color.primary,
             tagVariant === 'default' ? background.alternate : background.washed,
-            'p-1 px-3 rounded-full flex items-center justify-center',
+            'flex items-center justify-center rounded-full p-1 px-3',
           )}
         >
           {tag}

--- a/src/earn/components/EarnDetails.tsx
+++ b/src/earn/components/EarnDetails.tsx
@@ -1,5 +1,5 @@
-import { TokenChip } from '@/token';
 import { background, border, cn, color, text } from '@/styles/theme';
+import { TokenChip } from '@/token';
 import type { EarnDetailsReact } from '../types';
 
 export function EarnDetails({

--- a/src/earn/components/EarnProvider.tsx
+++ b/src/earn/components/EarnProvider.tsx
@@ -28,6 +28,8 @@ export function EarnProvider({ vaultAddress, children }: EarnProviderReact) {
     apy: '',
     // TODO: update when we have logic to fetch interest
     interest: '',
+    withdrawCalls: [],
+    depositCalls: [],
   });
 
   return <EarnContext.Provider value={value}>{children}</EarnContext.Provider>;

--- a/src/earn/components/EarnProvider.tsx
+++ b/src/earn/components/EarnProvider.tsx
@@ -24,6 +24,10 @@ export function EarnProvider({ vaultAddress, children }: EarnProviderReact) {
     setWithdrawAmount,
     // TODO: update when we have logic to fetch deposited amount
     depositedAmount: '',
+    // TODO: update when we have logic to fetch apy
+    apy: '',
+    // TODO: update when we have logic to fetch interest
+    interest: '',
   });
 
   return <EarnContext.Provider value={value}>{children}</EarnContext.Provider>;

--- a/src/earn/components/EarnWithdraw.test.tsx
+++ b/src/earn/components/EarnWithdraw.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useEarnContext } from './EarnProvider';
 import { EarnWithdraw } from './EarnWithdraw';
 
-vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+vi.mock('@/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));
 
@@ -21,6 +21,8 @@ const baseContext = {
   withdrawAmount: '0',
   setWithdrawAmount: vi.fn(),
   interest: '1.2k',
+  depositCalls: [],
+  withdrawCalls: [],
 };
 
 describe('EarnWithdraw Component', () => {

--- a/src/earn/components/EarnWithdraw.test.tsx
+++ b/src/earn/components/EarnWithdraw.test.tsx
@@ -1,3 +1,4 @@
+import type { Call } from '@/transaction/types';
 import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -26,7 +27,11 @@ const baseContext = {
 };
 
 vi.mock('@/transaction', () => ({
-  Transaction: ({ className, calls, children }: any) => (
+  Transaction: ({
+    className,
+    calls,
+    children,
+  }: { className: string; calls: Call[]; children: React.ReactNode }) => (
     <div
       data-testid="transaction"
       className={className}

--- a/src/earn/components/EarnWithdraw.test.tsx
+++ b/src/earn/components/EarnWithdraw.test.tsx
@@ -41,7 +41,9 @@ vi.mock('@/transaction', () => ({
     </div>
   ),
   TransactionButton: ({ text }: { text: string }) => (
-    <button data-testid="transaction-button">{text}</button>
+    <button data-testid="transaction-button" type="button">
+      {text}
+    </button>
   ),
 }));
 

--- a/src/earn/components/EarnWithdraw.test.tsx
+++ b/src/earn/components/EarnWithdraw.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useEarnContext } from './EarnProvider';
 import { EarnWithdraw } from './EarnWithdraw';
 

--- a/src/earn/components/EarnWithdraw.test.tsx
+++ b/src/earn/components/EarnWithdraw.test.tsx
@@ -25,6 +25,21 @@ const baseContext = {
   withdrawCalls: [],
 };
 
+vi.mock('@/transaction', () => ({
+  Transaction: ({ className, calls, children }: any) => (
+    <div
+      data-testid="transaction"
+      className={className}
+      data-calls={JSON.stringify(calls)}
+    >
+      {children}
+    </div>
+  ),
+  TransactionButton: ({ text }: { text: string }) => (
+    <button data-testid="transaction-button">{text}</button>
+  ),
+}));
+
 describe('EarnWithdraw Component', () => {
   beforeEach(() => {
     vi.mocked(useEarnContext).mockReturnValue(baseContext);

--- a/src/earn/components/EarnWithdraw.test.tsx
+++ b/src/earn/components/EarnWithdraw.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { Address } from 'viem';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useEarnContext } from './EarnProvider';
+import { EarnWithdraw } from './EarnWithdraw';
+
+vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+vi.mock('./EarnProvider', () => ({
+  useEarnContext: vi.fn(),
+}));
+
+const baseContext = {
+  convertedBalance: '1000',
+  setDepositAmount: vi.fn(),
+  vaultAddress: '0x123' as Address,
+  depositAmount: '0',
+  depositedAmount: '0',
+  withdrawAmount: '0',
+  setWithdrawAmount: vi.fn(),
+  interest: '1.2k',
+};
+
+describe('EarnWithdraw Component', () => {
+  beforeEach(() => {
+    vi.mocked(useEarnContext).mockReturnValue(baseContext);
+  });
+
+  it('renders children when provided', () => {
+    const mockChildren = <p>Custom Children</p>;
+    render(<EarnWithdraw>{mockChildren}</EarnWithdraw>);
+
+    const earnCard = screen.getByTestId('ockEarnCard');
+    expect(earnCard).toBeInTheDocument();
+    expect(earnCard).toHaveTextContent('Custom Children');
+  });
+
+  it('renders default components when children are not provided', () => {
+    render(<EarnWithdraw />);
+
+    const earnCard = screen.getByTestId('ockEarnCard');
+    expect(earnCard).toBeInTheDocument();
+
+    expect(screen.getByTestId('ockEarnDetails')).toBeInTheDocument();
+    expect(screen.getByTestId('ockEarnAmountInput')).toBeInTheDocument();
+    expect(screen.getByTestId('ockEarnBalance')).toBeInTheDocument();
+  });
+
+  it('applies custom className to the EarnCard', () => {
+    const customClass = 'custom-class';
+    render(<EarnWithdraw className={customClass} />);
+
+    const earnCard = screen.getByTestId('ockEarnCard');
+    expect(earnCard).toHaveClass(customClass);
+  });
+});

--- a/src/earn/components/EarnWithdraw.test.tsx
+++ b/src/earn/components/EarnWithdraw.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { Address } from 'viem';
+import type { Address } from 'viem';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useEarnContext } from './EarnProvider';
 import { EarnWithdraw } from './EarnWithdraw';

--- a/src/earn/components/EarnWithdraw.test.tsx
+++ b/src/earn/components/EarnWithdraw.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useEarnContext } from './EarnProvider';
 import { EarnWithdraw } from './EarnWithdraw';
 

--- a/src/earn/components/EarnWithdraw.tsx
+++ b/src/earn/components/EarnWithdraw.tsx
@@ -1,0 +1,20 @@
+import type { EarnWithdrawReact } from '../types';
+import { EarnCard } from './EarnCard';
+import { WithdrawAmountInput } from './WithdrawAmountInput';
+import { WithdrawBalance } from './WithdrawBalance';
+import { WithdrawDetails } from './WithdrawDetails';
+
+export function EarnWithdraw({ children, className }: EarnWithdrawReact) {
+  if (children) {
+    return <EarnCard className={className}>{children}</EarnCard>;
+  }
+
+  return (
+    <EarnCard className={className}>
+      <WithdrawDetails />
+      <WithdrawAmountInput />
+      <WithdrawBalance />
+      {/* TODO: add remaining components */}
+    </EarnCard>
+  );
+}

--- a/src/earn/components/EarnWithdraw.tsx
+++ b/src/earn/components/EarnWithdraw.tsx
@@ -2,6 +2,7 @@ import type { EarnWithdrawReact } from '../types';
 import { EarnCard } from './EarnCard';
 import { WithdrawAmountInput } from './WithdrawAmountInput';
 import { WithdrawBalance } from './WithdrawBalance';
+import { WithdrawButton } from './WithdrawButton';
 import { WithdrawDetails } from './WithdrawDetails';
 
 export function EarnWithdraw({ children, className }: EarnWithdrawReact) {
@@ -14,7 +15,7 @@ export function EarnWithdraw({ children, className }: EarnWithdrawReact) {
       <WithdrawDetails />
       <WithdrawAmountInput />
       <WithdrawBalance />
-      {/* TODO: add remaining components */}
+      <WithdrawButton />
     </EarnCard>
   );
 }

--- a/src/earn/components/EarnWithdraw.tsx
+++ b/src/earn/components/EarnWithdraw.tsx
@@ -5,17 +5,20 @@ import { WithdrawBalance } from './WithdrawBalance';
 import { WithdrawButton } from './WithdrawButton';
 import { WithdrawDetails } from './WithdrawDetails';
 
-export function EarnWithdraw({ children, className }: EarnWithdrawReact) {
-  if (children) {
-    return <EarnCard className={className}>{children}</EarnCard>;
-  }
+export function EarnWithdraw({
+  children = <EarnWithdrawDefaultContent />,
+  className,
+}: EarnWithdrawReact) {
+  return <EarnCard className={className}>{children}</EarnCard>;
+}
 
+function EarnWithdrawDefaultContent() {
   return (
-    <EarnCard className={className}>
+    <>
       <WithdrawDetails />
       <WithdrawAmountInput />
       <WithdrawBalance />
       <WithdrawButton />
-    </EarnCard>
+    </>
   );
 }

--- a/src/earn/components/WithdrawBalance.test.tsx
+++ b/src/earn/components/WithdrawBalance.test.tsx
@@ -16,6 +16,8 @@ const baseContext = {
   depositedAmount: '1000',
   withdrawAmount: '0',
   setWithdrawAmount: vi.fn(),
+  depositCalls: [],
+  withdrawCalls: [],
 };
 
 describe('WithdrawBalance', () => {

--- a/src/earn/components/WithdrawButton.test.tsx
+++ b/src/earn/components/WithdrawButton.test.tsx
@@ -2,7 +2,7 @@ import type { Call } from '@/transaction/types';
 import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
 import { describe, expect, it, vi } from 'vitest';
-import { DepositButton } from './DepositButton';
+import { WithdrawButton } from './WithdrawButton';
 import { useEarnContext } from './EarnProvider';
 
 vi.mock('./EarnProvider', () => ({
@@ -96,7 +96,7 @@ vi.mock('@/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));
 
-describe('DepositButton Component', () => {
+describe('WithdrawButton Component', () => {
   it('renders Transaction with depositCalls from EarnProvider', () => {
     const mockDepositCalls = [{ to: '0x123', data: '0x456' }] as Call[];
     vi.mocked(useEarnContext).mockReturnValue({
@@ -104,7 +104,7 @@ describe('DepositButton Component', () => {
       depositCalls: mockDepositCalls,
     });
 
-    render(<DepositButton />);
+    render(<WithdrawButton />);
 
     const transactionElement = screen.getByTestId('transaction');
     expect(transactionElement).toBeInTheDocument();
@@ -116,7 +116,7 @@ describe('DepositButton Component', () => {
       depositCalls: [],
     });
 
-    const { container } = render(<DepositButton />);
+    const { container } = render(<WithdrawButton />);
 
     expect(container).toHaveTextContent('Withdraw');
   });

--- a/src/earn/components/WithdrawButton.test.tsx
+++ b/src/earn/components/WithdrawButton.test.tsx
@@ -2,8 +2,8 @@ import type { Call } from '@/transaction/types';
 import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
 import { describe, expect, it, vi } from 'vitest';
-import { WithdrawButton } from './WithdrawButton';
 import { useEarnContext } from './EarnProvider';
+import { WithdrawButton } from './WithdrawButton';
 
 vi.mock('./EarnProvider', () => ({
   useEarnContext: vi.fn(),

--- a/src/earn/components/WithdrawButton.tsx
+++ b/src/earn/components/WithdrawButton.tsx
@@ -1,0 +1,13 @@
+import { Transaction, TransactionButton } from '@/transaction';
+import type { WithdrawButtonReact } from '../types';
+import { useEarnContext } from './EarnProvider';
+
+export function WithdrawButton({ className }: WithdrawButtonReact) {
+  const { withdrawCalls } = useEarnContext();
+
+  return (
+    <Transaction className={className} calls={withdrawCalls}>
+      <TransactionButton text="Withdraw" />
+    </Transaction>
+  );
+}

--- a/src/earn/components/WithdrawDetails.test.tsx
+++ b/src/earn/components/WithdrawDetails.test.tsx
@@ -9,7 +9,7 @@ vi.mock('./EarnProvider', () => ({
   useEarnContext: vi.fn(),
 }));
 
-vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+vi.mock('@/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));
 
@@ -21,6 +21,8 @@ const baseContext = {
   depositedAmount: '0',
   withdrawAmount: '0',
   setWithdrawAmount: vi.fn(),
+  depositCalls: [],
+  withdrawCalls: [],
 };
 
 describe('WithdrawDetails Component', () => {

--- a/src/earn/components/WithdrawDetails.test.tsx
+++ b/src/earn/components/WithdrawDetails.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
 import { usdcToken } from '@/token/constants';
+import { render, screen } from '@testing-library/react';
 import type { Address } from 'viem';
-import { type Mock, describe, it, expect, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useEarnContext } from './EarnProvider';
 import { WithdrawDetails } from './WithdrawDetails';
 

--- a/src/earn/components/WithdrawDetails.test.tsx
+++ b/src/earn/components/WithdrawDetails.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { usdcToken } from '@/token/constants';
+import type { Address } from 'viem';
+import { type Mock, describe, it, expect, vi } from 'vitest';
+import { useEarnContext } from './EarnProvider';
+import { WithdrawDetails } from './WithdrawDetails';
+
+vi.mock('./EarnProvider', () => ({
+  useEarnContext: vi.fn(),
+}));
+
+vi.mock('../../core-react/internal/hooks/useTheme', () => ({
+  useTheme: vi.fn(),
+}));
+
+const baseContext = {
+  convertedBalance: '1000',
+  setDepositAmount: vi.fn(),
+  vaultAddress: '0x123' as Address,
+  depositAmount: '0',
+  depositedAmount: '0',
+  withdrawAmount: '0',
+  setWithdrawAmount: vi.fn(),
+};
+
+describe('WithdrawDetails Component', () => {
+  it('renders EarnDetails with interest earned when interest is provided', () => {
+    const mockInterest = '1.2k';
+    vi.mocked(useEarnContext).mockReturnValue({
+      ...baseContext,
+      interest: mockInterest,
+    });
+
+    const { container } = render(<WithdrawDetails />);
+
+    const tokenElement = screen.getByTestId('ockTokenChip_Button');
+    expect(tokenElement).toHaveTextContent(usdcToken.name);
+
+    expect(container).toHaveTextContent(`${mockInterest} interest earned`);
+  });
+
+  it('renders EarnDetails with an empty tag when interest is not provided', () => {
+    vi.mocked(useEarnContext).mockReturnValue({ ...baseContext, apy: '' });
+
+    render(<WithdrawDetails />);
+
+    const tokenElement = screen.getByTestId('ockTokenChip_Button');
+    expect(tokenElement).toHaveTextContent(usdcToken.name);
+  });
+
+  it('applies custom className to the EarnDetails container', () => {
+    const customClass = 'custom-class';
+    (useEarnContext as Mock).mockReturnValue({ apy: null });
+
+    render(<WithdrawDetails className={customClass} />);
+
+    const earnDetails = screen.getByTestId('ockEarnDetails');
+    expect(earnDetails).toHaveClass(customClass);
+  });
+});

--- a/src/earn/components/WithdrawDetails.tsx
+++ b/src/earn/components/WithdrawDetails.tsx
@@ -1,9 +1,10 @@
 import { usdcToken } from '@/token/constants';
 import { useMemo } from 'react';
+import type { WithdrawDetailsReact } from '../types';
 import { EarnDetails } from './EarnDetails';
 import { useEarnContext } from './EarnProvider';
 
-export function WithdrawDetails() {
+export function WithdrawDetails({ className }: WithdrawDetailsReact) {
   const { interest } = useEarnContext();
 
   const tag = useMemo(() => {
@@ -14,5 +15,12 @@ export function WithdrawDetails() {
   }, [interest]);
 
   // TODO: update token when we have logic to fetch vault info
-  return <EarnDetails token={usdcToken} tag={tag} tagVariant="primary" />;
+  return (
+    <EarnDetails
+      className={className}
+      token={usdcToken}
+      tag={tag}
+      tagVariant="primary"
+    />
+  );
 }

--- a/src/earn/components/WithdrawDetails.tsx
+++ b/src/earn/components/WithdrawDetails.tsx
@@ -1,0 +1,18 @@
+import { usdcToken } from '@/token/constants';
+import { useMemo } from 'react';
+import { EarnDetails } from './EarnDetails';
+import { useEarnContext } from './EarnProvider';
+
+export function WithdrawDetails() {
+  const { interest } = useEarnContext();
+
+  const tag = useMemo(() => {
+    if (interest) {
+      return `${interest} interest earned`;
+    }
+    return '';
+  }, [interest]);
+
+  // TODO: update token when we have logic to fetch vault info
+  return <EarnDetails token={usdcToken} tag={tag} tagVariant="primary" />;
+}

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -1,4 +1,11 @@
+import type { Token } from '@/token';
 import type { Address } from 'viem';
+
+export type EarnReact = {
+  children?: React.ReactNode;
+  className?: string;
+  vaultAddress: Address;
+};
 
 export type EarnProviderReact = {
   children: React.ReactNode;
@@ -6,13 +13,15 @@ export type EarnProviderReact = {
 };
 
 export type EarnContextType = {
+  apy?: string;
   convertedBalance?: string;
   vaultAddress: Address;
   depositAmount: string;
   depositedAmount: string;
+  interest?: string;
   setDepositAmount: (amount: string) => void;
-  withdrawAmount: string;
   setWithdrawAmount: (amount: string) => void;
+  withdrawAmount: string;
 };
 
 export type EarnAmountInputReact = {
@@ -44,4 +53,26 @@ export type DepositBalanceReact = {
 
 export type WithdrawBalanceReact = {
   className?: string;
+};
+
+export type EarnCardReact = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export type EarnDepositReact = {
+  children?: React.ReactNode;
+  className?: string;
+};
+
+export type EarnWithdrawReact = {
+  children?: React.ReactNode;
+  className?: string;
+};
+
+export type EarnDetailsReact = {
+  className?: string;
+  token?: Token;
+  tag?: string;
+  tagVariant?: 'default' | 'primary';
 };

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -1,4 +1,5 @@
 import type { Token } from '@/token';
+import type { Call } from '@/transaction/types';
 import type { Address } from 'viem';
 
 export type EarnReact = {
@@ -22,6 +23,8 @@ export type EarnContextType = {
   setDepositAmount: (amount: string) => void;
   setWithdrawAmount: (amount: string) => void;
   withdrawAmount: string;
+  withdrawCalls: Call[];
+  depositCalls: Call[];
 };
 
 export type EarnAmountInputReact = {
@@ -82,5 +85,13 @@ export type DepositDetailsReact = {
 };
 
 export type WithdrawDetailsReact = {
+  className?: string;
+};
+
+export type DepositButtonReact = {
+  className?: string;
+};
+
+export type WithdrawButtonReact = {
   className?: string;
 };

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -76,3 +76,11 @@ export type EarnDetailsReact = {
   tag?: string;
   tagVariant?: 'default' | 'primary';
 };
+
+export type DepositDetailsReact = {
+  className?: string;
+};
+
+export type WithdrawDetailsReact = {
+  className?: string;
+};

--- a/src/internal/components/tabs/Tabs.tsx
+++ b/src/internal/components/tabs/Tabs.tsx
@@ -40,7 +40,10 @@ export function Tabs({ children, defaultValue, className }: TabsReact) {
   const componentTheme = useTheme();
   return (
     <TabsProvider defaultValue={defaultValue}>
-      <div className={cn(componentTheme, 'flex flex-col', className)}>
+      <div
+        data-testid="ockTabs"
+        className={cn(componentTheme, 'flex flex-col', className)}
+      >
         {children}
       </div>
     </TabsProvider>

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,0 +1,4 @@
+export { Tabs } from './components/tabs/Tabs';
+export { Tab } from './components/tabs/Tab';
+export { TabsList } from './components/tabs/TabsList';
+export { TabContent } from './components/tabs/TabContent';


### PR DESCRIPTION
**What changed? Why?**
- `WithdrawCard` / `DepositCard` -> wrappers for `EarnCard`

![Screenshot 2025-01-27 at 12 30 38 PM](https://github.com/user-attachments/assets/a968cd70-b8b9-43d0-9449-849870c30162)



- `WithdrawDetails` / `DepositDetails` -> wrappers for `EarnDetails`
![Screenshot 2025-01-27 at 9 45 19 AM](https://github.com/user-attachments/assets/b097efef-f7c7-4322-a208-f5d0df336fef)
![Screenshot 2025-01-27 at 9 45 11 AM](https://github.com/user-attachments/assets/ff7a79bb-38cd-408d-abe8-8a672077c5a7)


- `Earn`
- `WithdrawButton` / `DepositButton` -> wrappers of `Transaction`


**Notes to reviewers**

**How has it been tested?**
