### PR TITLE
docs: Remove deprecated withWalletAggregator prop

### DIFF
--- a/site/docs/pages/wallet/types.mdx
+++ b/site/docs/pages/wallet/types.mdx
@@ -12,7 +12,6 @@ type ConnectWalletReact = {
   children?: React.ReactNode; // Children can be utilized to display customized content when the wallet is connected.
   className?: string; // Optional className override for button element
   text?: string; // Optional text override for button. Note: Prefer using `ConnectWalletText` component instead as this will be deprecated in a future version.
-  withWalletAggregator?: boolean; // Optional flag to enable the wallet aggregator like RainbowKit
   onConnect?: () => void; // Optional callback function that is called when the wallet is connected. Can be used to trigger SIWE prompts or other actions.
 };
 ```


### PR DESCRIPTION
**What changed? Why?**
The `withWalletAggregator` prop has been deprecated. Updating old documentation. 

**Notes to reviewers**

**How has it been tested?**
