### PR TITLE
docs: Fix inconsistent description in <FundButton /> in fund-button.mdx

### DIFF
--- a/site/docs/pages/fund/fund-button.mdx
+++ b/site/docs/pages/fund/fund-button.mdx
@@ -1,6 +1,6 @@
 ---
 title: <FundButton /> · OnchainKit
-description: The `<FundButton />` component provides a way for users to onramp from fiat to crypto from within your app.
+description: The `<FundButton />` component provides a way for users to fund their wallet from within your app.
 ---
 
 import { Avatar, Name } from '@coinbase/onchainkit/identity';


### PR DESCRIPTION
**What changed? Why?**
 
A small inconsistency in the `<FundButton />` documentation. The introduction mentions "onramp from fiat to crypto," while the detailed description correctly states "fund their wallet." To align the documentation, I updated the introduction to match the accurate description:  

> The `<FundButton />` component provides a way for users to **fund their wallet** from within your app.  

This change ensures consistency and clarity throughout the documentation.
