### PR TITLE
fix spelling error in `getBuyQuote.ts` and `AmountInput.tsx` for improved clarity

### DIFF
--- a/src/buy/utils/getBuyQuote.ts
+++ b/src/buy/utils/getBuyQuote.ts
@@ -38,7 +38,7 @@ export async function getBuyQuote({
   if (to?.symbol !== from?.symbol) {
     // switching to and from here
     // instead of getting a quote for how much of X do we need to sell to get the input token amount
-    // we can get a quote for how much of X we will recieve if we sell the input token amount
+    // we can get a quote for how much of X we will receive if we sell the input token amount
     response = await getSwapQuote(
       {
         amount,

--- a/src/internal/components/amount-input/AmountInput.tsx
+++ b/src/internal/components/amount-input/AmountInput.tsx
@@ -129,7 +129,7 @@ export function AmountInput({
 
       {/* Hidden span for measuring text width
           Without this span the input field would not adjust its width based on the text width and would look like this:
-          [0.12--------Empty Space-------][ETH] - As you can see the currency symbol is far away from the inputed value
+          [0.12--------Empty Space-------][ETH] - As you can see the currency symbol is far away from the inputted value
 
           With this span we can measure the width of the text in the input field and set the width of the input field to match the text width
           [0.12][ETH] - Now the currency symbol is displayed next to the input field


### PR DESCRIPTION
- **Improved sentence structure in `getBuyQuote.ts`**  
  - "how much of X we will recieve if we sell the input token amount" →  
    "how much of X we will receive if we sell the input token amount"  

- **Refined comment in `AmountInput.tsx`**  
  - "currency symbol is far away from the inputed value" →  
    "currency symbol is far away from the inputted value"  

#### Modified Files:  
- `src/buy/utils/getBuyQuote.ts`  
- `src/internal/components/amount-input/AmountInput.tsx` 
