### PR TITLE
fix: fix sitemap filter logic to correctly exclude unwanted URLs

### DIFF
--- a/site/createSitemap.js
+++ b/site/createSitemap.js
@@ -4,14 +4,13 @@ let pagesInSitemap = 0;
 
 const generator = SitemapGenerator('https://onchainkit.xyz', {
   changeFreq: 'daily',
-  ignore: (url) => {
-    // Ignore coverage pages
+  filter: (url) => {
     const hasCoverage = url.includes('coverage');
     if (!hasCoverage) {
       pagesInSitemap += 1;
       console.log('🌊', url);
     }
-    return hasCoverage;
+    return !hasCoverage;
   },
   filepath: './docs/public/sitemap.xml',
   lastMod: true,


### PR DESCRIPTION
### **Title:**  
Fix sitemap filter logic to correctly exclude unwanted URLs  

### **Description:**  

**What changed? Why?**  
The `ignore` option in the sitemap configuration was not being used by `SitemapGenerator`, meaning all URLs were included regardless of filtering. This fix replaces `ignore` with `filter`, which is the correct option provided by `sitemap-generator-cli`. Now, URLs containing `"coverage"` are properly excluded, and the `pagesInSitemap` counter is accurate.  

**Notes to reviewers**  
Let me know if there are any edge cases I might have missed. The change should align with the expected behavior of sitemap generation.  

**How has it been tested?**  
Ran the generator locally and verified that URLs containing `"coverage"` were excluded while all other URLs were correctly added to the sitemap. The console logs also confirmed an accurate page count.
