### PR TITLE
docs: fix type typo, add sidebar

### DIFF
--- a/site/docs/pages/api/types.mdx
+++ b/site/docs/pages/api/types.mdx
@@ -142,10 +142,10 @@ type BuildMintTransactionParams = {
 type BuildMintTransactionResponse = MintTransaction | APIError;
 ```
 
-## `GetPortfolioParams`
+## `GetPortfoliosParams`
 
 ```ts
-type GetPortfolioParams = {
+type GetPortfoliosParams = {
   addresses: Address[] | null | undefined;
 };
 ```

--- a/site/sidebar.ts
+++ b/site/sidebar.ts
@@ -281,6 +281,15 @@ export const sidebar = [
           },
         ],
       },
+      {
+        text: 'Wallet',
+        items: [
+          {
+            text: 'getPortfolios',
+            link: '/api/get-portfolios',
+          },
+        ],
+      },
     ],
   },
   {


### PR DESCRIPTION
**What changed? Why?**
* added `getPortfolios` documentation to sidebar
* fixed typo in type and type link

**Notes to reviewers**

**How has it been tested?**
