### PR TITLE
fix: prevent layout shift in Transaction component

### DIFF
--- a/src/transaction/components/Transaction.tsx
+++ b/src/transaction/components/Transaction.tsx
@@ -23,7 +23,11 @@ export function Transaction({
 
   // prevents SSR hydration issue
   if (!isMounted) {
-    return null;
+    return (
+      <div
+        className={cn(componentTheme, 'flex w-full flex-col gap-2', className)}
+      />
+    );
   }
 
   // If chainId is not provided,


### PR DESCRIPTION
**What changed? Why?**
Returning `null` causes layout shift in the `<Transaction />` component. This PR updates the component to return a div with similar styling in order to prevent layout shift on mount.

**Notes to reviewers**

**How has it been tested?**
