### PR TITLE
chore: Add origin to analytics

### DIFF
--- a/src/core/analytics/hooks/useAnalytics.test.ts
+++ b/src/core/analytics/hooks/useAnalytics.test.ts
@@ -18,9 +18,19 @@ describe('useAnalytics', () => {
   const mockApiKey = 'test-api-key';
   const mockSessionId = 'test-session-id';
   const mockAnalyticsUrl = 'https://custom-analytics.example.com';
+  const mockOrigin = 'https://example.com';
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    delete (window as any).location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...window.location,
+        origin: mockOrigin,
+      },
+    });
 
     (useOnchainKit as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
       apiKey: mockApiKey,
@@ -69,6 +79,7 @@ describe('useAnalytics', () => {
         timestamp: expect.any(Number),
         eventType: event,
         data,
+        origin: mockOrigin,
       },
     });
   });

--- a/src/core/analytics/hooks/useAnalytics.test.ts
+++ b/src/core/analytics/hooks/useAnalytics.test.ts
@@ -23,7 +23,6 @@ describe('useAnalytics', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    delete (window as any).location;
     Object.defineProperty(window, 'location', {
       configurable: true,
       value: {

--- a/src/core/analytics/hooks/useAnalytics.ts
+++ b/src/core/analytics/hooks/useAnalytics.ts
@@ -13,9 +13,11 @@ import { useEffect, useState } from 'react';
 export const useAnalytics = () => {
   const { apiKey, sessionId, config } = useOnchainKit();
   const [appName, setAppName] = useState('');
+  const [origin, setOrigin] = useState('');
 
   useEffect(() => {
     setAppName(document.title);
+    setOrigin(window.location.origin);
   }, []);
 
   const prepareAnalyticsPayload = <T extends AnalyticsEvent>(
@@ -33,6 +35,7 @@ export const useAnalytics = () => {
         timestamp: Date.now(),
         eventType: event,
         data,
+        origin,
       },
     };
   };

--- a/src/core/analytics/utils/sendAnalytics.test.ts
+++ b/src/core/analytics/utils/sendAnalytics.test.ts
@@ -63,6 +63,7 @@ describe('sendAnalytics', () => {
         timestamp: Date.now(),
         eventType: 'test-event',
         data: { foo: 'bar' },
+        origin: 'test-origin',
       },
     };
 
@@ -92,6 +93,7 @@ describe('sendAnalytics', () => {
         timestamp: Date.now(),
         eventType: 'test-event',
         data: { foo: 'bar' },
+        origin: 'test-origin',
       },
     };
 
@@ -119,6 +121,7 @@ describe('sendAnalytics', () => {
         timestamp: Date.now(),
         eventType: 'test-event',
         data: { foo: 'bar' },
+        origin: 'test-origin',
       },
     };
 
@@ -147,6 +150,7 @@ describe('sendAnalytics', () => {
         timestamp: Date.now(),
         eventType: 'test-event',
         data: { foo: 'bar' },
+        origin: 'test-origin',
       },
     };
 
@@ -168,6 +172,7 @@ describe('sendAnalytics', () => {
         timestamp: Date.now(),
         eventType: 'test-event',
         data: { foo: 'bar' },
+        origin: 'test-origin',
       },
     };
 
@@ -190,6 +195,7 @@ describe('sendAnalytics', () => {
         timestamp: Date.now(),
         eventType: 'test-event',
         data: { foo: 'bar' },
+        origin: 'test-origin',
       },
     };
 
@@ -200,6 +206,32 @@ describe('sendAnalytics', () => {
     expect(mockFetch).toHaveBeenCalledWith(
       ANALYTICS_API_URL,
       expect.any(Object),
+    );
+  });
+
+  it('should include origin in analytics data', async () => {
+    const request: AnalyticsRequestParams = {
+      url: ANALYTICS_API_URL,
+      headers: {},
+      body: {
+        apiKey: 'test-api-key',
+        sessionId: 'test-session-id',
+        timestamp: Date.now(),
+        eventType: 'test-event',
+        data: { foo: 'bar' },
+        origin: 'custom-origin',
+      },
+    };
+
+    mockFetch.mockResolvedValueOnce({});
+
+    await sendAnalytics(request);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining('"origin":"custom-origin"'),
+      }),
     );
   });
 });

--- a/src/core/analytics/utils/sendAnalytics.ts
+++ b/src/core/analytics/utils/sendAnalytics.ts
@@ -9,6 +9,7 @@ export type AnalyticsRequestParams = {
     timestamp: number;
     eventType: string;
     data: Record<string, unknown>;
+    origin: string;
   };
 };
 


### PR DESCRIPTION
**What changed? Why?**
Allowing the client application to explicitly set the origin.

With our current setup, grabbing the origin from the request header in the backend, the presence of Origin is unreliable - resulting in many events having an empty origin field. 

<img width="542" alt="Screenshot 2025-02-19 at 10 20 58 AM" src="https://github.com/user-attachments/assets/740203ca-67af-4518-bd20-f1e754424aa5" />

**Notes to reviewers**

**How has it been tested?**
