### PR TITLE
fix: revert change resulting in slow identity resolution

### DIFF
--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.36.9",
+  "version": "0.36.10",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",
@@ -79,7 +79,7 @@
     "tailwindcss": "^3.4.3",
     "tscpaths": "^0.0.9",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.3",
+    "typescript": "~5.3.3",
     "vite": "^5.3.3",
     "vitest": "^3.0.5"
   },
@@ -139,12 +139,6 @@
       "module": "./esm/core/index.js",
       "import": "./esm/core/index.js",
       "default": "./esm/core/index.js"
-    },
-    "./earn": {
-      "types": "./esm/earn/index.d.ts",
-      "module": "./esm/earn/index.js",
-      "import": "./esm/earn/index.js",
-      "default": "./esm/earn/index.js"
     },
     "./fund": {
       "types": "./esm/fund/index.d.ts",

--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.36.10",
+  "version": "0.36.9",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",
@@ -79,7 +79,7 @@
     "tailwindcss": "^3.4.3",
     "tscpaths": "^0.0.9",
     "tsup": "^8.3.5",
-    "typescript": "~5.3.3",
+    "typescript": "^5.7.3",
     "vite": "^5.3.3",
     "vitest": "^3.0.5"
   },
@@ -139,6 +139,12 @@
       "module": "./esm/core/index.js",
       "import": "./esm/core/index.js",
       "default": "./esm/core/index.js"
+    },
+    "./earn": {
+      "types": "./esm/earn/index.d.ts",
+      "module": "./esm/earn/index.js",
+      "import": "./esm/earn/index.js",
+      "default": "./esm/earn/index.js"
     },
     "./fund": {
       "types": "./esm/fund/index.d.ts",

--- a/src/identity/utils/getName.ts
+++ b/src/identity/utils/getName.ts
@@ -26,7 +26,7 @@ export const getName = async ({
     );
   }
 
-  const client = getChainPublicClient(chain);
+  let client = getChainPublicClient(chain);
 
   if (chainIsBase) {
     const addressReverseNode = convertReverseNodeToBytes(address, base.id);
@@ -44,6 +44,9 @@ export const getName = async ({
       // This is a best effort attempt, so we don't need to do anything here.
     }
   }
+
+  // Default to mainnet
+  client = getChainPublicClient(mainnet);
 
   // ENS username
   const ensName = await client.getEnsName({


### PR DESCRIPTION
**What changed? Why?**
This PR fixes logic for fetching Basenames and ENS names in `getName`.

In the case where the chain is Base and the user does _not_ have a Basename, we hit an arm in the if/else where nothing is returned, allowing us to hit the case where we fallback to the ENS name. In that case, we want to be sure that we read from mainnet. Instead, we were attempting to read from Base, which caused retries and ultimately a timeout that returned null.

This reverts the prior change [here](https://github.com/coinbase/onchainkit/pull/1875/files#diff-35ac9703d5627d9d638ebb29587e99301f5710dd0e4313417e063619c56d7767).

**Notes to reviewers**

**How has it been tested?**
