### PR TITLE
feat: add `isSponsored` to `<Earn />`

### DIFF
--- a/src/earn/components/DepositButton.tsx
+++ b/src/earn/components/DepositButton.tsx
@@ -21,6 +21,7 @@ export function DepositButton({ className }: DepositButtonReact) {
     depositAmountError,
     updateLifecycleStatus,
     refetchWalletBalance,
+    isSponsored,
   } = useEarnContext();
   const [depositedAmount, setDepositedAmount] = useState('');
   const { setTransactionState } = useDepositAnalytics(depositedAmount);
@@ -76,6 +77,7 @@ export function DepositButton({ className }: DepositButtonReact) {
       calls={depositCalls}
       onStatus={handleOnStatus}
       onSuccess={handleOnSuccess}
+      isSponsored={isSponsored}
       resetAfter={3_000}
     >
       <TransactionButton

--- a/src/earn/components/Earn.tsx
+++ b/src/earn/components/Earn.tsx
@@ -44,9 +44,10 @@ export function Earn({
   children = <EarnDefaultContent />,
   className,
   vaultAddress,
+  isSponsored,
 }: EarnReact) {
   return (
-    <EarnProvider vaultAddress={vaultAddress}>
+    <EarnProvider vaultAddress={vaultAddress} isSponsored={isSponsored}>
       <div
         className={cn(
           'flex w-[375px] flex-col overflow-hidden',

--- a/src/earn/components/EarnProvider.tsx
+++ b/src/earn/components/EarnProvider.tsx
@@ -21,7 +21,11 @@ import type {
 
 const EarnContext = createContext<EarnContextType | undefined>(undefined);
 
-export function EarnProvider({ vaultAddress, children }: EarnProviderReact) {
+export function EarnProvider({
+  vaultAddress,
+  children,
+  isSponsored,
+}: EarnProviderReact) {
   if (!vaultAddress) {
     throw new Error(
       'vaultAddress is required. For a list of vaults, see: https://app.morpho.org/base/earn',
@@ -167,6 +171,7 @@ export function EarnProvider({ vaultAddress, children }: EarnProviderReact) {
     depositCalls,
     lifecycleStatus,
     updateLifecycleStatus,
+    isSponsored,
   });
 
   return <EarnContext.Provider value={value}>{children}</EarnContext.Provider>;

--- a/src/earn/components/WithdrawButton.tsx
+++ b/src/earn/components/WithdrawButton.tsx
@@ -21,6 +21,7 @@ export function WithdrawButton({ className }: WithdrawButtonReact) {
     refetchDepositedBalance,
     withdrawAmountError,
     vaultToken,
+    isSponsored,
   } = useEarnContext();
   const [withdrawnAmount, setWithdrawnAmount] = useState('');
   const { setTransactionState } = useWithdrawAnalytics(withdrawnAmount);
@@ -74,6 +75,7 @@ export function WithdrawButton({ className }: WithdrawButtonReact) {
       calls={withdrawCalls}
       onStatus={handleOnStatus}
       onSuccess={handleOnSuccess}
+      isSponsored={isSponsored}
       resetAfter={3_000}
     >
       <TransactionButton

--- a/src/earn/mocks/index.ts
+++ b/src/earn/mocks/index.ts
@@ -30,4 +30,5 @@ export const MOCK_EARN_CONTEXT: EarnContextType = {
   withdrawCalls: [],
   lifecycleStatus: { statusName: 'init', statusData: null } as const,
   updateLifecycleStatus: vi.fn(),
+  isSponsored: false,
 };

--- a/src/earn/types.ts
+++ b/src/earn/types.ts
@@ -13,6 +13,7 @@ export type EarnReact = {
   children?: React.ReactNode;
   className?: string;
   vaultAddress: Address;
+  isSponsored?: boolean;
 };
 
 /**
@@ -21,6 +22,7 @@ export type EarnReact = {
 export type EarnProviderReact = {
   children: React.ReactNode;
   vaultAddress: Address;
+  isSponsored?: boolean;
 };
 
 /**
@@ -70,6 +72,7 @@ export type EarnContextType = {
   updateLifecycleStatus: (
     status: LifecycleStatusUpdate<LifecycleStatus>,
   ) => void;
+  isSponsored?: boolean;
 };
 
 /**


### PR DESCRIPTION
**What changed? Why?**
This PR updates `<Earn />` to accept an `isSponsored` prop which is then used to sponsor deposit and withdraw transactions

**Notes to reviewers**

**How has it been tested?**
Locally in playground
