### PR TITLE
fix: show proper theme in `EarnAmountInput`

### DIFF
--- a/src/earn/components/Earn.tsx
+++ b/src/earn/components/Earn.tsx
@@ -47,12 +47,12 @@ export function Earn({
   vaultAddress,
   isSponsored,
 }: EarnReact) {
-  const componentTheme = useTheme();
+  const theme = useTheme();
   return (
     <EarnProvider vaultAddress={vaultAddress} isSponsored={isSponsored}>
       <div
         className={cn(
-          componentTheme,
+          theme,
           'flex w-[375px] flex-col overflow-hidden',
           border.radius,
           border.lineDefault,

--- a/src/earn/components/Earn.tsx
+++ b/src/earn/components/Earn.tsx
@@ -47,12 +47,12 @@ export function Earn({
   vaultAddress,
   isSponsored,
 }: EarnReact) {
-  const theme = useTheme();
+  const componentTheme = useTheme();
   return (
     <EarnProvider vaultAddress={vaultAddress} isSponsored={isSponsored}>
       <div
         className={cn(
-          theme,
+          componentTheme,
           'flex w-[375px] flex-col overflow-hidden',
           border.radius,
           border.lineDefault,

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@/internal/components/TextInput';
 import { isValidAmount } from '@/internal/utils/isValidAmount';
-import { cn } from '@/styles/theme';
+import { cn, color, text } from '@/styles/theme';
 import { formatAmount } from '@/swap/utils/formatAmount';
 import type { EarnAmountInputReact } from '../types';
 
@@ -18,7 +18,9 @@ export function EarnAmountInput({
     >
       <TextInput
         className={cn(
-          'ock-font-family w-full border-none bg-transparent text-5xl',
+          text.base,
+          color.foreground,
+          'w-full border-none bg-transparent text-5xl',
           'leading-none outline-none',
         )}
         placeholder="0.0"

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -1,8 +1,9 @@
 import { TextInput } from '@/internal/components/TextInput';
 import { isValidAmount } from '@/internal/utils/isValidAmount';
-import { cn } from '@/styles/theme';
+import { cn, text } from '@/styles/theme';
 import { formatAmount } from '@/swap/utils/formatAmount';
 import type { EarnAmountInputReact } from '../types';
+import { useTheme } from '@/internal/hooks/useTheme';
 
 export function EarnAmountInput({
   className,
@@ -11,6 +12,7 @@ export function EarnAmountInput({
   onChange,
   'aria-label': ariaLabel,
 }: EarnAmountInputReact) {
+  const theme = useTheme();
   return (
     <div
       data-testid="ockEarnAmountInput"
@@ -18,7 +20,7 @@ export function EarnAmountInput({
     >
       <TextInput
         className={cn(
-          'w-full border-none bg-transparent font-display text-5xl',
+          'ock-font-family w-full border-none bg-transparent text-5xl',
           'leading-none outline-none',
         )}
         placeholder="0.0"

--- a/src/earn/components/EarnAmountInput.tsx
+++ b/src/earn/components/EarnAmountInput.tsx
@@ -1,9 +1,8 @@
 import { TextInput } from '@/internal/components/TextInput';
 import { isValidAmount } from '@/internal/utils/isValidAmount';
-import { cn, text } from '@/styles/theme';
+import { cn } from '@/styles/theme';
 import { formatAmount } from '@/swap/utils/formatAmount';
 import type { EarnAmountInputReact } from '../types';
-import { useTheme } from '@/internal/hooks/useTheme';
 
 export function EarnAmountInput({
   className,
@@ -12,7 +11,6 @@ export function EarnAmountInput({
   onChange,
   'aria-label': ariaLabel,
 }: EarnAmountInputReact) {
-  const theme = useTheme();
   return (
     <div
       data-testid="ockEarnAmountInput"

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -6,6 +6,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export const text = {
+  base: 'ock-font-family',
   body: 'ock-font-family font-normal text-base',
   caption: 'ock-font-family font-semibold text-xs',
   headline: 'ock-font-family font-semibold',


### PR DESCRIPTION
**What changed? Why?**
Updating the `EarnAmountInput` component to handle font family based on theme.

**Notes to reviewers**

**How has it been tested?**
