### PR TITLE
fix: ensure token addresses are checksummed

### DIFF
--- a/src/token/constants.ts
+++ b/src/token/constants.ts
@@ -13,7 +13,7 @@ export const ethToken: Token = {
 
 export const usdcToken: Token = {
   name: 'USDC',
-  address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
   symbol: 'USDC',
   decimals: 6,
   image:
@@ -23,7 +23,7 @@ export const usdcToken: Token = {
 
 export const degenToken: Token = {
   name: 'DEGEN',
-  address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+  address: '0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed',
   symbol: 'DEGEN',
   decimals: 18,
   image:


### PR DESCRIPTION
**What changed? Why?**
Several token addresses are not checksummed causing issues in future PRs when comparing addresses.

**Notes to reviewers**

[Read more](https://docs.alchemy.com/docs/how-to-handle-checksum-addresses)

**How has it been tested?**
