### PR TITLE
chore: Add OCK logo to ConnectWallet in the playground

### DIFF
--- a/playground/nextjs-app-router/components/AppProvider.tsx
+++ b/playground/nextjs-app-router/components/AppProvider.tsx
@@ -178,7 +178,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         config={{
           appearance: {
             name: 'OnchainKit Playground',
-            logo: `https://pbs.twimg.com/media/GkXUnEnaoAIkKvG?format=jpg&name=medium`,
+            logo: 'https://pbs.twimg.com/media/GkXUnEnaoAIkKvG?format=jpg&name=medium',
             mode: componentMode,
             theme: componentTheme === 'none' ? undefined : componentTheme,
           },

--- a/playground/nextjs-app-router/components/AppProvider.tsx
+++ b/playground/nextjs-app-router/components/AppProvider.tsx
@@ -178,7 +178,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         config={{
           appearance: {
             name: 'OnchainKit Playground',
-            logo: 'https://onchainkit.xyz/favicon/48x48.png?v4-19-24',
+            logo: `https://pbs.twimg.com/media/GkXUnEnaoAIkKvG?format=jpg&name=medium`,
             mode: componentMode,
             theme: componentTheme === 'none' ? undefined : componentTheme,
           },

--- a/playground/nextjs-app-router/components/OnchainProviders.tsx
+++ b/playground/nextjs-app-router/components/OnchainProviders.tsx
@@ -39,7 +39,7 @@ function OnchainProviders({ children }: { children: ReactNode }) {
           config={{
             appearance: {
               name: 'OnchainKit Playground',
-              logo: 'https://onchainkit.xyz/favicon/48x48.png?v4-19-24',
+              logo: 'https://pbs.twimg.com/media/GkXUnEnaoAIkKvG?format=jpg&name=medium',
               mode: 'auto',
               theme: 'default',
             },


### PR DESCRIPTION
**What changed? Why?**
The old image broken during the OnchainKit move to Base.org. Updating with the new logo.

<img width="384" alt="Screenshot 2025-02-25 at 12 34 53 PM" src="https://github.com/user-attachments/assets/0b48ff79-6755-4413-91b9-d4a2acc54081" />

<img width="422" alt="Screenshot 2025-02-25 at 12 38 05 PM" src="https://github.com/user-attachments/assets/856cf096-7028-41ef-a3e7-4ed9d431e773" />

**Notes to reviewers**

**How has it been tested?**
