### PR TITLE
feat: Add onramp component level tracking param

### DIFF
--- a/src/fund/components/FundButton.tsx
+++ b/src/fund/components/FundButton.tsx
@@ -38,7 +38,10 @@ export function FundButton({
 }: FundButtonReact) {
   const componentTheme = useTheme();
   // If the fundingUrl prop is undefined, fallback to our recommended funding URL based on the wallet type
-  const fallbackFundingUrl = useGetFundingUrl(fiatCurrency);
+  const fallbackFundingUrl = useGetFundingUrl({
+    fiatCurrency,
+    originComponentName: 'FundButton',
+  });
   const { address } = useAccount();
   const fundingUrlToRender = fundingUrl ?? fallbackFundingUrl;
   const isDisabled = disabled || !fundingUrlToRender;

--- a/src/fund/hooks/useFundCardFundingUrl.ts
+++ b/src/fund/hooks/useFundCardFundingUrl.ts
@@ -36,6 +36,7 @@ export const useFundCardFundingUrl = () => {
       defaultPaymentMethod: selectedPaymentMethod?.id,
       addresses: { [address]: [chain.name.toLowerCase()] },
       fiatCurrency: currency,
+      originComponentName: 'FundCard',
     });
   }, [
     asset,

--- a/src/fund/hooks/useGetFundingUrl.test.ts
+++ b/src/fund/hooks/useGetFundingUrl.test.ts
@@ -42,7 +42,7 @@ describe('useGetFundingUrl', () => {
       'https://keys.coinbase.com/fund',
     );
 
-    const { result } = renderHook(() => useGetFundingUrl());
+    const { result } = renderHook(() => useGetFundingUrl({}));
 
     expect(result.current).toBe('https://keys.coinbase.com/fund');
   });
@@ -59,7 +59,7 @@ describe('useGetFundingUrl', () => {
     (useIsWalletACoinbaseSmartWallet as Mock).mockReturnValue(false);
     (getOnrampBuyUrl as Mock).mockReturnValue('https://pay.coinbase.com/buy');
 
-    const { result } = renderHook(() => useGetFundingUrl());
+    const { result } = renderHook(() => useGetFundingUrl({}));
 
     expect(result.current).toBe('https://pay.coinbase.com/buy');
 
@@ -83,7 +83,7 @@ describe('useGetFundingUrl', () => {
     (useIsWalletACoinbaseSmartWallet as Mock).mockReturnValue(false);
     (getOnrampBuyUrl as Mock).mockReturnValue('https://pay.coinbase.com/buy');
 
-    const { result } = renderHook(() => useGetFundingUrl());
+    const { result } = renderHook(() => useGetFundingUrl({}));
 
     expect(result.current).toBe('https://pay.coinbase.com/buy');
 
@@ -106,7 +106,7 @@ describe('useGetFundingUrl', () => {
     });
     (useIsWalletACoinbaseSmartWallet as Mock).mockReturnValue(false);
 
-    const { result } = renderHook(() => useGetFundingUrl());
+    const { result } = renderHook(() => useGetFundingUrl({}));
 
     expect(result.current).toBeUndefined();
   });
@@ -122,7 +122,7 @@ describe('useGetFundingUrl', () => {
     });
     (useIsWalletACoinbaseSmartWallet as Mock).mockReturnValue(false);
 
-    const { result } = renderHook(() => useGetFundingUrl());
+    const { result } = renderHook(() => useGetFundingUrl({}));
 
     expect(result.current).toBeUndefined();
   });

--- a/src/fund/hooks/useGetFundingUrl.ts
+++ b/src/fund/hooks/useGetFundingUrl.ts
@@ -10,7 +10,13 @@ import { getOnrampBuyUrl } from '../utils/getOnrampBuyUrl';
  * user to keys.coinbase.com, otherwise it will send them to pay.coinbase.com.
  * @returns the funding URL and optional popup dimensions if the URL requires them
  */
-export function useGetFundingUrl(fiatCurrency?: string): string | undefined {
+export function useGetFundingUrl({
+  fiatCurrency,
+  originComponentName,
+}: {
+  fiatCurrency?: string;
+  originComponentName?: string;
+}): string | undefined {
   const { projectId, chain: defaultChain } = useOnchainKit();
   const { address, chain: accountChain } = useAccount();
   const isCoinbaseSmartWallet = useIsWalletACoinbaseSmartWallet();
@@ -32,6 +38,14 @@ export function useGetFundingUrl(fiatCurrency?: string): string | undefined {
       projectId,
       addresses: { [address]: [chain.name.toLowerCase()] },
       fiatCurrency,
+      originComponentName,
     });
-  }, [isCoinbaseSmartWallet, projectId, address, chain, fiatCurrency]);
+  }, [
+    isCoinbaseSmartWallet,
+    projectId,
+    address,
+    chain,
+    fiatCurrency,
+    originComponentName,
+  ]);
 }

--- a/src/fund/types.ts
+++ b/src/fund/types.ts
@@ -104,6 +104,11 @@ type GetOnrampBuyUrlOptionalProps = {
    * on the domain allowlist in Coinbase Developer Platform (https://portal.cdp.coinbase.com/products/onramp).
    */
   redirectUrl?: string;
+
+  /**
+   * The name of the component that is calling the Onramp buy URL. This will be used for analytics.
+   */
+  originComponentName?: string;
 };
 
 /**
@@ -206,7 +211,11 @@ export type EventMetadata =
   | RequestOpenUrlEvent;
 
 export type OnrampError = {
-  errorType: 'internal_error' | 'handled_error' | 'network_error';
+  errorType:
+    | 'internal_error'
+    | 'handled_error'
+    | 'network_error'
+    | 'unknown_error';
   code?: string;
   debugMessage?: string;
 };

--- a/src/fund/utils/getOnrampBuyUrl.ts
+++ b/src/fund/utils/getOnrampBuyUrl.ts
@@ -12,6 +12,7 @@ import type {
  */
 export function getOnrampBuyUrl({
   projectId,
+  originComponentName,
   ...props
 }: GetOnrampUrlWithProjectIdParams | GetOnrampUrlWithSessionTokenParams) {
   const url = new URL(ONRAMP_BUY_URL);
@@ -32,7 +33,14 @@ export function getOnrampBuyUrl({
     }
   }
 
-  url.searchParams.append('sdkVersion', `onchainkit@${version}`);
+  if (originComponentName) {
+    url.searchParams.append(
+      'sdkVersion',
+      `onchainkit@${version}:${originComponentName}`,
+    );
+  } else {
+    url.searchParams.append('sdkVersion', `onchainkit@${version}`);
+  }
 
   url.searchParams.sort();
 

--- a/src/wallet/components/WalletDropdownFundLink.tsx
+++ b/src/wallet/components/WalletDropdownFundLink.tsx
@@ -19,7 +19,11 @@ export function WalletDropdownFundLink({
   text = 'Fund wallet',
 }: WalletDropdownFundLinkReact) {
   // If we can't get a funding URL, this component will be a no-op and render a disabled link
-  const fundingUrlToRender = fundingUrl ?? useGetFundingUrl({});
+  const fundingUrlToRender =
+    fundingUrl ??
+    useGetFundingUrl({
+      originComponentName: 'WalletDropdownFundLink',
+    });
   const iconSvg = useIcon({ icon });
 
   const handleClick = useCallback(

--- a/src/wallet/components/WalletDropdownFundLink.tsx
+++ b/src/wallet/components/WalletDropdownFundLink.tsx
@@ -19,7 +19,7 @@ export function WalletDropdownFundLink({
   text = 'Fund wallet',
 }: WalletDropdownFundLinkReact) {
   // If we can't get a funding URL, this component will be a no-op and render a disabled link
-  const fundingUrlToRender = fundingUrl ?? useGetFundingUrl();
+  const fundingUrlToRender = fundingUrl ?? useGetFundingUrl({});
   const iconSvg = useIcon({ icon });
 
   const handleClick = useCallback(


### PR DESCRIPTION
**What changed? Why?**
Currently when calling onramp url from the OCK we don't know what component is making the request. 
Adding component name to the sdkVersion

**BEFORE**
`sdkVersion: "onchainkit@0.36.9"`

**AFTER**
`sdkVersion: "onchainkit@0.36.9:FundCard"`

**Notes to reviewers**

**How has it been tested?**
