### PR TITLE
feat: appchain bridge hooks

### DIFF
--- a/src/appchain/bridge/abi.ts
+++ b/src/appchain/bridge/abi.ts
@@ -1,0 +1,1119 @@
+export const DeployChainABI = [
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: 'chainID',
+        type: 'uint256',
+      },
+    ],
+    name: 'deployAddresses',
+    outputs: [
+      {
+        components: [
+          {
+            internalType: 'address',
+            name: 'l2OutputOracle',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'systemConfig',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'optimismPortal',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'l1CrossDomainMessenger',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'l1StandardBridge',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'l1ERC721Bridge',
+            type: 'address',
+          },
+          {
+            internalType: 'address',
+            name: 'optimismMintableERC20Factory',
+            type: 'address',
+          },
+        ],
+        internalType: 'struct DeployChain.DeployAddresses',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+export const StandardBridgeABI = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint32',
+        name: '_minGasLimit',
+        type: 'uint32',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'bridgeETHTo',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '_localToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_remoteToken',
+        type: 'address',
+      },
+      {
+        internalType: 'address',
+        name: '_to',
+        type: 'address',
+      },
+      {
+        internalType: 'uint256',
+        name: '_amount',
+        type: 'uint256',
+      },
+      {
+        internalType: 'uint32',
+        name: '_minGasLimit',
+        type: 'uint32',
+      },
+      {
+        internalType: 'bytes',
+        name: '_extraData',
+        type: 'bytes',
+      },
+    ],
+    name: 'bridgeERC20To',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+export const ERC20ABI = [
+  {
+    name: 'approve',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'spender', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ type: 'bool' }],
+  },
+] as const;
+
+export const L2OutputOracleABI = [
+  {
+    inputs: [
+      { internalType: 'uint256', name: '_submissionInterval', type: 'uint256' },
+      { internalType: 'uint256', name: '_l2BlockTime', type: 'uint256' },
+      {
+        internalType: 'uint256',
+        name: '_startingBlockNumber',
+        type: 'uint256',
+      },
+      { internalType: 'uint256', name: '_startingTimestamp', type: 'uint256' },
+      { internalType: 'address', name: '_proposer', type: 'address' },
+      { internalType: 'address', name: '_challenger', type: 'address' },
+      {
+        internalType: 'uint256',
+        name: '_finalizationPeriodSeconds',
+        type: 'uint256',
+      },
+    ],
+    stateMutability: 'nonpayable',
+    type: 'constructor',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: false, internalType: 'uint8', name: 'version', type: 'uint8' },
+    ],
+    name: 'Initialized',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'bytes32',
+        name: 'outputRoot',
+        type: 'bytes32',
+      },
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'l2OutputIndex',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'l2BlockNumber',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'l1Timestamp',
+        type: 'uint256',
+      },
+    ],
+    name: 'OutputProposed',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'prevNextOutputIndex',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'newNextOutputIndex',
+        type: 'uint256',
+      },
+    ],
+    name: 'OutputsDeleted',
+    type: 'event',
+  },
+  {
+    inputs: [],
+    name: 'CHALLENGER',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'FINALIZATION_PERIOD_SECONDS',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'L2_BLOCK_TIME',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'PROPOSER',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'SUBMISSION_INTERVAL',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: '_l2BlockNumber', type: 'uint256' },
+    ],
+    name: 'computeL2Timestamp',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: '_l2OutputIndex', type: 'uint256' },
+    ],
+    name: 'deleteL2Outputs',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: '_l2OutputIndex', type: 'uint256' },
+    ],
+    name: 'getL2Output',
+    outputs: [
+      {
+        components: [
+          { internalType: 'bytes32', name: 'outputRoot', type: 'bytes32' },
+          { internalType: 'uint128', name: 'timestamp', type: 'uint128' },
+          { internalType: 'uint128', name: 'l2BlockNumber', type: 'uint128' },
+        ],
+        internalType: 'struct Types.OutputProposal',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: '_l2BlockNumber', type: 'uint256' },
+    ],
+    name: 'getL2OutputAfter',
+    outputs: [
+      {
+        components: [
+          { internalType: 'bytes32', name: 'outputRoot', type: 'bytes32' },
+          { internalType: 'uint128', name: 'timestamp', type: 'uint128' },
+          { internalType: 'uint128', name: 'l2BlockNumber', type: 'uint128' },
+        ],
+        internalType: 'struct Types.OutputProposal',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: '_l2BlockNumber', type: 'uint256' },
+    ],
+    name: 'getL2OutputIndexAfter',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '_startingBlockNumber',
+        type: 'uint256',
+      },
+      { internalType: 'uint256', name: '_startingTimestamp', type: 'uint256' },
+    ],
+    name: 'initialize',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'latestBlockNumber',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'latestOutputIndex',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'nextBlockNumber',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'nextOutputIndex',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'bytes32', name: '_outputRoot', type: 'bytes32' },
+      { internalType: 'uint256', name: '_l2BlockNumber', type: 'uint256' },
+      { internalType: 'bytes32', name: '_l1BlockHash', type: 'bytes32' },
+      { internalType: 'uint256', name: '_l1BlockNumber', type: 'uint256' },
+    ],
+    name: 'proposeL2Output',
+    outputs: [],
+    stateMutability: 'payable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'startingBlockNumber',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'startingTimestamp',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'version',
+    outputs: [{ internalType: 'string', name: '', type: 'string' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'latestL2Output',
+    outputs: [
+      {
+        components: [
+          { internalType: 'bytes32', name: 'outputRoot', type: 'bytes32' },
+          { internalType: 'uint128', name: 'timestamp', type: 'uint128' },
+          { internalType: 'uint128', name: 'l2BlockNumber', type: 'uint128' },
+        ],
+        internalType: 'struct Types.OutputProposal',
+        name: '',
+        type: 'tuple',
+      },
+    ],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const;
+
+export const OptimismPortalABI = [
+  {
+    type: 'constructor',
+    inputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'receive',
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'balance',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'depositERC20Transaction',
+    inputs: [
+      {
+        name: '_to',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_mint',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_value',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_gasLimit',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: '_isCreation',
+        type: 'bool',
+        internalType: 'bool',
+      },
+      {
+        name: '_data',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'depositTransaction',
+    inputs: [
+      {
+        name: '_to',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_value',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_gasLimit',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: '_isCreation',
+        type: 'bool',
+        internalType: 'bool',
+      },
+      {
+        name: '_data',
+        type: 'bytes',
+        internalType: 'bytes',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'donateETH',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'payable',
+  },
+  {
+    type: 'function',
+    name: 'finalizeWithdrawalTransaction',
+    inputs: [
+      {
+        name: '_tx',
+        type: 'tuple',
+        internalType: 'struct Types.WithdrawalTransaction',
+        components: [
+          {
+            name: 'nonce',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'sender',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'target',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'value',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'gasLimit',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'data',
+            type: 'bytes',
+            internalType: 'bytes',
+          },
+        ],
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'finalizedWithdrawals',
+    inputs: [
+      {
+        name: '',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'guardian',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'initialize',
+    inputs: [
+      {
+        name: '_l2Oracle',
+        type: 'address',
+        internalType: 'contract OutputOracle',
+      },
+      {
+        name: '_systemConfig',
+        type: 'address',
+        internalType: 'contract ISystemConfig',
+      },
+      {
+        name: '_superchainConfig',
+        type: 'address',
+        internalType: 'contract ISuperchainConfig',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'isOutputFinalized',
+    inputs: [
+      {
+        name: '_l2OutputIndex',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'l2Oracle',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract OutputOracle',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'l2Sender',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'address',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'minimumGasLimit',
+    inputs: [
+      {
+        name: '_byteCount',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    stateMutability: 'pure',
+  },
+  {
+    type: 'function',
+    name: 'params',
+    inputs: [],
+    outputs: [
+      {
+        name: 'prevBaseFee',
+        type: 'uint128',
+        internalType: 'uint128',
+      },
+      {
+        name: 'prevBoughtGas',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+      {
+        name: 'prevBlockNum',
+        type: 'uint64',
+        internalType: 'uint64',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'paused',
+    inputs: [],
+    outputs: [
+      {
+        name: 'paused_',
+        type: 'bool',
+        internalType: 'bool',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'proveAndFinalizeWithdrawalTransaction',
+    inputs: [
+      {
+        name: '_tx',
+        type: 'tuple',
+        internalType: 'struct Types.WithdrawalTransaction',
+        components: [
+          {
+            name: 'nonce',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'sender',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'target',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'value',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'gasLimit',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'data',
+            type: 'bytes',
+            internalType: 'bytes',
+          },
+        ],
+      },
+      {
+        name: '_l2OutputIndex',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_outputRootProof',
+        type: 'tuple',
+        internalType: 'struct Types.OutputRootProof',
+        components: [
+          {
+            name: 'version',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'stateRoot',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'messagePasserStorageRoot',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'latestBlockhash',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+        ],
+      },
+      {
+        name: '_withdrawalProof',
+        type: 'bytes[]',
+        internalType: 'bytes[]',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'proveWithdrawalTransaction',
+    inputs: [
+      {
+        name: '_tx',
+        type: 'tuple',
+        internalType: 'struct Types.WithdrawalTransaction',
+        components: [
+          {
+            name: 'nonce',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'sender',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'target',
+            type: 'address',
+            internalType: 'address',
+          },
+          {
+            name: 'value',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'gasLimit',
+            type: 'uint256',
+            internalType: 'uint256',
+          },
+          {
+            name: 'data',
+            type: 'bytes',
+            internalType: 'bytes',
+          },
+        ],
+      },
+      {
+        name: '_l2OutputIndex',
+        type: 'uint256',
+        internalType: 'uint256',
+      },
+      {
+        name: '_outputRootProof',
+        type: 'tuple',
+        internalType: 'struct Types.OutputRootProof',
+        components: [
+          {
+            name: 'version',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'stateRoot',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'messagePasserStorageRoot',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+          {
+            name: 'latestBlockhash',
+            type: 'bytes32',
+            internalType: 'bytes32',
+          },
+        ],
+      },
+      {
+        name: '_withdrawalProof',
+        type: 'bytes[]',
+        internalType: 'bytes[]',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'setGasPayingToken',
+    inputs: [
+      {
+        name: '_token',
+        type: 'address',
+        internalType: 'address',
+      },
+      {
+        name: '_decimals',
+        type: 'uint8',
+        internalType: 'uint8',
+      },
+      {
+        name: '_name',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+      {
+        name: '_symbol',
+        type: 'bytes32',
+        internalType: 'bytes32',
+      },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'superchainConfig',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract ISuperchainConfig',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'systemConfig',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'address',
+        internalType: 'contract ISystemConfig',
+      },
+    ],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'version',
+    inputs: [],
+    outputs: [
+      {
+        name: '',
+        type: 'string',
+        internalType: 'string',
+      },
+    ],
+    stateMutability: 'pure',
+  },
+  {
+    type: 'event',
+    name: 'Initialized',
+    inputs: [
+      {
+        name: 'version',
+        type: 'uint8',
+        indexed: false,
+        internalType: 'uint8',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'TransactionDeposited',
+    inputs: [
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'version',
+        type: 'uint256',
+        indexed: true,
+        internalType: 'uint256',
+      },
+      {
+        name: 'opaqueData',
+        type: 'bytes',
+        indexed: false,
+        internalType: 'bytes',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'WithdrawalFinalized',
+    inputs: [
+      {
+        name: 'withdrawalHash',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
+      {
+        name: 'success',
+        type: 'bool',
+        indexed: false,
+        internalType: 'bool',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'event',
+    name: 'WithdrawalProven',
+    inputs: [
+      {
+        name: 'withdrawalHash',
+        type: 'bytes32',
+        indexed: true,
+        internalType: 'bytes32',
+      },
+      {
+        name: 'from',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+      {
+        name: 'to',
+        type: 'address',
+        indexed: true,
+        internalType: 'address',
+      },
+    ],
+    anonymous: false,
+  },
+  {
+    type: 'error',
+    name: 'BadTarget',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'CallPaused',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'ContentLengthMismatch',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'EmptyItem',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'GasEstimation',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InvalidDataRemainder',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'InvalidHeader',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'LargeCalldata',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'NoValue',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'NonReentrant',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OnlyCustomGasToken',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'OutOfGas',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'SmallGasLimit',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'TransferFailed',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'Unauthorized',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'UnexpectedList',
+    inputs: [],
+  },
+  {
+    type: 'error',
+    name: 'UnexpectedString',
+    inputs: [],
+  },
+] as const;

--- a/src/appchain/bridge/constants.ts
+++ b/src/appchain/bridge/constants.ts
@@ -1,4 +1,10 @@
 import type { Token } from '@/token';
+import {
+  ethSepoliaToken,
+  ethToken,
+  usdcSepoliaToken,
+  usdcToken,
+} from '@/token/constants';
 import type { Address, Hex } from 'viem';
 import { base, baseSepolia } from 'viem/chains';
 
@@ -13,45 +19,13 @@ export const APPCHAIN_DEPLOY_CONTRACT_ADDRESS = {
 };
 
 export const ETH_BY_CHAIN: Record<number, Token> = {
-  [base.id]: {
-    name: 'ETH',
-    address: '',
-    symbol: 'ETH',
-    decimals: 18,
-    image:
-      'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
-    chainId: base.id,
-  },
-  [baseSepolia.id]: {
-    name: 'ETH',
-    address: '',
-    symbol: 'ETH',
-    decimals: 18,
-    image:
-      'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
-    chainId: baseSepolia.id,
-  },
+  [base.id]: ethToken,
+  [baseSepolia.id]: ethSepoliaToken,
 };
 
 export const USDC_BY_CHAIN: Record<number, Token> = {
-  [base.id]: {
-    name: 'USDC',
-    address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
-    symbol: 'USDC',
-    decimals: 6,
-    image:
-      'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
-    chainId: base.id,
-  },
-  [baseSepolia.id]: {
-    name: 'USDC',
-    address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-    symbol: 'USDC',
-    decimals: 6,
-    image:
-      'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
-    chainId: baseSepolia.id,
-  },
+  [base.id]: usdcToken,
+  [baseSepolia.id]: usdcSepoliaToken,
 };
 
 export const MIN_GAS_LIMIT = 100000;

--- a/src/appchain/bridge/constants.ts
+++ b/src/appchain/bridge/constants.ts
@@ -1,0 +1,60 @@
+import type { Token } from '@/token';
+import type { Address, Hex } from 'viem';
+import { base, baseSepolia } from 'viem/chains';
+
+export const APPCHAIN_BRIDGE_ADDRESS =
+  '0x4200000000000000000000000000000000000010';
+
+export const APPCHAIN_L2_TO_L1_MESSAGE_PASSER_ADDRESS =
+  '0x4200000000000000000000000000000000000016';
+
+export const APPCHAIN_DEPLOY_CONTRACT_ADDRESS = {
+  [baseSepolia.id]: '0x8B4dB9468126EA0AA6EC8f1FAEb32173de3A27c7' as Address,
+};
+
+export const ETH_BY_CHAIN: Record<number, Token> = {
+  [base.id]: {
+    name: 'ETH',
+    address: '',
+    symbol: 'ETH',
+    decimals: 18,
+    image:
+      'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+    chainId: base.id,
+  },
+  [baseSepolia.id]: {
+    name: 'ETH',
+    address: '',
+    symbol: 'ETH',
+    decimals: 18,
+    image:
+      'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+    chainId: baseSepolia.id,
+  },
+};
+
+export const USDC_BY_CHAIN: Record<number, Token> = {
+  [base.id]: {
+    name: 'USDC',
+    address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+    symbol: 'USDC',
+    decimals: 6,
+    image:
+      'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
+    chainId: base.id,
+  },
+  [baseSepolia.id]: {
+    name: 'USDC',
+    address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+    symbol: 'USDC',
+    decimals: 6,
+    image:
+      'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
+    chainId: baseSepolia.id,
+  },
+};
+
+export const MIN_GAS_LIMIT = 100000;
+export const EXTRA_DATA = '0x';
+export const OUTPUT_ROOT_PROOF_VERSION =
+  '0x0000000000000000000000000000000000000000000000000000000000000000' as Hex;

--- a/src/appchain/bridge/hooks/useAppchainConfig.test.ts
+++ b/src/appchain/bridge/hooks/useAppchainConfig.test.ts
@@ -1,0 +1,95 @@
+import { getNewReactQueryTestProvider } from '@/identity/hooks/getNewReactQueryTestProvider';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useReadContract } from 'wagmi';
+import { APPCHAIN_DEPLOY_CONTRACT_ADDRESS } from '../constants';
+import { useChainConfig } from './useAppchainConfig';
+
+vi.mock('wagmi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useReadContract: vi.fn(),
+  };
+});
+
+const wrapper = getNewReactQueryTestProvider();
+
+const mockContractData = {
+  l2OutputOracle: '0xOutputOracle',
+  systemConfig: '0xSystemConfig',
+  optimismPortal: '0xOptimismPortal',
+  l1CrossDomainMessenger: '0xCrossDomainMessenger',
+  l1StandardBridge: '0xStandardBridge',
+  l1ERC721Bridge: '0xERC721Bridge',
+  optimismMintableERC20Factory: '0xERC20Factory',
+};
+
+describe('useChainConfig', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (useReadContract as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: mockContractData,
+      isLoading: false,
+      isError: false,
+      error: null,
+    });
+  });
+
+  it('should return config with contract addresses when successful', () => {
+    const { result } = renderHook(
+      () => useChainConfig({ l2ChainId: 8453, appchainChainId: 1 }),
+      { wrapper },
+    );
+    expect(result.current.config).toEqual({
+      chainId: 1,
+      contracts: mockContractData,
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it('should call useReadContract with correct parameters', () => {
+    renderHook(() => useChainConfig({ l2ChainId: 84532, appchainChainId: 1 }), {
+      wrapper,
+    });
+    expect(useReadContract).toHaveBeenCalledWith({
+      abi: expect.any(Array),
+      functionName: 'deployAddresses',
+      args: [BigInt(1)],
+      address: APPCHAIN_DEPLOY_CONTRACT_ADDRESS[84532],
+      query: {
+        staleTime: 1000 * 60 * 60,
+        retry: 2,
+        enabled: true,
+        gcTime: 0,
+      },
+      chainId: 84532,
+    });
+  });
+
+  it('should disable query when chainIds are not provided', () => {
+    renderHook(() => useChainConfig({ l2ChainId: 0, appchainChainId: 0 }), {
+      wrapper,
+    });
+    expect(useReadContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          enabled: false,
+        }),
+      }),
+    );
+  });
+
+  it('should return undefined config when error', () => {
+    (useReadContract as ReturnType<typeof vi.fn>).mockReturnValue({
+      error: new Error('test error'),
+    });
+    const { result } = renderHook(
+      () => useChainConfig({ l2ChainId: 84532, appchainChainId: 1 }),
+      { wrapper },
+    );
+    expect(result.current.config).toBeUndefined();
+  });
+});

--- a/src/appchain/bridge/hooks/useAppchainConfig.ts
+++ b/src/appchain/bridge/hooks/useAppchainConfig.ts
@@ -1,0 +1,41 @@
+import { useReadContract } from 'wagmi';
+import { DeployChainABI } from '../abi';
+import { APPCHAIN_DEPLOY_CONTRACT_ADDRESS } from '../constants';
+import type { AppchainConfig } from '../types';
+
+export interface ChainConfigParams {
+  l2ChainId: number;
+  appchainChainId: number;
+}
+
+export function useChainConfig(params: ChainConfigParams) {
+  const { data, isLoading, isError, error } = useReadContract({
+    abi: DeployChainABI,
+    functionName: 'deployAddresses',
+    args: [BigInt(params.appchainChainId)],
+    address:
+      APPCHAIN_DEPLOY_CONTRACT_ADDRESS[
+        params.l2ChainId as keyof typeof APPCHAIN_DEPLOY_CONTRACT_ADDRESS
+      ],
+    query: {
+      staleTime: 1000 * 60 * 60, // 1 hour
+      retry: 2,
+      enabled: !!params.l2ChainId && !!params.appchainChainId,
+      gcTime: 0,
+    },
+    // Read from the L2 contract
+    chainId: params.l2ChainId,
+  });
+
+  return {
+    config: error
+      ? undefined
+      : ({
+          chainId: params.appchainChainId,
+          contracts: data,
+        } as AppchainConfig),
+    isLoading,
+    isError,
+    error,
+  };
+}

--- a/src/appchain/bridge/hooks/useAppchainConfig.ts
+++ b/src/appchain/bridge/hooks/useAppchainConfig.ts
@@ -28,12 +28,13 @@ export function useChainConfig(params: ChainConfigParams) {
   });
 
   return {
-    config: error
-      ? undefined
-      : ({
-          chainId: params.appchainChainId,
-          contracts: data,
-        } as AppchainConfig),
+    config:
+      isLoading || error
+        ? undefined
+        : ({
+            chainId: params.appchainChainId,
+            contracts: data,
+          } as AppchainConfig),
     isLoading,
     isError,
     error,

--- a/src/appchain/bridge/hooks/useAppchainConfig.ts
+++ b/src/appchain/bridge/hooks/useAppchainConfig.ts
@@ -28,13 +28,12 @@ export function useChainConfig(params: ChainConfigParams) {
   });
 
   return {
-    config:
-      isLoading || error
-        ? undefined
-        : ({
-            chainId: params.appchainChainId,
-            contracts: data,
-          } as AppchainConfig),
+    config: error
+      ? undefined
+      : ({
+          chainId: params.appchainChainId,
+          contracts: data,
+        } as AppchainConfig),
     isLoading,
     isError,
     error,

--- a/src/appchain/bridge/hooks/useDeposit.test.ts
+++ b/src/appchain/bridge/hooks/useDeposit.test.ts
@@ -163,7 +163,7 @@ describe('useDeposit', () => {
       },
     });
     await waitFor(() => {
-      expect(result.current.depositStatus).toBe('success');
+      expect(result.current.depositStatus).toBe('depositSuccess');
     });
   });
 
@@ -228,7 +228,7 @@ describe('useDeposit', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.depositStatus).toBe('rejected');
+      expect(result.current.depositStatus).toBe('depositRejected');
     });
   });
 

--- a/src/appchain/bridge/hooks/useDeposit.test.ts
+++ b/src/appchain/bridge/hooks/useDeposit.test.ts
@@ -1,0 +1,253 @@
+import { getNewReactQueryTestProvider } from '@/identity/hooks/getNewReactQueryTestProvider';
+import { renderHook, waitFor } from '@testing-library/react';
+import { type Chain, parseEther, parseUnits } from 'viem';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccount, useConfig, useSwitchChain, useWriteContract } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import { useDeposit } from './useDeposit';
+
+vi.mock('wagmi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useAccount: vi.fn(),
+    useConfig: vi.fn(),
+    useSwitchChain: vi.fn(),
+    useWriteContract: vi.fn(),
+  };
+});
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn(),
+}));
+
+const mockWriteContractAsync = vi.fn();
+const mockSwitchChainAsync = vi.fn();
+
+const wrapper = getNewReactQueryTestProvider();
+
+const mockAppchainConfig = {
+  chainId: 1,
+  contracts: {
+    l2OutputOracle: '0xOutputOracle',
+    systemConfig: '0xSystemConfig',
+    optimismPortal: '0xOptimismPortal',
+    l1CrossDomainMessenger: '0xCrossDomainMessenger',
+    l1StandardBridge: '0xStandardBridge',
+    l1ERC721Bridge: '0xERC721Bridge',
+    optimismMintableERC20Factory: '0xERC20Factory',
+  },
+} as const;
+const mockChain = {
+  id: 1,
+  name: 'Base',
+  nativeCurrency: {
+    name: 'Base',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+} as Chain;
+const mockBridgeParams = {
+  token: {
+    address: '0x123',
+    remoteToken: '0x456',
+    decimals: 18,
+    chainId: 1,
+    image: '',
+    name: 'Mock Token',
+    symbol: 'MOCK',
+  },
+  amount: '1',
+  recipient: '0x789',
+  amountUSD: '100',
+} as const;
+
+describe('useDeposit', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({ chainId: 1 });
+    (useConfig as ReturnType<typeof vi.fn>).mockReturnValue({});
+    (useSwitchChain as ReturnType<typeof vi.fn>).mockReturnValue({
+      switchChainAsync: mockSwitchChainAsync,
+    });
+    (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
+      writeContractAsync: mockWriteContractAsync,
+      data: '0xmocktxhash',
+    });
+    (waitForTransactionReceipt as ReturnType<typeof vi.fn>).mockResolvedValue(
+      {},
+    );
+  });
+
+  it('should throw error if recipient is not provided', async () => {
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    await expect(
+      result.current.deposit({
+        config: mockAppchainConfig,
+        from: mockChain,
+        bridgeParams: { ...mockBridgeParams, recipient: undefined },
+      }),
+    ).rejects.toThrow('Recipient is required');
+  });
+
+  it('should switch chain if not on correct network', async () => {
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    await result.current.deposit({
+      config: mockAppchainConfig,
+      from: { ...mockChain, id: 2 },
+      bridgeParams: mockBridgeParams,
+    });
+    expect(mockSwitchChainAsync).toHaveBeenCalledWith({ chainId: 2 });
+  });
+
+  it('should handle native ETH deposits correctly', async () => {
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    await result.current.deposit({
+      config: mockAppchainConfig,
+      from: mockChain,
+      bridgeParams: {
+        ...mockBridgeParams,
+        token: { ...mockBridgeParams.token, address: '' },
+      },
+    });
+    expect(mockWriteContractAsync).toHaveBeenCalledWith({
+      abi: expect.any(Array),
+      functionName: 'bridgeETHTo',
+      args: [mockBridgeParams.recipient, 100000, '0x'],
+      address: mockAppchainConfig.contracts.l1StandardBridge,
+      value: parseEther(mockBridgeParams.amount),
+      chainId: mockChain.id,
+    });
+  });
+
+  it('should handle ERC20 deposits correctly', async () => {
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    await result.current.deposit({
+      config: mockAppchainConfig,
+      from: mockChain,
+      bridgeParams: mockBridgeParams,
+    });
+    expect(mockWriteContractAsync).toHaveBeenCalledWith({
+      abi: expect.any(Array),
+      functionName: 'approve',
+      args: [
+        mockAppchainConfig.contracts.l1StandardBridge,
+        parseUnits(mockBridgeParams.amount, mockBridgeParams.token.decimals),
+      ],
+      address: mockBridgeParams.token.address,
+    });
+    expect(mockWriteContractAsync).toHaveBeenCalledWith({
+      abi: expect.any(Array),
+      functionName: 'bridgeERC20To',
+      args: [
+        mockBridgeParams.token.address,
+        mockBridgeParams.token.remoteToken,
+        mockBridgeParams.recipient,
+        parseUnits(mockBridgeParams.amount, mockBridgeParams.token.decimals),
+        100000,
+        '0x',
+      ],
+      address: mockAppchainConfig.contracts.l1StandardBridge,
+    });
+  });
+
+  it('should update status correctly through the deposit flow', async () => {
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    expect(result.current.depositStatus).toBe('idle');
+    await result.current.deposit({
+      config: mockAppchainConfig,
+      from: mockChain,
+      bridgeParams: {
+        ...mockBridgeParams,
+        token: { ...mockBridgeParams.token, address: '' },
+      },
+    });
+    await waitFor(() => {
+      expect(result.current.depositStatus).toBe('success');
+    });
+  });
+
+  it('should expose transaction hash', async () => {
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    await result.current.deposit({
+      config: mockAppchainConfig,
+      from: mockChain,
+      bridgeParams: {
+        ...mockBridgeParams,
+        token: { ...mockBridgeParams.token, address: '' },
+      },
+    });
+    expect(result.current.transactionHash).toBe('0xmocktxhash');
+  });
+
+  it('should reset deposit status when called', () => {
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+
+    // Set some non-idle status first
+    result.current.deposit({
+      config: mockAppchainConfig,
+      from: mockChain,
+      bridgeParams: mockBridgeParams,
+    });
+
+    // Reset status
+    result.current.resetDepositStatus();
+
+    expect(result.current.depositStatus).toBe('idle');
+  });
+
+  it('should throw error if remote token address is missing for ERC20', async () => {
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    await result.current.deposit({
+      config: mockAppchainConfig,
+      from: mockChain,
+      bridgeParams: {
+        ...mockBridgeParams,
+        token: { ...mockBridgeParams.token, remoteToken: undefined },
+      },
+    });
+    await waitFor(() => {
+      expect(result.current.depositStatus).toBe('error');
+    });
+  });
+
+  it('should handle user rejection', async () => {
+    const mockError = {
+      cause: {
+        name: 'UserRejectedRequestError',
+      },
+      message: 'Request denied.',
+    };
+    mockWriteContractAsync.mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    await result.current.deposit({
+      config: mockAppchainConfig,
+      from: mockChain,
+      bridgeParams: mockBridgeParams,
+    });
+
+    await waitFor(() => {
+      expect(result.current.depositStatus).toBe('rejected');
+    });
+  });
+
+  it('should handle other errors', async () => {
+    const mockError = {
+      cause: new Error('Some other error'),
+      message: 'Something went wrong. Please try again.',
+    };
+    mockWriteContractAsync.mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useDeposit(), { wrapper });
+    await result.current.deposit({
+      config: mockAppchainConfig,
+      from: mockChain,
+      bridgeParams: mockBridgeParams,
+    });
+
+    await waitFor(() => {
+      expect(result.current.depositStatus).toBe('error');
+    });
+  });
+});

--- a/src/appchain/bridge/hooks/useDeposit.ts
+++ b/src/appchain/bridge/hooks/useDeposit.ts
@@ -4,6 +4,7 @@ import type { Chain } from 'viem';
 import { useAccount, useConfig, useSwitchChain, useWriteContract } from 'wagmi';
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import { ERC20ABI, StandardBridgeABI } from '../abi';
+import { EXTRA_DATA, MIN_GAS_LIMIT } from '../constants';
 import type { AppchainConfig } from '../types';
 import type { BridgeParams } from '../types';
 import { isUserRejectedRequestError } from '../utils/isUserRejectedRequestError';
@@ -37,9 +38,6 @@ export function useDeposit() {
       await switchChainAsync({ chainId: from.id });
     }
 
-    const minGasLimit = 100000;
-    const extraData = '0x';
-
     setStatus('depositPending');
 
     try {
@@ -48,7 +46,7 @@ export function useDeposit() {
         const txHash = await writeContractAsync({
           abi: StandardBridgeABI,
           functionName: 'bridgeETHTo',
-          args: [bridgeParams.recipient, minGasLimit, extraData],
+          args: [bridgeParams.recipient, MIN_GAS_LIMIT, EXTRA_DATA],
           address: config.contracts.l1StandardBridge,
           value: parseEther(bridgeParams.amount),
           chainId: from.id,
@@ -91,8 +89,8 @@ export function useDeposit() {
             bridgeParams.token.remoteToken, // TODO: manually calculate the salted address
             bridgeParams.recipient,
             formattedAmount,
-            minGasLimit,
-            extraData,
+            MIN_GAS_LIMIT,
+            EXTRA_DATA,
           ],
           address: config.contracts.l1StandardBridge,
         });

--- a/src/appchain/bridge/hooks/useDeposit.ts
+++ b/src/appchain/bridge/hooks/useDeposit.ts
@@ -1,0 +1,123 @@
+import { useCallback, useState } from 'react';
+import { parseEther, parseUnits } from 'viem';
+import type { Chain } from 'viem';
+import { useAccount, useConfig, useSwitchChain, useWriteContract } from 'wagmi';
+import { waitForTransactionReceipt } from 'wagmi/actions';
+import { ERC20ABI, StandardBridgeABI } from '../abi';
+import type { AppchainConfig } from '../types';
+import type { BridgeParams } from '../types';
+import { isUserRejectedRequestError } from '../utils/isUserRejectedRequestError';
+
+interface DepositParams {
+  config: AppchainConfig;
+  from: Chain;
+  bridgeParams: BridgeParams;
+}
+
+export function useDeposit() {
+  const { writeContractAsync, data } = useWriteContract();
+  const { switchChainAsync } = useSwitchChain();
+  const { chainId } = useAccount();
+  const wagmiConfig = useConfig();
+  const [status, setStatus] = useState<
+    'pending' | 'success' | 'error' | 'idle' | 'rejected'
+  >('idle');
+
+  const resetDepositStatus = useCallback(() => {
+    setStatus('idle');
+  }, []);
+
+  const deposit = async ({ config, from, bridgeParams }: DepositParams) => {
+    if (!bridgeParams.recipient) {
+      throw new Error('Recipient is required');
+    }
+
+    if (chainId !== from.id) {
+      await switchChainAsync({ chainId: from.id });
+    }
+
+    const minGasLimit = 100000;
+    const extraData = '0x';
+
+    setStatus('pending');
+
+    try {
+      // Native ETH
+      if (bridgeParams.token.address === '') {
+        const txHash = await writeContractAsync({
+          abi: StandardBridgeABI,
+          functionName: 'bridgeETHTo',
+          args: [bridgeParams.recipient, minGasLimit, extraData],
+          address: config.contracts.l1StandardBridge,
+          value: parseEther(bridgeParams.amount),
+          chainId: from.id,
+        });
+
+        await waitForTransactionReceipt(wagmiConfig, {
+          hash: txHash,
+          confirmations: 1,
+          chainId: from.id,
+        });
+      } else {
+        // ERC20
+        if (!bridgeParams.token.remoteToken) {
+          throw new Error('Remote token address is required for ERC-20 tokens');
+        }
+
+        const formattedAmount = parseUnits(
+          bridgeParams.amount,
+          bridgeParams.token.decimals,
+        );
+        // Approve the L1StandardBridge to spend tokens
+        const approveTx = await writeContractAsync({
+          abi: ERC20ABI,
+          functionName: 'approve',
+          args: [config.contracts.l1StandardBridge, formattedAmount],
+          address: bridgeParams.token.address,
+        });
+        await waitForTransactionReceipt(wagmiConfig, {
+          hash: approveTx,
+          confirmations: 1,
+          chainId: from.id,
+        });
+
+        // Bridge the tokens
+        const bridgeTx = await writeContractAsync({
+          abi: StandardBridgeABI,
+          functionName: 'bridgeERC20To',
+          args: [
+            bridgeParams.token.address,
+            bridgeParams.token.remoteToken, // TODO: manually calculate the salted address
+            bridgeParams.recipient,
+            formattedAmount,
+            minGasLimit,
+            extraData,
+          ],
+          address: config.contracts.l1StandardBridge,
+        });
+
+        await waitForTransactionReceipt(wagmiConfig, {
+          hash: bridgeTx,
+          confirmations: 1,
+          chainId: from.id,
+        });
+      }
+
+      setStatus('success');
+    } catch (error) {
+      if (isUserRejectedRequestError(error)) {
+        console.error('User rejected request');
+        setStatus('rejected');
+      } else {
+        setStatus('error');
+      }
+    }
+  };
+
+  return {
+    deposit,
+    depositStatus: status,
+    transactionHash: data,
+    resetDepositStatus,
+  };
+}

--- a/src/appchain/bridge/hooks/useDeposit.ts
+++ b/src/appchain/bridge/hooks/useDeposit.ts
@@ -27,6 +27,7 @@ export function useDeposit() {
     setStatus('idle');
   }, []);
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: ignore
   const deposit = async ({ config, from, bridgeParams }: DepositParams) => {
     if (!bridgeParams.recipient) {
       throw new Error('Recipient is required');

--- a/src/appchain/bridge/hooks/useDeposit.ts
+++ b/src/appchain/bridge/hooks/useDeposit.ts
@@ -20,7 +20,7 @@ export function useDeposit() {
   const { chainId } = useAccount();
   const wagmiConfig = useConfig();
   const [status, setStatus] = useState<
-    'pending' | 'success' | 'error' | 'idle' | 'rejected'
+    'depositPending' | 'depositSuccess' | 'error' | 'idle' | 'depositRejected'
   >('idle');
 
   const resetDepositStatus = useCallback(() => {
@@ -40,7 +40,7 @@ export function useDeposit() {
     const minGasLimit = 100000;
     const extraData = '0x';
 
-    setStatus('pending');
+    setStatus('depositPending');
 
     try {
       // Native ETH
@@ -104,11 +104,11 @@ export function useDeposit() {
         });
       }
 
-      setStatus('success');
+      setStatus('depositSuccess');
     } catch (error) {
       if (isUserRejectedRequestError(error)) {
         console.error('User rejected request');
-        setStatus('rejected');
+        setStatus('depositRejected');
       } else {
         setStatus('error');
       }

--- a/src/appchain/bridge/hooks/useDepositButton.test.tsx
+++ b/src/appchain/bridge/hooks/useDepositButton.test.tsx
@@ -1,0 +1,132 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccount } from 'wagmi';
+import type { BridgeableToken } from '../types';
+import { useDepositButton } from './useDepositButton';
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+}));
+
+const mockToken = {
+  name: 'USDC',
+  address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  symbol: 'USDC',
+  decimals: 6,
+  image:
+    'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
+  chainId: 8453,
+} as BridgeableToken;
+
+describe('useDepositButton', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
+      isConnected: true,
+    });
+  });
+
+  it('should show spinner when deposit is pending', () => {
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'pending',
+        withdrawStatus: 'idle',
+        bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
+      }),
+    );
+    expect(result.current.isPending).toBe(true);
+    expect(typeof result.current.buttonContent).toBe('object');
+  });
+
+  it('should show spinner when withdraw is pending', () => {
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'idle',
+        withdrawStatus: 'withdrawPending',
+        bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
+      }),
+    );
+    expect(result.current.isPending).toBe(true);
+    expect(typeof result.current.buttonContent).toBe('object');
+  });
+
+  it('should show "View in Explorer" when deposit is successful', () => {
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'success',
+        withdrawStatus: 'idle',
+        bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
+      }),
+    );
+    expect(result.current.buttonContent).toBe('View in Explorer');
+  });
+
+  it('should show "Connect Wallet" when wallet is not connected', () => {
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({
+      isConnected: false,
+    });
+
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'idle',
+        withdrawStatus: 'idle',
+        bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
+      }),
+    );
+    expect(result.current.buttonContent).toBe('Connect Wallet');
+  });
+
+  it('should show "Confirm" when wallet is connected and no pending actions', () => {
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'idle',
+        withdrawStatus: 'idle',
+        bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
+      }),
+    );
+    expect(result.current.buttonContent).toBe('Confirm');
+  });
+
+  it('should be disabled when amount is empty', () => {
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'idle',
+        withdrawStatus: 'idle',
+        bridgeParams: { amount: '', amountUSD: '', token: mockToken },
+      }),
+    );
+    expect(result.current.isDisabled).toBe(true);
+  });
+
+  it('should be disabled when amount is zero', () => {
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'idle',
+        withdrawStatus: 'idle',
+        bridgeParams: { amount: '0', amountUSD: '0', token: mockToken },
+      }),
+    );
+    expect(result.current.isDisabled).toBe(true);
+  });
+
+  it('should be disabled during pending operations', () => {
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'pending',
+        withdrawStatus: 'idle',
+        bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
+      }),
+    );
+    expect(result.current.isDisabled).toBe(true);
+  });
+
+  it('should track rejection status correctly', () => {
+    const { result } = renderHook(() =>
+      useDepositButton({
+        depositStatus: 'rejected',
+        withdrawStatus: 'idle',
+        bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
+      }),
+    );
+    expect(result.current.isRejected).toBe(true);
+  });
+});

--- a/src/appchain/bridge/hooks/useDepositButton.test.tsx
+++ b/src/appchain/bridge/hooks/useDepositButton.test.tsx
@@ -28,7 +28,7 @@ describe('useDepositButton', () => {
   it('should show spinner when deposit is pending', () => {
     const { result } = renderHook(() =>
       useDepositButton({
-        depositStatus: 'pending',
+        depositStatus: 'depositPending',
         withdrawStatus: 'idle',
         bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
       }),
@@ -52,7 +52,7 @@ describe('useDepositButton', () => {
   it('should show "View in Explorer" when deposit is successful', () => {
     const { result } = renderHook(() =>
       useDepositButton({
-        depositStatus: 'success',
+        depositStatus: 'depositSuccess',
         withdrawStatus: 'idle',
         bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
       }),
@@ -111,7 +111,7 @@ describe('useDepositButton', () => {
   it('should be disabled during pending operations', () => {
     const { result } = renderHook(() =>
       useDepositButton({
-        depositStatus: 'pending',
+        depositStatus: 'depositPending',
         withdrawStatus: 'idle',
         bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
       }),
@@ -122,7 +122,7 @@ describe('useDepositButton', () => {
   it('should track rejection status correctly', () => {
     const { result } = renderHook(() =>
       useDepositButton({
-        depositStatus: 'rejected',
+        depositStatus: 'depositRejected',
         withdrawStatus: 'idle',
         bridgeParams: { amount: '1', amountUSD: '1', token: mockToken },
       }),

--- a/src/appchain/bridge/hooks/useDepositButton.tsx
+++ b/src/appchain/bridge/hooks/useDepositButton.tsx
@@ -1,6 +1,8 @@
 import { Spinner } from '@/internal/components/Spinner';
+import { useMemo } from 'react';
 import { useAccount } from 'wagmi';
 import type { BridgeParams } from '../types';
+
 interface UseDepositButtonProps {
   depositStatus: string;
   withdrawStatus: string;
@@ -15,9 +17,10 @@ export function useDepositButton({
   const { isConnected } = useAccount();
 
   const isPending =
-    depositStatus === 'pending' || withdrawStatus === 'withdrawPending';
+    depositStatus === 'depositPending' || withdrawStatus === 'withdrawPending';
   const isRejected =
-    depositStatus === 'rejected' || withdrawStatus === 'withdrawRejected';
+    depositStatus === 'depositRejected' ||
+    withdrawStatus === 'withdrawRejected';
 
   const buttonContent = isPending ? (
     <Spinner />
@@ -31,7 +34,7 @@ export function useDepositButton({
 
   const isDisabled =
     isConnected &&
-    (depositStatus === 'pending' ||
+    (depositStatus === 'depositPending' ||
       withdrawStatus === 'withdrawPending' ||
       bridgeParams.amount === '' ||
       Number(bridgeParams.amount) === 0);

--- a/src/appchain/bridge/hooks/useDepositButton.tsx
+++ b/src/appchain/bridge/hooks/useDepositButton.tsx
@@ -37,8 +37,7 @@ export function useDepositButton({
 
   const isDisabled =
     isConnected &&
-    (depositStatus === 'depositPending' ||
-      withdrawStatus === 'withdrawPending' ||
+    (isPending ||
       bridgeParams.amount === '' ||
       Number(bridgeParams.amount) === 0);
 

--- a/src/appchain/bridge/hooks/useDepositButton.tsx
+++ b/src/appchain/bridge/hooks/useDepositButton.tsx
@@ -1,0 +1,45 @@
+import { Spinner } from '@/internal/components/Spinner';
+import { useAccount } from 'wagmi';
+import type { BridgeParams } from '../types';
+interface UseDepositButtonProps {
+  depositStatus: string;
+  withdrawStatus: string;
+  bridgeParams: BridgeParams;
+}
+
+export function useDepositButton({
+  depositStatus,
+  withdrawStatus,
+  bridgeParams,
+}: UseDepositButtonProps) {
+  const { isConnected } = useAccount();
+
+  const isPending =
+    depositStatus === 'pending' || withdrawStatus === 'withdrawPending';
+  const isRejected =
+    depositStatus === 'rejected' || withdrawStatus === 'withdrawRejected';
+
+  const buttonContent = isPending ? (
+    <Spinner />
+  ) : depositStatus === 'success' ? (
+    'View in Explorer'
+  ) : isConnected ? (
+    'Confirm'
+  ) : (
+    'Connect Wallet'
+  );
+
+  const isDisabled =
+    isConnected &&
+    (depositStatus === 'pending' ||
+      withdrawStatus === 'withdrawPending' ||
+      bridgeParams.amount === '' ||
+      Number(bridgeParams.amount) === 0);
+
+  return {
+    isPending,
+    isRejected,
+    buttonContent,
+    isDisabled,
+  };
+}

--- a/src/appchain/bridge/hooks/useDepositButton.tsx
+++ b/src/appchain/bridge/hooks/useDepositButton.tsx
@@ -22,15 +22,18 @@ export function useDepositButton({
     depositStatus === 'depositRejected' ||
     withdrawStatus === 'withdrawRejected';
 
-  const buttonContent = isPending ? (
-    <Spinner />
-  ) : depositStatus === 'success' ? (
-    'View in Explorer'
-  ) : isConnected ? (
-    'Confirm'
-  ) : (
-    'Connect Wallet'
-  );
+  const buttonContent = useMemo(() => {
+    if (isPending) {
+      return <Spinner />;
+    }
+    if (depositStatus === 'depositSuccess') {
+      return 'View in Explorer';
+    }
+    if (isConnected) {
+      return 'Confirm';
+    }
+    return 'Connect Wallet';
+  }, [isPending, depositStatus, isConnected]);
 
   const isDisabled =
     isConnected &&

--- a/src/appchain/bridge/hooks/useWithdraw.test.ts
+++ b/src/appchain/bridge/hooks/useWithdraw.test.ts
@@ -1,0 +1,339 @@
+import { getNewReactQueryTestProvider } from '@/identity/hooks/getNewReactQueryTestProvider';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { Address, Chain, Hex } from 'viem';
+import { parseEther } from 'viem';
+import { getWithdrawals } from 'viem/op-stack';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccount, useConfig, useSwitchChain, useWriteContract } from 'wagmi';
+import { readContract, waitForTransactionReceipt } from 'wagmi/actions';
+import {
+  APPCHAIN_BRIDGE_ADDRESS,
+  EXTRA_DATA,
+  MIN_GAS_LIMIT,
+} from '../constants';
+import type { AppchainConfig, BridgeParams } from '../types';
+import { useWithdraw } from './useWithdraw';
+
+vi.mock('wagmi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useAccount: vi.fn(),
+    useConfig: vi.fn(),
+    useSwitchChain: vi.fn(),
+    useWriteContract: vi.fn(),
+  };
+});
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn(),
+  readContract: vi.fn(),
+}));
+
+vi.mock('viem/op-stack', () => ({
+  getWithdrawals: vi.fn(),
+}));
+
+vi.mock('../utils/getOutput', () => ({
+  getOutput: vi.fn().mockResolvedValue({
+    outputIndex: 1n,
+    l2BlockNumber: 100n,
+  }),
+}));
+
+vi.mock('wagmi/actions', () => ({
+  waitForTransactionReceipt: vi.fn(),
+  readContract: vi.fn(),
+}));
+
+const mockSwitchChainAsync = vi.fn();
+const mockWriteContractAsync = vi.fn();
+
+const mockChain = {
+  id: 1,
+  name: 'Ethereum',
+} as Chain;
+
+const mockAppchainConfig: AppchainConfig = {
+  chainId: 1,
+  contracts: {
+    l2OutputOracle: '0x123' as Address,
+    systemConfig: '0x124' as Address,
+    optimismPortal: '0x125' as Address,
+    l1CrossDomainMessenger: '0x126' as Address,
+    l1StandardBridge: '0x127' as Address,
+    l1ERC721Bridge: '0x128' as Address,
+    optimismMintableERC20Factory: '0x129' as Address,
+  },
+};
+
+const mockBridgeParams: BridgeParams = {
+  amount: '100',
+  amountUSD: '100',
+  recipient: '0x456' as Address,
+  token: {
+    address: '0x789' as Address,
+    decimals: 18,
+    symbol: 'TEST',
+    remoteToken: '0x790' as Address,
+    chainId: 1,
+    image: 'https://example.com/image.png',
+    name: 'Test Token',
+  },
+};
+
+const wrapper = getNewReactQueryTestProvider();
+
+describe('useWithdraw', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (useAccount as ReturnType<typeof vi.fn>).mockReturnValue({ chainId: 1 });
+    (useConfig as ReturnType<typeof vi.fn>).mockReturnValue({});
+    (useSwitchChain as ReturnType<typeof vi.fn>).mockReturnValue({
+      switchChainAsync: mockSwitchChainAsync,
+    });
+    (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
+      writeContractAsync: mockWriteContractAsync,
+      data: '0xmocktxhash',
+    });
+    (waitForTransactionReceipt as ReturnType<typeof vi.fn>).mockResolvedValue(
+      {},
+    );
+  });
+
+  it('should throw error if recipient is not provided', async () => {
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: { ...mockBridgeParams, recipient: undefined },
+        }),
+      { wrapper },
+    );
+    await expect(result.current.withdraw()).rejects.toThrow(
+      'Recipient is required',
+    );
+  });
+
+  it('should switch chain if not on correct network', async () => {
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: { ...mockAppchainConfig, chainId: 0 },
+          chain: mockChain,
+          bridgeParams: mockBridgeParams,
+        }),
+      { wrapper },
+    );
+    await result.current.withdraw();
+    await waitFor(() => {
+      expect(mockSwitchChainAsync).toHaveBeenCalledWith({ chainId: 0 });
+    });
+  });
+
+  it('should handle successful ERC-20withdrawal', async () => {
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: mockBridgeParams,
+        }),
+      { wrapper },
+    );
+    await result.current.withdraw();
+    await waitFor(() => {
+      expect(result.current.withdrawStatus).toBe('withdrawSuccess');
+    });
+  });
+
+  it('should handle withdrawal rejection', async () => {
+    const mockError = {
+      cause: {
+        name: 'UserRejectedRequestError',
+      },
+      message: 'Request denied.',
+    };
+    mockWriteContractAsync.mockRejectedValue(mockError);
+
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: mockBridgeParams,
+        }),
+      { wrapper },
+    );
+    await result.current.withdraw();
+    await waitFor(() => {
+      expect(result.current.withdrawStatus).toBe('withdrawRejected');
+    });
+  });
+
+  it('should reset withdraw status', () => {
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: mockBridgeParams,
+        }),
+      { wrapper },
+    );
+    result.current.resetWithdrawStatus();
+    expect(result.current.withdrawStatus).toBe('idle');
+  });
+
+  it('should handle error states', async () => {
+    mockWriteContractAsync.mockRejectedValue(new Error('Network error'));
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: mockBridgeParams,
+        }),
+      { wrapper },
+    );
+    await result.current.withdraw();
+    await waitFor(() => {
+      expect(result.current.withdrawStatus).toBe('error');
+    });
+  });
+
+  it('should handle native ETH withdrawal', async () => {
+    const nativeBridgeParams = {
+      ...mockBridgeParams,
+      token: {
+        ...mockBridgeParams.token,
+        address: '',
+      },
+    } as BridgeParams;
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: nativeBridgeParams,
+        }),
+      { wrapper },
+    );
+    await result.current.withdraw();
+    await waitFor(() => {
+      expect(mockWriteContractAsync).toHaveBeenCalledWith({
+        abi: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'bridgeETHTo',
+            type: 'function',
+          }),
+        ]),
+        functionName: 'bridgeETHTo',
+        args: [nativeBridgeParams.recipient, MIN_GAS_LIMIT, EXTRA_DATA],
+        address: APPCHAIN_BRIDGE_ADDRESS,
+        value: parseEther(nativeBridgeParams.amount),
+        chainId: mockAppchainConfig.chainId,
+      });
+      expect(result.current.withdrawStatus).toBe('withdrawSuccess');
+    });
+  });
+
+  it('should throw error if remote token is not provided', async () => {
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: {
+            ...mockBridgeParams,
+            token: { ...mockBridgeParams.token, remoteToken: undefined },
+          },
+        }),
+      { wrapper },
+    );
+    await result.current.withdraw();
+    await waitFor(() => {
+      expect(result.current.withdrawStatus).toBe('error');
+    });
+  });
+
+  it('should handle waiting for withdrawal', async () => {
+    const mockLatestBlockNumber = vi
+      .fn()
+      .mockResolvedValueOnce(5n) // First call returns lower block number
+      .mockResolvedValueOnce(15n); // Second call returns higher block number
+    (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
+      writeContractAsync: mockWriteContractAsync,
+      data: '0xmocktxhash',
+    });
+    (waitForTransactionReceipt as ReturnType<typeof vi.fn>).mockResolvedValue({
+      blockNumber: 10n,
+    });
+    (readContract as ReturnType<typeof vi.fn>).mockImplementation(
+      mockLatestBlockNumber,
+    );
+    (getWithdrawals as ReturnType<typeof vi.fn>).mockReturnValue([
+      {
+        nonce: 1n,
+        sender: '0x123' as Hex,
+        target: '0x456' as Hex,
+        value: parseEther(mockBridgeParams.amount),
+        gasLimit: 100000n,
+        data: '0x' as Hex,
+        withdrawalHash: '0xabc123' as Hex,
+      },
+    ]);
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: mockBridgeParams,
+        }),
+      { wrapper },
+    );
+    await result.current.waitForWithdrawal();
+    await waitFor(() => {
+      expect(result.current.withdrawStatus).toBe('claimReady');
+    });
+    expect(mockLatestBlockNumber).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        address: mockAppchainConfig.contracts.l2OutputOracle,
+        functionName: 'latestBlockNumber',
+        chainId: mockChain.id,
+      }),
+    );
+  });
+
+  it('should handle waiting for withdrawal when data is null', async () => {
+    const mockLatestBlockNumber = vi.fn().mockResolvedValue(15n);
+    (useWriteContract as ReturnType<typeof vi.fn>).mockReturnValue({
+      writeContractAsync: mockWriteContractAsync,
+      data: null,
+    });
+    (waitForTransactionReceipt as ReturnType<typeof vi.fn>).mockResolvedValue({
+      blockNumber: 10n,
+    });
+    (readContract as ReturnType<typeof vi.fn>).mockImplementation(
+      mockLatestBlockNumber,
+    );
+    (getWithdrawals as ReturnType<typeof vi.fn>).mockReturnValue([]);
+
+    const { result } = renderHook(
+      () =>
+        useWithdraw({
+          config: mockAppchainConfig,
+          chain: mockChain,
+          bridgeParams: mockBridgeParams,
+        }),
+      { wrapper },
+    );
+
+    await result.current.waitForWithdrawal();
+    await waitFor(() => {
+      expect(result.current.withdrawStatus).toBe('idle');
+    });
+  });
+});

--- a/src/appchain/bridge/hooks/useWithdraw.ts
+++ b/src/appchain/bridge/hooks/useWithdraw.ts
@@ -1,0 +1,265 @@
+import { useCallback, useState } from 'react';
+import {
+  type Chain,
+  type Hex,
+  erc20Abi,
+  keccak256,
+  parseEther,
+  parseUnits,
+} from 'viem';
+import { getWithdrawalHashStorageSlot, getWithdrawals } from 'viem/op-stack';
+import { useAccount, useConfig, useSwitchChain, useWriteContract } from 'wagmi';
+import {
+  getBlock,
+  getProof,
+  readContract,
+  waitForTransactionReceipt,
+} from 'wagmi/actions';
+import {
+  L2OutputOracleABI,
+  OptimismPortalABI,
+  StandardBridgeABI,
+} from '../abi';
+import {
+  APPCHAIN_BRIDGE_ADDRESS,
+  APPCHAIN_L2_TO_L1_MESSAGE_PASSER_ADDRESS,
+  EXTRA_DATA,
+  MIN_GAS_LIMIT,
+  OUTPUT_ROOT_PROOF_VERSION,
+} from '../constants';
+import type { AppchainConfig } from '../types';
+import type { BridgeParams } from '../types';
+import { getOutput } from '../utils/getOutput';
+import { isUserRejectedRequestError } from '../utils/isUserRejectedRequestError';
+import { maybeAddProofNode } from '../utils/maybeAddProofNode';
+
+interface UseWithdrawParams {
+  config: AppchainConfig;
+  chain: Chain;
+  bridgeParams: BridgeParams;
+}
+
+export const useWithdraw = ({
+  config,
+  chain,
+  bridgeParams,
+}: UseWithdrawParams) => {
+  const { chainId } = useAccount();
+  const { switchChainAsync } = useSwitchChain();
+  const { writeContractAsync, data } = useWriteContract();
+  const wagmiConfig = useConfig();
+  const [withdrawStatus, setWithdrawStatus] = useState<
+    | 'idle'
+    | 'withdrawPending'
+    | 'withdrawSuccess'
+    | 'withdrawRejected'
+    | 'claimReady'
+    | 'claimPending'
+    | 'claimSuccess'
+    | 'claimRejected'
+    | 'error'
+  >('idle');
+  const [withdrawal, setWithdrawal] = useState<ReturnType<
+    typeof getWithdrawals
+  > | null>(null);
+
+  const resetWithdrawStatus = useCallback(() => {
+    setWithdrawStatus('idle');
+    setWithdrawal(null);
+  }, []);
+
+  const withdraw = async () => {
+    if (!bridgeParams.recipient) {
+      throw new Error('Recipient is required');
+    }
+
+    setWithdrawStatus('withdrawPending');
+    try {
+      // Switch networks to the appchain
+      if (chainId !== config.chainId) {
+        await switchChainAsync({ chainId: config.chainId });
+      }
+
+      let transactionHash: Hex = '0x';
+
+      // Native ETH
+      if (bridgeParams.token.address === '') {
+        transactionHash = await writeContractAsync({
+          abi: StandardBridgeABI,
+          functionName: 'bridgeETHTo',
+          args: [bridgeParams.recipient, MIN_GAS_LIMIT, EXTRA_DATA],
+          address: APPCHAIN_BRIDGE_ADDRESS,
+          value: parseEther(bridgeParams.amount),
+          chainId: config.chainId,
+        });
+      } else {
+        // ERC-20
+        if (!bridgeParams.token.remoteToken) {
+          throw new Error('Remote token is required');
+        }
+
+        const formattedAmount = parseUnits(
+          bridgeParams.amount,
+          bridgeParams.token.decimals,
+        );
+        const approveTx = await writeContractAsync({
+          abi: erc20Abi,
+          functionName: 'approve',
+          args: [APPCHAIN_BRIDGE_ADDRESS, formattedAmount],
+          address: bridgeParams.token.address,
+          chainId: config.chainId,
+        });
+
+        await waitForTransactionReceipt(wagmiConfig, {
+          hash: approveTx,
+          confirmations: 1,
+        });
+
+        transactionHash = await writeContractAsync({
+          abi: StandardBridgeABI,
+          functionName: 'bridgeERC20To',
+          args: [
+            bridgeParams.token.remoteToken,
+            bridgeParams.token.address,
+            bridgeParams.recipient,
+            formattedAmount,
+            MIN_GAS_LIMIT,
+            EXTRA_DATA,
+          ],
+          address: APPCHAIN_BRIDGE_ADDRESS,
+          chainId: config.chainId,
+        });
+      }
+
+      setWithdrawStatus('withdrawSuccess');
+      return transactionHash;
+    } catch (error) {
+      if (isUserRejectedRequestError(error)) {
+        console.error('User rejected request');
+        setWithdrawStatus('withdrawRejected');
+      } else {
+        console.error('Error', error);
+        setWithdrawStatus('error');
+      }
+    }
+  };
+
+  const waitForWithdrawal = async () => {
+    if (!data) {
+      return;
+    }
+
+    const withdrawalReceipt = await waitForTransactionReceipt(wagmiConfig, {
+      hash: data,
+      confirmations: 1,
+      chainId: config.chainId,
+    });
+
+    // Poll until the required block number is reached
+    const pollInterval = 1000; // 1 second
+    const maxAttempts = 60; // Prevent infinite polling, poll for maximum 1 minute
+    let attempts = 0;
+
+    while (attempts < maxAttempts) {
+      const latestBlockNumber = await readContract(wagmiConfig, {
+        address: config.contracts.l2OutputOracle,
+        abi: L2OutputOracleABI,
+        functionName: 'latestBlockNumber',
+        chainId: chain.id,
+      });
+      if (latestBlockNumber >= withdrawalReceipt.blockNumber) {
+        setWithdrawStatus('claimReady');
+        const [_withdrawal] = getWithdrawals(withdrawalReceipt);
+        setWithdrawal([_withdrawal]);
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      attempts++;
+    }
+  };
+
+  /* v8 ignore start */
+  const proveAndFinalizeWithdrawal = async () => {
+    if (!withdrawal || withdrawal.length === 0) {
+      console.error('no withdrawals to prove');
+      return;
+    }
+    setWithdrawStatus('claimPending');
+
+    // Build proof
+    const output = await getOutput({
+      config,
+      chain,
+      wagmiConfig,
+    });
+    const slot = getWithdrawalHashStorageSlot({
+      withdrawalHash: withdrawal[0].withdrawalHash,
+    });
+    const [proof, block] = await Promise.all([
+      // On the L2ToL1MessagePasser on the appchain
+      getProof(wagmiConfig, {
+        address: APPCHAIN_L2_TO_L1_MESSAGE_PASSER_ADDRESS,
+        storageKeys: [slot],
+        blockNumber: output.l2BlockNumber,
+        chainId: config.chainId,
+      }),
+      getBlock(wagmiConfig, {
+        blockNumber: output.l2BlockNumber,
+        chainId: config.chainId,
+      }),
+    ]);
+    const args = {
+      l2OutputIndex: output.outputIndex,
+      outputRootProof: {
+        version: OUTPUT_ROOT_PROOF_VERSION,
+        stateRoot: block.stateRoot,
+        messagePasserStorageRoot: proof.storageHash,
+        latestBlockhash: block.hash,
+      },
+      withdrawalProof: maybeAddProofNode(
+        keccak256(slot),
+        proof.storageProof[0].proof,
+      ),
+      withdrawal: withdrawal[0],
+    };
+
+    try {
+      // Switch networks to Base
+      if (chainId !== chain.id) {
+        await switchChainAsync({ chainId: chain.id });
+      }
+
+      // Finalize the withdrawal
+      await writeContractAsync({
+        abi: OptimismPortalABI,
+        address: config.contracts.optimismPortal,
+        functionName: 'proveAndFinalizeWithdrawalTransaction',
+        args: [
+          withdrawal[0],
+          args.l2OutputIndex,
+          args.outputRootProof,
+          args.withdrawalProof,
+        ],
+        chainId: chain.id,
+      });
+
+      setWithdrawStatus('claimSuccess');
+    } catch (error) {
+      if (isUserRejectedRequestError(error)) {
+        console.error('User rejected request');
+        setWithdrawStatus('claimRejected');
+      } else {
+        setWithdrawStatus('error');
+      }
+    }
+  };
+  /* v8 ignore stop */
+
+  return {
+    withdraw,
+    withdrawStatus,
+    waitForWithdrawal,
+    proveAndFinalizeWithdrawal,
+    resetWithdrawStatus,
+  };
+};

--- a/src/appchain/bridge/hooks/useWithdraw.ts
+++ b/src/appchain/bridge/hooks/useWithdraw.ts
@@ -68,6 +68,7 @@ export const useWithdraw = ({
     setWithdrawal(null);
   }, []);
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: ignore
   const withdraw = async () => {
     if (!bridgeParams.recipient) {
       throw new Error('Recipient is required');
@@ -179,6 +180,7 @@ export const useWithdraw = ({
   };
 
   /* v8 ignore start */
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: ignore
   const proveAndFinalizeWithdrawal = async () => {
     if (!withdrawal || withdrawal.length === 0) {
       console.error('no withdrawals to prove');

--- a/src/appchain/bridge/hooks/useWithdrawButton.test.tsx
+++ b/src/appchain/bridge/hooks/useWithdrawButton.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { type Mock, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { useWithdrawButton } from './useWithdrawButton';
 
@@ -13,9 +13,9 @@ describe('useWithdrawButton', () => {
   };
 
   it('should return initial state when status is idle', () => {
-    vi.mocked(useAccount).mockReturnValue({
+    (useAccount as Mock).mockReturnValue({
       isConnected: true,
-    } as any);
+    });
 
     const { result } = renderHook(() => useWithdrawButton(mockProps));
 
@@ -30,9 +30,9 @@ describe('useWithdrawButton', () => {
   });
 
   it('should show pending state when status is claimPending', () => {
-    vi.mocked(useAccount).mockReturnValue({
+    (useAccount as Mock).mockReturnValue({
       isConnected: true,
-    } as any);
+    });
 
     const { result } = renderHook(() =>
       useWithdrawButton({ withdrawStatus: 'claimPending' }),
@@ -49,9 +49,9 @@ describe('useWithdrawButton', () => {
   });
 
   it('should show success state when status is claimSuccess', () => {
-    vi.mocked(useAccount).mockReturnValue({
+    (useAccount as Mock).mockReturnValue({
       isConnected: true,
-    } as any);
+    });
 
     const { result } = renderHook(() =>
       useWithdrawButton({ withdrawStatus: 'claimSuccess' }),
@@ -68,9 +68,9 @@ describe('useWithdrawButton', () => {
   });
 
   it('should show claim ready state when status is claimReady', () => {
-    vi.mocked(useAccount).mockReturnValue({
+    (useAccount as Mock).mockReturnValue({
       isConnected: true,
-    } as any);
+    });
 
     const { result } = renderHook(() =>
       useWithdrawButton({ withdrawStatus: 'claimReady' }),
@@ -87,9 +87,9 @@ describe('useWithdrawButton', () => {
   });
 
   it('should show claim rejected state when status is claimRejected', () => {
-    vi.mocked(useAccount).mockReturnValue({
+    (useAccount as Mock).mockReturnValue({
       isConnected: true,
-    } as any);
+    });
 
     const { result } = renderHook(() =>
       useWithdrawButton({ withdrawStatus: 'claimRejected' }),
@@ -106,12 +106,12 @@ describe('useWithdrawButton', () => {
   });
 
   it('should handle unknown status gracefully', () => {
-    vi.mocked(useAccount).mockReturnValue({
+    (useAccount as Mock).mockReturnValue({
       isConnected: true,
-    } as any);
+    });
 
     const { result } = renderHook(() =>
-      useWithdrawButton({ withdrawStatus: 'unknown' as any }),
+      useWithdrawButton({ withdrawStatus: 'unknown' }),
     );
 
     expect(result.current).toEqual({

--- a/src/appchain/bridge/hooks/useWithdrawButton.test.tsx
+++ b/src/appchain/bridge/hooks/useWithdrawButton.test.tsx
@@ -1,0 +1,126 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAccount } from 'wagmi';
+import { useWithdrawButton } from './useWithdrawButton';
+
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+}));
+
+describe('useWithdrawButton', () => {
+  const mockProps = {
+    withdrawStatus: 'idle',
+  };
+
+  it('should return initial state when status is idle', () => {
+    vi.mocked(useAccount).mockReturnValue({
+      isConnected: true,
+    } as any);
+
+    const { result } = renderHook(() => useWithdrawButton(mockProps));
+
+    expect(result.current).toEqual({
+      isPending: false,
+      isSuccess: false,
+      buttonDisabled: false,
+      buttonContent: 'Claim',
+      shouldShowClaim: false,
+      label: 'Confirming transaction',
+    });
+  });
+
+  it('should show pending state when status is claimPending', () => {
+    vi.mocked(useAccount).mockReturnValue({
+      isConnected: true,
+    } as any);
+
+    const { result } = renderHook(() =>
+      useWithdrawButton({ withdrawStatus: 'claimPending' }),
+    );
+
+    expect(result.current).toEqual({
+      isPending: true,
+      isSuccess: false,
+      buttonDisabled: true,
+      buttonContent: expect.any(Object),
+      shouldShowClaim: true,
+      label: 'Claim is ready',
+    });
+  });
+
+  it('should show success state when status is claimSuccess', () => {
+    vi.mocked(useAccount).mockReturnValue({
+      isConnected: true,
+    } as any);
+
+    const { result } = renderHook(() =>
+      useWithdrawButton({ withdrawStatus: 'claimSuccess' }),
+    );
+
+    expect(result.current).toEqual({
+      isPending: false,
+      isSuccess: true,
+      buttonDisabled: false,
+      buttonContent: 'Claim',
+      shouldShowClaim: false,
+      label: 'Transaction complete',
+    });
+  });
+
+  it('should show claim ready state when status is claimReady', () => {
+    vi.mocked(useAccount).mockReturnValue({
+      isConnected: true,
+    } as any);
+
+    const { result } = renderHook(() =>
+      useWithdrawButton({ withdrawStatus: 'claimReady' }),
+    );
+
+    expect(result.current).toEqual({
+      isPending: false,
+      isSuccess: false,
+      buttonDisabled: false,
+      buttonContent: 'Claim',
+      shouldShowClaim: true,
+      label: 'Claim is ready',
+    });
+  });
+
+  it('should show claim rejected state when status is claimRejected', () => {
+    vi.mocked(useAccount).mockReturnValue({
+      isConnected: true,
+    } as any);
+
+    const { result } = renderHook(() =>
+      useWithdrawButton({ withdrawStatus: 'claimRejected' }),
+    );
+
+    expect(result.current).toEqual({
+      isPending: false,
+      isSuccess: false,
+      buttonDisabled: false,
+      buttonContent: 'Claim',
+      shouldShowClaim: true,
+      label: 'Claim is ready',
+    });
+  });
+
+  it('should handle unknown status gracefully', () => {
+    vi.mocked(useAccount).mockReturnValue({
+      isConnected: true,
+    } as any);
+
+    const { result } = renderHook(() =>
+      useWithdrawButton({ withdrawStatus: 'unknown' as any }),
+    );
+
+    expect(result.current).toEqual({
+      isPending: false,
+      isSuccess: false,
+      buttonDisabled: false,
+      buttonContent: 'Claim',
+      shouldShowClaim: false,
+      label: 'Confirming transaction',
+    });
+  });
+});

--- a/src/appchain/bridge/hooks/useWithdrawButton.tsx
+++ b/src/appchain/bridge/hooks/useWithdrawButton.tsx
@@ -1,0 +1,42 @@
+import { Spinner } from '@/internal/components/Spinner';
+import type { ReactNode } from 'react';
+
+interface UseWithdrawButtonProps {
+  withdrawStatus: string;
+}
+
+interface UseWithdrawButtonReturn {
+  isPending: boolean;
+  isSuccess: boolean;
+  buttonDisabled: boolean;
+  buttonContent: ReactNode;
+  shouldShowClaim: boolean;
+  label: string;
+}
+
+export function useWithdrawButton({
+  withdrawStatus,
+}: UseWithdrawButtonProps): UseWithdrawButtonReturn {
+  const isPending = withdrawStatus === 'claimPending';
+  const isSuccess = withdrawStatus === 'claimSuccess';
+  const buttonDisabled = isPending;
+  const buttonContent = isPending ? <Spinner /> : 'Claim';
+  const shouldShowClaim =
+    withdrawStatus === 'claimReady' ||
+    isPending ||
+    withdrawStatus === 'claimRejected';
+  const label = shouldShowClaim
+    ? 'Claim is ready'
+    : isSuccess
+      ? 'Transaction complete'
+      : 'Confirming transaction';
+
+  return {
+    isPending,
+    isSuccess,
+    buttonDisabled,
+    buttonContent,
+    shouldShowClaim,
+    label,
+  };
+}

--- a/src/appchain/bridge/hooks/useWithdrawButton.tsx
+++ b/src/appchain/bridge/hooks/useWithdrawButton.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from '@/internal/components/Spinner';
+import { useMemo } from 'react';
 import type { ReactNode } from 'react';
 
 interface UseWithdrawButtonProps {
@@ -25,11 +26,11 @@ export function useWithdrawButton({
     withdrawStatus === 'claimReady' ||
     isPending ||
     withdrawStatus === 'claimRejected';
-  const label = shouldShowClaim
-    ? 'Claim is ready'
-    : isSuccess
-      ? 'Transaction complete'
-      : 'Confirming transaction';
+  const label = useMemo(() => {
+    if (shouldShowClaim) return 'Claim is ready';
+    if (isSuccess) return 'Transaction complete';
+    return 'Confirming transaction';
+  }, [shouldShowClaim, isSuccess, isPending]);
 
   return {
     isPending,

--- a/src/appchain/bridge/hooks/useWithdrawButton.tsx
+++ b/src/appchain/bridge/hooks/useWithdrawButton.tsx
@@ -27,10 +27,14 @@ export function useWithdrawButton({
     isPending ||
     withdrawStatus === 'claimRejected';
   const label = useMemo(() => {
-    if (shouldShowClaim) return 'Claim is ready';
-    if (isSuccess) return 'Transaction complete';
+    if (shouldShowClaim) {
+      return 'Claim is ready';
+    }
+    if (isSuccess) {
+      return 'Transaction complete';
+    }
     return 'Confirming transaction';
-  }, [shouldShowClaim, isSuccess, isPending]);
+  }, [shouldShowClaim, isSuccess]);
 
   return {
     isPending,

--- a/src/appchain/bridge/types.ts
+++ b/src/appchain/bridge/types.ts
@@ -1,17 +1,31 @@
 import type { Token } from '@/token';
 import type { Address, Chain } from 'viem';
 
+/**
+ * Note: exported as public Type
+ */
 export type Appchain = {
+  /** The chain to bridge to. */
   chain: Chain;
+  /** Optional icon to display for the appchain. */
   icon?: React.ReactNode;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type AppchainBridgeReact = {
+  /** The source chain to bridge from. This should beBase or Base Sepolia. */
   chain: Chain;
+  /** The appchain to bridge to. */
   appchain: Appchain;
+  /** Optional children to render within the component. */
   children?: React.ReactNode;
+  /** Optional className override for the component. */
   className?: string;
+  /** Optional title for the component. */
   title?: string;
+  /** Optional array of bridgeable tokens. */
   bridgeableTokens?: BridgeableToken[];
 };
 
@@ -43,16 +57,27 @@ export type AppchainBridgeContextType = {
   setIsWithdrawModalOpen: (open: boolean) => void;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type BridgeableToken = Token & {
+  /** The address of the remote token on the appchain. */
   remoteToken?: Address;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type ChainWithIcon = Chain & {
   icon: React.ReactNode;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type AppchainConfig = {
   chainId: number;
+  /** The OP Bedrock contract addresses for an appchain. These are on Base and retrieved from DeployContract. */
   contracts: {
     l2OutputOracle: Address;
     systemConfig: Address;

--- a/src/appchain/bridge/types.ts
+++ b/src/appchain/bridge/types.ts
@@ -1,0 +1,77 @@
+import type { Token } from '@/token';
+import type { Address, Chain } from 'viem';
+
+export type Appchain = {
+  chain: Chain;
+  icon?: React.ReactNode;
+};
+
+export type AppchainBridgeReact = {
+  chain: Chain;
+  appchain: Appchain;
+  children?: React.ReactNode;
+  className?: string;
+  title?: string;
+  bridgeableTokens?: BridgeableToken[];
+};
+
+export type AppchainBridgeContextType = {
+  // Configuration
+  config: AppchainConfig;
+  from: ChainWithIcon;
+  to: ChainWithIcon;
+  bridgeParams: BridgeParams;
+
+  // UI State
+  isPriceLoading: boolean;
+  isAddressModalOpen: boolean;
+  isWithdrawModalOpen: boolean;
+  balance: string;
+  depositStatus: string;
+  withdrawStatus: string;
+  direction: string;
+
+  // Handler Functions
+  handleToggle: () => void;
+  handleAmountChange: (params: { amount: string; token: Token }) => void;
+  handleAddressSelect: (address: Address) => void;
+  handleDeposit: () => void;
+  handleWithdraw: () => void;
+  waitForWithdrawal: () => Promise<void>;
+  proveAndFinalizeWithdrawal: () => Promise<void>;
+  setIsAddressModalOpen: (open: boolean) => void;
+  setIsWithdrawModalOpen: (open: boolean) => void;
+};
+
+export type BridgeableToken = Token & {
+  remoteToken?: Address;
+};
+
+export type ChainWithIcon = Chain & {
+  icon: React.ReactNode;
+};
+
+export type AppchainConfig = {
+  chainId: number;
+  contracts: {
+    l2OutputOracle: Address;
+    systemConfig: Address;
+    optimismPortal: Address;
+    l1CrossDomainMessenger: Address;
+    l1StandardBridge: Address;
+    l1ERC721Bridge: Address;
+    optimismMintableERC20Factory: Address;
+  };
+};
+
+export type BridgeParams = {
+  amount: string;
+  amountUSD: string;
+  token: BridgeableToken;
+  recipient?: Address;
+};
+
+export type FinalizeWithdrawalParams = {
+  config: AppchainConfig;
+  chain: Chain;
+};

--- a/src/appchain/bridge/utils/getETHPrice.test.ts
+++ b/src/appchain/bridge/utils/getETHPrice.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getETHPrice } from './getETHPrice';
+
+describe('getETHPrice', () => {
+  beforeEach(() => {
+    // Clear all mocks before each test
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore all mocks after each test
+    vi.restoreAllMocks();
+  });
+
+  it('should return ETH price when API call is successful', async () => {
+    const mockResponse = {
+      data: {
+        amount: '1850.50',
+        base: 'ETH',
+        currency: 'USD',
+      },
+    };
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
+    const price = await getETHPrice();
+
+    expect(price).toBe('1850.50');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.coinbase.com/v2/prices/ETH-USD/spot',
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('should return "0" when API call fails with non-200 status', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+    });
+
+    const price = await getETHPrice();
+
+    expect(price).toBe('0');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error fetching ETH price:',
+      expect.any(Error),
+    );
+  });
+
+  it('should return "0" when API call throws an error', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+    const price = await getETHPrice();
+
+    expect(price).toBe('0');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error fetching ETH price:',
+      expect.any(Error),
+    );
+  });
+
+  it('should return "0" when response JSON is invalid', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.reject(new Error('Invalid JSON')),
+    });
+
+    const price = await getETHPrice();
+
+    expect(price).toBe('0');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error fetching ETH price:',
+      expect.any(Error),
+    );
+  });
+});

--- a/src/appchain/bridge/utils/getETHPrice.ts
+++ b/src/appchain/bridge/utils/getETHPrice.ts
@@ -1,0 +1,27 @@
+interface CoinbaseResponse {
+  data: {
+    amount: string;
+    base: string;
+    currency: string;
+  };
+}
+
+export async function getETHPrice(): Promise<string> {
+  try {
+    const response = await fetch(
+      'https://api.coinbase.com/v2/prices/ETH-USD/spot',
+    );
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data: CoinbaseResponse = await response.json();
+    const amount = data.data.amount;
+
+    return amount;
+  } catch (error) {
+    console.error('Error fetching ETH price:', error);
+    return '0';
+  }
+}

--- a/src/appchain/bridge/utils/getOutput.test.ts
+++ b/src/appchain/bridge/utils/getOutput.test.ts
@@ -1,0 +1,90 @@
+import { http } from 'viem';
+import { base } from 'viem/chains';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createConfig } from 'wagmi';
+import { readContract } from 'wagmi/actions';
+import { L2OutputOracleABI } from '../abi';
+import type { AppchainConfig } from '../types';
+import { getOutput } from './getOutput';
+
+vi.mock('wagmi/actions', () => ({
+  readContract: vi.fn(),
+}));
+
+describe('getOutput', () => {
+  const mockConfig: AppchainConfig = {
+    chainId: 8453,
+    contracts: {
+      l2OutputOracle:
+        '0x56315b90c40730925ec5485cf004d835058518A0' as `0x${string}`,
+      systemConfig: '0x0' as `0x${string}`,
+      optimismPortal: '0x0' as `0x${string}`,
+      l1CrossDomainMessenger: '0x0' as `0x${string}`,
+      l1StandardBridge: '0x0' as `0x${string}`,
+      l1ERC721Bridge: '0x0' as `0x${string}`,
+      optimismMintableERC20Factory: '0x0' as `0x${string}`,
+    },
+  };
+
+  const mockWagmiConfig = createConfig({
+    chains: [base],
+    transports: {
+      [base.id]: http(),
+    },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fetch output index and output data', async () => {
+    const mockOutputIndex = 123n;
+    const mockOutput = {
+      outputRoot: '0x123' as `0x${string}`,
+      timestamp: 456n,
+      l2BlockNumber: 789n,
+    };
+
+    (readContract as Mock).mockResolvedValueOnce(mockOutputIndex);
+    (readContract as Mock).mockResolvedValueOnce(mockOutput);
+
+    const result = await getOutput({
+      config: mockConfig,
+      chain: base,
+      wagmiConfig: mockWagmiConfig,
+    });
+
+    expect(readContract).toHaveBeenNthCalledWith(1, mockWagmiConfig, {
+      address: mockConfig.contracts.l2OutputOracle,
+      abi: L2OutputOracleABI,
+      functionName: 'latestOutputIndex',
+      args: [],
+      chainId: base.id,
+    });
+    expect(readContract).toHaveBeenNthCalledWith(2, mockWagmiConfig, {
+      address: mockConfig.contracts.l2OutputOracle,
+      abi: L2OutputOracleABI,
+      functionName: 'getL2Output',
+      args: [mockOutputIndex],
+      chainId: base.id,
+    });
+
+    expect(result).toEqual({
+      outputIndex: mockOutputIndex,
+      ...mockOutput,
+    });
+  });
+
+  it('should throw an error if contract calls fail', async () => {
+    const mockError = new Error('Contract call failed');
+    (readContract as Mock).mockRejectedValueOnce(mockError);
+
+    await expect(
+      getOutput({
+        config: mockConfig,
+        chain: base,
+        wagmiConfig: mockWagmiConfig,
+      }),
+    ).rejects.toThrow('Contract call failed');
+  });
+});

--- a/src/appchain/bridge/utils/getOutput.ts
+++ b/src/appchain/bridge/utils/getOutput.ts
@@ -1,0 +1,36 @@
+import type { Chain } from 'viem';
+import type { Config } from 'wagmi';
+import { readContract } from 'wagmi/actions';
+import { L2OutputOracleABI } from '../abi';
+import type { AppchainConfig } from '../types';
+
+export const getOutput = async ({
+  config,
+  chain,
+  wagmiConfig,
+}: {
+  config: AppchainConfig;
+  chain: Chain;
+  wagmiConfig: Config;
+}) => {
+  const outputIndex = await readContract(wagmiConfig, {
+    address: config.contracts.l2OutputOracle,
+    abi: L2OutputOracleABI,
+    functionName: 'latestOutputIndex',
+    args: [],
+    chainId: chain.id,
+  });
+
+  const output = await readContract(wagmiConfig, {
+    address: config.contracts.l2OutputOracle,
+    abi: L2OutputOracleABI,
+    functionName: 'getL2Output',
+    args: [outputIndex],
+    chainId: chain.id,
+  });
+
+  return {
+    outputIndex,
+    ...output,
+  };
+};

--- a/src/appchain/bridge/utils/isUserRejectedRequestError.test.ts
+++ b/src/appchain/bridge/utils/isUserRejectedRequestError.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { isUserRejectedRequestError } from './isUserRejectedRequestError';
+
+describe('isUserRejectedRequestError', () => {
+  it('should return true if error is UserRejectedRequestError', () => {
+    const error = {
+      cause: {
+        name: 'UserRejectedRequestError',
+      },
+    };
+    expect(isUserRejectedRequestError(error)).toBe(true);
+  });
+
+  it('should return false if error is not UserRejectedRequestError', () => {
+    const error = {
+      cause: {
+        name: 'Error',
+      },
+    };
+    expect(isUserRejectedRequestError(error)).toBe(false);
+  });
+
+  it('should return true if error message includes User rejected the request.', () => {
+    const error = {
+      shortMessage: 'User rejected the request.',
+    };
+    expect(isUserRejectedRequestError(error)).toBe(true);
+  });
+
+  it('should return false if error message does not include User rejected the request.', () => {
+    const error = {
+      message: 'Error',
+    };
+    expect(isUserRejectedRequestError(error)).toBe(false);
+  });
+});

--- a/src/appchain/bridge/utils/isUserRejectedRequestError.ts
+++ b/src/appchain/bridge/utils/isUserRejectedRequestError.ts
@@ -1,0 +1,18 @@
+import type {
+  ContractFunctionExecutionError,
+  UserRejectedRequestError,
+} from 'viem';
+
+export function isUserRejectedRequestError(err: unknown) {
+  if (
+    (err as ContractFunctionExecutionError)?.cause?.name ===
+      'UserRejectedRequestError' ||
+    (err as UserRejectedRequestError)?.name === 'UserRejectedRequestError' ||
+    (err as ContractFunctionExecutionError)?.shortMessage?.includes(
+      'User rejected the request.',
+    )
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/src/appchain/bridge/utils/maybeAddProofNode.ts
+++ b/src/appchain/bridge/utils/maybeAddProofNode.ts
@@ -1,0 +1,26 @@
+import { type Hex, fromRlp, toRlp } from 'viem';
+
+/* v8 ignore start */
+export function maybeAddProofNode(key: string, proof: readonly Hex[]) {
+  const lastProofRlp = proof[proof.length - 1];
+  const lastProof = fromRlp(lastProofRlp);
+  if (lastProof.length !== 17) return proof;
+
+  const modifiedProof = [...proof];
+  for (const item of lastProof) {
+    // Find any nodes located inside of the branch node.
+    if (!Array.isArray(item)) continue;
+    // Check if the key inside the node matches the key we're looking for. We remove the first
+    // two characters (0x) and then we remove one more character (the first nibble) since this
+    // is the identifier for the type of node we're looking at. In this case we don't actually
+    // care what type of node it is because a branch node would only ever be the final proof
+    // element if (1) it includes the leaf node we're looking for or (2) it stores the value
+    // within itself. If (1) then this logic will work, if (2) then this won't find anything
+    // and we won't append any proof elements, which is exactly what we would want.
+    const suffix = item[0].slice(3);
+    if (typeof suffix !== 'string' || !key.endsWith(suffix)) continue;
+    modifiedProof.push(toRlp(item));
+  }
+  return modifiedProof;
+}
+/* v8 ignore stop */

--- a/src/appchain/bridge/utils/maybeAddProofNode.ts
+++ b/src/appchain/bridge/utils/maybeAddProofNode.ts
@@ -1,15 +1,20 @@
 import { type Hex, fromRlp, toRlp } from 'viem';
 
 /* v8 ignore start */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: ignore
 export function maybeAddProofNode(key: string, proof: readonly Hex[]) {
   const lastProofRlp = proof[proof.length - 1];
   const lastProof = fromRlp(lastProofRlp);
-  if (lastProof.length !== 17) return proof;
+  if (lastProof.length !== 17) {
+    return proof;
+  }
 
   const modifiedProof = [...proof];
   for (const item of lastProof) {
     // Find any nodes located inside of the branch node.
-    if (!Array.isArray(item)) continue;
+    if (!Array.isArray(item)) {
+      continue;
+    }
     // Check if the key inside the node matches the key we're looking for. We remove the first
     // two characters (0x) and then we remove one more character (the first nibble) since this
     // is the identifier for the type of node we're looking at. In this case we don't actually
@@ -18,7 +23,9 @@ export function maybeAddProofNode(key: string, proof: readonly Hex[]) {
     // within itself. If (1) then this logic will work, if (2) then this won't find anything
     // and we won't append any proof elements, which is exactly what we would want.
     const suffix = item[0].slice(3);
-    if (typeof suffix !== 'string' || !key.endsWith(suffix)) continue;
+    if (typeof suffix !== 'string' || !key.endsWith(suffix)) {
+      continue;
+    }
     modifiedProof.push(toRlp(item));
   }
   return modifiedProof;

--- a/src/token/constants.ts
+++ b/src/token/constants.ts
@@ -1,4 +1,4 @@
-import { base } from 'viem/chains';
+import { base, baseSepolia } from 'viem/chains';
 import type { Token } from './types';
 
 export const ethToken: Token = {
@@ -11,6 +11,16 @@ export const ethToken: Token = {
   chainId: base.id,
 };
 
+export const ethSepoliaToken: Token = {
+  name: 'ETH',
+  address: '',
+  symbol: 'ETH',
+  decimals: 18,
+  image:
+    'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+  chainId: baseSepolia.id,
+};
+
 export const usdcToken: Token = {
   name: 'USDC',
   address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
@@ -19,6 +29,16 @@ export const usdcToken: Token = {
   image:
     'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
   chainId: base.id,
+};
+
+export const usdcSepoliaToken: Token = {
+  name: 'USDC',
+  address: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
+  symbol: 'USDC',
+  decimals: 6,
+  image:
+    'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
+  chainId: baseSepolia.id,
 };
 
 export const degenToken: Token = {


### PR DESCRIPTION
**What changed? Why?**

add hooks for appchain bridge component

`useAppchainConfig`
- queries the DeployChain for an appchain's configuration

`useDeposit`
- wraps Wagmi hooks to make a deposit to the L2's `StandardBridge` contract

`useWithdraw`
- wraps Wagmi hooks to make a withdrawal from the appchain's `StandardBridge` and `OptimismPortal` contracts

`useDepositButton` and `useWithdrawButton`
- manages states for components (later PR)

and misc. util functions

**Notes to reviewers**

**How has it been tested?**
unit tests and locally in playground (entire PR)
