### PR TITLE
fix: types naming convention

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -41,7 +41,7 @@ export type CreateWagmiConfigParams = {
 /**
  * Note: exported as public Type
  */
-export type isBaseOptions = {
+export type IsBaseOptions = {
   /** Chain ID for the network */
   chainId: number;
   /** If the chainId check is only allowed on mainnet */
@@ -51,7 +51,7 @@ export type isBaseOptions = {
 /**
  * Note: exported as public Type
  */
-export type isEthereumOptions = {
+export type IsEthereumOptions = {
   /** Chain ID for the network */
   chainId: number;
   /** If the chainId check is only allowed on mainnet */


### PR DESCRIPTION
### Fixed TypeScript naming convention:
- isBaseOptions to IsBaseOptions
- isEthereumOptions to IsEthereumOptions