### PR TITLE
feat: add `AppchainBridgeResumeTransaction`

### DIFF
--- a/.changeset/witty-snakes-serve.md
+++ b/.changeset/witty-snakes-serve.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+**feat** added `AppchainBridgeResumeTransaction`. by @0xAlec #2038

--- a/src/appchain/bridge/components/AppchainBridge.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridge.test.tsx
@@ -236,6 +236,20 @@ describe('AppchainBridge Component', () => {
     expect(screen.getByTestId('ockAppchainBridge_Success')).toBeInTheDocument();
   });
 
+  it('renders resume transaction modal when isResumeTransactionModalOpen is true', async () => {
+    (useAppchainBridgeContext as Mock).mockReturnValue({
+      isResumeTransactionModalOpen: true,
+    });
+    await act(async () => {
+      render(<AppchainBridge chain={mockChain} appchain={mockAppchain} />, {
+        wrapper,
+      });
+    });
+    expect(
+      screen.getByTestId('ockAppchainBridge_ResumeTransaction'),
+    ).toBeInTheDocument();
+  });
+
   it('should not render when not mounted', () => {
     (useIsMounted as Mock).mockReturnValueOnce(false);
     const { container } = render(

--- a/src/appchain/bridge/components/AppchainBridge.tsx
+++ b/src/appchain/bridge/components/AppchainBridge.tsx
@@ -7,18 +7,36 @@ import { AppchainBridgeInput } from './AppchainBridgeInput';
 import { AppchainBridgeNetwork } from './AppchainBridgeNetwork';
 import { AppchainBridgeProvider } from './AppchainBridgeProvider';
 import { useAppchainBridgeContext } from './AppchainBridgeProvider';
+import { AppchainBridgeResumeTransaction } from './AppchainBridgeResumeTransaction';
 import { AppchainBridgeSuccess } from './AppchainBridgeSuccess';
 import { AppchainBridgeTransactionButton } from './AppchainBridgeTransactionButton';
 import { AppchainBridgeWithdraw } from './AppchainBridgeWithdraw';
 import { AppchainNetworkToggleButton } from './AppchainNetworkToggleButton';
-
 const AppchainBridgeDefaultContent = ({
   title,
 }: {
   title: string;
 }) => {
-  const { isAddressModalOpen, isWithdrawModalOpen, isSuccessModalOpen } =
-    useAppchainBridgeContext();
+  const {
+    isAddressModalOpen,
+    isWithdrawModalOpen,
+    isSuccessModalOpen,
+    isResumeTransactionModalOpen,
+    setIsResumeTransactionModalOpen,
+  } = useAppchainBridgeContext();
+
+  if (isResumeTransactionModalOpen) {
+    return (
+      <div
+        className="relative flex min-h-60"
+        data-testid="ockAppchainBridge_ResumeTransaction"
+      >
+        <div className="w-full">
+          <AppchainBridgeResumeTransaction />
+        </div>
+      </div>
+    );
+  }
 
   if (isSuccessModalOpen) {
     return (
@@ -65,10 +83,27 @@ const AppchainBridgeDefaultContent = ({
       data-testid="ockAppchainBridge_DefaultContent"
     >
       <div className="w-full">
-        <div className="mb-4 flex items-center justify-between">
+        <div className="relative mb-4 flex items-center justify-between">
           <h3 className={cn(text.title3)} data-testid="ockSwap_Title">
             {title}
           </h3>
+          <span
+            className={cn(
+              text.label2,
+              color.foregroundMuted,
+              'absolute right-0',
+            )}
+          >
+            <button
+              type="button"
+              /* v8 ignore next 3 */
+              onClick={() => {
+                setIsResumeTransactionModalOpen(true);
+              }}
+            >
+              Resume
+            </button>
+          </span>
         </div>
         <div className="relative flex">
           <div className="flex flex-col gap-2">

--- a/src/appchain/bridge/components/AppchainBridgeProvider.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeProvider.test.tsx
@@ -238,6 +238,28 @@ describe('AppchainBridgeProvider', () => {
     expect(mockDeposit).toHaveBeenCalled();
   });
 
+  it('should set resumeWithdrawalTxHash when handleResumeTransaction is called', async () => {
+    const result = await renderBridgeProvider();
+    await waitFor(async () => {
+      result.current.handleResumeTransaction(
+        '0x1234567890123456789012345678901234567890123456789012345678901234',
+      );
+    });
+    expect(result.current.resumeWithdrawalTxHash).toBe(
+      '0x1234567890123456789012345678901234567890123456789012345678901234',
+    );
+    expect(result.current.isResumeTransactionModalOpen).toBe(false);
+    expect(result.current.isValidResumeTxHash).toBe(true);
+  });
+
+  it('should validate input when handleResumeTransaction is called', async () => {
+    const result = await renderBridgeProvider();
+    await waitFor(async () => {
+      result.current.handleResumeTransaction('0x123');
+    });
+    expect(result.current.isValidResumeTxHash).toBe(false);
+  });
+
   it('should validate required props', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')

--- a/src/appchain/bridge/components/AppchainBridgeProvider.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeProvider.test.tsx
@@ -474,4 +474,15 @@ describe('AppchainBridgeProvider', () => {
       '_blank',
     );
   });
+
+  it('should reset state when handleResetState is called', async () => {
+    const result = await renderBridgeProvider();
+    await waitFor(async () => {
+      result.current.handleResetState();
+    });
+    expect(result.current.resumeWithdrawalTxHash).toBeUndefined();
+    expect(result.current.isWithdrawModalOpen).toBe(false);
+    expect(result.current.isSuccessModalOpen).toBe(false);
+    expect(result.current.isResumeTransactionModalOpen).toBe(false);
+  });
 });

--- a/src/appchain/bridge/components/AppchainBridgeProvider.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeProvider.test.tsx
@@ -249,15 +249,6 @@ describe('AppchainBridgeProvider', () => {
       '0x1234567890123456789012345678901234567890123456789012345678901234',
     );
     expect(result.current.isResumeTransactionModalOpen).toBe(false);
-    expect(result.current.isValidResumeTxHash).toBe(true);
-  });
-
-  it('should validate input when handleResumeTransaction is called', async () => {
-    const result = await renderBridgeProvider();
-    await waitFor(async () => {
-      result.current.handleResumeTransaction('0x123');
-    });
-    expect(result.current.isValidResumeTxHash).toBe(false);
   });
 
   it('should validate required props', () => {

--- a/src/appchain/bridge/components/AppchainBridgeProvider.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeProvider.tsx
@@ -313,6 +313,7 @@ export const AppchainBridgeProvider = ({
     isResumeTransactionModalOpen,
     setIsResumeTransactionModalOpen,
     resumeWithdrawalTxHash,
+    setResumeWithdrawalTxHash,
     handleResumeTransaction,
 
     // Deposits and Withdrawals
@@ -329,7 +330,6 @@ export const AppchainBridgeProvider = ({
     setIsWithdrawModalOpen,
     resetDepositStatus,
     resetWithdrawStatus,
-    setResumeWithdrawalTxHash,
   });
 
   return (

--- a/src/appchain/bridge/components/AppchainBridgeProvider.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeProvider.tsx
@@ -88,7 +88,6 @@ export const AppchainBridgeProvider = ({
   const direction = from.id === chain.id ? 'deposit' : 'withdraw';
   const [balance, setBalance] = useState<string>('');
   const [resumeWithdrawalTxHash, setResumeWithdrawalTxHash] = useState<Hex>();
-  const [isValidResumeTxHash, setIsValidResumeTxHash] = useState(true);
 
   // Deposit
   const {
@@ -224,11 +223,6 @@ export const AppchainBridgeProvider = ({
   }, []);
 
   const handleResumeTransaction = useCallback((txHash: Hex) => {
-    if (!txHash?.startsWith('0x') || txHash.length !== 66) {
-      setIsValidResumeTxHash(false);
-      return;
-    }
-
     setResumeWithdrawalTxHash(txHash);
     setIsResumeTransactionModalOpen(false);
   }, []);
@@ -320,7 +314,6 @@ export const AppchainBridgeProvider = ({
     isResumeTransactionModalOpen,
     setIsResumeTransactionModalOpen,
     resumeWithdrawalTxHash,
-    isValidResumeTxHash,
     handleResumeTransaction,
 
     // Deposits and Withdrawals

--- a/src/appchain/bridge/components/AppchainBridgeProvider.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeProvider.tsx
@@ -88,6 +88,7 @@ export const AppchainBridgeProvider = ({
   const direction = from.id === chain.id ? 'deposit' : 'withdraw';
   const [balance, setBalance] = useState<string>('');
   const [resumeWithdrawalTxHash, setResumeWithdrawalTxHash] = useState<Hex>();
+  const [isValidResumeTxHash, setIsValidResumeTxHash] = useState(true);
 
   // Deposit
   const {
@@ -222,6 +223,16 @@ export const AppchainBridgeProvider = ({
     }));
   }, []);
 
+  const handleResumeTransaction = useCallback((txHash: Hex) => {
+    if (!txHash?.startsWith('0x') || txHash.length !== 66) {
+      setIsValidResumeTxHash(false);
+      return;
+    }
+
+    setResumeWithdrawalTxHash(txHash);
+    setIsResumeTransactionModalOpen(false);
+  }, []);
+
   const handleOpenExplorer = useCallback(() => {
     const blockExplorerUrl = getChainExplorer(from.id);
     const txHash =
@@ -309,6 +320,8 @@ export const AppchainBridgeProvider = ({
     isResumeTransactionModalOpen,
     setIsResumeTransactionModalOpen,
     resumeWithdrawalTxHash,
+    isValidResumeTxHash,
+    handleResumeTransaction,
 
     // Deposits and Withdrawals
     handleDeposit,

--- a/src/appchain/bridge/components/AppchainBridgeProvider.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeProvider.tsx
@@ -254,7 +254,6 @@ export const AppchainBridgeProvider = ({
     setIsResumeTransactionModalOpen(false);
 
     setResumeWithdrawalTxHash(undefined);
-    // Maybe we want to reset the params here too?
   }, []);
 
   // Open withdraw modal when withdraw is successful, or when transaction is resumed

--- a/src/appchain/bridge/components/AppchainBridgeResumeTransaction.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeResumeTransaction.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppchainBridgeContext } from './AppchainBridgeProvider';
 import { AppchainBridgeResumeTransaction } from './AppchainBridgeResumeTransaction';
@@ -16,7 +16,6 @@ describe('AppchainBridgeResumeTransaction', () => {
     (useAppchainBridgeContext as Mock).mockReturnValue({
       handleResumeTransaction: mockHandleResumeTransaction,
       setIsResumeTransactionModalOpen: mockSetIsResumeTransactionModalOpen,
-      isValidResumeTxHash: true,
     });
   });
 
@@ -43,40 +42,45 @@ describe('AppchainBridgeResumeTransaction', () => {
     render(<AppchainBridgeResumeTransaction />);
 
     const input = screen.getByPlaceholderText('0x...');
-    fireEvent.change(input, { target: { value: '0x123' } });
+    fireEvent.change(input, { target: { value: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' } });
 
-    expect(input).toHaveValue('0x123');
+    expect(input).toHaveValue('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
   });
 
-  it('shows validation message when transaction hash is invalid', () => {
+  it('shows validation message when transaction hash is invalid', async () => {
     (useAppchainBridgeContext as Mock).mockReturnValue({
       handleResumeTransaction: mockHandleResumeTransaction,
       setIsResumeTransactionModalOpen: mockSetIsResumeTransactionModalOpen,
-      isValidResumeTxHash: false,
     });
 
     render(<AppchainBridgeResumeTransaction />);
 
     const input = screen.getByPlaceholderText('0x...');
-    fireEvent.change(input, { target: { value: '0x123' } });
-
-    expect(
-      screen.getByText('Please enter a valid transaction hash'),
-    ).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: '0xinvalid' } });
+    const resumeButton = screen.getByText('Resume Transaction', {
+      selector: 'div',
+    });
+    fireEvent.click(resumeButton);
+    
+    await waitFor(() => {
+      expect(
+        screen.getByText('Please enter a valid transaction hash'),
+      ).toBeInTheDocument();
+    });
   });
 
   it('handles resume transaction with valid hash', () => {
     render(<AppchainBridgeResumeTransaction />);
 
     const input = screen.getByPlaceholderText('0x...');
-    fireEvent.change(input, { target: { value: '0x123' } });
+    fireEvent.change(input, { target: { value: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' } });
 
     const resumeButton = screen.getByText('Resume Transaction', {
       selector: 'div',
     });
     fireEvent.click(resumeButton);
 
-    expect(mockHandleResumeTransaction).toHaveBeenCalledWith('0x123');
+    expect(mockHandleResumeTransaction).toHaveBeenCalledWith('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
   });
 
   it('applies correct styles to input field', () => {

--- a/src/appchain/bridge/components/AppchainBridgeResumeTransaction.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeResumeTransaction.test.tsx
@@ -8,14 +8,15 @@ vi.mock('./AppchainBridgeProvider', () => ({
 }));
 
 describe('AppchainBridgeResumeTransaction', () => {
-  const mockSetResumeWithdrawalTxHash = vi.fn();
+  const mockHandleResumeTransaction = vi.fn();
   const mockSetIsResumeTransactionModalOpen = vi.fn();
 
   beforeEach(() => {
     vi.resetAllMocks();
     (useAppchainBridgeContext as Mock).mockReturnValue({
-      setResumeWithdrawalTxHash: mockSetResumeWithdrawalTxHash,
+      handleResumeTransaction: mockHandleResumeTransaction,
       setIsResumeTransactionModalOpen: mockSetIsResumeTransactionModalOpen,
+      isValidResumeTxHash: true,
     });
   });
 
@@ -47,6 +48,23 @@ describe('AppchainBridgeResumeTransaction', () => {
     expect(input).toHaveValue('0x123');
   });
 
+  it('shows validation message when transaction hash is invalid', () => {
+    (useAppchainBridgeContext as Mock).mockReturnValue({
+      handleResumeTransaction: mockHandleResumeTransaction,
+      setIsResumeTransactionModalOpen: mockSetIsResumeTransactionModalOpen,
+      isValidResumeTxHash: false,
+    });
+
+    render(<AppchainBridgeResumeTransaction />);
+
+    const input = screen.getByPlaceholderText('0x...');
+    fireEvent.change(input, { target: { value: '0x123' } });
+
+    expect(
+      screen.getByText('Please enter a valid transaction hash'),
+    ).toBeInTheDocument();
+  });
+
   it('handles resume transaction with valid hash', () => {
     render(<AppchainBridgeResumeTransaction />);
 
@@ -58,20 +76,7 @@ describe('AppchainBridgeResumeTransaction', () => {
     });
     fireEvent.click(resumeButton);
 
-    expect(mockSetResumeWithdrawalTxHash).toHaveBeenCalledWith('0x123');
-    expect(mockSetIsResumeTransactionModalOpen).toHaveBeenCalledWith(false);
-  });
-
-  it('does not call handlers when transaction hash is empty', () => {
-    render(<AppchainBridgeResumeTransaction />);
-
-    const resumeButton = screen.getByText('Resume Transaction', {
-      selector: 'div',
-    });
-    fireEvent.click(resumeButton);
-
-    expect(mockSetResumeWithdrawalTxHash).not.toHaveBeenCalled();
-    expect(mockSetIsResumeTransactionModalOpen).not.toHaveBeenCalled();
+    expect(mockHandleResumeTransaction).toHaveBeenCalledWith('0x123');
   });
 
   it('applies correct styles to input field', () => {

--- a/src/appchain/bridge/components/AppchainBridgeResumeTransaction.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeResumeTransaction.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppchainBridgeContext } from './AppchainBridgeProvider';
+import { AppchainBridgeResumeTransaction } from './AppchainBridgeResumeTransaction';
+
+vi.mock('./AppchainBridgeProvider', () => ({
+  useAppchainBridgeContext: vi.fn(),
+}));
+
+describe('AppchainBridgeResumeTransaction', () => {
+  const mockSetResumeWithdrawalTxHash = vi.fn();
+  const mockSetIsResumeTransactionModalOpen = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (useAppchainBridgeContext as Mock).mockReturnValue({
+      setResumeWithdrawalTxHash: mockSetResumeWithdrawalTxHash,
+      setIsResumeTransactionModalOpen: mockSetIsResumeTransactionModalOpen,
+    });
+  });
+
+  it('renders the component with initial state', () => {
+    render(<AppchainBridgeResumeTransaction />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Resume Transaction' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Transaction hash')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('0x...')).toBeInTheDocument();
+  });
+
+  it('handles back button click', () => {
+    render(<AppchainBridgeResumeTransaction />);
+
+    const backButton = screen.getByLabelText('Back button');
+    fireEvent.click(backButton);
+
+    expect(mockSetIsResumeTransactionModalOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('updates transaction hash input value', () => {
+    render(<AppchainBridgeResumeTransaction />);
+
+    const input = screen.getByPlaceholderText('0x...');
+    fireEvent.change(input, { target: { value: '0x123' } });
+
+    expect(input).toHaveValue('0x123');
+  });
+
+  it('handles resume transaction with valid hash', () => {
+    render(<AppchainBridgeResumeTransaction />);
+
+    const input = screen.getByPlaceholderText('0x...');
+    fireEvent.change(input, { target: { value: '0x123' } });
+
+    const resumeButton = screen.getByText('Resume Transaction', {
+      selector: 'div',
+    });
+    fireEvent.click(resumeButton);
+
+    expect(mockSetResumeWithdrawalTxHash).toHaveBeenCalledWith('0x123');
+    expect(mockSetIsResumeTransactionModalOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('does not call handlers when transaction hash is empty', () => {
+    render(<AppchainBridgeResumeTransaction />);
+
+    const resumeButton = screen.getByText('Resume Transaction', {
+      selector: 'div',
+    });
+    fireEvent.click(resumeButton);
+
+    expect(mockSetResumeWithdrawalTxHash).not.toHaveBeenCalled();
+    expect(mockSetIsResumeTransactionModalOpen).not.toHaveBeenCalled();
+  });
+
+  it('applies correct styles to input field', () => {
+    render(<AppchainBridgeResumeTransaction />);
+
+    const input = screen.getByPlaceholderText('0x...');
+    expect(input).toHaveClass(
+      'w-full',
+      'border-none',
+      'focus:border-none',
+      'focus:outline-none',
+      'focus:ring-0',
+    );
+  });
+});

--- a/src/appchain/bridge/components/AppchainBridgeResumeTransaction.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeResumeTransaction.test.tsx
@@ -42,9 +42,16 @@ describe('AppchainBridgeResumeTransaction', () => {
     render(<AppchainBridgeResumeTransaction />);
 
     const input = screen.getByPlaceholderText('0x...');
-    fireEvent.change(input, { target: { value: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' } });
+    fireEvent.change(input, {
+      target: {
+        value:
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      },
+    });
 
-    expect(input).toHaveValue('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
+    expect(input).toHaveValue(
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    );
   });
 
   it('shows validation message when transaction hash is invalid', async () => {
@@ -61,7 +68,7 @@ describe('AppchainBridgeResumeTransaction', () => {
       selector: 'div',
     });
     fireEvent.click(resumeButton);
-    
+
     await waitFor(() => {
       expect(
         screen.getByText('Please enter a valid transaction hash'),
@@ -73,14 +80,21 @@ describe('AppchainBridgeResumeTransaction', () => {
     render(<AppchainBridgeResumeTransaction />);
 
     const input = screen.getByPlaceholderText('0x...');
-    fireEvent.change(input, { target: { value: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' } });
+    fireEvent.change(input, {
+      target: {
+        value:
+          '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      },
+    });
 
     const resumeButton = screen.getByText('Resume Transaction', {
       selector: 'div',
     });
     fireEvent.click(resumeButton);
 
-    expect(mockHandleResumeTransaction).toHaveBeenCalledWith('0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef');
+    expect(mockHandleResumeTransaction).toHaveBeenCalledWith(
+      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    );
   });
 
   it('applies correct styles to input field', () => {

--- a/src/appchain/bridge/components/AppchainBridgeResumeTransaction.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeResumeTransaction.tsx
@@ -7,12 +7,10 @@ import type { Hex } from 'viem';
 import { useAppchainBridgeContext } from './AppchainBridgeProvider';
 
 export const AppchainBridgeResumeTransaction = () => {
-  const {
-    setIsResumeTransactionModalOpen,
-    handleResumeTransaction,
-    isValidResumeTxHash,
-  } = useAppchainBridgeContext();
+  const { setIsResumeTransactionModalOpen, handleResumeTransaction } =
+    useAppchainBridgeContext();
   const [withdrawalTxHash, setWithdrawalTxHash] = useState<string | null>(null);
+  const [invalidInput, setInvalidInput] = useState<boolean>(false);
 
   const backButton = (
     <PressableIcon
@@ -66,7 +64,7 @@ export const AppchainBridgeResumeTransaction = () => {
             value={withdrawalTxHash || ''}
           />
         </div>
-        {withdrawalTxHash && !isValidResumeTxHash && (
+        {withdrawalTxHash && invalidInput && (
           <div className="mt-2 flex">
             <p className="text-foregroundMuted text-red-500 text-sm">
               Please enter a valid transaction hash
@@ -83,6 +81,13 @@ export const AppchainBridgeResumeTransaction = () => {
             'text-center',
           )}
           onClick={() => {
+            if (
+              !withdrawalTxHash?.startsWith('0x') ||
+              withdrawalTxHash.length !== 66
+            ) {
+              setInvalidInput(true);
+              return;
+            }
             handleResumeTransaction(withdrawalTxHash as Hex);
           }}
         >

--- a/src/appchain/bridge/components/AppchainBridgeResumeTransaction.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeResumeTransaction.tsx
@@ -38,7 +38,7 @@ export const AppchainBridgeResumeTransaction = () => {
           className={cn(
             background.secondary,
             border.radius,
-            'box-border flex h-[80px] w-full flex-col items-start justify-center gap-2 p-4',
+            'box-border flex h-20 w-full flex-col items-start justify-center gap-2 p-4',
             'mt-4',
           )}
         >

--- a/src/appchain/bridge/components/AppchainBridgeResumeTransaction.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeResumeTransaction.tsx
@@ -5,9 +5,13 @@ import { background, border, cn, color, pressable, text } from '@/styles/theme';
 import { useState } from 'react';
 import type { Hex } from 'viem';
 import { useAppchainBridgeContext } from './AppchainBridgeProvider';
+
 export const AppchainBridgeResumeTransaction = () => {
-  const { setResumeWithdrawalTxHash, setIsResumeTransactionModalOpen } =
-    useAppchainBridgeContext();
+  const {
+    setIsResumeTransactionModalOpen,
+    handleResumeTransaction,
+    isValidResumeTxHash,
+  } = useAppchainBridgeContext();
   const [withdrawalTxHash, setWithdrawalTxHash] = useState<string | null>(null);
 
   const backButton = (
@@ -62,6 +66,13 @@ export const AppchainBridgeResumeTransaction = () => {
             value={withdrawalTxHash || ''}
           />
         </div>
+        {withdrawalTxHash && !isValidResumeTxHash && (
+          <div className="mt-2 flex">
+            <p className="text-foregroundMuted text-red-500 text-sm">
+              Please enter a valid transaction hash
+            </p>
+          </div>
+        )}
       </div>
       <div className="flex w-full justify-between">
         <button
@@ -72,11 +83,7 @@ export const AppchainBridgeResumeTransaction = () => {
             'text-center',
           )}
           onClick={() => {
-            // TODO: Validate input
-            if (withdrawalTxHash) {
-              setResumeWithdrawalTxHash(withdrawalTxHash as Hex);
-              setIsResumeTransactionModalOpen(false);
-            }
+            handleResumeTransaction(withdrawalTxHash as Hex);
           }}
         >
           <div

--- a/src/appchain/bridge/components/AppchainBridgeResumeTransaction.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeResumeTransaction.tsx
@@ -1,0 +1,91 @@
+import { PressableIcon } from '@/internal/components/PressableIcon';
+import { TextInput } from '@/internal/components/TextInput';
+import { backArrowSvg } from '@/internal/svg/backArrowSvg';
+import { background, border, cn, color, pressable, text } from '@/styles/theme';
+import { useState } from 'react';
+import type { Hex } from 'viem';
+import { useAppchainBridgeContext } from './AppchainBridgeProvider';
+export const AppchainBridgeResumeTransaction = () => {
+  const { setResumeWithdrawalTxHash, setIsResumeTransactionModalOpen } =
+    useAppchainBridgeContext();
+  const [withdrawalTxHash, setWithdrawalTxHash] = useState<string | null>(null);
+
+  const backButton = (
+    <PressableIcon
+      ariaLabel="Back button"
+      onClick={() => {
+        setIsResumeTransactionModalOpen(false);
+      }}
+    >
+      <div className="p-2">{backArrowSvg}</div>
+    </PressableIcon>
+  );
+
+  return (
+    <div className="flex h-full w-full flex-col justify-between">
+      <div>
+        <div className="flex items-center">
+          {backButton}
+          <h2 className="ock-text-foreground flex-1 text-center font-medium text-md">
+            Resume Transaction
+          </h2>
+        </div>
+        <div
+          className={cn(
+            background.secondary,
+            border.radius,
+            'box-border flex h-[80px] w-full flex-col items-start justify-center gap-2 p-4',
+            'mt-4',
+          )}
+        >
+          <span
+            className={cn(
+              text.label2,
+              color.foregroundMuted,
+              'flex items-center gap-1',
+            )}
+          >
+            Transaction hash
+          </span>
+          <TextInput
+            className={cn(
+              text.label2,
+              color.foregroundMuted,
+              background.secondary,
+              'w-full border-none',
+              'focus:border-none focus:outline-none focus:ring-0',
+            )}
+            placeholder="0x..."
+            onChange={(value) => {
+              setWithdrawalTxHash(value);
+            }}
+            value={withdrawalTxHash || ''}
+          />
+        </div>
+      </div>
+      <div className="flex w-full justify-between">
+        <button
+          type="button"
+          className={cn(
+            pressable.primary,
+            'w-full rounded-xl px-4 py-3 font-medium text-base leading-6',
+            'text-center',
+          )}
+          onClick={() => {
+            // TODO: Validate input
+            if (withdrawalTxHash) {
+              setResumeWithdrawalTxHash(withdrawalTxHash as Hex);
+              setIsResumeTransactionModalOpen(false);
+            }
+          }}
+        >
+          <div
+            className={cn(text.headline, color.inverse, 'flex justify-center')}
+          >
+            Resume Transaction
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/appchain/bridge/components/AppchainBridgeSuccess.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeSuccess.test.tsx
@@ -9,14 +9,14 @@ vi.mock('./AppchainBridgeProvider', () => ({
 
 describe('AppchainBridgeSuccess', () => {
   const mockHandleOpenExplorer = vi.fn();
-  const mockSetIsSuccessModalOpen = vi.fn();
+  const mockHandleResetState = vi.fn();
 
   beforeEach(() => {
     vi.resetAllMocks();
 
     (useAppchainBridgeContext as Mock).mockReturnValue({
       handleOpenExplorer: mockHandleOpenExplorer,
-      setIsSuccessModalOpen: mockSetIsSuccessModalOpen,
+      handleResetState: mockHandleResetState,
     });
   });
 
@@ -51,13 +51,13 @@ describe('AppchainBridgeSuccess', () => {
     expect(mockHandleOpenExplorer).toHaveBeenCalledTimes(1);
   });
 
-  it('calls setIsSuccessModalOpen when secondary button is clicked', () => {
+  it('calls handleResetState when secondary button is clicked', () => {
     render(<AppchainBridgeSuccess />);
 
     const secondaryButton = screen.getByText('Back to bridge');
     fireEvent.click(secondaryButton);
 
-    expect(mockSetIsSuccessModalOpen).toHaveBeenCalledWith(false);
+    expect(mockHandleResetState).toHaveBeenCalledTimes(1);
   });
 
   it('applies correct button styles', () => {

--- a/src/appchain/bridge/components/AppchainBridgeSuccess.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeSuccess.tsx
@@ -8,8 +8,7 @@ export const AppchainBridgeSuccess = ({
   primaryButtonLabel = 'View Transaction',
   secondaryButtonLabel = 'Back to bridge',
 }: AppchainBridgeSuccessReact) => {
-  const { handleOpenExplorer, setIsSuccessModalOpen } =
-    useAppchainBridgeContext();
+  const { handleOpenExplorer, handleResetState } = useAppchainBridgeContext();
 
   return (
     <div className="flex h-full w-full flex-col justify-between">
@@ -38,7 +37,7 @@ export const AppchainBridgeSuccess = ({
               },
               {
                 label: secondaryButtonLabel,
-                action: () => setIsSuccessModalOpen(false),
+                action: handleResetState,
                 variant: 'secondary',
                 textColor: color.foreground,
               },

--- a/src/appchain/bridge/components/AppchainBridgeWithdraw.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeWithdraw.test.tsx
@@ -82,6 +82,20 @@ describe('AppchainBridgeWithdraw', () => {
     expect(mockProveAndFinalizeWithdrawal).toHaveBeenCalledTimes(1);
   });
 
+  it('renders the error state correctly', () => {
+    (useWithdrawButton as Mock).mockReturnValue({
+      isError: true,
+    });
+
+    render(<AppchainBridgeWithdraw />);
+
+    expect(
+      screen.getByText((content) =>
+        content.includes('There was an error processing your withdrawal.'),
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('shows error message when claim is rejected', () => {
     (useAppchainBridgeContext as Mock).mockReturnValue({
       withdrawStatus: 'claimRejected',

--- a/src/appchain/bridge/components/AppchainBridgeWithdraw.test.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeWithdraw.test.tsx
@@ -108,6 +108,17 @@ describe('AppchainBridgeWithdraw', () => {
     expect(mockWaitForWithdrawal).toHaveBeenCalled();
   });
 
+  it('calls waitForWithdrawal with resumeWithdrawalTxHash when resumeWithdrawalTxHash is set', () => {
+    (useAppchainBridgeContext as Mock).mockReturnValue({
+      resumeWithdrawalTxHash: '0x123',
+      waitForWithdrawal: mockWaitForWithdrawal,
+    });
+
+    render(<AppchainBridgeWithdraw />);
+
+    expect(mockWaitForWithdrawal).toHaveBeenCalledWith('0x123');
+  });
+
   it('disables claim button when buttonDisabled is true', () => {
     (useWithdrawButton as Mock).mockReturnValue({
       isSuccess: false,

--- a/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
@@ -6,8 +6,12 @@ import { useWithdrawButton } from '../hooks/useWithdrawButton';
 import { useAppchainBridgeContext } from './AppchainBridgeProvider';
 
 export const AppchainBridgeWithdraw = () => {
-  const { withdrawStatus, waitForWithdrawal, proveAndFinalizeWithdrawal } =
-    useAppchainBridgeContext();
+  const {
+    withdrawStatus,
+    waitForWithdrawal,
+    proveAndFinalizeWithdrawal,
+    resumeWithdrawalTxHash,
+  } = useAppchainBridgeContext();
 
   const { buttonDisabled, buttonContent, shouldShowClaim, label } =
     useWithdrawButton({
@@ -20,8 +24,12 @@ export const AppchainBridgeWithdraw = () => {
         // If appchain withdrawal is successful, wait for claim to be ready
         waitForWithdrawal();
       }
+      if (resumeWithdrawalTxHash) {
+        // If the user has resumed a withdrawal transaction, wait for claim to be ready
+        waitForWithdrawal(resumeWithdrawalTxHash);
+      }
     })();
-  }, [withdrawStatus, waitForWithdrawal]);
+  }, [withdrawStatus, waitForWithdrawal, resumeWithdrawalTxHash]);
 
   const buttonStyles = cn(
     pressable.primary,

--- a/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from '@/internal/components/Spinner';
+import { ErrorSvg } from '@/internal/svg/fullWidthErrorSvg';
 import { SuccessSvg } from '@/internal/svg/fullWidthSuccessSvg';
 import { border, cn, color, pressable, text } from '@/styles/theme';
 import { useEffect, useMemo } from 'react';
@@ -11,9 +12,10 @@ export const AppchainBridgeWithdraw = () => {
     waitForWithdrawal,
     proveAndFinalizeWithdrawal,
     resumeWithdrawalTxHash,
+    handleResetState,
   } = useAppchainBridgeContext();
 
-  const { buttonDisabled, buttonContent, shouldShowClaim, label } =
+  const { buttonDisabled, buttonContent, shouldShowClaim, label, isError } =
     useWithdrawButton({
       withdrawStatus,
     });
@@ -26,6 +28,7 @@ export const AppchainBridgeWithdraw = () => {
       }
       if (resumeWithdrawalTxHash) {
         // If the user has resumed a withdrawal transaction, wait for claim to be ready
+        console.log('calling waitForWithdrawal');
         waitForWithdrawal(resumeWithdrawalTxHash);
       }
     })();
@@ -81,7 +84,45 @@ export const AppchainBridgeWithdraw = () => {
     [buttonStyles, buttonDisabled, buttonContent, proveAndFinalizeWithdrawal],
   );
 
+  const ErrorContent = useMemo(
+    () => () => (
+      <div className="flex flex-col items-center gap-16">
+        <div className="flex justify-center">
+          <div className="h-20 w-20">
+            <ErrorSvg fill="var(--ock-bg-error)" />
+          </div>
+        </div>
+        <div className="flex flex-col items-center gap-4">
+          <span className="px-4 text-center font-medium text-base">
+            There was an error processing your withdrawal.
+            <br />
+            If the issue persists, please contact support.
+          </span>
+          <button
+            onClick={handleResetState}
+            className={buttonStyles}
+            type="button"
+          >
+            <div
+              className={cn(
+                text.headline,
+                color.inverse,
+                'flex justify-center',
+              )}
+            >
+              Back to bridge
+            </div>
+          </button>
+        </div>
+      </div>
+    ),
+    [handleResetState, buttonStyles],
+  );
+
   const renderContent = () => {
+    if (isError) {
+      return <ErrorContent />;
+    }
     return shouldShowClaim ? <ClaimContent /> : <LoadingContent />;
   };
 

--- a/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
@@ -28,7 +28,6 @@ export const AppchainBridgeWithdraw = () => {
       }
       if (resumeWithdrawalTxHash) {
         // If the user has resumed a withdrawal transaction, wait for claim to be ready
-        console.log('calling waitForWithdrawal');
         waitForWithdrawal(resumeWithdrawalTxHash);
       }
     })();

--- a/src/appchain/bridge/hooks/useWithdraw.ts
+++ b/src/appchain/bridge/hooks/useWithdraw.ts
@@ -145,13 +145,16 @@ export const useWithdraw = ({
     }
   };
 
-  const waitForWithdrawal = async () => {
-    if (!data) {
+  const waitForWithdrawal = async (txHash?: Hex) => {
+    const hash = txHash || data;
+    if (!hash) {
       return;
     }
 
     const withdrawalReceipt = await waitForTransactionReceipt(wagmiConfig, {
-      hash: data,
+      // By default, use the withdrawal hash from Wagmi hook
+      // If the user has resumed a withdrawal transaction, use the txHash provided
+      hash,
       confirmations: 1,
       chainId: config.chainId,
     });

--- a/src/appchain/bridge/hooks/useWithdrawButton.test.tsx
+++ b/src/appchain/bridge/hooks/useWithdrawButton.test.tsx
@@ -22,6 +22,7 @@ describe('useWithdrawButton', () => {
     expect(result.current).toEqual({
       isPending: false,
       isSuccess: false,
+      isError: false,
       buttonDisabled: false,
       buttonContent: 'Claim',
       shouldShowClaim: false,
@@ -41,6 +42,7 @@ describe('useWithdrawButton', () => {
     expect(result.current).toEqual({
       isPending: true,
       isSuccess: false,
+      isError: false,
       buttonDisabled: true,
       buttonContent: expect.any(Object),
       shouldShowClaim: true,
@@ -60,6 +62,7 @@ describe('useWithdrawButton', () => {
     expect(result.current).toEqual({
       isPending: false,
       isSuccess: true,
+      isError: false,
       buttonDisabled: false,
       buttonContent: 'Claim',
       shouldShowClaim: false,
@@ -79,6 +82,7 @@ describe('useWithdrawButton', () => {
     expect(result.current).toEqual({
       isPending: false,
       isSuccess: false,
+      isError: false,
       buttonDisabled: false,
       buttonContent: 'Claim',
       shouldShowClaim: true,
@@ -98,10 +102,31 @@ describe('useWithdrawButton', () => {
     expect(result.current).toEqual({
       isPending: false,
       isSuccess: false,
+      isError: false,
       buttonDisabled: false,
       buttonContent: 'Claim',
       shouldShowClaim: true,
       label: 'Claim is ready',
+    });
+  });
+
+  it('should show error state when status is error', () => {
+    (useAccount as Mock).mockReturnValue({
+      isConnected: true,
+    });
+
+    const { result } = renderHook(() =>
+      useWithdrawButton({ withdrawStatus: 'error' }),
+    );
+
+    expect(result.current).toEqual({
+      isPending: false,
+      isSuccess: false,
+      isError: true,
+      buttonDisabled: false,
+      buttonContent: 'Claim',
+      shouldShowClaim: false,
+      label: 'Error processing withdrawal',
     });
   });
 
@@ -117,6 +142,7 @@ describe('useWithdrawButton', () => {
     expect(result.current).toEqual({
       isPending: false,
       isSuccess: false,
+      isError: false,
       buttonDisabled: false,
       buttonContent: 'Claim',
       shouldShowClaim: false,

--- a/src/appchain/bridge/hooks/useWithdrawButton.tsx
+++ b/src/appchain/bridge/hooks/useWithdrawButton.tsx
@@ -5,6 +5,7 @@ import type { UseWithdrawButtonParams } from '../types';
 export function useWithdrawButton({ withdrawStatus }: UseWithdrawButtonParams) {
   const isPending = withdrawStatus === 'claimPending';
   const isSuccess = withdrawStatus === 'claimSuccess';
+  const isError = withdrawStatus === 'error';
   const buttonDisabled = isPending;
   const buttonContent = isPending ? <Spinner /> : 'Claim';
   const shouldShowClaim =
@@ -18,12 +19,16 @@ export function useWithdrawButton({ withdrawStatus }: UseWithdrawButtonParams) {
     if (isSuccess) {
       return 'Transaction complete';
     }
+    if (isError) {
+      return 'Error processing withdrawal';
+    }
     return 'Confirming transaction';
-  }, [shouldShowClaim, isSuccess]);
+  }, [shouldShowClaim, isSuccess, isError]);
 
   return {
     isPending,
     isSuccess,
+    isError,
     buttonDisabled,
     buttonContent,
     shouldShowClaim,

--- a/src/appchain/bridge/types.ts
+++ b/src/appchain/bridge/types.ts
@@ -66,7 +66,6 @@ export type AppchainBridgeContextType = {
   depositTransactionHash?: Hex;
   finalizedWithdrawalTxHash?: Hex;
   resumeWithdrawalTxHash?: Hex;
-  isValidResumeTxHash: boolean;
 
   // Handler Functions
   handleToggle: () => void;

--- a/src/appchain/bridge/types.ts
+++ b/src/appchain/bridge/types.ts
@@ -58,12 +58,14 @@ export type AppchainBridgeContextType = {
   isAddressModalOpen: boolean;
   isWithdrawModalOpen: boolean;
   isSuccessModalOpen: boolean;
+  isResumeTransactionModalOpen: boolean;
   balance: string;
   depositStatus: string;
   withdrawStatus: string;
   direction: string;
   depositTransactionHash?: Hex;
   finalizedWithdrawalTxHash?: Hex;
+  resumeWithdrawalTxHash?: Hex;
 
   // Handler Functions
   handleToggle: () => void;
@@ -72,12 +74,15 @@ export type AppchainBridgeContextType = {
   handleDeposit: () => void;
   handleWithdraw: () => void;
   handleOpenExplorer: () => void;
-  waitForWithdrawal: () => Promise<void>;
+  handleResetState: () => void;
+  waitForWithdrawal: (txHash?: Hex) => Promise<void>;
   proveAndFinalizeWithdrawal: () => Promise<void>;
   setIsAddressModalOpen: (open: boolean) => void;
   setIsWithdrawModalOpen: (open: boolean) => void;
   setIsSuccessModalOpen: (open: boolean) => void;
   resetDepositStatus: () => void;
+  setResumeWithdrawalTxHash: (txHash: Hex) => void;
+  setIsResumeTransactionModalOpen: (open: boolean) => void;
 };
 
 /**

--- a/src/appchain/bridge/types.ts
+++ b/src/appchain/bridge/types.ts
@@ -66,11 +66,13 @@ export type AppchainBridgeContextType = {
   depositTransactionHash?: Hex;
   finalizedWithdrawalTxHash?: Hex;
   resumeWithdrawalTxHash?: Hex;
+  isValidResumeTxHash: boolean;
 
   // Handler Functions
   handleToggle: () => void;
   handleAmountChange: (params: { amount: string; token: Token }) => void;
   handleAddressSelect: (address: Address) => void;
+  handleResumeTransaction: (txHash: Hex) => void;
   handleDeposit: () => void;
   handleWithdraw: () => void;
   handleOpenExplorer: () => void;

--- a/src/internal/svg/fullWidthErrorSvg.tsx
+++ b/src/internal/svg/fullWidthErrorSvg.tsx
@@ -1,0 +1,17 @@
+export const ErrorSvg = ({ fill = '#E11D48' }) => (
+  <svg
+    aria-label="ock-errorSvg"
+    width="100%"
+    height="100%"
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    data-testid="ock-errorSvg"
+  >
+    <title>Error</title>
+    <path
+      d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58171 12.4183 0 8 0C3.58172 0 0 3.58171 0 8C0 12.4183 3.58172 16 8 16ZM11.7576 5.0909L8.84853 8L11.7576 10.9091L10.9091 11.7576L8 8.84851L5.09093 11.7576L4.2424 10.9091L7.15147 8L4.2424 5.0909L5.09093 4.24239L8 7.15145L10.9091 4.24239L11.7576 5.0909Z"
+      fill={fill}
+    />
+  </svg>
+);


### PR DESCRIPTION
**What changed? Why?**
- add `AppchainBridgeResumeTransaction`

this lets users resume a claim (e.g. if they accidentally exited out of the previous one)

**Notes to reviewers**

**How has it been tested?**
unit tests, see Slack for video
