### PR TITLE
fix: add test coverage for `getName` fallback function

### DIFF
--- a/src/identity/utils/getName.test.ts
+++ b/src/identity/utils/getName.test.ts
@@ -124,5 +124,7 @@ describe('getName', () => {
     const name = await getName({ address: walletAddress, chain: base });
     expect(name).toBe(expectedEnsName);
     expect(getChainPublicClient).toHaveBeenCalledWith(base);
+    // Ensure it falls back to mainnet
+    expect(getChainPublicClient).toHaveBeenLastCalledWith(mainnet);
   });
 });


### PR DESCRIPTION
**What changed? Why?**
We recently had a regression where our fallback for `getName` on mainnet was changed to read from `base` instead, causing slow resolution the `Wallet` component. This PR improves test coverage to prevent a regression in the future.

**Notes to reviewers**

**How has it been tested?**
