### PR TITLE
chore: Update IsBaseOptions and IsEthereumOptions naming convention 

### DIFF
--- a/.changeset/tame-rice-dress.md
+++ b/.changeset/tame-rice-dress.md
@@ -2,7 +2,7 @@
 "@coinbase/onchainkit": minor
 ---
 
-- **chore**: Update `IsBaseOptions` and `IsEthereumOptions` type naming convention to PascalCase. By @cpcramer #1920
+- **chore**: Update `IsBaseOptions` and `IsEthereumOptions` type naming convention to PascalCase. By @crStiv @cpcramer #1920
 
 Breaking Changes: 
 - Types `IsBaseOptions` and `IsEthereumOptions` have been updated from camelCase to PascalCase. 

--- a/.changeset/tame-rice-dress.md
+++ b/.changeset/tame-rice-dress.md
@@ -1,0 +1,8 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+- **chore**: Update `IsBaseOptions` and `IsEthereumOptions` type naming convention to PascalCase. By @cpcramer #1920
+
+Breaking Changes: 
+- Types `IsBaseOptions` and `IsEthereumOptions` have been updated from camelCase to PascalCase. 

--- a/site/docs/pages/config/is-base.mdx
+++ b/site/docs/pages/config/is-base.mdx
@@ -30,4 +30,4 @@ true;
 
 ## Parameters
 
-[`isBaseOptions`](/config/types#isbaseoptions)
+[`IsBaseOptions`](/config/types#isbaseoptions)

--- a/site/docs/pages/config/is-ethereum.mdx
+++ b/site/docs/pages/config/is-ethereum.mdx
@@ -30,4 +30,4 @@ true;
 
 ## Parameters
 
-[`isEthereumOptions`](/config/types#isethereumoptions)
+[`IsEthereumOptions`](/config/types#isethereumoptions)

--- a/site/docs/pages/config/types.mdx
+++ b/site/docs/pages/config/types.mdx
@@ -19,19 +19,19 @@ type AppConfig = {
 };
 ```
 
-## `isBaseOptions`
+## `IsBaseOptions`
 
 ```ts
-type isBaseOptions = {
+type IsBaseOptions = {
   chainId: number;
   isMainnetOnly?: boolean; // If the chainId check is only allowed on mainnet
 };
 ```
 
-## `isEthereumOptions`
+## `IsEthereumOptions`
 
 ```ts
-type isEthereumOptions = {
+type IsEthereumOptions = {
   chainId: number;
   isMainnetOnly?: boolean; // If the chainId check is only allowed on mainnet
 };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -49,6 +49,11 @@ export type IsBaseOptions = {
 };
 
 /**
+ * @deprecated Use IsBaseOptions instead
+ */
+export type isBaseOptions = IsBaseOptions;
+
+/**
  * Note: exported as public Type
  */
 export type IsEthereumOptions = {
@@ -57,6 +62,11 @@ export type IsEthereumOptions = {
   /** If the chainId check is only allowed on mainnet */
   isMainnetOnly?: boolean;
 };
+
+/**
+ * @deprecated Use IsEthereumOptions instead
+ */
+export type isEthereumOptions = IsEthereumOptions;
 
 export type Mode = 'auto' | 'light' | 'dark';
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -41,7 +41,7 @@ export type CreateWagmiConfigParams = {
 /**
  * Note: exported as public Type
  */
-export type isBaseOptions = {
+export type IsBaseOptions = {
   /** Chain ID for the network */
   chainId: number;
   /** If the chainId check is only allowed on mainnet */
@@ -51,7 +51,7 @@ export type isBaseOptions = {
 /**
  * Note: exported as public Type
  */
-export type isEthereumOptions = {
+export type IsEthereumOptions = {
   /** Chain ID for the network */
   chainId: number;
   /** If the chainId check is only allowed on mainnet */

--- a/src/core/utils/isBase.ts
+++ b/src/core/utils/isBase.ts
@@ -1,5 +1,5 @@
 import { base, baseSepolia } from 'viem/chains';
-import type { isBaseOptions } from '../types';
+import type { IsBaseOptions } from '../types';
 
 /**
  * isBase
@@ -9,7 +9,7 @@ import type { isBaseOptions } from '../types';
 export function isBase({
   chainId,
   isMainnetOnly = false,
-}: isBaseOptions): boolean {
+}: IsBaseOptions): boolean {
   // If only Base mainnet
   if (isMainnetOnly && chainId === base.id) {
     return true;

--- a/src/core/utils/isEthereum.ts
+++ b/src/core/utils/isEthereum.ts
@@ -1,5 +1,5 @@
 import { mainnet, sepolia } from 'viem/chains';
-import type { isEthereumOptions } from '../types';
+import type { IsEthereumOptions } from '../types';
 
 /**
  * isEthereum
@@ -8,7 +8,7 @@ import type { isEthereumOptions } from '../types';
 export function isEthereum({
   chainId,
   isMainnetOnly = false,
-}: isEthereumOptions): boolean {
+}: IsEthereumOptions): boolean {
   // If only ETH mainnet
   if (isMainnetOnly && chainId === mainnet.id) {
     return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ export { useOnchainKit } from './useOnchainKit';
 export { version } from './version';
 export type {
   AppConfig,
-  isBaseOptions,
-  isEthereumOptions,
+  IsBaseOptions,
+  IsEthereumOptions,
   OnchainKitConfig,
   OnchainKitContextType,
 } from './core/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export type {
   IsEthereumOptions,
   OnchainKitConfig,
   OnchainKitContextType,
+  isBaseOptions,
+  isEthereumOptions,
 } from './core/types';
 
 export type { OnchainKitProviderReact } from './types';


### PR DESCRIPTION
**What changed? Why?**

Interfaces and Types should use `PascalCase`, we currently are using `camelCase` for type `isBaseOptions` and `isEthereumOptions`. 

Updating types to use `PascalCase` to remain consistent across our library. 

Note that this is a breaking change. 

This naming convention issue was brought up in this PR [fix: types naming convention](https://github.com/coinbase/onchainkit/pull/1915#top) 

**Notes to reviewers**

**How has it been tested?**
