### PR TITLE
fix: add onchainkit boundary

### DIFF
--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -7,6 +7,7 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createContext, useMemo } from 'react';
 import { WagmiProvider } from 'wagmi';
+import OnchainKitProviderBoundary from './OnchainKitProviderBoundary';
 import { DEFAULT_PRIVACY_URL, DEFAULT_TERMS_URL } from './core/constants';
 import { createWagmiConfig } from './core/createWagmiConfig';
 import type { OnchainKitContextType } from './core/types';
@@ -118,7 +119,7 @@ export function OnchainKitProvider({
       <WagmiProvider config={defaultConfig}>
         <QueryClientProvider client={defaultQueryClient}>
           <OnchainKitContext.Provider value={value}>
-            {children}
+            <OnchainKitProviderBoundary>{children}</OnchainKitProviderBoundary>
           </OnchainKitContext.Provider>
         </QueryClientProvider>
       </WagmiProvider>
@@ -127,7 +128,7 @@ export function OnchainKitProvider({
 
   return (
     <OnchainKitContext.Provider value={value}>
-      {children}
+      <OnchainKitProviderBoundary>{children}</OnchainKitProviderBoundary>
     </OnchainKitContext.Provider>
   );
 }

--- a/src/OnchainKitProviderBoundary.test.tsx
+++ b/src/OnchainKitProviderBoundary.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import OnchainKitProviderBoundary from './OnchainKitProviderBoundary';
+import { sendAnalyticsPayload } from './core/analytics/hooks/useAnalytics';
+import { ErrorEvent as AnalyticsErrorEvent } from './core/analytics/types';
+
+vi.mock('./core/analytics/hooks/useAnalytics', () => {
+  return {
+    sendAnalyticsPayload: vi.fn(),
+  };
+});
+
+// disable error output
+function onError(e: ErrorEvent) {
+  e.preventDefault();
+}
+
+const ErrorThrowingChild = () => {
+  throw new Error('Test error');
+};
+
+const FallbackComponent = ({ error }: { error: Error }) => (
+  <div data-testid="fallback">{error.message}</div>
+);
+
+describe('OnchainKitProviderBoundary', () => {
+  beforeEach(() => {
+    window.addEventListener('error', onError);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('error', onError);
+  });
+
+  it('should render children when there is no error', () => {
+    const { getByTestId } = render(
+      <OnchainKitProviderBoundary>
+        <div data-testid="child">Child Component</div>
+      </OnchainKitProviderBoundary>,
+    );
+
+    expect(getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('should send analytics when there is an error', () => {
+    render(
+      <OnchainKitProviderBoundary>
+        <ErrorThrowingChild />
+      </OnchainKitProviderBoundary>,
+    );
+
+    expect(sendAnalyticsPayload).toHaveBeenCalledWith(
+      AnalyticsErrorEvent.ComponentError,
+      {
+        component: 'OnchainKitProviderBoundary',
+        error: 'Test error',
+        metadata: expect.objectContaining({
+          message: 'Test error',
+          stack: expect.any(String),
+        }),
+      },
+    );
+  });
+
+  it('renders fallback component when there is an error', () => {
+    const { getByTestId } = render(
+      <OnchainKitProviderBoundary fallback={FallbackComponent}>
+        <ErrorThrowingChild />
+      </OnchainKitProviderBoundary>,
+    );
+
+    expect(getByTestId('fallback')).toBeInTheDocument();
+    expect(getByTestId('fallback')).toHaveTextContent('Test error');
+  });
+
+  it('renders default error message when there is an error and no fallback is provided', () => {
+    const { getByText } = render(
+      <OnchainKitProviderBoundary>
+        <ErrorThrowingChild />
+      </OnchainKitProviderBoundary>,
+    );
+
+    expect(getByText('Sorry, we had an unhandled error')).toBeInTheDocument();
+  });
+});

--- a/src/OnchainKitProviderBoundary.tsx
+++ b/src/OnchainKitProviderBoundary.tsx
@@ -1,0 +1,53 @@
+import {
+  Component,
+  type ComponentType,
+  type ErrorInfo,
+  type ReactNode,
+} from 'react';
+import { sendAnalyticsPayload } from './core/analytics/hooks/useAnalytics';
+import { ErrorEvent } from './core/analytics/types';
+type Props = {
+  fallback?: ComponentType<{ error: Error }>;
+  children: ReactNode;
+};
+
+type State = {
+  error: Error | null;
+};
+
+class OnchainKitProviderBoundary extends Component<Props, State> {
+  state: State = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo);
+
+    sendAnalyticsPayload(ErrorEvent.ComponentError, {
+      component: 'OnchainKitProviderBoundary',
+      error: error.message,
+      metadata: {
+        message: error.message,
+        stack: errorInfo.componentStack,
+      },
+    });
+  }
+
+  render() {
+    if (this.state.error) {
+      if (this.props.fallback) {
+        const Fallback = this.props.fallback;
+        return <Fallback error={this.state.error} />;
+      }
+      return <h1>Sorry, we had an unhandled error</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default OnchainKitProviderBoundary;

--- a/src/core/analytics/hooks/useAnalytics.test.ts
+++ b/src/core/analytics/hooks/useAnalytics.test.ts
@@ -1,13 +1,24 @@
+import {
+  type ONCHAIN_KIT_CONFIG,
+  getOnchainKitConfig,
+} from '@/core/OnchainKitConfig';
 import { ANALYTICS_API_URL } from '@/core/analytics/constants';
 import { WalletEvent } from '@/core/analytics/types';
 import { sendAnalytics } from '@/core/analytics/utils/sendAnalytics';
-import { useOnchainKit } from '@/useOnchainKit';
 import { cleanup, renderHook } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { useAnalytics } from './useAnalytics';
 
-vi.mock('@/useOnchainKit', () => ({
-  useOnchainKit: vi.fn(),
+vi.mock('@/core/OnchainKitConfig', () => ({
+  getOnchainKitConfig: vi.fn(),
 }));
 
 vi.mock('@/core/analytics/utils/sendAnalytics', () => ({
@@ -31,14 +42,19 @@ describe('useAnalytics', () => {
       },
     });
 
-    (useOnchainKit as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      apiKey: mockApiKey,
-      sessionId: mockSessionId,
-      config: {
-        analytics: true,
-        analyticsUrl: mockAnalyticsUrl,
+    (getOnchainKitConfig as Mock).mockImplementation(
+      (key: keyof typeof ONCHAIN_KIT_CONFIG) => {
+        const config = {
+          apiKey: mockApiKey,
+          sessionId: mockSessionId,
+          config: {
+            analytics: true,
+            analyticsUrl: mockAnalyticsUrl,
+          },
+        };
+        return config[key as keyof typeof config];
       },
-    });
+    );
   });
 
   afterEach(() => {
@@ -84,13 +100,18 @@ describe('useAnalytics', () => {
   });
 
   it('should not send analytics when disabled in config', () => {
-    (useOnchainKit as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      apiKey: mockApiKey,
-      sessionId: mockSessionId,
-      config: {
-        analytics: false,
+    (getOnchainKitConfig as Mock).mockImplementation(
+      (key: keyof typeof ONCHAIN_KIT_CONFIG) => {
+        const config = {
+          apiKey: mockApiKey,
+          sessionId: mockSessionId,
+          config: {
+            analytics: false,
+          },
+        };
+        return config[key as keyof typeof config];
       },
-    });
+    );
 
     const { result } = renderHook(() => useAnalytics());
     const event = WalletEvent.ConnectSuccess;
@@ -106,13 +127,18 @@ describe('useAnalytics', () => {
   });
 
   it('should use default analytics URL when not provided in config', () => {
-    (useOnchainKit as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      apiKey: mockApiKey,
-      sessionId: mockSessionId,
-      config: {
-        analytics: true,
+    (getOnchainKitConfig as Mock).mockImplementation(
+      (key: keyof typeof ONCHAIN_KIT_CONFIG) => {
+        const config = {
+          apiKey: mockApiKey,
+          sessionId: mockSessionId,
+          config: {
+            analytics: true,
+          },
+        };
+        return config[key as keyof typeof config];
       },
-    });
+    );
 
     const { result } = renderHook(() => useAnalytics());
     const event = WalletEvent.ConnectError;
@@ -133,13 +159,18 @@ describe('useAnalytics', () => {
   });
 
   it('should handle undefined apiKey and sessionId', () => {
-    (useOnchainKit as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
-      apiKey: undefined,
-      sessionId: undefined,
-      config: {
-        analytics: true,
+    (getOnchainKitConfig as Mock).mockImplementation(
+      (key: keyof typeof ONCHAIN_KIT_CONFIG) => {
+        const config = {
+          apiKey: undefined,
+          sessionId: undefined,
+          config: {
+            analytics: true,
+          },
+        };
+        return config[key as keyof typeof config];
       },
-    });
+    );
 
     const { result } = renderHook(() => useAnalytics());
     const event = WalletEvent.ConnectInitiated;

--- a/src/core/analytics/hooks/useAnalytics.ts
+++ b/src/core/analytics/hooks/useAnalytics.ts
@@ -1,56 +1,56 @@
+import { getOnchainKitConfig } from '@/core/OnchainKitConfig';
 import { ANALYTICS_API_URL } from '@/core/analytics/constants';
 import type {
   AnalyticsEvent,
   AnalyticsEventData,
 } from '@/core/analytics/types';
 import { sendAnalytics } from '@/core/analytics/utils/sendAnalytics';
-import { useOnchainKit } from '@/useOnchainKit';
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
+
+const prepareAnalyticsPayload = <T extends AnalyticsEvent>(
+  event: T,
+  data: AnalyticsEventData[T],
+) => {
+  const config = getOnchainKitConfig('config');
+
+  return {
+    url: config?.analyticsUrl ?? ANALYTICS_API_URL,
+    headers: {
+      'OnchainKit-App-Name': document.title,
+    },
+    body: {
+      apiKey: getOnchainKitConfig('apiKey') ?? 'undefined',
+      sessionId: getOnchainKitConfig('sessionId') ?? 'undefined',
+      timestamp: Date.now(),
+      eventType: event,
+      data,
+      origin: window.location.origin,
+    },
+  };
+};
+
+export function sendAnalyticsPayload<T extends AnalyticsEvent>(
+  event: T,
+  data: AnalyticsEventData[T],
+): void {
+  // Don't send analytics if disabled
+  const config = getOnchainKitConfig('config');
+
+  if (!config?.analytics) {
+    return;
+  }
+  const payload = prepareAnalyticsPayload(event, data);
+  sendAnalytics(payload);
+}
 
 /**
  * useAnalytics handles analytics events and data preparation
  */
 export const useAnalytics = () => {
-  const { apiKey, sessionId, config } = useOnchainKit();
-  const [appName, setAppName] = useState('');
-  const [origin, setOrigin] = useState('');
-
-  useEffect(() => {
-    setAppName(document.title);
-    setOrigin(window.location.origin);
-  }, []);
-
-  const prepareAnalyticsPayload = <T extends AnalyticsEvent>(
-    event: T,
-    data: AnalyticsEventData[T],
-  ) => {
-    return {
-      url: config?.analyticsUrl ?? ANALYTICS_API_URL,
-      headers: {
-        'OnchainKit-App-Name': appName,
-      },
-      body: {
-        apiKey: apiKey ?? 'undefined',
-        sessionId: sessionId ?? 'undefined',
-        timestamp: Date.now(),
-        eventType: event,
-        data,
-        origin,
-      },
-    };
-  };
-
-  return {
-    sendAnalytics: <T extends AnalyticsEvent>(
-      event: T,
-      data: AnalyticsEventData[T],
-    ) => {
-      // Don't send analytics if disabled
-      if (!config?.analytics) {
-        return;
-      }
-      const payload = prepareAnalyticsPayload(event, data);
-      sendAnalytics(payload);
-    },
-  };
+  return useMemo(
+    () => ({
+      sendAnalytics: sendAnalyticsPayload,
+    }),
+    [],
+  );
 };


### PR DESCRIPTION
**What changed? Why?**
Adding a boundary around all of onchainkit to catch any unhandled errors, ideally components will implement their own more granular boundaries, but this will at least prevent ock from crashing a developers application.

**Notes to reviewers**

**How has it been tested?**
