### PR TITLE
fix: await sequential transaction calls in `<Transaction />`

### DIFF
--- a/src/transaction/hooks/useSendWalletTransactions.test.tsx
+++ b/src/transaction/hooks/useSendWalletTransactions.test.tsx
@@ -9,6 +9,12 @@ import { useSendWalletTransactions } from './useSendWalletTransactions';
 vi.mock('../utils/sendBatchedTransactions');
 vi.mock('../utils/sendSingleTransactions');
 
+// Mock wagmi provider
+vi.mock('wagmi', () => ({
+  useConfig: vi.fn(),
+  useProviderDependencies: vi.fn(),
+}));
+
 describe('useSendWalletTransactions', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/transaction/hooks/useSendWalletTransactions.tsx
+++ b/src/transaction/hooks/useSendWalletTransactions.tsx
@@ -4,6 +4,7 @@ import { Capabilities } from '../../core/constants';
 import type { Call, UseSendWalletTransactionsParams } from '../types';
 import { sendBatchedTransactions } from '../utils/sendBatchedTransactions';
 import { sendSingleTransactions } from '../utils/sendSingleTransactions';
+import { useConfig } from 'wagmi';
 
 /**
  * Sends transactions to the wallet using the appropriate hook based on Transaction props and wallet capabilities
@@ -14,6 +15,7 @@ export const useSendWalletTransactions = ({
   sendCallsAsync,
   walletCapabilities,
 }: UseSendWalletTransactionsParams) => {
+  const config = useConfig();
   return useCallback(
     async (
       transactions?:
@@ -39,11 +41,12 @@ export const useSendWalletTransactions = ({
       } else {
         // Non-batched transactions
         await sendSingleTransactions({
+          config,
           sendCallAsync,
           transactions: resolvedTransactions,
         });
       }
     },
-    [sendCallsAsync, sendCallAsync, capabilities, walletCapabilities],
+    [sendCallsAsync, sendCallAsync, capabilities, walletCapabilities, config],
   );
 };

--- a/src/transaction/hooks/useSendWalletTransactions.tsx
+++ b/src/transaction/hooks/useSendWalletTransactions.tsx
@@ -1,10 +1,10 @@
 import { useCallback } from 'react';
 import type { ContractFunctionParameters } from 'viem';
+import { useConfig } from 'wagmi';
 import { Capabilities } from '../../core/constants';
 import type { Call, UseSendWalletTransactionsParams } from '../types';
 import { sendBatchedTransactions } from '../utils/sendBatchedTransactions';
 import { sendSingleTransactions } from '../utils/sendSingleTransactions';
-import { useConfig } from 'wagmi';
 
 /**
  * Sends transactions to the wallet using the appropriate hook based on Transaction props and wallet capabilities

--- a/src/transaction/types.ts
+++ b/src/transaction/types.ts
@@ -131,6 +131,7 @@ export type SendBatchedTransactionsParams = {
 };
 
 export type SendSingleTransactionParams = {
+  config: Config;
   sendCallAsync: SendTransactionMutateAsync<Config, unknown> | (() => void);
   transactions: (Call | ContractFunctionParameters)[];
 };

--- a/src/transaction/utils/sendSingleTransactions.test.ts
+++ b/src/transaction/utils/sendSingleTransactions.test.ts
@@ -1,10 +1,10 @@
-import { encodeFunctionData, erc20Abi, http } from 'viem';
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Call } from '../types';
-import { sendSingleTransactions } from './sendSingleTransactions';
+import { http, encodeFunctionData, erc20Abi } from 'viem';
 import { baseSepolia } from 'viem/chains';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createConfig } from 'wagmi';
 import { mock } from 'wagmi/connectors';
+import type { Call } from '../types';
+import { sendSingleTransactions } from './sendSingleTransactions';
 
 vi.mock('viem', async (importOriginal) => {
   const actual = await importOriginal<typeof import('viem')>();

--- a/src/transaction/utils/sendSingleTransactions.ts
+++ b/src/transaction/utils/sendSingleTransactions.ts
@@ -1,8 +1,10 @@
 import { encodeFunctionData } from 'viem';
-import type { Call, SendSingleTransactionParams } from '../types';
+import type { SendSingleTransactionParams } from '../types';
 import { isContract } from './isContract';
+import { waitForTransactionReceipt } from 'wagmi/actions';
 
 export const sendSingleTransactions = async ({
+  config,
   sendCallAsync,
   transactions,
 }: SendSingleTransactionParams) => {
@@ -19,8 +21,18 @@ export const sendSingleTransactions = async ({
     }
     return transaction;
   });
+  console.log('YO!');
 
   for (const call of calls) {
-    await sendCallAsync(call as Call);
+    console.log('call:', call);
+    const txHash = await sendCallAsync(call);
+    console.log('txHash:', txHash);
+    if (txHash) {
+      console.log('txHash:', txHash);
+      await waitForTransactionReceipt(config, {
+        hash: txHash,
+        confirmations: 1,
+      });
+    }
   }
 };

--- a/src/transaction/utils/sendSingleTransactions.ts
+++ b/src/transaction/utils/sendSingleTransactions.ts
@@ -1,7 +1,7 @@
 import { encodeFunctionData } from 'viem';
+import { waitForTransactionReceipt } from 'wagmi/actions';
 import type { SendSingleTransactionParams } from '../types';
 import { isContract } from './isContract';
-import { waitForTransactionReceipt } from 'wagmi/actions';
 
 export const sendSingleTransactions = async ({
   config,

--- a/src/transaction/utils/sendSingleTransactions.ts
+++ b/src/transaction/utils/sendSingleTransactions.ts
@@ -21,7 +21,6 @@ export const sendSingleTransactions = async ({
     }
     return transaction;
   });
-  console.log('YO!');
 
   for (const call of calls) {
     console.log('call:', call);

--- a/src/transaction/utils/sendSingleTransactions.ts
+++ b/src/transaction/utils/sendSingleTransactions.ts
@@ -23,11 +23,8 @@ export const sendSingleTransactions = async ({
   });
 
   for (const call of calls) {
-    console.log('call:', call);
     const txHash = await sendCallAsync(call);
-    console.log('txHash:', txHash);
     if (txHash) {
-      console.log('txHash:', txHash);
       await waitForTransactionReceipt(config, {
         hash: txHash,
         confirmations: 1,


### PR DESCRIPTION
**What changed? Why?**
When passing multiple `Calls` to the `<Transaction />` component, if latter calls rely on the prior calls being confirmed, they will fail when using an EOA.

This PR ensures that we `await` prior transactions before calling the next `call`