### PR TITLE
feat: add onchainkit-context

### DIFF
--- a/src/api/buildMintTransaction.test.ts
+++ b/src/api/buildMintTransaction.test.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_MINT_TOKEN } from '@/core/network/definitions/nft';
 import { sendRequest } from '@/core/network/request';
 import { type Mock, describe, expect, it, vi } from 'vitest';
@@ -39,7 +39,7 @@ describe('buildMintTransaction', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_MINT_TOKEN,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -63,7 +63,7 @@ describe('buildMintTransaction', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_MINT_TOKEN,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -80,7 +80,7 @@ describe('buildMintTransaction', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_MINT_TOKEN,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 });

--- a/src/api/buildMintTransaction.test.ts
+++ b/src/api/buildMintTransaction.test.ts
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_MINT_TOKEN } from '@/core/network/definitions/nft';
 import { sendRequest } from '@/core/network/request';
 import { type Mock, describe, expect, it, vi } from 'vitest';
@@ -38,7 +39,7 @@ describe('buildMintTransaction', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_MINT_TOKEN,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -62,7 +63,7 @@ describe('buildMintTransaction', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_MINT_TOKEN,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -79,7 +80,7 @@ describe('buildMintTransaction', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_MINT_TOKEN,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 });

--- a/src/api/buildMintTransaction.test.ts
+++ b/src/api/buildMintTransaction.test.ts
@@ -35,7 +35,11 @@ describe('buildMintTransaction', () => {
     const result = await buildMintTransaction(params);
 
     expect(result).toEqual(mockResponse.result);
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_MINT_TOKEN, [params]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_MINT_TOKEN,
+      [params],
+      'api',
+    );
   });
 
   it('should return error details when request fails with an error', async () => {
@@ -55,7 +59,11 @@ describe('buildMintTransaction', () => {
       error: 'Error building mint transaction',
       message: 'Not Found',
     });
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_MINT_TOKEN, [params]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_MINT_TOKEN,
+      [params],
+      'api',
+    );
   });
 
   it('should return uncaught error details when an exception is thrown', async () => {
@@ -68,6 +76,10 @@ describe('buildMintTransaction', () => {
       error: 'Something went wrong',
       message: 'Error building mint transaction',
     });
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_MINT_TOKEN, [params]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_MINT_TOKEN,
+      [params],
+      'api',
+    );
   });
 });

--- a/src/api/buildMintTransaction.ts
+++ b/src/api/buildMintTransaction.ts
@@ -1,5 +1,5 @@
 import { CDP_MINT_TOKEN } from '../core/network/definitions/nft';
-import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
+import { type JSONRPCContext, sendRequest } from '../core/network/request';
 import type {
   BuildMintTransactionParams,
   BuildMintTransactionResponse,
@@ -10,7 +10,7 @@ import type {
  */
 export async function buildMintTransaction(
   params: BuildMintTransactionParams,
-  _referrer: JSONRPCReferrer = 'api',
+  _context: JSONRPCContext = 'api',
 ): Promise<BuildMintTransactionResponse> {
   const { mintAddress, tokenId, network = '', quantity, takerAddress } = params;
 
@@ -29,7 +29,7 @@ export async function buildMintTransaction(
           tokenId,
         },
       ],
-      _referrer,
+      _context,
     );
     if (res.error) {
       return {

--- a/src/api/buildMintTransaction.ts
+++ b/src/api/buildMintTransaction.ts
@@ -1,5 +1,6 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_MINT_TOKEN } from '../core/network/definitions/nft';
-import { type JSONRPCContext, sendRequest } from '../core/network/request';
+import { sendRequest } from '../core/network/request';
 import type {
   BuildMintTransactionParams,
   BuildMintTransactionResponse,
@@ -10,7 +11,7 @@ import type {
  */
 export async function buildMintTransaction(
   params: BuildMintTransactionParams,
-  _context: JSONRPCContext = 'api',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
 ): Promise<BuildMintTransactionResponse> {
   const { mintAddress, tokenId, network = '', quantity, takerAddress } = params;
 
@@ -29,7 +30,7 @@ export async function buildMintTransaction(
           tokenId,
         },
       ],
-      _context,
+      REQUEST_CONTEXT.API,
     );
     if (res.error) {
       return {

--- a/src/api/buildMintTransaction.ts
+++ b/src/api/buildMintTransaction.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_MINT_TOKEN } from '../core/network/definitions/nft';
 import { sendRequest } from '../core/network/request';
 import type {
@@ -11,7 +11,7 @@ import type {
  */
 export async function buildMintTransaction(
   params: BuildMintTransactionParams,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
+  _context: RequestContext = RequestContext.API,
 ): Promise<BuildMintTransactionResponse> {
   const { mintAddress, tokenId, network = '', quantity, takerAddress } = params;
 
@@ -30,7 +30,7 @@ export async function buildMintTransaction(
           tokenId,
         },
       ],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
     if (res.error) {
       return {

--- a/src/api/buildMintTransaction.ts
+++ b/src/api/buildMintTransaction.ts
@@ -1,5 +1,5 @@
 import { CDP_MINT_TOKEN } from '../core/network/definitions/nft';
-import { sendRequest } from '../core/network/request';
+import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
 import type {
   BuildMintTransactionParams,
   BuildMintTransactionResponse,
@@ -8,26 +8,29 @@ import type {
 /**
  * Retrieves contract to mint an NFT
  */
-export async function buildMintTransaction({
-  mintAddress,
-  tokenId,
-  network = '',
-  quantity,
-  takerAddress,
-}: BuildMintTransactionParams): Promise<BuildMintTransactionResponse> {
+export async function buildMintTransaction(
+  params: BuildMintTransactionParams,
+  _referrer: JSONRPCReferrer = 'api',
+): Promise<BuildMintTransactionResponse> {
+  const { mintAddress, tokenId, network = '', quantity, takerAddress } = params;
+
   try {
     const res = await sendRequest<
       BuildMintTransactionParams,
       BuildMintTransactionResponse
-    >(CDP_MINT_TOKEN, [
-      {
-        mintAddress,
-        network,
-        quantity,
-        takerAddress,
-        tokenId,
-      },
-    ]);
+    >(
+      CDP_MINT_TOKEN,
+      [
+        {
+          mintAddress,
+          network,
+          quantity,
+          takerAddress,
+          tokenId,
+        },
+      ],
+      _referrer,
+    );
     if (res.error) {
       return {
         code: `${res.error.code}`,

--- a/src/api/buildPayTransaction.test.ts
+++ b/src/api/buildPayTransaction.test.ts
@@ -50,9 +50,11 @@ describe('buildPayTransaction', () => {
     const payTransaction = await buildPayTransaction(mockParams);
     expect(payTransaction).toEqual(MOCK_HYDRATE_CHARGE_SUCCESS_RESPONSE.result);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_HYDRATE_CHARGE, [
-      mockAPIParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_HYDRATE_CHARGE,
+      [mockAPIParams],
+      'api',
+    );
   });
 
   it('should return a Pay Transaction with productId', async () => {
@@ -72,9 +74,11 @@ describe('buildPayTransaction', () => {
       MOCK_CREATE_PRODUCT_CHARGE_SUCCESS_RESPONSE.result,
     );
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_CREATE_PRODUCT_CHARGE, [
-      mockAPIParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_CREATE_PRODUCT_CHARGE,
+      [mockAPIParams],
+      'api',
+    );
   });
 
   it('should return an error if neither chargeId nor productId is provided', async () => {
@@ -126,8 +130,10 @@ describe('buildPayTransaction', () => {
       message: CHECKOUT_INVALID_CHARGE_ERROR_MESSAGE,
     });
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_HYDRATE_CHARGE, [
-      mockAPIParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_HYDRATE_CHARGE,
+      [mockAPIParams],
+      'api',
+    );
   });
 });

--- a/src/api/buildPayTransaction.test.ts
+++ b/src/api/buildPayTransaction.test.ts
@@ -2,7 +2,7 @@ import {
   CHECKOUT_INVALID_CHARGE_ERROR_MESSAGE,
   UNCAUGHT_CHECKOUT_ERROR_MESSAGE,
 } from '@/checkout/constants';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import {
   CDP_CREATE_PRODUCT_CHARGE,
   CDP_HYDRATE_CHARGE,
@@ -54,7 +54,7 @@ describe('buildPayTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_HYDRATE_CHARGE,
       [mockAPIParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -78,7 +78,7 @@ describe('buildPayTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_CREATE_PRODUCT_CHARGE,
       [mockAPIParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -134,7 +134,7 @@ describe('buildPayTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_HYDRATE_CHARGE,
       [mockAPIParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 });

--- a/src/api/buildPayTransaction.test.ts
+++ b/src/api/buildPayTransaction.test.ts
@@ -2,6 +2,7 @@ import {
   CHECKOUT_INVALID_CHARGE_ERROR_MESSAGE,
   UNCAUGHT_CHECKOUT_ERROR_MESSAGE,
 } from '@/checkout/constants';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import {
   CDP_CREATE_PRODUCT_CHARGE,
   CDP_HYDRATE_CHARGE,
@@ -53,7 +54,7 @@ describe('buildPayTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_HYDRATE_CHARGE,
       [mockAPIParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -77,7 +78,7 @@ describe('buildPayTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_CREATE_PRODUCT_CHARGE,
       [mockAPIParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -133,7 +134,7 @@ describe('buildPayTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_HYDRATE_CHARGE,
       [mockAPIParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 });

--- a/src/api/buildPayTransaction.ts
+++ b/src/api/buildPayTransaction.ts
@@ -3,7 +3,7 @@ import {
   CDP_HYDRATE_CHARGE,
 } from '../core/network/definitions/pay';
 import {
-  type JSONRPCReferrer,
+  type JSONRPCContext,
   type JSONRPCResult,
   sendRequest,
 } from '../core/network/request';
@@ -17,7 +17,7 @@ import { getPayErrorMessage } from './utils/getPayErrorMessage';
 
 export async function buildPayTransaction(
   params: BuildPayTransactionParams,
-  _referrer: JSONRPCReferrer = 'api',
+  _context: JSONRPCContext = 'api',
 ): Promise<BuildPayTransactionResponse> {
   const { address, chargeId, productId } = params;
 
@@ -35,7 +35,7 @@ export async function buildPayTransaction(
             chargeId,
           },
         ],
-        _referrer,
+        _context,
       );
     } else if (productId) {
       res = await sendRequest<
@@ -49,7 +49,7 @@ export async function buildPayTransaction(
             productId,
           },
         ],
-        _referrer,
+        _context,
       );
     } else {
       return {

--- a/src/api/buildPayTransaction.ts
+++ b/src/api/buildPayTransaction.ts
@@ -1,12 +1,9 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import {
   CDP_CREATE_PRODUCT_CHARGE,
   CDP_HYDRATE_CHARGE,
 } from '../core/network/definitions/pay';
-import {
-  type JSONRPCContext,
-  type JSONRPCResult,
-  sendRequest,
-} from '../core/network/request';
+import { type JSONRPCResult, sendRequest } from '../core/network/request';
 import type {
   BuildPayTransactionParams,
   BuildPayTransactionResponse,
@@ -17,7 +14,7 @@ import { getPayErrorMessage } from './utils/getPayErrorMessage';
 
 export async function buildPayTransaction(
   params: BuildPayTransactionParams,
-  _context: JSONRPCContext = 'api',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
 ): Promise<BuildPayTransactionResponse> {
   const { address, chargeId, productId } = params;
 

--- a/src/api/buildPayTransaction.ts
+++ b/src/api/buildPayTransaction.ts
@@ -2,7 +2,11 @@ import {
   CDP_CREATE_PRODUCT_CHARGE,
   CDP_HYDRATE_CHARGE,
 } from '../core/network/definitions/pay';
-import { type JSONRPCResult, sendRequest } from '../core/network/request';
+import {
+  type JSONRPCReferrer,
+  type JSONRPCResult,
+  sendRequest,
+} from '../core/network/request';
 import type {
   BuildPayTransactionParams,
   BuildPayTransactionResponse,
@@ -11,33 +15,42 @@ import type {
 } from './types';
 import { getPayErrorMessage } from './utils/getPayErrorMessage';
 
-export async function buildPayTransaction({
-  address,
-  chargeId,
-  productId,
-}: BuildPayTransactionParams): Promise<BuildPayTransactionResponse> {
+export async function buildPayTransaction(
+  params: BuildPayTransactionParams,
+  _referrer: JSONRPCReferrer = 'api',
+): Promise<BuildPayTransactionResponse> {
+  const { address, chargeId, productId } = params;
+
   try {
     let res: JSONRPCResult<BuildPayTransactionResponse>;
     if (chargeId) {
       res = await sendRequest<
         HydrateChargeAPIParams,
         BuildPayTransactionResponse
-      >(CDP_HYDRATE_CHARGE, [
-        {
-          sender: address,
-          chargeId,
-        },
-      ]);
+      >(
+        CDP_HYDRATE_CHARGE,
+        [
+          {
+            sender: address,
+            chargeId,
+          },
+        ],
+        _referrer,
+      );
     } else if (productId) {
       res = await sendRequest<
         CreateProductChargeParams,
         BuildPayTransactionResponse
-      >(CDP_CREATE_PRODUCT_CHARGE, [
-        {
-          sender: address,
-          productId,
-        },
-      ]);
+      >(
+        CDP_CREATE_PRODUCT_CHARGE,
+        [
+          {
+            sender: address,
+            productId,
+          },
+        ],
+        _referrer,
+      );
     } else {
       return {
         code: 'AmBPTa01', // Api Module Build Pay Transaction Error 01

--- a/src/api/buildPayTransaction.ts
+++ b/src/api/buildPayTransaction.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import {
   CDP_CREATE_PRODUCT_CHARGE,
   CDP_HYDRATE_CHARGE,
@@ -14,7 +14,7 @@ import { getPayErrorMessage } from './utils/getPayErrorMessage';
 
 export async function buildPayTransaction(
   params: BuildPayTransactionParams,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
+  _context: RequestContext = RequestContext.API,
 ): Promise<BuildPayTransactionResponse> {
   const { address, chargeId, productId } = params;
 

--- a/src/api/buildSwapTransaction.test.ts
+++ b/src/api/buildSwapTransaction.test.ts
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_GET_SWAP_TRADE } from '@/core/network/definitions/swap';
 import { sendRequest } from '@/core/network/request';
 import { SwapMessage } from '@/swap/constants';
@@ -118,7 +119,7 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_TRADE,
       [mockApiParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -202,7 +203,7 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_TRADE,
       [mockApiParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -341,7 +342,7 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_TRADE,
       [mockApiParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -374,7 +375,7 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_TRADE,
       [mockApiParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -415,7 +416,7 @@ describe('buildSwapTransaction', () => {
           slippagePercentage: '30',
         }),
       ],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 });

--- a/src/api/buildSwapTransaction.test.ts
+++ b/src/api/buildSwapTransaction.test.ts
@@ -115,9 +115,11 @@ describe('buildSwapTransaction', () => {
     expect(quote.fee).toEqual(expectedResponse.fee);
     expect(quote.warning).toEqual(expectedResponse.warning);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_TRADE, [
-      mockApiParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_TRADE,
+      [mockApiParams],
+      'api',
+    );
   });
 
   it('should return a swap with useAggregator=false', async () => {
@@ -197,9 +199,11 @@ describe('buildSwapTransaction', () => {
     expect(quote.fee).toEqual(expectedResponse.fee);
     expect(quote.warning).toEqual(expectedResponse.warning);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_TRADE, [
-      mockApiParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_TRADE,
+      [mockApiParams],
+      'api',
+    );
   });
 
   it('should return an error for an unsupported amount reference', async () => {
@@ -301,12 +305,16 @@ describe('buildSwapTransaction', () => {
     expect(quote.fee).toEqual(expectedResponse.fee);
     expect(quote.warning).toEqual(expectedResponse.warning);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_TRADE, [
-      {
-        slippagePercentage: '30',
-        ...mockApiParams,
-      },
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_TRADE,
+      [
+        {
+          slippagePercentage: '30',
+          ...mockApiParams,
+        },
+      ],
+      'api',
+    );
   });
 
   it('should return an error if sendRequest fails', async () => {
@@ -330,9 +338,11 @@ describe('buildSwapTransaction', () => {
       message: '',
     });
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_TRADE, [
-      mockApiParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_TRADE,
+      [mockApiParams],
+      'api',
+    );
   });
 
   it('should return an error object from buildSwapTransaction', async () => {
@@ -361,9 +371,11 @@ describe('buildSwapTransaction', () => {
       message: '',
     });
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_TRADE, [
-      mockApiParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_TRADE,
+      [mockApiParams],
+      'api',
+    );
   });
 
   it('should return an error object from buildSwapTransaction for invalid `amount` input', async () => {
@@ -396,10 +408,14 @@ describe('buildSwapTransaction', () => {
     };
     await buildSwapTransaction(mockParams);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_TRADE, [
-      expect.objectContaining({
-        slippagePercentage: '30',
-      }),
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_TRADE,
+      [
+        expect.objectContaining({
+          slippagePercentage: '30',
+        }),
+      ],
+      'api',
+    );
   });
 });

--- a/src/api/buildSwapTransaction.test.ts
+++ b/src/api/buildSwapTransaction.test.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_SWAP_TRADE } from '@/core/network/definitions/swap';
 import { sendRequest } from '@/core/network/request';
 import { SwapMessage } from '@/swap/constants';
@@ -119,7 +119,7 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_TRADE,
       [mockApiParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -203,7 +203,7 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_TRADE,
       [mockApiParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -314,7 +314,7 @@ describe('buildSwapTransaction', () => {
           ...mockApiParams,
         },
       ],
-      'api',
+      RequestContext.API,
     );
   });
 
@@ -342,7 +342,7 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_TRADE,
       [mockApiParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -375,7 +375,7 @@ describe('buildSwapTransaction', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_TRADE,
       [mockApiParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -416,7 +416,7 @@ describe('buildSwapTransaction', () => {
           slippagePercentage: '30',
         }),
       ],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 });

--- a/src/api/buildSwapTransaction.ts
+++ b/src/api/buildSwapTransaction.ts
@@ -1,7 +1,8 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_TRADE } from '../core/network/definitions/swap';
-import { type JSONRPCContext, sendRequest } from '../core/network/request';
+import { sendRequest } from '../core/network/request';
 import type { SwapAPIResponse } from '../swap/types';
 import { getSwapErrorCode } from '../swap/utils/getSwapErrorCode';
 import type {
@@ -17,7 +18,7 @@ import { getSwapTransaction } from './utils/getSwapTransaction';
  */
 export async function buildSwapTransaction(
   params: BuildSwapTransactionParams,
-  _context: JSONRPCContext = 'api',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
 ): Promise<BuildSwapTransactionResponse> {
   // Default parameters
   const defaultParams = {

--- a/src/api/buildSwapTransaction.ts
+++ b/src/api/buildSwapTransaction.ts
@@ -1,7 +1,7 @@
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_TRADE } from '../core/network/definitions/swap';
-import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
+import { type JSONRPCContext, sendRequest } from '../core/network/request';
 import type { SwapAPIResponse } from '../swap/types';
 import { getSwapErrorCode } from '../swap/utils/getSwapErrorCode';
 import type {
@@ -17,7 +17,7 @@ import { getSwapTransaction } from './utils/getSwapTransaction';
  */
 export async function buildSwapTransaction(
   params: BuildSwapTransactionParams,
-  _referrer: JSONRPCReferrer = 'api',
+  _context: JSONRPCContext = 'api',
 ): Promise<BuildSwapTransactionResponse> {
   // Default parameters
   const defaultParams = {
@@ -65,7 +65,7 @@ export async function buildSwapTransaction(
     const res = await sendRequest<SwapAPIParams, SwapAPIResponse>(
       CDP_GET_SWAP_TRADE,
       [apiParams],
-      _referrer,
+      _context,
     );
     if (res.error) {
       return {

--- a/src/api/buildSwapTransaction.ts
+++ b/src/api/buildSwapTransaction.ts
@@ -1,7 +1,7 @@
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_TRADE } from '../core/network/definitions/swap';
-import { sendRequest } from '../core/network/request';
+import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
 import type { SwapAPIResponse } from '../swap/types';
 import { getSwapErrorCode } from '../swap/utils/getSwapErrorCode';
 import type {
@@ -17,6 +17,7 @@ import { getSwapTransaction } from './utils/getSwapTransaction';
  */
 export async function buildSwapTransaction(
   params: BuildSwapTransactionParams,
+  _referrer: JSONRPCReferrer = 'api',
 ): Promise<BuildSwapTransactionResponse> {
   // Default parameters
   const defaultParams = {
@@ -64,6 +65,7 @@ export async function buildSwapTransaction(
     const res = await sendRequest<SwapAPIParams, SwapAPIResponse>(
       CDP_GET_SWAP_TRADE,
       [apiParams],
+      _referrer,
     );
     if (res.error) {
       return {

--- a/src/api/buildSwapTransaction.ts
+++ b/src/api/buildSwapTransaction.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_TRADE } from '../core/network/definitions/swap';
@@ -18,7 +18,7 @@ import { getSwapTransaction } from './utils/getSwapTransaction';
  */
 export async function buildSwapTransaction(
   params: BuildSwapTransactionParams,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
+  _context: RequestContext = RequestContext.API,
 ): Promise<BuildSwapTransactionResponse> {
   // Default parameters
   const defaultParams = {

--- a/src/api/getMintDetails.test.ts
+++ b/src/api/getMintDetails.test.ts
@@ -43,9 +43,11 @@ describe('getMintDetails', () => {
     const result = await getMintDetails(params);
 
     expect(result).toEqual(mockResponse.result);
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_GET_MINT_DETAILS, [
-      params,
-    ]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_GET_MINT_DETAILS,
+      [params],
+      'api',
+    );
   });
 
   it('should return error details when request fails with an error', async () => {
@@ -65,9 +67,11 @@ describe('getMintDetails', () => {
       error: 'Error fetching mint details',
       message: 'Not Found',
     });
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_GET_MINT_DETAILS, [
-      params,
-    ]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_GET_MINT_DETAILS,
+      [params],
+      'api',
+    );
   });
 
   it('should return uncaught error details when an exception is thrown', async () => {
@@ -80,8 +84,10 @@ describe('getMintDetails', () => {
       error: 'Something went wrong',
       message: 'Error fetching mint details',
     });
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_GET_MINT_DETAILS, [
-      params,
-    ]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_GET_MINT_DETAILS,
+      [params],
+      'api',
+    );
   });
 });

--- a/src/api/getMintDetails.test.ts
+++ b/src/api/getMintDetails.test.ts
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_GET_MINT_DETAILS } from '@/core/network/definitions/nft';
 import { sendRequest } from '@/core/network/request';
 import { type Mock, describe, expect, it, vi } from 'vitest';
@@ -46,7 +47,7 @@ describe('getMintDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_MINT_DETAILS,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -70,7 +71,7 @@ describe('getMintDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_MINT_DETAILS,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -87,7 +88,7 @@ describe('getMintDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_MINT_DETAILS,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 });

--- a/src/api/getMintDetails.test.ts
+++ b/src/api/getMintDetails.test.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_MINT_DETAILS } from '@/core/network/definitions/nft';
 import { sendRequest } from '@/core/network/request';
 import { type Mock, describe, expect, it, vi } from 'vitest';
@@ -47,7 +47,7 @@ describe('getMintDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_MINT_DETAILS,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -71,7 +71,7 @@ describe('getMintDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_MINT_DETAILS,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -88,7 +88,7 @@ describe('getMintDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_MINT_DETAILS,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 });

--- a/src/api/getMintDetails.ts
+++ b/src/api/getMintDetails.ts
@@ -1,15 +1,16 @@
 import { CDP_GET_MINT_DETAILS } from '../core/network/definitions/nft';
-import { sendRequest } from '../core/network/request';
+import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
 import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
 
 /**
  * Retrieves mint details for an NFT contract and token ID
  */
-export async function getMintDetails({
-  contractAddress,
-  takerAddress,
-  tokenId,
-}: GetMintDetailsParams): Promise<GetMintDetailsResponse> {
+export async function getMintDetails(
+  params: GetMintDetailsParams,
+  _referrer: JSONRPCReferrer = 'api',
+): Promise<GetMintDetailsResponse> {
+  const { contractAddress, takerAddress, tokenId } = params;
+
   try {
     const res = await sendRequest<GetMintDetailsParams, GetMintDetailsResponse>(
       CDP_GET_MINT_DETAILS,
@@ -20,6 +21,7 @@ export async function getMintDetails({
           tokenId,
         },
       ],
+      _referrer,
     );
     if (res.error) {
       return {

--- a/src/api/getMintDetails.ts
+++ b/src/api/getMintDetails.ts
@@ -1,5 +1,6 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_GET_MINT_DETAILS } from '../core/network/definitions/nft';
-import { type JSONRPCContext, sendRequest } from '../core/network/request';
+import { sendRequest } from '../core/network/request';
 import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
 
 /**
@@ -7,7 +8,7 @@ import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
  */
 export async function getMintDetails(
   params: GetMintDetailsParams,
-  _context: JSONRPCContext = 'api',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
 ): Promise<GetMintDetailsResponse> {
   const { contractAddress, takerAddress, tokenId } = params;
 
@@ -21,7 +22,7 @@ export async function getMintDetails(
           tokenId,
         },
       ],
-      _context,
+      REQUEST_CONTEXT.API,
     );
     if (res.error) {
       return {

--- a/src/api/getMintDetails.ts
+++ b/src/api/getMintDetails.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_MINT_DETAILS } from '../core/network/definitions/nft';
 import { sendRequest } from '../core/network/request';
 import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
@@ -8,7 +8,7 @@ import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
  */
 export async function getMintDetails(
   params: GetMintDetailsParams,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
+  _context: RequestContext = RequestContext.API,
 ): Promise<GetMintDetailsResponse> {
   const { contractAddress, takerAddress, tokenId } = params;
 
@@ -22,7 +22,7 @@ export async function getMintDetails(
           tokenId,
         },
       ],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
     if (res.error) {
       return {

--- a/src/api/getMintDetails.ts
+++ b/src/api/getMintDetails.ts
@@ -1,5 +1,5 @@
 import { CDP_GET_MINT_DETAILS } from '../core/network/definitions/nft';
-import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
+import { type JSONRPCContext, sendRequest } from '../core/network/request';
 import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
 
 /**
@@ -7,7 +7,7 @@ import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
  */
 export async function getMintDetails(
   params: GetMintDetailsParams,
-  _referrer: JSONRPCReferrer = 'api',
+  _context: JSONRPCContext = 'api',
 ): Promise<GetMintDetailsResponse> {
   const { contractAddress, takerAddress, tokenId } = params;
 
@@ -21,7 +21,7 @@ export async function getMintDetails(
           tokenId,
         },
       ],
-      _referrer,
+      _context,
     );
     if (res.error) {
       return {

--- a/src/api/getPortfolios.test.ts
+++ b/src/api/getPortfolios.test.ts
@@ -50,6 +50,7 @@ describe('getPortfolios', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_PORTFOLIO_TOKEN_BALANCES,
       [{ addresses: mockAddresses }],
+      'api',
     );
   });
 

--- a/src/api/getPortfolios.test.ts
+++ b/src/api/getPortfolios.test.ts
@@ -1,5 +1,5 @@
 import type { Portfolio, PortfolioTokenWithFiatValue } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
 import type { Address } from 'viem';
 import { type Mock, describe, expect, it, vi } from 'vitest';
@@ -51,7 +51,7 @@ describe('getPortfolios', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_PORTFOLIO_TOKEN_BALANCES,
       [{ addresses: mockAddresses }],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 

--- a/src/api/getPortfolios.test.ts
+++ b/src/api/getPortfolios.test.ts
@@ -1,4 +1,5 @@
 import type { Portfolio, PortfolioTokenWithFiatValue } from '@/api/types';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
 import type { Address } from 'viem';
 import { type Mock, describe, expect, it, vi } from 'vitest';
@@ -50,7 +51,7 @@ describe('getPortfolios', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_PORTFOLIO_TOKEN_BALANCES,
       [{ addresses: mockAddresses }],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 

--- a/src/api/getPortfolios.ts
+++ b/src/api/getPortfolios.ts
@@ -1,5 +1,5 @@
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
-import { type JSONRPCReferrer, sendRequest } from '@/core/network/request';
+import { type JSONRPCContext, sendRequest } from '@/core/network/request';
 import type {
   APIError,
   GetPortfoliosParams,
@@ -11,7 +11,7 @@ import type {
  */
 export async function getPortfolios(
   params: GetPortfoliosParams,
-  _referrer: JSONRPCReferrer = 'api',
+  _context: JSONRPCContext = 'api',
 ): Promise<GetPortfoliosResponse | APIError> {
   const { addresses } = params;
 
@@ -19,7 +19,7 @@ export async function getPortfolios(
     const res = await sendRequest<GetPortfoliosParams, GetPortfoliosResponse>(
       CDP_GET_PORTFOLIO_TOKEN_BALANCES,
       [{ addresses }],
-      _referrer,
+      _context,
     );
     if (res.error) {
       return {

--- a/src/api/getPortfolios.ts
+++ b/src/api/getPortfolios.ts
@@ -1,15 +1,25 @@
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
-import { sendRequest } from '@/core/network/request';
-import type { GetPortfoliosParams, GetPortfoliosResponse } from './types';
+import { type JSONRPCReferrer, sendRequest } from '@/core/network/request';
+import type {
+  APIError,
+  GetPortfoliosParams,
+  GetPortfoliosResponse,
+} from './types';
 
 /**
  * Retrieves the portfolios for the provided addresses
  */
-export async function getPortfolios({ addresses }: GetPortfoliosParams) {
+export async function getPortfolios(
+  params: GetPortfoliosParams,
+  _referrer: JSONRPCReferrer = 'api',
+): Promise<GetPortfoliosResponse | APIError> {
+  const { addresses } = params;
+
   try {
     const res = await sendRequest<GetPortfoliosParams, GetPortfoliosResponse>(
       CDP_GET_PORTFOLIO_TOKEN_BALANCES,
       [{ addresses }],
+      _referrer,
     );
     if (res.error) {
       return {

--- a/src/api/getPortfolios.ts
+++ b/src/api/getPortfolios.ts
@@ -1,5 +1,6 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
-import { type JSONRPCContext, sendRequest } from '@/core/network/request';
+import { sendRequest } from '@/core/network/request';
 import type {
   APIError,
   GetPortfoliosParams,
@@ -11,7 +12,7 @@ import type {
  */
 export async function getPortfolios(
   params: GetPortfoliosParams,
-  _context: JSONRPCContext = 'api',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
 ): Promise<GetPortfoliosResponse | APIError> {
   const { addresses } = params;
 

--- a/src/api/getPortfolios.ts
+++ b/src/api/getPortfolios.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
 import { sendRequest } from '@/core/network/request';
 import type {
@@ -12,7 +12,7 @@ import type {
  */
 export async function getPortfolios(
   params: GetPortfoliosParams,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
+  _context: RequestContext = RequestContext.API,
 ): Promise<GetPortfoliosResponse | APIError> {
   const { addresses } = params;
 

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_GET_SWAP_QUOTE } from '@/core/network/definitions/swap';
 import { sendRequest } from '@/core/network/request';
 import { SwapMessage } from '@/swap/constants';
@@ -51,7 +52,7 @@ describe('getSwapQuote', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_QUOTE,
       [mockApiParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -95,7 +96,7 @@ describe('getSwapQuote', () => {
           ...mockApiParams,
         },
       ],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -136,7 +137,7 @@ describe('getSwapQuote', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_QUOTE,
       [mockApiParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -168,7 +169,7 @@ describe('getSwapQuote', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_QUOTE,
       [mockApiParams],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -225,7 +226,7 @@ describe('getSwapQuote', () => {
           slippagePercentage: '30',
         },
       ],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -266,7 +267,7 @@ describe('getSwapQuote', () => {
           slippagePercentage: '3',
         },
       ],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 });

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -48,9 +48,11 @@ describe('getSwapQuote', () => {
     const quote = await getSwapQuote(mockParams);
     expect(quote).toEqual(mockResponse.result);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
-      mockApiParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_QUOTE,
+      [mockApiParams],
+      'api',
+    );
   });
 
   it('should return a quote for a swap with useAggregator=false', async () => {
@@ -85,12 +87,16 @@ describe('getSwapQuote', () => {
     const quote = await getSwapQuote(mockParams);
     expect(quote).toEqual(mockResponse.result);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
-      {
-        slippagePercentage: '3',
-        ...mockApiParams,
-      },
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_QUOTE,
+      [
+        {
+          slippagePercentage: '3',
+          ...mockApiParams,
+        },
+      ],
+      'api',
+    );
   });
 
   it('should return an error for an unsupported amount reference', async () => {
@@ -127,9 +133,11 @@ describe('getSwapQuote', () => {
       message: '',
     });
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
-      mockApiParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_QUOTE,
+      [mockApiParams],
+      'api',
+    );
   });
 
   it('should return an error object from getSwapQuote', async () => {
@@ -157,9 +165,11 @@ describe('getSwapQuote', () => {
       message: '',
     });
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
-      mockApiParams,
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_QUOTE,
+      [mockApiParams],
+      'api',
+    );
   });
 
   it('should return a SwapError from getSwapQuote for invalid `amount` input', async () => {
@@ -207,12 +217,16 @@ describe('getSwapQuote', () => {
     (sendRequest as Mock).mockResolvedValue(mockResponse);
     await getSwapQuote(mockParams);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
-      {
-        ...mockApiParams,
-        slippagePercentage: '30',
-      },
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_QUOTE,
+      [
+        {
+          ...mockApiParams,
+          slippagePercentage: '30',
+        },
+      ],
+      'api',
+    );
   });
 
   it('should not adjust slippage when useAggregator is false', async () => {
@@ -243,12 +257,16 @@ describe('getSwapQuote', () => {
     (sendRequest as Mock).mockResolvedValue(mockResponse);
     await getSwapQuote(mockParams);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_GET_SWAP_QUOTE, [
-      {
-        ...mockApiParams,
-        v2Enabled: true,
-        slippagePercentage: '3',
-      },
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_GET_SWAP_QUOTE,
+      [
+        {
+          ...mockApiParams,
+          v2Enabled: true,
+          slippagePercentage: '3',
+        },
+      ],
+      'api',
+    );
   });
 });

--- a/src/api/getSwapQuote.test.ts
+++ b/src/api/getSwapQuote.test.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_SWAP_QUOTE } from '@/core/network/definitions/swap';
 import { sendRequest } from '@/core/network/request';
 import { SwapMessage } from '@/swap/constants';
@@ -52,7 +52,7 @@ describe('getSwapQuote', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_QUOTE,
       [mockApiParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -96,7 +96,7 @@ describe('getSwapQuote', () => {
           ...mockApiParams,
         },
       ],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -137,7 +137,7 @@ describe('getSwapQuote', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_QUOTE,
       [mockApiParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -169,7 +169,7 @@ describe('getSwapQuote', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_GET_SWAP_QUOTE,
       [mockApiParams],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -226,7 +226,7 @@ describe('getSwapQuote', () => {
           slippagePercentage: '30',
         },
       ],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -267,7 +267,7 @@ describe('getSwapQuote', () => {
           slippagePercentage: '3',
         },
       ],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 });

--- a/src/api/getSwapQuote.ts
+++ b/src/api/getSwapQuote.ts
@@ -1,7 +1,8 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_QUOTE } from '../core/network/definitions/swap';
-import { type JSONRPCContext, sendRequest } from '../core/network/request';
+import { sendRequest } from '../core/network/request';
 import type { SwapQuote } from '../swap/types';
 import { getSwapErrorCode } from '../swap/utils/getSwapErrorCode';
 import type {
@@ -16,7 +17,7 @@ import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
  */
 export async function getSwapQuote(
   params: GetSwapQuoteParams,
-  _context: JSONRPCContext = 'api',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {

--- a/src/api/getSwapQuote.ts
+++ b/src/api/getSwapQuote.ts
@@ -1,7 +1,7 @@
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_QUOTE } from '../core/network/definitions/swap';
-import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
+import { type JSONRPCContext, sendRequest } from '../core/network/request';
 import type { SwapQuote } from '../swap/types';
 import { getSwapErrorCode } from '../swap/utils/getSwapErrorCode';
 import type {
@@ -16,7 +16,7 @@ import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
  */
 export async function getSwapQuote(
   params: GetSwapQuoteParams,
-  _referrer: JSONRPCReferrer = 'api',
+  _context: JSONRPCContext = 'api',
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {
@@ -63,7 +63,7 @@ export async function getSwapQuote(
     const res = await sendRequest<SwapAPIParams, SwapQuote>(
       CDP_GET_SWAP_QUOTE,
       [apiParams],
-      _referrer,
+      _context,
     );
     if (res.error) {
       return {

--- a/src/api/getSwapQuote.ts
+++ b/src/api/getSwapQuote.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_QUOTE } from '../core/network/definitions/swap';
@@ -17,7 +17,7 @@ import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
  */
 export async function getSwapQuote(
   params: GetSwapQuoteParams,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
+  _context: RequestContext = RequestContext.API,
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {

--- a/src/api/getSwapQuote.ts
+++ b/src/api/getSwapQuote.ts
@@ -1,7 +1,7 @@
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_QUOTE } from '../core/network/definitions/swap';
-import { sendRequest } from '../core/network/request';
+import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
 import type { SwapQuote } from '../swap/types';
 import { getSwapErrorCode } from '../swap/utils/getSwapErrorCode';
 import type {
@@ -16,6 +16,7 @@ import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
  */
 export async function getSwapQuote(
   params: GetSwapQuoteParams,
+  _referrer: JSONRPCReferrer = 'api',
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {
@@ -62,6 +63,7 @@ export async function getSwapQuote(
     const res = await sendRequest<SwapAPIParams, SwapQuote>(
       CDP_GET_SWAP_QUOTE,
       [apiParams],
+      _referrer,
     );
     if (res.error) {
       return {

--- a/src/api/getTokenDetails.test.ts
+++ b/src/api/getTokenDetails.test.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_TOKEN_DETAILS } from '@/core/network/definitions/nft';
 import { sendRequest } from '@/core/network/request';
 import { type Mock, describe, expect, it, vi } from 'vitest';
@@ -43,7 +43,7 @@ describe('getTokenDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_TOKEN_DETAILS,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -67,7 +67,7 @@ describe('getTokenDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_TOKEN_DETAILS,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -84,7 +84,7 @@ describe('getTokenDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_TOKEN_DETAILS,
       [params],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 });

--- a/src/api/getTokenDetails.test.ts
+++ b/src/api/getTokenDetails.test.ts
@@ -39,9 +39,11 @@ describe('getTokenDetails', () => {
     const result = await getTokenDetails(params);
 
     expect(result).toEqual(mockResponse.result);
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_GET_TOKEN_DETAILS, [
-      params,
-    ]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_GET_TOKEN_DETAILS,
+      [params],
+      'api',
+    );
   });
 
   it('should return error details when request fails with an error', async () => {
@@ -61,9 +63,11 @@ describe('getTokenDetails', () => {
       error: 'Error fetching token details',
       message: 'Not Found',
     });
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_GET_TOKEN_DETAILS, [
-      params,
-    ]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_GET_TOKEN_DETAILS,
+      [params],
+      'api',
+    );
   });
 
   it('should return uncaught error details when an exception is thrown', async () => {
@@ -76,8 +80,10 @@ describe('getTokenDetails', () => {
       error: 'Something went wrong',
       message: 'Error fetching token details',
     });
-    expect(mockSendRequest).toHaveBeenCalledWith(CDP_GET_TOKEN_DETAILS, [
-      params,
-    ]);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_GET_TOKEN_DETAILS,
+      [params],
+      'api',
+    );
   });
 });

--- a/src/api/getTokenDetails.test.ts
+++ b/src/api/getTokenDetails.test.ts
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_GET_TOKEN_DETAILS } from '@/core/network/definitions/nft';
 import { sendRequest } from '@/core/network/request';
 import { type Mock, describe, expect, it, vi } from 'vitest';
@@ -42,7 +43,7 @@ describe('getTokenDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_TOKEN_DETAILS,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -66,7 +67,7 @@ describe('getTokenDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_TOKEN_DETAILS,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -83,7 +84,7 @@ describe('getTokenDetails', () => {
     expect(mockSendRequest).toHaveBeenCalledWith(
       CDP_GET_TOKEN_DETAILS,
       [params],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 });

--- a/src/api/getTokenDetails.ts
+++ b/src/api/getTokenDetails.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_TOKEN_DETAILS } from '../core/network/definitions/nft';
 import { sendRequest } from '../core/network/request';
 import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
@@ -8,7 +8,7 @@ import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
  */
 export async function getTokenDetails(
   params: GetTokenDetailsParams,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
+  _context: RequestContext = RequestContext.API,
 ): Promise<GetTokenDetailsResponse> {
   const { contractAddress, tokenId } = params;
 

--- a/src/api/getTokenDetails.ts
+++ b/src/api/getTokenDetails.ts
@@ -1,5 +1,5 @@
 import { CDP_GET_TOKEN_DETAILS } from '../core/network/definitions/nft';
-import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
+import { type JSONRPCContext, sendRequest } from '../core/network/request';
 import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
 
 /**
@@ -7,7 +7,7 @@ import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
  */
 export async function getTokenDetails(
   params: GetTokenDetailsParams,
-  _referrer: JSONRPCReferrer = 'api',
+  _context: JSONRPCContext = 'api',
 ): Promise<GetTokenDetailsResponse> {
   const { contractAddress, tokenId } = params;
 
@@ -23,7 +23,7 @@ export async function getTokenDetails(
           tokenId,
         },
       ],
-      _referrer,
+      _context,
     );
     if (res.error) {
       return {

--- a/src/api/getTokenDetails.ts
+++ b/src/api/getTokenDetails.ts
@@ -1,5 +1,6 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_GET_TOKEN_DETAILS } from '../core/network/definitions/nft';
-import { type JSONRPCContext, sendRequest } from '../core/network/request';
+import { sendRequest } from '../core/network/request';
 import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
 
 /**
@@ -7,7 +8,7 @@ import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
  */
 export async function getTokenDetails(
   params: GetTokenDetailsParams,
-  _context: JSONRPCContext = 'api',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
 ): Promise<GetTokenDetailsResponse> {
   const { contractAddress, tokenId } = params;
 

--- a/src/api/getTokenDetails.ts
+++ b/src/api/getTokenDetails.ts
@@ -1,24 +1,30 @@
 import { CDP_GET_TOKEN_DETAILS } from '../core/network/definitions/nft';
-import { sendRequest } from '../core/network/request';
+import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
 import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
 
 /**
  * Retrieves token details for an NFT contract and token ID
  */
-export async function getTokenDetails({
-  contractAddress,
-  tokenId,
-}: GetTokenDetailsParams): Promise<GetTokenDetailsResponse> {
+export async function getTokenDetails(
+  params: GetTokenDetailsParams,
+  _referrer: JSONRPCReferrer = 'api',
+): Promise<GetTokenDetailsResponse> {
+  const { contractAddress, tokenId } = params;
+
   try {
     const res = await sendRequest<
       GetTokenDetailsParams,
       GetTokenDetailsResponse
-    >(CDP_GET_TOKEN_DETAILS, [
-      {
-        contractAddress,
-        tokenId,
-      },
-    ]);
+    >(
+      CDP_GET_TOKEN_DETAILS,
+      [
+        {
+          contractAddress,
+          tokenId,
+        },
+      ],
+      _referrer,
+    );
     if (res.error) {
       return {
         code: `${res.error.code}`,

--- a/src/api/getTokens.test.ts
+++ b/src/api/getTokens.test.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_LIST_SWAP_ASSETS } from '@/core/network/definitions/swap';
 import { sendRequest } from '@/core/network/request';
 import { type Mock, afterEach, describe, expect, it, vi } from 'vitest';
@@ -60,7 +60,7 @@ describe('getTokens', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_LIST_SWAP_ASSETS,
       [{ limit: '50', page: '1' }],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -94,7 +94,7 @@ describe('getTokens', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_LIST_SWAP_ASSETS,
       [{ limit: '1', page: '1' }],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -117,7 +117,7 @@ describe('getTokens', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_LIST_SWAP_ASSETS,
       [{ limit: '50', page: '1' }],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 
@@ -136,7 +136,7 @@ describe('getTokens', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_LIST_SWAP_ASSETS,
       [{ limit: '50', page: '1' }],
-      REQUEST_CONTEXT.API,
+      RequestContext.API,
     );
   });
 });

--- a/src/api/getTokens.test.ts
+++ b/src/api/getTokens.test.ts
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_LIST_SWAP_ASSETS } from '@/core/network/definitions/swap';
 import { sendRequest } from '@/core/network/request';
 import { type Mock, afterEach, describe, expect, it, vi } from 'vitest';
@@ -59,7 +60,7 @@ describe('getTokens', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_LIST_SWAP_ASSETS,
       [{ limit: '50', page: '1' }],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -93,7 +94,7 @@ describe('getTokens', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_LIST_SWAP_ASSETS,
       [{ limit: '1', page: '1' }],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -116,7 +117,7 @@ describe('getTokens', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_LIST_SWAP_ASSETS,
       [{ limit: '50', page: '1' }],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 
@@ -135,7 +136,7 @@ describe('getTokens', () => {
     expect(sendRequest).toHaveBeenCalledWith(
       CDP_LIST_SWAP_ASSETS,
       [{ limit: '50', page: '1' }],
-      'api',
+      REQUEST_CONTEXT.API,
     );
   });
 });

--- a/src/api/getTokens.test.ts
+++ b/src/api/getTokens.test.ts
@@ -56,9 +56,11 @@ describe('getTokens', () => {
       },
     ]);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_LIST_SWAP_ASSETS, [
-      { limit: '50', page: '1' },
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_LIST_SWAP_ASSETS,
+      [{ limit: '50', page: '1' }],
+      'api',
+    );
   });
 
   it('should accept options parameters', async () => {
@@ -88,9 +90,11 @@ describe('getTokens', () => {
       },
     ]);
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_LIST_SWAP_ASSETS, [
-      { limit: '1', page: '1' },
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_LIST_SWAP_ASSETS,
+      [{ limit: '1', page: '1' }],
+      'api',
+    );
   });
 
   it('should return an error object if sendRequest returns an error', async () => {
@@ -109,9 +113,11 @@ describe('getTokens', () => {
       message: 'Request failed',
     });
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_LIST_SWAP_ASSETS, [
-      { limit: '50', page: '1' },
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_LIST_SWAP_ASSETS,
+      [{ limit: '50', page: '1' }],
+      'api',
+    );
   });
 
   it('should rethrow the error if an error occurs during token retrieval', async () => {
@@ -126,8 +132,10 @@ describe('getTokens', () => {
       message: 'Request failed',
     });
     expect(sendRequest).toHaveBeenCalledTimes(1);
-    expect(sendRequest).toHaveBeenCalledWith(CDP_LIST_SWAP_ASSETS, [
-      { limit: '50', page: '1' },
-    ]);
+    expect(sendRequest).toHaveBeenCalledWith(
+      CDP_LIST_SWAP_ASSETS,
+      [{ limit: '50', page: '1' }],
+      'api',
+    );
   });
 });

--- a/src/api/getTokens.ts
+++ b/src/api/getTokens.ts
@@ -1,5 +1,6 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { CDP_LIST_SWAP_ASSETS } from '../core/network/definitions/swap';
-import { type JSONRPCContext, sendRequest } from '../core/network/request';
+import { sendRequest } from '../core/network/request';
 import type { Token } from '../token/types';
 import type { GetTokensOptions, GetTokensResponse } from './types';
 
@@ -8,7 +9,7 @@ import type { GetTokensOptions, GetTokensResponse } from './types';
  */
 export async function getTokens(
   options?: GetTokensOptions,
-  _context: JSONRPCContext = 'api',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
 ): Promise<GetTokensResponse> {
   // Default filter values
   const defaultFilter: GetTokensOptions = {

--- a/src/api/getTokens.ts
+++ b/src/api/getTokens.ts
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { CDP_LIST_SWAP_ASSETS } from '../core/network/definitions/swap';
 import { sendRequest } from '../core/network/request';
 import type { Token } from '../token/types';
@@ -9,7 +9,7 @@ import type { GetTokensOptions, GetTokensResponse } from './types';
  */
 export async function getTokens(
   options?: GetTokensOptions,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.API,
+  _context: RequestContext = RequestContext.API,
 ): Promise<GetTokensResponse> {
   // Default filter values
   const defaultFilter: GetTokensOptions = {

--- a/src/api/getTokens.ts
+++ b/src/api/getTokens.ts
@@ -1,5 +1,5 @@
 import { CDP_LIST_SWAP_ASSETS } from '../core/network/definitions/swap';
-import { sendRequest } from '../core/network/request';
+import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
 import type { Token } from '../token/types';
 import type { GetTokensOptions, GetTokensResponse } from './types';
 
@@ -8,6 +8,7 @@ import type { GetTokensOptions, GetTokensResponse } from './types';
  */
 export async function getTokens(
   options?: GetTokensOptions,
+  _referrer: JSONRPCReferrer = 'api',
 ): Promise<GetTokensResponse> {
   // Default filter values
   const defaultFilter: GetTokensOptions = {
@@ -20,6 +21,7 @@ export async function getTokens(
     const res = await sendRequest<GetTokensOptions, Token[]>(
       CDP_LIST_SWAP_ASSETS,
       [filters],
+      _referrer,
     );
     if (res.error) {
       return {

--- a/src/api/getTokens.ts
+++ b/src/api/getTokens.ts
@@ -1,5 +1,5 @@
 import { CDP_LIST_SWAP_ASSETS } from '../core/network/definitions/swap';
-import { type JSONRPCReferrer, sendRequest } from '../core/network/request';
+import { type JSONRPCContext, sendRequest } from '../core/network/request';
 import type { Token } from '../token/types';
 import type { GetTokensOptions, GetTokensResponse } from './types';
 
@@ -8,7 +8,7 @@ import type { GetTokensOptions, GetTokensResponse } from './types';
  */
 export async function getTokens(
   options?: GetTokensOptions,
-  _referrer: JSONRPCReferrer = 'api',
+  _context: JSONRPCContext = 'api',
 ): Promise<GetTokensResponse> {
   // Default filter values
   const defaultFilter: GetTokensOptions = {
@@ -21,7 +21,7 @@ export async function getTokens(
     const res = await sendRequest<GetTokensOptions, Token[]>(
       CDP_LIST_SWAP_ASSETS,
       [filters],
-      _referrer,
+      _context,
     );
     if (res.error) {
       return {

--- a/src/buy/components/BuyProvider.tsx
+++ b/src/buy/components/BuyProvider.tsx
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { useLifecycleStatus } from '@/internal/hooks/useLifecycleStatus';
 import {
   createContext,
@@ -361,7 +361,7 @@ export function BuyProvider({
             to: to.token,
             useAggregator,
           },
-          REQUEST_CONTEXT.BUY,
+          RequestContext.Buy,
         );
         if (isSwapError(response)) {
           updateLifecycleStatus({

--- a/src/buy/components/BuyProvider.tsx
+++ b/src/buy/components/BuyProvider.tsx
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { useLifecycleStatus } from '@/internal/hooks/useLifecycleStatus';
 import {
   createContext,
@@ -360,7 +361,7 @@ export function BuyProvider({
             to: to.token,
             useAggregator,
           },
-          'buy',
+          REQUEST_CONTEXT.BUY,
         );
         if (isSwapError(response)) {
           updateLifecycleStatus({

--- a/src/buy/components/BuyProvider.tsx
+++ b/src/buy/components/BuyProvider.tsx
@@ -351,14 +351,17 @@ export function BuyProvider({
 
       try {
         const maxSlippage = lifecycleStatus.statusData.maxSlippage;
-        const response = await buildSwapTransaction({
-          amount: from.amount,
-          fromAddress: address,
-          from: from.token,
-          maxSlippage: String(maxSlippage),
-          to: to.token,
-          useAggregator,
-        });
+        const response = await buildSwapTransaction(
+          {
+            amount: from.amount,
+            fromAddress: address,
+            from: from.token,
+            maxSlippage: String(maxSlippage),
+            to: to.token,
+            useAggregator,
+          },
+          'buy',
+        );
         if (isSwapError(response)) {
           updateLifecycleStatus({
             statusName: 'error',

--- a/src/buy/utils/getBuyQuote.test.ts
+++ b/src/buy/utils/getBuyQuote.test.ts
@@ -1,5 +1,5 @@
 import { getSwapQuote } from '@/api/getSwapQuote';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { formatTokenAmount } from '@/internal/utils/formatTokenAmount';
 import { isSwapError } from '@/swap/utils/isSwapError';
 import type { Token } from '@/token/types';
@@ -110,7 +110,7 @@ describe('getBuyQuote', () => {
         to: fromToken,
         useAggregator: true,
       },
-      REQUEST_CONTEXT.BUY,
+      RequestContext.Buy,
     );
 
     expect(formatTokenAmount).toHaveBeenCalledWith('100000000000000000', 18);
@@ -147,7 +147,7 @@ describe('getBuyQuote', () => {
         to: fromToken,
         useAggregator: true,
       },
-      REQUEST_CONTEXT.BUY,
+      RequestContext.Buy,
     );
 
     expect(formatTokenAmount).not.toHaveBeenCalled();

--- a/src/buy/utils/getBuyQuote.test.ts
+++ b/src/buy/utils/getBuyQuote.test.ts
@@ -100,14 +100,17 @@ describe('getBuyQuote', () => {
       fromSwapUnit: mockFromSwapUnit,
     });
 
-    expect(getSwapQuote).toHaveBeenCalledWith({
-      amount: '1',
-      amountReference: 'from',
-      from: toToken,
-      maxSlippage: '0.5',
-      to: fromToken,
-      useAggregator: true,
-    });
+    expect(getSwapQuote).toHaveBeenCalledWith(
+      {
+        amount: '1',
+        amountReference: 'from',
+        from: toToken,
+        maxSlippage: '0.5',
+        to: fromToken,
+        useAggregator: true,
+      },
+      'buy',
+    );
 
     expect(formatTokenAmount).toHaveBeenCalledWith('100000000000000000', 18);
     expect(mockFromSwapUnit.setAmountUSD).toHaveBeenCalledWith('100');
@@ -134,14 +137,17 @@ describe('getBuyQuote', () => {
       fromSwapUnit: mockFromSwapUnit,
     });
 
-    expect(getSwapQuote).toHaveBeenCalledWith({
-      amount: '1',
-      amountReference: 'from',
-      from: toToken,
-      maxSlippage: '0.5',
-      to: fromToken,
-      useAggregator: true,
-    });
+    expect(getSwapQuote).toHaveBeenCalledWith(
+      {
+        amount: '1',
+        amountReference: 'from',
+        from: toToken,
+        maxSlippage: '0.5',
+        to: fromToken,
+        useAggregator: true,
+      },
+      'buy',
+    );
 
     expect(formatTokenAmount).not.toHaveBeenCalled();
     expect(mockFromSwapUnit.setAmountUSD).toHaveBeenCalledWith('');

--- a/src/buy/utils/getBuyQuote.test.ts
+++ b/src/buy/utils/getBuyQuote.test.ts
@@ -1,4 +1,5 @@
 import { getSwapQuote } from '@/api/getSwapQuote';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { formatTokenAmount } from '@/internal/utils/formatTokenAmount';
 import { isSwapError } from '@/swap/utils/isSwapError';
 import type { Token } from '@/token/types';
@@ -109,7 +110,7 @@ describe('getBuyQuote', () => {
         to: fromToken,
         useAggregator: true,
       },
-      'buy',
+      REQUEST_CONTEXT.BUY,
     );
 
     expect(formatTokenAmount).toHaveBeenCalledWith('100000000000000000', 18);
@@ -146,7 +147,7 @@ describe('getBuyQuote', () => {
         to: fromToken,
         useAggregator: true,
       },
-      'buy',
+      REQUEST_CONTEXT.BUY,
     );
 
     expect(formatTokenAmount).not.toHaveBeenCalled();

--- a/src/buy/utils/getBuyQuote.ts
+++ b/src/buy/utils/getBuyQuote.ts
@@ -1,6 +1,6 @@
 import { getSwapQuote } from '@/api/getSwapQuote';
 import type { GetSwapQuoteParams, GetSwapQuoteResponse } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { formatTokenAmount } from '@/internal/utils/formatTokenAmount';
 import type { SwapError, SwapUnit } from '../../swap/types';
 import { isSwapError } from '../../swap/utils/isSwapError';
@@ -48,7 +48,7 @@ export async function getBuyQuote({
         to: from,
         useAggregator,
       },
-      REQUEST_CONTEXT.BUY,
+      RequestContext.Buy,
     );
   }
 

--- a/src/buy/utils/getBuyQuote.ts
+++ b/src/buy/utils/getBuyQuote.ts
@@ -1,5 +1,6 @@
 import { getSwapQuote } from '@/api/getSwapQuote';
 import type { GetSwapQuoteParams, GetSwapQuoteResponse } from '@/api/types';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { formatTokenAmount } from '@/internal/utils/formatTokenAmount';
 import type { SwapError, SwapUnit } from '../../swap/types';
 import { isSwapError } from '../../swap/utils/isSwapError';
@@ -47,7 +48,7 @@ export async function getBuyQuote({
         to: from,
         useAggregator,
       },
-      'buy',
+      REQUEST_CONTEXT.BUY,
     );
   }
 

--- a/src/buy/utils/getBuyQuote.ts
+++ b/src/buy/utils/getBuyQuote.ts
@@ -37,15 +37,18 @@ export async function getBuyQuote({
   if (to?.symbol !== from?.symbol) {
     // switching to and from here
     // instead of getting a quote for how much of X do we need to sell to get the input token amount
-    // we can get a quote for how much of X we will receive if we sell the input token amount
-    response = await getSwapQuote({
-      amount,
-      amountReference: 'from',
-      from: to,
-      maxSlippage,
-      to: from,
-      useAggregator,
-    });
+    // we can get a quote for how much of X we will recieve if we sell the input token amount
+    response = await getSwapQuote(
+      {
+        amount,
+        amountReference: 'from',
+        from: to,
+        maxSlippage,
+        to: from,
+        useAggregator,
+      },
+      'buy',
+    );
   }
 
   let formattedFromAmount = '';

--- a/src/checkout/utils/handlePayRequest.test.ts
+++ b/src/checkout/utils/handlePayRequest.test.ts
@@ -2,7 +2,7 @@ import type { Address } from 'viem';
 import { type Mock, describe, expect, it, vi } from 'vitest';
 
 import { buildPayTransaction } from '@/api';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { handlePayRequest } from './handlePayRequest';
 
 vi.mock('@/api', () => ({
@@ -27,7 +27,7 @@ describe('handlePayRequest', () => {
         address: mockAddress,
         chargeId: mockChargeId,
       },
-      REQUEST_CONTEXT.CHECKOUT,
+      RequestContext.Checkout,
     );
     expect(result).toEqual(mockResponse);
   });
@@ -45,7 +45,7 @@ describe('handlePayRequest', () => {
         address: mockAddress,
         productId: mockProductId,
       },
-      REQUEST_CONTEXT.CHECKOUT,
+      RequestContext.Checkout,
     );
     expect(result).toEqual(mockResponse);
   });
@@ -56,7 +56,7 @@ describe('handlePayRequest', () => {
     const result = await handlePayRequest({ address: mockAddress });
     expect(buildPayTransaction).toHaveBeenCalledWith(
       { address: mockAddress },
-      REQUEST_CONTEXT.CHECKOUT,
+      RequestContext.Checkout,
     );
     expect(result).toEqual(mockResponse);
   });

--- a/src/checkout/utils/handlePayRequest.test.ts
+++ b/src/checkout/utils/handlePayRequest.test.ts
@@ -2,6 +2,7 @@ import type { Address } from 'viem';
 import { type Mock, describe, expect, it, vi } from 'vitest';
 
 import { buildPayTransaction } from '@/api';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { handlePayRequest } from './handlePayRequest';
 
 vi.mock('@/api', () => ({
@@ -26,7 +27,7 @@ describe('handlePayRequest', () => {
         address: mockAddress,
         chargeId: mockChargeId,
       },
-      'checkout',
+      REQUEST_CONTEXT.CHECKOUT,
     );
     expect(result).toEqual(mockResponse);
   });
@@ -44,7 +45,7 @@ describe('handlePayRequest', () => {
         address: mockAddress,
         productId: mockProductId,
       },
-      'checkout',
+      REQUEST_CONTEXT.CHECKOUT,
     );
     expect(result).toEqual(mockResponse);
   });
@@ -55,7 +56,7 @@ describe('handlePayRequest', () => {
     const result = await handlePayRequest({ address: mockAddress });
     expect(buildPayTransaction).toHaveBeenCalledWith(
       { address: mockAddress },
-      'checkout',
+      REQUEST_CONTEXT.CHECKOUT,
     );
     expect(result).toEqual(mockResponse);
   });

--- a/src/checkout/utils/handlePayRequest.test.ts
+++ b/src/checkout/utils/handlePayRequest.test.ts
@@ -21,10 +21,13 @@ describe('handlePayRequest', () => {
       chargeHandler: mockChargeHandler,
     });
     expect(mockChargeHandler).toHaveBeenCalled();
-    expect(buildPayTransaction).toHaveBeenCalledWith({
-      address: mockAddress,
-      chargeId: mockChargeId,
-    });
+    expect(buildPayTransaction).toHaveBeenCalledWith(
+      {
+        address: mockAddress,
+        chargeId: mockChargeId,
+      },
+      'checkout',
+    );
     expect(result).toEqual(mockResponse);
   });
 
@@ -36,10 +39,13 @@ describe('handlePayRequest', () => {
       address: mockAddress,
       productId: mockProductId,
     });
-    expect(buildPayTransaction).toHaveBeenCalledWith({
-      address: mockAddress,
-      productId: mockProductId,
-    });
+    expect(buildPayTransaction).toHaveBeenCalledWith(
+      {
+        address: mockAddress,
+        productId: mockProductId,
+      },
+      'checkout',
+    );
     expect(result).toEqual(mockResponse);
   });
 
@@ -47,7 +53,10 @@ describe('handlePayRequest', () => {
     const mockResponse = { success: true };
     (buildPayTransaction as Mock).mockResolvedValue(mockResponse);
     const result = await handlePayRequest({ address: mockAddress });
-    expect(buildPayTransaction).toHaveBeenCalledWith({ address: mockAddress });
+    expect(buildPayTransaction).toHaveBeenCalledWith(
+      { address: mockAddress },
+      'checkout',
+    );
     expect(result).toEqual(mockResponse);
   });
 

--- a/src/checkout/utils/handlePayRequest.ts
+++ b/src/checkout/utils/handlePayRequest.ts
@@ -17,7 +17,10 @@ export const handlePayRequest = async ({
     buildPayTransactionParams.productId = productId;
   }
 
-  const response = await buildPayTransaction(buildPayTransactionParams);
+  const response = await buildPayTransaction(
+    buildPayTransactionParams,
+    'checkout',
+  );
 
   if ('error' in response) {
     throw new Error(response.error);

--- a/src/checkout/utils/handlePayRequest.ts
+++ b/src/checkout/utils/handlePayRequest.ts
@@ -1,5 +1,6 @@
 import { buildPayTransaction } from '@/api';
 import type { BuildPayTransactionParams } from '@/api';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import type { HandlePayRequestParams } from '../types';
 
 export const handlePayRequest = async ({
@@ -19,7 +20,7 @@ export const handlePayRequest = async ({
 
   const response = await buildPayTransaction(
     buildPayTransactionParams,
-    'checkout',
+    REQUEST_CONTEXT.CHECKOUT,
   );
 
   if ('error' in response) {

--- a/src/checkout/utils/handlePayRequest.ts
+++ b/src/checkout/utils/handlePayRequest.ts
@@ -1,6 +1,6 @@
 import { buildPayTransaction } from '@/api';
 import type { BuildPayTransactionParams } from '@/api';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import type { HandlePayRequestParams } from '../types';
 
 export const handlePayRequest = async ({
@@ -20,7 +20,7 @@ export const handlePayRequest = async ({
 
   const response = await buildPayTransaction(
     buildPayTransactionParams,
-    REQUEST_CONTEXT.CHECKOUT,
+    RequestContext.Checkout,
   );
 
   if ('error' in response) {

--- a/src/core/network/constants.ts
+++ b/src/core/network/constants.ts
@@ -5,14 +5,15 @@ export const JSON_HEADERS = {
   'Content-Type': 'application/json',
   'OnchainKit-Version': version,
 };
+export const CONTEXT_HEADER = 'OnchainKit-Context';
 export const JSON_RPC_VERSION = '2.0';
 export const ANALYTICS_API_URL = 'https://api.developer.coinbase.com/analytics';
-export const ALLOWABLE_REFERRERS = [
-  'api',
-  'buy',
-  'checkout',
-  'hook',
-  'nft',
-  'swap',
-  'wallet',
-];
+export const VALID_CONTEXTS = {
+  api: true,
+  buy: true,
+  checkout: true,
+  hook: true,
+  nft: true,
+  swap: true,
+  wallet: true,
+};

--- a/src/core/network/constants.ts
+++ b/src/core/network/constants.ts
@@ -7,3 +7,12 @@ export const JSON_HEADERS = {
 };
 export const JSON_RPC_VERSION = '2.0';
 export const ANALYTICS_API_URL = 'https://api.developer.coinbase.com/analytics';
+export const ALLOWABLE_REFERRERS = [
+  'api',
+  'buy',
+  'checkout',
+  'hook',
+  'nft',
+  'swap',
+  'wallet',
+];

--- a/src/core/network/constants.ts
+++ b/src/core/network/constants.ts
@@ -8,12 +8,19 @@ export const JSON_HEADERS = {
 export const CONTEXT_HEADER = 'OnchainKit-Context';
 export const JSON_RPC_VERSION = '2.0';
 export const ANALYTICS_API_URL = 'https://api.developer.coinbase.com/analytics';
-export const VALID_CONTEXTS = {
-  api: true,
-  buy: true,
-  checkout: true,
-  hook: true,
-  nft: true,
-  swap: true,
-  wallet: true,
-};
+
+/**
+ * Internal - The context where the request originated
+ *
+ * @enum {string}
+ * @readonly
+ */
+export enum REQUEST_CONTEXT {
+  API = 'api',
+  BUY = 'buy',
+  CHECKOUT = 'checkout',
+  HOOK = 'hook',
+  NFT = 'nft',
+  SWAP = 'swap',
+  WALLET = 'wallet',
+}

--- a/src/core/network/constants.ts
+++ b/src/core/network/constants.ts
@@ -15,12 +15,12 @@ export const ANALYTICS_API_URL = 'https://api.developer.coinbase.com/analytics';
  * @enum {string}
  * @readonly
  */
-export enum REQUEST_CONTEXT {
+export enum RequestContext {
   API = 'api',
-  BUY = 'buy',
-  CHECKOUT = 'checkout',
-  HOOK = 'hook',
+  Buy = 'buy',
+  Checkout = 'checkout',
+  Hook = 'hook',
   NFT = 'nft',
-  SWAP = 'swap',
-  WALLET = 'wallet',
+  Swap = 'swap',
+  Wallet = 'wallet',
 }

--- a/src/core/network/request.test.ts
+++ b/src/core/network/request.test.ts
@@ -54,6 +54,78 @@ describe('request', () => {
       expect(response).toEqual(mockResponse);
     });
 
+    it('should set the Onchainkit-Referrer if one is set', async () => {
+      const mockResponse = {
+        jsonrpc: '2.0',
+        result: 'exampleResult',
+        id: 1,
+      };
+      const mockFetch = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue(mockResponse),
+      });
+      global.fetch = mockFetch;
+
+      const requestBody = {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'exampleMethod',
+        params: ['param1', 'param2'],
+      };
+
+      const response = await sendRequest(
+        'exampleMethod',
+        ['param1', 'param2'],
+        'api',
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(expect.any(String), {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+          'OnchainKit-Version': version,
+          'OnchainKit-Referrer': 'api',
+        },
+      });
+      expect(response).toEqual(mockResponse);
+    });
+
+    it('should default to api if an invalid referrer is set', async () => {
+      const mockResponse = {
+        jsonrpc: '2.0',
+        result: 'exampleResult',
+        id: 1,
+      };
+      const mockFetch = vi.fn().mockResolvedValue({
+        json: vi.fn().mockResolvedValue(mockResponse),
+      });
+      global.fetch = mockFetch;
+
+      const requestBody = {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'exampleMethod',
+        params: ['param1', 'param2'],
+      };
+
+      const response = await sendRequest(
+        'exampleMethod',
+        ['param1', 'param2'],
+        'fake',
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(expect.any(String), {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+          'OnchainKit-Version': version,
+          'OnchainKit-Referrer': 'api',
+        },
+      });
+      expect(response).toEqual(mockResponse);
+    });
+
     it('should throw an error if an error occurs while sending the request', async () => {
       const mockError = new Error('Example error');
       const mockFetch = vi.fn().mockRejectedValue(mockError);

--- a/src/core/network/request.test.ts
+++ b/src/core/network/request.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { version } from '../../version';
 import { setOnchainKitConfig } from '../OnchainKitConfig';
-import { buildRequestBody, sendRequest } from './request';
+import { type JSONRPCContext, buildRequestBody, sendRequest } from './request';
 
 describe('request', () => {
   describe('buildRequestBody', () => {
@@ -54,7 +54,7 @@ describe('request', () => {
       expect(response).toEqual(mockResponse);
     });
 
-    it('should set the Onchainkit-Referrer if one is set', async () => {
+    it('should set the Onchainkit-Context if one is set', async () => {
       const mockResponse = {
         jsonrpc: '2.0',
         result: 'exampleResult',
@@ -84,13 +84,13 @@ describe('request', () => {
         headers: {
           'Content-Type': 'application/json',
           'OnchainKit-Version': version,
-          'OnchainKit-Referrer': 'api',
+          'OnchainKit-Context': 'api',
         },
       });
       expect(response).toEqual(mockResponse);
     });
 
-    it('should default to api if an invalid referrer is set', async () => {
+    it('should default to api if an invalid context is set', async () => {
       const mockResponse = {
         jsonrpc: '2.0',
         result: 'exampleResult',
@@ -111,7 +111,7 @@ describe('request', () => {
       const response = await sendRequest(
         'exampleMethod',
         ['param1', 'param2'],
-        'fake',
+        'fake' as JSONRPCContext,
       );
 
       expect(mockFetch).toHaveBeenCalledWith(expect.any(String), {
@@ -120,7 +120,7 @@ describe('request', () => {
         headers: {
           'Content-Type': 'application/json',
           'OnchainKit-Version': version,
-          'OnchainKit-Referrer': 'api',
+          'OnchainKit-Context': 'api',
         },
       });
       expect(response).toEqual(mockResponse);

--- a/src/core/network/request.test.ts
+++ b/src/core/network/request.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { version } from '../../version';
 import { setOnchainKitConfig } from '../OnchainKitConfig';
-import { type JSONRPCContext, buildRequestBody, sendRequest } from './request';
+import { RequestContext } from './constants';
+import { buildRequestBody, sendRequest } from './request';
 
 describe('request', () => {
   describe('buildRequestBody', () => {
@@ -75,7 +76,7 @@ describe('request', () => {
       const response = await sendRequest(
         'exampleMethod',
         ['param1', 'param2'],
-        'api',
+        RequestContext.API,
       );
 
       expect(mockFetch).toHaveBeenCalledWith(expect.any(String), {
@@ -111,7 +112,7 @@ describe('request', () => {
       const response = await sendRequest(
         'exampleMethod',
         ['param1', 'param2'],
-        'fake' as JSONRPCContext,
+        'fake' as RequestContext,
       );
 
       expect(mockFetch).toHaveBeenCalledWith(expect.any(String), {

--- a/src/core/network/request.ts
+++ b/src/core/network/request.ts
@@ -3,7 +3,7 @@ import {
   JSON_HEADERS,
   JSON_RPC_VERSION,
   POST_METHOD,
-  REQUEST_CONTEXT,
+  RequestContext,
 } from './constants';
 import { getRPCUrl } from './getRPCUrl';
 
@@ -53,14 +53,14 @@ export function buildRequestBody<T>(
  * @returns The headers for the JSON-RPC request.
  */
 export function buildRequestHeaders(
-  context?: REQUEST_CONTEXT,
+  context?: RequestContext,
 ): Record<string, string> {
   if (context) {
     // if an invalid context is provided, default to 'api'
-    if (!Object.values(REQUEST_CONTEXT).includes(context)) {
+    if (!Object.values(RequestContext).includes(context)) {
       return {
         ...JSON_HEADERS,
-        [CONTEXT_HEADER]: REQUEST_CONTEXT.API,
+        [CONTEXT_HEADER]: RequestContext.API,
       };
     }
 
@@ -84,7 +84,7 @@ export function buildRequestHeaders(
 export async function sendRequest<T, V>(
   method: string,
   params: T[],
-  _context?: REQUEST_CONTEXT,
+  _context?: RequestContext,
 ): Promise<JSONRPCResult<V>> {
   try {
     const body = buildRequestBody<T>(method, params);

--- a/src/core/network/request.ts
+++ b/src/core/network/request.ts
@@ -1,4 +1,9 @@
-import { JSON_HEADERS, JSON_RPC_VERSION, POST_METHOD } from './constants';
+import {
+  ALLOWABLE_REFERRERS,
+  JSON_HEADERS,
+  JSON_RPC_VERSION,
+  POST_METHOD,
+} from './constants';
 import { getRPCUrl } from './getRPCUrl';
 
 export type JSONRPCError = {
@@ -19,6 +24,8 @@ export type JSONRPCResult<T> = {
   jsonrpc: string;
   result: T;
 };
+
+export type JSONRPCReferrer = (typeof ALLOWABLE_REFERRERS)[number];
 
 /**
  * Builds a JSON-RPC request body.
@@ -41,23 +48,51 @@ export function buildRequestBody<T>(
 }
 
 /**
+ * Builds the headers for a JSON-RPC request.
+ *
+ * @params referrer - The referrer to add to the header
+ * @returns The headers for the JSON-RPC request.
+ */
+export function buildRequestHeaders(
+  referrer?: JSONRPCReferrer,
+): Record<string, string> {
+  if (referrer) {
+    // if an invalid referrer is provided, default to 'api'
+    if (!ALLOWABLE_REFERRERS.includes(referrer)) {
+      return {
+        ...JSON_HEADERS,
+        'OnchainKit-Referrer': 'api',
+      };
+    }
+
+    return {
+      ...JSON_HEADERS,
+      'OnchainKit-Referrer': referrer,
+    };
+  }
+  return JSON_HEADERS;
+}
+
+/**
  * Sends a JSON-RPC request to configured RPC URL.
  * Defaults to using the Coinbase Developer Platform Node.
  *
- * @param body - The JSON-RPC request body.
+ * @param method - The method name.
+ * @param params - The parameters for the method.
  * @returns A promise that resolves to the JSON-RPC response.
  * @throws If an error occurs while sending the request.
  */
 export async function sendRequest<T, V>(
   method: string,
   params: T[],
+  referrer?: JSONRPCReferrer,
 ): Promise<JSONRPCResult<V>> {
   try {
     const body = buildRequestBody<T>(method, params);
     const url = getRPCUrl();
     const response = await fetch(url, {
       body: JSON.stringify(body),
-      headers: JSON_HEADERS,
+      headers: buildRequestHeaders(referrer),
       method: POST_METHOD,
     });
     const data: JSONRPCResult<V> = await response.json();

--- a/src/core/network/request.ts
+++ b/src/core/network/request.ts
@@ -3,7 +3,7 @@ import {
   JSON_HEADERS,
   JSON_RPC_VERSION,
   POST_METHOD,
-  VALID_CONTEXTS,
+  REQUEST_CONTEXT,
 } from './constants';
 import { getRPCUrl } from './getRPCUrl';
 
@@ -25,11 +25,6 @@ export type JSONRPCResult<T> = {
   jsonrpc: string;
   result: T;
 };
-
-/**
- * Internal - specifies the context where the request originated
- */
-export type JSONRPCContext = keyof typeof VALID_CONTEXTS;
 
 /**
  * Builds a JSON-RPC request body.
@@ -58,14 +53,14 @@ export function buildRequestBody<T>(
  * @returns The headers for the JSON-RPC request.
  */
 export function buildRequestHeaders(
-  context?: JSONRPCContext,
+  context?: REQUEST_CONTEXT,
 ): Record<string, string> {
   if (context) {
     // if an invalid context is provided, default to 'api'
-    if (!VALID_CONTEXTS[context]) {
+    if (!Object.values(REQUEST_CONTEXT).includes(context)) {
       return {
         ...JSON_HEADERS,
-        [CONTEXT_HEADER]: 'api',
+        [CONTEXT_HEADER]: REQUEST_CONTEXT.API,
       };
     }
 
@@ -89,7 +84,7 @@ export function buildRequestHeaders(
 export async function sendRequest<T, V>(
   method: string,
   params: T[],
-  _context?: JSONRPCContext,
+  _context?: REQUEST_CONTEXT,
 ): Promise<JSONRPCResult<V>> {
   try {
     const body = buildRequestBody<T>(method, params);

--- a/src/internal/hooks/useExchangeRate.tsx
+++ b/src/internal/hooks/useExchangeRate.tsx
@@ -32,12 +32,15 @@ export async function useExchangeRate({
   const toToken = selectedInputType === 'crypto' ? usdcToken : token;
 
   try {
-    const response = await getSwapQuote({
-      amount: '1', // hardcoded amount of 1 because we only need the exchange rate
-      from: fromToken,
-      to: toToken,
-      useAggregator: false,
-    });
+    const response = await getSwapQuote(
+      {
+        amount: '1', // hardcoded amount of 1 because we only need the exchange rate
+        from: fromToken,
+        to: toToken,
+        useAggregator: false,
+      },
+      'wallet',
+    );
     if (isApiError(response)) {
       console.error('Error fetching exchange rate:', response.error);
       return;

--- a/src/internal/hooks/useExchangeRate.tsx
+++ b/src/internal/hooks/useExchangeRate.tsx
@@ -1,4 +1,5 @@
 import { getSwapQuote } from '@/api';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import type { Token } from '@/token';
 import { usdcToken } from '@/token/constants';
@@ -39,7 +40,7 @@ export async function useExchangeRate({
         to: toToken,
         useAggregator: false,
       },
-      'wallet',
+      REQUEST_CONTEXT.WALLET,
     );
     if (isApiError(response)) {
       console.error('Error fetching exchange rate:', response.error);

--- a/src/internal/hooks/useExchangeRate.tsx
+++ b/src/internal/hooks/useExchangeRate.tsx
@@ -1,5 +1,5 @@
 import { getSwapQuote } from '@/api';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import type { Token } from '@/token';
 import { usdcToken } from '@/token/constants';
@@ -40,7 +40,7 @@ export async function useExchangeRate({
         to: toToken,
         useAggregator: false,
       },
-      REQUEST_CONTEXT.WALLET,
+      RequestContext.Wallet,
     );
     if (isApiError(response)) {
       console.error('Error fetching exchange rate:', response.error);

--- a/src/nft/hooks/useMintData.ts
+++ b/src/nft/hooks/useMintData.ts
@@ -1,4 +1,5 @@
 import type { NFTError } from '@/api/types';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { convertIpfsToHttps } from '@/nft/utils/ipfs';
 import { useEffect, useState } from 'react';
 import { useAccount } from 'wagmi';
@@ -29,7 +30,7 @@ export function useMintData(
       takerAddress: address,
       ...(tokenId ? { tokenId } : {}),
     },
-    'nft',
+    REQUEST_CONTEXT.NFT,
   );
 
   if (mintError && !error) {

--- a/src/nft/hooks/useMintData.ts
+++ b/src/nft/hooks/useMintData.ts
@@ -23,11 +23,14 @@ export function useMintData(
     }
   }, [error, updateLifecycleStatus]);
 
-  const { error: mintError, data: mintData } = useMintDetails({
-    contractAddress,
-    takerAddress: address,
-    ...(tokenId ? { tokenId } : {}),
-  });
+  const { error: mintError, data: mintData } = useMintDetails(
+    {
+      contractAddress,
+      takerAddress: address,
+      ...(tokenId ? { tokenId } : {}),
+    },
+    'nft',
+  );
 
   if (mintError && !error) {
     setError({

--- a/src/nft/hooks/useMintData.ts
+++ b/src/nft/hooks/useMintData.ts
@@ -1,5 +1,5 @@
 import type { NFTError } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { convertIpfsToHttps } from '@/nft/utils/ipfs';
 import { useEffect, useState } from 'react';
 import { useAccount } from 'wagmi';
@@ -30,7 +30,7 @@ export function useMintData(
       takerAddress: address,
       ...(tokenId ? { tokenId } : {}),
     },
-    REQUEST_CONTEXT.NFT,
+    RequestContext.NFT,
   );
 
   if (mintError && !error) {

--- a/src/nft/hooks/useMintDetails.ts
+++ b/src/nft/hooks/useMintDetails.ts
@@ -1,23 +1,27 @@
 import { getMintDetails } from '@/api/getMintDetails';
 import type { MintDetails } from '@/api/types';
+import type { JSONRPCReferrer } from '@/core/network/request';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseMintDetailsParams } from '../types';
 
-export function useMintDetails({
-  contractAddress,
-  takerAddress,
-  tokenId,
-  queryOptions,
-}: UseMintDetailsParams<MintDetails>): UseQueryResult<MintDetails> {
+export function useMintDetails(
+  params: UseMintDetailsParams<MintDetails>,
+  _referrer: JSONRPCReferrer = 'hook',
+): UseQueryResult<MintDetails> {
+  const { contractAddress, takerAddress, tokenId, queryOptions } = params;
+
   return useQuery({
     queryKey: ['useMintDetails', contractAddress, takerAddress, tokenId],
     queryFn: async () => {
-      const mintDetails = await getMintDetails({
-        contractAddress,
-        takerAddress,
-        tokenId,
-      });
+      const mintDetails = await getMintDetails(
+        {
+          contractAddress,
+          takerAddress,
+          tokenId,
+        },
+        _referrer,
+      );
 
       if (isNFTError(mintDetails)) {
         throw mintDetails;

--- a/src/nft/hooks/useMintDetails.ts
+++ b/src/nft/hooks/useMintDetails.ts
@@ -1,13 +1,13 @@
 import { getMintDetails } from '@/api/getMintDetails';
 import type { MintDetails } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseMintDetailsParams } from '../types';
 
 export function useMintDetails(
   params: UseMintDetailsParams<MintDetails>,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.HOOK,
+  _context: RequestContext = RequestContext.Hook,
 ): UseQueryResult<MintDetails> {
   const { contractAddress, takerAddress, tokenId, queryOptions } = params;
 

--- a/src/nft/hooks/useMintDetails.ts
+++ b/src/nft/hooks/useMintDetails.ts
@@ -1,13 +1,13 @@
 import { getMintDetails } from '@/api/getMintDetails';
 import type { MintDetails } from '@/api/types';
-import type { JSONRPCContext } from '@/core/network/request';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseMintDetailsParams } from '../types';
 
 export function useMintDetails(
   params: UseMintDetailsParams<MintDetails>,
-  _context: JSONRPCContext = 'hook',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.HOOK,
 ): UseQueryResult<MintDetails> {
   const { contractAddress, takerAddress, tokenId, queryOptions } = params;
 

--- a/src/nft/hooks/useMintDetails.ts
+++ b/src/nft/hooks/useMintDetails.ts
@@ -1,13 +1,13 @@
 import { getMintDetails } from '@/api/getMintDetails';
 import type { MintDetails } from '@/api/types';
-import type { JSONRPCReferrer } from '@/core/network/request';
+import type { JSONRPCContext } from '@/core/network/request';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseMintDetailsParams } from '../types';
 
 export function useMintDetails(
   params: UseMintDetailsParams<MintDetails>,
-  _referrer: JSONRPCReferrer = 'hook',
+  _context: JSONRPCContext = 'hook',
 ): UseQueryResult<MintDetails> {
   const { contractAddress, takerAddress, tokenId, queryOptions } = params;
 
@@ -20,7 +20,7 @@ export function useMintDetails(
           takerAddress,
           tokenId,
         },
-        _referrer,
+        _context,
       );
 
       if (isNFTError(mintDetails)) {

--- a/src/nft/hooks/useNFTData.ts
+++ b/src/nft/hooks/useNFTData.ts
@@ -1,5 +1,5 @@
 import type { ContractType, NFTError } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { convertIpfsToHttps } from '@/nft/utils/ipfs';
 import { useEffect, useState } from 'react';
 import { useNFTLifecycleContext } from '../components/NFTLifecycleProvider';
@@ -27,7 +27,7 @@ export function useNFTData(
       contractAddress,
       tokenId: tokenId,
     },
-    REQUEST_CONTEXT.NFT,
+    RequestContext.NFT,
   );
 
   if (tokenError && !error) {

--- a/src/nft/hooks/useNFTData.ts
+++ b/src/nft/hooks/useNFTData.ts
@@ -1,4 +1,5 @@
 import type { ContractType, NFTError } from '@/api/types';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { convertIpfsToHttps } from '@/nft/utils/ipfs';
 import { useEffect, useState } from 'react';
 import { useNFTLifecycleContext } from '../components/NFTLifecycleProvider';
@@ -26,7 +27,7 @@ export function useNFTData(
       contractAddress,
       tokenId: tokenId,
     },
-    'nft',
+    REQUEST_CONTEXT.NFT,
   );
 
   if (tokenError && !error) {

--- a/src/nft/hooks/useNFTData.ts
+++ b/src/nft/hooks/useNFTData.ts
@@ -21,10 +21,13 @@ export function useNFTData(
     }
   }, [error, updateLifecycleStatus]);
 
-  const { error: tokenError, data: tokenDetails } = useTokenDetails({
-    contractAddress,
-    tokenId: tokenId,
-  });
+  const { error: tokenError, data: tokenDetails } = useTokenDetails(
+    {
+      contractAddress,
+      tokenId: tokenId,
+    },
+    'nft',
+  );
 
   if (tokenError && !error) {
     setError({

--- a/src/nft/hooks/useTokenDetails.ts
+++ b/src/nft/hooks/useTokenDetails.ts
@@ -1,21 +1,26 @@
 import { getTokenDetails } from '@/api/getTokenDetails';
 import type { TokenDetails } from '@/api/types';
+import type { JSONRPCReferrer } from '@/core/network/request';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseTokenDetailsParams } from '../types';
 
-export function useTokenDetails({
-  contractAddress,
-  tokenId,
-  queryOptions,
-}: UseTokenDetailsParams<TokenDetails>): UseQueryResult<TokenDetails> {
+export function useTokenDetails(
+  params: UseTokenDetailsParams<TokenDetails>,
+  _referrer: JSONRPCReferrer = 'hook',
+): UseQueryResult<TokenDetails> {
+  const { contractAddress, tokenId, queryOptions } = params;
+
   return useQuery({
     queryKey: ['useTokenDetails', contractAddress, tokenId],
     queryFn: async () => {
-      const tokenDetails = await getTokenDetails({
-        contractAddress,
-        tokenId,
-      });
+      const tokenDetails = await getTokenDetails(
+        {
+          contractAddress,
+          tokenId,
+        },
+        _referrer,
+      );
 
       if (isNFTError(tokenDetails)) {
         throw tokenDetails;

--- a/src/nft/hooks/useTokenDetails.ts
+++ b/src/nft/hooks/useTokenDetails.ts
@@ -1,13 +1,13 @@
 import { getTokenDetails } from '@/api/getTokenDetails';
 import type { TokenDetails } from '@/api/types';
-import type { JSONRPCContext } from '@/core/network/request';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseTokenDetailsParams } from '../types';
 
 export function useTokenDetails(
   params: UseTokenDetailsParams<TokenDetails>,
-  _context: JSONRPCContext = 'hook',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.HOOK,
 ): UseQueryResult<TokenDetails> {
   const { contractAddress, tokenId, queryOptions } = params;
 

--- a/src/nft/hooks/useTokenDetails.ts
+++ b/src/nft/hooks/useTokenDetails.ts
@@ -1,13 +1,13 @@
 import { getTokenDetails } from '@/api/getTokenDetails';
 import type { TokenDetails } from '@/api/types';
-import type { JSONRPCReferrer } from '@/core/network/request';
+import type { JSONRPCContext } from '@/core/network/request';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseTokenDetailsParams } from '../types';
 
 export function useTokenDetails(
   params: UseTokenDetailsParams<TokenDetails>,
-  _referrer: JSONRPCReferrer = 'hook',
+  _context: JSONRPCContext = 'hook',
 ): UseQueryResult<TokenDetails> {
   const { contractAddress, tokenId, queryOptions } = params;
 
@@ -19,7 +19,7 @@ export function useTokenDetails(
           contractAddress,
           tokenId,
         },
-        _referrer,
+        _context,
       );
 
       if (isNFTError(tokenDetails)) {

--- a/src/nft/hooks/useTokenDetails.ts
+++ b/src/nft/hooks/useTokenDetails.ts
@@ -1,13 +1,13 @@
 import { getTokenDetails } from '@/api/getTokenDetails';
 import type { TokenDetails } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseTokenDetailsParams } from '../types';
 
 export function useTokenDetails(
   params: UseTokenDetailsParams<TokenDetails>,
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.HOOK,
+  _context: RequestContext = RequestContext.Hook,
 ): UseQueryResult<TokenDetails> {
   const { contractAddress, tokenId, queryOptions } = params;
 

--- a/src/nft/utils/buildMintTransactionData.ts
+++ b/src/nft/utils/buildMintTransactionData.ts
@@ -1,5 +1,6 @@
 import { buildMintTransaction as buildMintTransactionApi } from '@/api/buildMintTransaction';
 import type { BuildMintTransactionParams } from '@/api/types';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import type { Address } from 'viem';
 import type { Call } from '../../transaction/types';
 
@@ -18,7 +19,7 @@ async function getMintTransaction({
       quantity,
       takerAddress,
     },
-    'nft',
+    REQUEST_CONTEXT.NFT,
   );
 
   if ('error' in mintTransactions) {

--- a/src/nft/utils/buildMintTransactionData.ts
+++ b/src/nft/utils/buildMintTransactionData.ts
@@ -1,6 +1,6 @@
 import { buildMintTransaction as buildMintTransactionApi } from '@/api/buildMintTransaction';
 import type { BuildMintTransactionParams } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import type { Address } from 'viem';
 import type { Call } from '../../transaction/types';
 
@@ -19,7 +19,7 @@ async function getMintTransaction({
       quantity,
       takerAddress,
     },
-    REQUEST_CONTEXT.NFT,
+    RequestContext.NFT,
   );
 
   if ('error' in mintTransactions) {

--- a/src/nft/utils/buildMintTransactionData.ts
+++ b/src/nft/utils/buildMintTransactionData.ts
@@ -10,13 +10,16 @@ async function getMintTransaction({
   quantity,
   takerAddress,
 }: BuildMintTransactionParams): Promise<Call[]> {
-  const mintTransactions = await buildMintTransactionApi({
-    mintAddress,
-    tokenId,
-    network,
-    quantity,
-    takerAddress,
-  });
+  const mintTransactions = await buildMintTransactionApi(
+    {
+      mintAddress,
+      tokenId,
+      network,
+      quantity,
+      takerAddress,
+    },
+    'nft',
+  );
 
   if ('error' in mintTransactions) {
     throw mintTransactions.message;

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -594,6 +594,7 @@ describe('SwapProvider', () => {
         to: DEGEN_TOKEN,
         useAggregator: true,
       }),
+      'swap',
     );
   });
 
@@ -621,6 +622,7 @@ describe('SwapProvider', () => {
         to: DEGEN_TOKEN,
         useAggregator: true,
       }),
+      'swap',
     );
   });
 

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -1,5 +1,5 @@
 import type { GetSwapQuoteResponse } from '@/api';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   fireEvent,
@@ -595,7 +595,7 @@ describe('SwapProvider', () => {
         to: DEGEN_TOKEN,
         useAggregator: true,
       }),
-      REQUEST_CONTEXT.SWAP,
+      RequestContext.Swap,
     );
   });
 
@@ -623,7 +623,7 @@ describe('SwapProvider', () => {
         to: DEGEN_TOKEN,
         useAggregator: true,
       }),
-      REQUEST_CONTEXT.SWAP,
+      RequestContext.Swap,
     );
   });
 

--- a/src/swap/components/SwapProvider.test.tsx
+++ b/src/swap/components/SwapProvider.test.tsx
@@ -1,4 +1,5 @@
 import type { GetSwapQuoteResponse } from '@/api';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   fireEvent,
@@ -594,7 +595,7 @@ describe('SwapProvider', () => {
         to: DEGEN_TOKEN,
         useAggregator: true,
       }),
-      'swap',
+      REQUEST_CONTEXT.SWAP,
     );
   });
 
@@ -622,7 +623,7 @@ describe('SwapProvider', () => {
         to: DEGEN_TOKEN,
         useAggregator: true,
       }),
-      'swap',
+      REQUEST_CONTEXT.SWAP,
     );
   });
 

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import {
   createContext,
   useCallback,
@@ -248,7 +249,7 @@ export function SwapProvider({
             to: destination.token,
             useAggregator,
           },
-          'swap',
+          REQUEST_CONTEXT.SWAP,
         );
         // If request resolves to error response set the quoteError
         // property of error state to the SwapError response
@@ -316,7 +317,7 @@ export function SwapProvider({
           to: to.token,
           useAggregator,
         },
-        'swap',
+        REQUEST_CONTEXT.SWAP,
       );
       if (isSwapError(response)) {
         updateLifecycleStatus({

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import {
   createContext,
   useCallback,
@@ -249,7 +249,7 @@ export function SwapProvider({
             to: destination.token,
             useAggregator,
           },
-          REQUEST_CONTEXT.SWAP,
+          RequestContext.Swap,
         );
         // If request resolves to error response set the quoteError
         // property of error state to the SwapError response
@@ -317,7 +317,7 @@ export function SwapProvider({
           to: to.token,
           useAggregator,
         },
-        REQUEST_CONTEXT.SWAP,
+        RequestContext.Swap,
       );
       if (isSwapError(response)) {
         updateLifecycleStatus({

--- a/src/swap/components/SwapProvider.tsx
+++ b/src/swap/components/SwapProvider.tsx
@@ -239,14 +239,17 @@ export function SwapProvider({
 
       try {
         const maxSlippage = lifecycleStatus.statusData.maxSlippage;
-        const response = await getSwapQuote({
-          amount,
-          amountReference: 'from',
-          from: source.token,
-          maxSlippage: String(maxSlippage),
-          to: destination.token,
-          useAggregator,
-        });
+        const response = await getSwapQuote(
+          {
+            amount,
+            amountReference: 'from',
+            from: source.token,
+            maxSlippage: String(maxSlippage),
+            to: destination.token,
+            useAggregator,
+          },
+          'swap',
+        );
         // If request resolves to error response set the quoteError
         // property of error state to the SwapError response
         if (isSwapError(response)) {
@@ -304,14 +307,17 @@ export function SwapProvider({
 
     try {
       const maxSlippage = lifecycleStatus.statusData.maxSlippage;
-      const response = await buildSwapTransaction({
-        amount: from.amount,
-        fromAddress: address,
-        from: from.token,
-        maxSlippage: String(maxSlippage),
-        to: to.token,
-        useAggregator,
-      });
+      const response = await buildSwapTransaction(
+        {
+          amount: from.amount,
+          fromAddress: address,
+          from: from.token,
+          maxSlippage: String(maxSlippage),
+          to: to.token,
+          useAggregator,
+        },
+        'swap',
+      );
       if (isSwapError(response)) {
         updateLifecycleStatus({
           statusName: 'error',

--- a/src/wallet/components/WalletAdvancedProvider.test.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.test.tsx
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { usePortfolio } from '@/wallet/hooks/usePortfolio';
 import { render, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -108,7 +108,7 @@ describe('useWalletAdvancedContext', () => {
       {
         address: null,
       },
-      REQUEST_CONTEXT.WALLET,
+      RequestContext.Wallet,
     );
 
     mockUseWalletContext.mockReturnValue({
@@ -122,7 +122,7 @@ describe('useWalletAdvancedContext', () => {
       {
         address: '0x123',
       },
-      REQUEST_CONTEXT.WALLET,
+      RequestContext.Wallet,
     );
   });
 

--- a/src/wallet/components/WalletAdvancedProvider.test.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.test.tsx
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { usePortfolio } from '@/wallet/hooks/usePortfolio';
 import { render, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -107,7 +108,7 @@ describe('useWalletAdvancedContext', () => {
       {
         address: null,
       },
-      'wallet',
+      REQUEST_CONTEXT.WALLET,
     );
 
     mockUseWalletContext.mockReturnValue({
@@ -121,7 +122,7 @@ describe('useWalletAdvancedContext', () => {
       {
         address: '0x123',
       },
-      'wallet',
+      REQUEST_CONTEXT.WALLET,
     );
   });
 

--- a/src/wallet/components/WalletAdvancedProvider.test.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.test.tsx
@@ -103,9 +103,12 @@ describe('useWalletAdvancedContext', () => {
       wrapper: WalletAdvancedProvider,
     });
 
-    expect(mockUsePortfolio).toHaveBeenCalledWith({
-      address: null,
-    });
+    expect(mockUsePortfolio).toHaveBeenCalledWith(
+      {
+        address: null,
+      },
+      'wallet',
+    );
 
     mockUseWalletContext.mockReturnValue({
       address: '0x123',
@@ -114,9 +117,12 @@ describe('useWalletAdvancedContext', () => {
 
     rerender();
 
-    expect(mockUsePortfolio).toHaveBeenCalledWith({
-      address: '0x123',
-    });
+    expect(mockUsePortfolio).toHaveBeenCalledWith(
+      {
+        address: '0x123',
+      },
+      'wallet',
+    );
   });
 
   describe('getAnimations', () => {

--- a/src/wallet/components/WalletAdvancedProvider.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.tsx
@@ -1,3 +1,4 @@
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { useValue } from '@/internal/hooks/useValue';
 import { usePortfolio } from '@/wallet/hooks/usePortfolio';
 import { type ReactNode, createContext, useContext, useState } from 'react';
@@ -37,7 +38,7 @@ export function WalletAdvancedProvider({
     refetch: refetchPortfolioData,
     isFetching: isFetchingPortfolioData,
     dataUpdatedAt: portfolioDataUpdatedAt,
-  } = usePortfolio({ address }, 'wallet');
+  } = usePortfolio({ address }, REQUEST_CONTEXT.WALLET);
 
   const portfolioFiatValue = portfolioData?.portfolioBalanceInUsd;
   const tokenBalances = portfolioData?.tokenBalances;

--- a/src/wallet/components/WalletAdvancedProvider.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.tsx
@@ -37,7 +37,7 @@ export function WalletAdvancedProvider({
     refetch: refetchPortfolioData,
     isFetching: isFetchingPortfolioData,
     dataUpdatedAt: portfolioDataUpdatedAt,
-  } = usePortfolio({ address });
+  } = usePortfolio({ address }, 'wallet');
 
   const portfolioFiatValue = portfolioData?.portfolioBalanceInUsd;
   const tokenBalances = portfolioData?.tokenBalances;

--- a/src/wallet/components/WalletAdvancedProvider.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.tsx
@@ -1,4 +1,4 @@
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { useValue } from '@/internal/hooks/useValue';
 import { usePortfolio } from '@/wallet/hooks/usePortfolio';
 import { type ReactNode, createContext, useContext, useState } from 'react';
@@ -38,7 +38,7 @@ export function WalletAdvancedProvider({
     refetch: refetchPortfolioData,
     isFetching: isFetchingPortfolioData,
     dataUpdatedAt: portfolioDataUpdatedAt,
-  } = usePortfolio({ address }, REQUEST_CONTEXT.WALLET);
+  } = usePortfolio({ address }, RequestContext.Wallet);
 
   const portfolioFiatValue = portfolioData?.portfolioBalanceInUsd;
   const tokenBalances = portfolioData?.tokenBalances;

--- a/src/wallet/hooks/usePortfolio.test.tsx
+++ b/src/wallet/hooks/usePortfolio.test.tsx
@@ -58,9 +58,12 @@ describe('usePortfolio', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getPortfolios).toHaveBeenCalledWith({
-      addresses: [mockAddress],
-    });
+    expect(getPortfolios).toHaveBeenCalledWith(
+      {
+        addresses: [mockAddress],
+      },
+      'hook',
+    );
 
     expect(result.current.data).toEqual(mockPortfolio);
   });

--- a/src/wallet/hooks/usePortfolio.test.tsx
+++ b/src/wallet/hooks/usePortfolio.test.tsx
@@ -1,5 +1,6 @@
 import { getPortfolios } from '@/api/getPortfolios';
 import type { Portfolio, PortfolioTokenWithFiatValue } from '@/api/types';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -62,7 +63,7 @@ describe('usePortfolio', () => {
       {
         addresses: [mockAddress],
       },
-      'hook',
+      REQUEST_CONTEXT.HOOK,
     );
 
     expect(result.current.data).toEqual(mockPortfolio);

--- a/src/wallet/hooks/usePortfolio.test.tsx
+++ b/src/wallet/hooks/usePortfolio.test.tsx
@@ -1,6 +1,6 @@
 import { getPortfolios } from '@/api/getPortfolios';
 import type { Portfolio, PortfolioTokenWithFiatValue } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -63,7 +63,7 @@ describe('usePortfolio', () => {
       {
         addresses: [mockAddress],
       },
-      REQUEST_CONTEXT.HOOK,
+      RequestContext.Hook,
     );
 
     expect(result.current.data).toEqual(mockPortfolio);

--- a/src/wallet/hooks/usePortfolio.ts
+++ b/src/wallet/hooks/usePortfolio.ts
@@ -1,6 +1,6 @@
 import { getPortfolios } from '@/api/getPortfolios';
 import type { Portfolio } from '@/api/types';
-import type { JSONRPCReferrer } from '@/core/network/request';
+import type { JSONRPCContext } from '@/core/network/request';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { Address } from 'viem';
@@ -11,7 +11,7 @@ import type { Address } from 'viem';
  */
 export function usePortfolio(
   { address }: { address: Address | undefined | null },
-  _referrer: JSONRPCReferrer = 'hook',
+  _context: JSONRPCContext = 'hook',
 ): UseQueryResult<Portfolio> {
   return useQuery({
     queryKey: ['usePortfolio', address],
@@ -20,7 +20,7 @@ export function usePortfolio(
         {
           addresses: [address as Address], // Safe to coerce to Address because useQuery's enabled flag will prevent the query from running if address is undefined
         },
-        _referrer,
+        _context,
       );
 
       if (isApiError(response)) {

--- a/src/wallet/hooks/usePortfolio.ts
+++ b/src/wallet/hooks/usePortfolio.ts
@@ -1,6 +1,6 @@
 import { getPortfolios } from '@/api/getPortfolios';
 import type { Portfolio } from '@/api/types';
-import type { JSONRPCContext } from '@/core/network/request';
+import { REQUEST_CONTEXT } from '@/core/network/constants';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { Address } from 'viem';
@@ -11,7 +11,7 @@ import type { Address } from 'viem';
  */
 export function usePortfolio(
   { address }: { address: Address | undefined | null },
-  _context: JSONRPCContext = 'hook',
+  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.HOOK,
 ): UseQueryResult<Portfolio> {
   return useQuery({
     queryKey: ['usePortfolio', address],

--- a/src/wallet/hooks/usePortfolio.ts
+++ b/src/wallet/hooks/usePortfolio.ts
@@ -1,6 +1,6 @@
 import { getPortfolios } from '@/api/getPortfolios';
 import type { Portfolio } from '@/api/types';
-import { REQUEST_CONTEXT } from '@/core/network/constants';
+import { RequestContext } from '@/core/network/constants';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { Address } from 'viem';
@@ -11,7 +11,7 @@ import type { Address } from 'viem';
  */
 export function usePortfolio(
   { address }: { address: Address | undefined | null },
-  _context: REQUEST_CONTEXT = REQUEST_CONTEXT.HOOK,
+  _context: RequestContext = RequestContext.Hook,
 ): UseQueryResult<Portfolio> {
   return useQuery({
     queryKey: ['usePortfolio', address],

--- a/src/wallet/hooks/usePortfolio.ts
+++ b/src/wallet/hooks/usePortfolio.ts
@@ -1,5 +1,6 @@
 import { getPortfolios } from '@/api/getPortfolios';
 import type { Portfolio } from '@/api/types';
+import type { JSONRPCReferrer } from '@/core/network/request';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { Address } from 'viem';
@@ -8,17 +9,19 @@ import type { Address } from 'viem';
  * Retrieves the portfolio for the provided address
  * portfolio includes the address, the balance of the address in USD, and the tokens in the address
  */
-export function usePortfolio({
-  address,
-}: {
-  address: Address | undefined | null;
-}): UseQueryResult<Portfolio> {
+export function usePortfolio(
+  { address }: { address: Address | undefined | null },
+  _referrer: JSONRPCReferrer = 'hook',
+): UseQueryResult<Portfolio> {
   return useQuery({
     queryKey: ['usePortfolio', address],
     queryFn: async () => {
-      const response = await getPortfolios({
-        addresses: [address as Address], // Safe to coerce to Address because useQuery's enabled flag will prevent the query from running if address is undefined
-      });
+      const response = await getPortfolios(
+        {
+          addresses: [address as Address], // Safe to coerce to Address because useQuery's enabled flag will prevent the query from running if address is undefined
+        },
+        _referrer,
+      );
 
       if (isApiError(response)) {
         throw new Error(response.message);


### PR DESCRIPTION
**What changed? Why?**
Adding context parameter to track the context in which our rpc-proxy API requests were used.  For example, this will allow us to differentiate in our analytics whether a swap was initiated from a Buy component, Swap component or directly from an API.

**Notes to reviewers**

**How has it been tested?**
