### PR TITLE
feat: Add telemetry opt-out

### DIFF
--- a/.changeset/selfish-cougars-travel.md
+++ b/.changeset/selfish-cougars-travel.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: Add analytics parameter. When set to false, all telemetry collection will be disabled and no data will be sent. @cpcramer #1934

--- a/src/OnchainKitProvider.test.tsx
+++ b/src/OnchainKitProvider.test.tsx
@@ -174,29 +174,34 @@ describe('OnchainKitProvider', () => {
       </WagmiProvider>,
     );
 
-    expect(setOnchainKitConfig).toHaveBeenCalledWith({
-      address: null,
-      apiKey,
-      config: {
-        analyticsUrl: null,
-        appearance: {
-          logo: appLogo,
-          name: appName,
-          mode: 'auto',
-          theme: 'default',
-        },
-        paymaster: paymasterUrl,
-        wallet: {
-          display: 'classic',
-          termsUrl: 'https://base.org/terms-of-service',
-          privacyUrl: 'https://base.org/privacy-policy',
-        },
-      },
-      chain: base,
-      rpcUrl: null,
-      schemaId,
-      projectId: null,
-      interactionId: expect.any(String),
+    await waitFor(() => {
+      expect(setOnchainKitConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: null,
+          apiKey,
+          config: {
+            analytics: true,
+            analyticsUrl: null,
+            appearance: {
+              logo: appLogo,
+              name: appName,
+              mode: 'auto',
+              theme: 'default',
+            },
+            paymaster: paymasterUrl,
+            wallet: {
+              display: 'classic',
+              termsUrl: 'https://base.org/terms-of-service',
+              privacyUrl: 'https://base.org/privacy-policy',
+            },
+          },
+          chain: base,
+          rpcUrl: null,
+          schemaId,
+          projectId: null,
+          interactionId: expect.any(String),
+        }),
+      );
     });
   });
 
@@ -215,6 +220,7 @@ describe('OnchainKitProvider', () => {
       expect(setOnchainKitConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           config: {
+            analytics: true,
             analyticsUrl: null,
             appearance: {
               logo: appLogo,
@@ -229,6 +235,32 @@ describe('OnchainKitProvider', () => {
               privacyUrl: 'https://base.org/privacy-policy',
             },
           },
+        }),
+      );
+    });
+  });
+
+  it('should respect analytics override when provided', async () => {
+    render(
+      <WagmiProvider config={mockConfig}>
+        <QueryClientProvider client={queryClient}>
+          <OnchainKitProvider
+            chain={base}
+            schemaId={schemaId}
+            analytics={false}
+          >
+            <TestComponent />
+          </OnchainKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    await waitFor(() => {
+      expect(setOnchainKitConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            analytics: false,
+          }),
         }),
       );
     });
@@ -252,6 +284,7 @@ describe('OnchainKitProvider', () => {
             schemaId={schemaId}
             apiKey={apiKey}
             config={customConfig}
+            analytics={false}
           >
             <TestComponent />
           </OnchainKitProvider>
@@ -266,6 +299,7 @@ describe('OnchainKitProvider', () => {
           apiKey: apiKey,
           chain: base,
           config: {
+            analytics: false,
             analyticsUrl: 'https://example.com',
             appearance: {
               name: 'custom name',

--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -23,6 +23,7 @@ export const OnchainKitContext =
  */
 export function OnchainKitProvider({
   address,
+  analytics,
   apiKey,
   chain,
   children,
@@ -49,6 +50,7 @@ export function OnchainKitProvider({
       apiKey: apiKey ?? null,
       chain: chain,
       config: {
+        analytics: analytics ?? true,
         analyticsUrl: config?.analyticsUrl ?? null,
         appearance: {
           name: config?.appearance?.name ?? 'Dapp',
@@ -72,6 +74,7 @@ export function OnchainKitProvider({
     return onchainKitConfig;
   }, [
     address,
+    analytics,
     apiKey,
     chain,
     config,

--- a/src/core/OnchainKitConfig.ts
+++ b/src/core/OnchainKitConfig.ts
@@ -10,6 +10,7 @@ export const ONCHAIN_KIT_CONFIG: OnchainKitConfig = {
   apiKey: null,
   chain: baseSepolia,
   config: {
+    analytics: true,
     analyticsUrl: null,
     appearance: {
       name: null,

--- a/src/core/network/sendAnalytics.ts
+++ b/src/core/network/sendAnalytics.ts
@@ -1,4 +1,5 @@
 import { ANALYTICS_API_URL, JSON_HEADERS } from '@/core/network/constants';
+import { useOnchainKit } from '@/useOnchainKit';
 
 interface AnalyticsParams {
   analyticsUrl?: string;
@@ -17,6 +18,13 @@ export const sendAnalytics = async ({
   event,
   interactionId,
 }: AnalyticsParams) => {
+  const { config } = useOnchainKit();
+  // If analytics is set to false in OnchainKitProvider config,
+  // all telemetry collection is disabled and no data will be sent
+  if (config?.analytics === false) {
+    return;
+  }
+
   try {
     await fetch(analyticsUrl, {
       method: 'POST',

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,8 @@ import type { Address, Chain } from 'viem';
  * Note: exported as public Type
  */
 export type AppConfig = {
+  /** Enable/disable telemetry. Set to false to disable telemetry. Defaults to true (enabled) */
+  analytics?: boolean;
   /** Optional analytics URL for analytics data, defaults to Coinbase */
   analyticsUrl?: string | null;
   appearance?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ import type { AppConfig } from './core/types';
  */
 export type OnchainKitProviderReact = {
   address?: Address;
+  analytics?: boolean;
   apiKey?: string;
   chain: Chain;
   children: ReactNode;


### PR DESCRIPTION
**What changed? Why?**
We are adding telemetry to applicable OnchainKit components. We want to make it as easy to opt out as possible if that is what users prefer. Adding an opt out parameter. 

**Notes to reviewers**

**How has it been tested?**
