### PR TITLE
fix: improve useOutsideClick portal handling

### DIFF
--- a/.changeset/yellow-toys-sin.md
+++ b/.changeset/yellow-toys-sin.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **fix** update useOutsideClick to handle portals. fixes issue with WalletAdvancedSwap. by @brendan-defi #2043

--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.36.11",
+  "version": "0.37.4",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",
@@ -121,6 +121,12 @@
       "module": "./esm/api/index.js",
       "import": "./esm/api/index.js",
       "default": "./esm/api/index.js"
+    },
+    "./appchain": {
+      "types": "./esm/appchain/index.d.ts",
+      "module": "./esm/appchain/index.js",
+      "import": "./esm/appchain/index.js",
+      "default": "./esm/appchain/index.js"
     },
     "./buy": {
       "types": "./esm/buy/index.d.ts",

--- a/src/internal/components/BottomSheet.tsx
+++ b/src/internal/components/BottomSheet.tsx
@@ -33,32 +33,34 @@ export function BottomSheet({
   }
 
   const bottomSheet = (
-    <FocusTrap active={isOpen}>
-      <DismissableLayer
-        onDismiss={onClose}
-        triggerRef={triggerRef}
-        preventTriggerEvents={!!triggerRef}
-      >
-        <div
-          aria-describedby={ariaDescribedby}
-          aria-label={ariaLabel}
-          aria-labelledby={ariaLabelledby}
-          data-testid="ockBottomSheet"
-          role="dialog"
-          className={cn(
-            componentTheme,
-            background.default,
-            zIndex.modal,
-            'fixed right-0 bottom-0 left-0',
-            'transform rounded-t-3xl p-2 transition-transform',
-            'fade-in slide-in-from-bottom-1/2 animate-in',
-            className,
-          )}
+    <div data-portal-origin="true">
+      <FocusTrap active={isOpen}>
+        <DismissableLayer
+          onDismiss={onClose}
+          triggerRef={triggerRef}
+          preventTriggerEvents={!!triggerRef}
         >
-          {children}
-        </div>
-      </DismissableLayer>
-    </FocusTrap>
+          <div
+            aria-describedby={ariaDescribedby}
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledby}
+            data-testid="ockBottomSheet"
+            role="dialog"
+            className={cn(
+              componentTheme,
+              background.default,
+              zIndex.modal,
+              'fixed right-0 bottom-0 left-0',
+              'transform rounded-t-3xl p-2 transition-transform',
+              'fade-in slide-in-from-bottom-1/2 animate-in',
+              className,
+            )}
+          >
+            {children}
+          </div>
+        </DismissableLayer>
+      </FocusTrap>
+    </div>
   );
 
   return createPortal(bottomSheet, document.body);

--- a/src/internal/components/Dialog.tsx
+++ b/src/internal/components/Dialog.tsx
@@ -49,6 +49,7 @@ export function Dialog({
         'bg-black/50 transition-opacity duration-200',
         'fade-in animate-in duration-200',
       )}
+      data-portal-origin="true"
     >
       <FocusTrap active={isOpen}>
         <DismissableLayer onDismiss={onClose}>

--- a/src/internal/components/DropdownMenu.tsx
+++ b/src/internal/components/DropdownMenu.tsx
@@ -91,6 +91,7 @@ export function DropdownMenu({
         zIndex.dropdown,
         'pointer-events-none fixed',
       )}
+      data-portal-origin="true"
     >
       <FocusTrap active={isOpen}>
         <DismissableLayer onDismiss={onClose} triggerRef={trigger}>

--- a/src/internal/components/Popover.tsx
+++ b/src/internal/components/Popover.tsx
@@ -176,6 +176,7 @@ export function Popover({
         zIndex.dropdown,
         'pointer-events-none fixed',
       )}
+      data-portal-origin="true"
     >
       <FocusTrap active={isOpen}>
         <DismissableLayer onDismiss={onClose} triggerRef={trigger}>

--- a/src/internal/hooks/useOutsideClick.ts
+++ b/src/internal/hooks/useOutsideClick.ts
@@ -10,8 +10,17 @@ export function useOutsideClick(
         return;
       }
 
+      const isOutsideClick = !elRef.current.contains(e.target as Node);
+
+      const eventPath = e.composedPath?.();
+
+      const hasPortalOrigin = eventPath?.some(
+        (el) =>
+          el instanceof HTMLElement && el.hasAttribute('data-portal-origin'),
+      );
+
       // Check if the clicked target is outside of the referenced element
-      if (!elRef.current.contains(e.target as Node)) {
+      if (!hasPortalOrigin && isOutsideClick) {
         callback();
       }
     },


### PR DESCRIPTION
**What changed? Why?**
* added `data-portal-origin="true"` property to all portal-using components
* added logic to `useOutsideClick` to exclude clicks from elements with data-porta-origin

why is excluding portal-clicks on `useOutsideClick` okay?
* if there is a portal open then...
  * either it opened from an outside click
  * or it opened from an "inside click"
* in the former case, `useOutsideClick` will call the callback
* in the latter case, given that the portal opened _because of an "inside click"_, clicks on the portal should not constitute outside clicks and should not call the callback

**Notes to reviewers**

**How has it been tested?**
in playground