### PR TITLE
fix: add fallback for docs site during deployment

### DIFF
--- a/site/docs/layout.tsx
+++ b/site/docs/layout.tsx
@@ -2,5 +2,11 @@ import type { ReactNode } from 'react';
 import ThemeProvider from './contexts/Theme.tsx';
 
 export default function Layout({ children }: { children: ReactNode }) {
+  // Fixes loading of dynamic imports during deployments
+  if (typeof window !== 'undefined') {
+    window.addEventListener('vite:preloadError', () => {
+      window.location.reload();
+    });
+  }
   return <ThemeProvider>{children}</ThemeProvider>;
 }

--- a/site/docs/layout.tsx
+++ b/site/docs/layout.tsx
@@ -3,6 +3,7 @@ import ThemeProvider from './contexts/Theme.tsx';
 
 export default function Layout({ children }: { children: ReactNode }) {
   // Fixes loading of dynamic imports during deployments
+  // https://vite.dev/guide/build#load-error-handling
   if (typeof window !== 'undefined') {
     window.addEventListener('vite:preloadError', () => {
       window.location.reload();


### PR DESCRIPTION
**What changed? Why?**
During deploys, our docs site occasionally goes down with the error `TypeError: Failed to fetch dynamically imported module`. This happens because previously built and deployed assets have become available as Vercel has removed the files but the client has not yet been updated. 

If that happens, we want to force the client to reload and fetch the lastest bundles.

**Notes to reviewers**

**How has it been tested?**
