### PR TITLE
fix: improve focus states in `Earn` for keyboard users

### DIFF
--- a/src/earn/components/Earn.tsx
+++ b/src/earn/components/Earn.tsx
@@ -12,10 +12,18 @@ function EarnDefaultContent() {
   return (
     <Tabs defaultValue="deposit">
       <TabsList>
-        <Tab value="deposit" onClick={refetchWalletBalance}>
+        <Tab
+          value="deposit"
+          onClick={refetchWalletBalance}
+          className="rounded-tl-[calc(var(--ock-border-radius)_-_1px)]"
+        >
           Deposit
         </Tab>
-        <Tab value="withdraw" onClick={refetchDepositedBalance}>
+        <Tab
+          value="withdraw"
+          onClick={refetchDepositedBalance}
+          className="rounded-tr-[calc(var(--ock-border-radius)_-_1px)]"
+        >
           Withdraw
         </Tab>
       </TabsList>

--- a/src/internal/components/tabs/Tab.tsx
+++ b/src/internal/components/tabs/Tab.tsx
@@ -34,7 +34,7 @@ export function Tab({
         isSelected ? background.primary : background.default,
         'w-1/2 text-center',
         'cursor-pointer px-3 py-2',
-        'focus:outline-none focus:ring-2 focus:ring-[var(--ock-color-foreground)] focus:ring-inset-4',
+        'focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ock-text-foreground)] focus-visible:ring-inset',
         className,
       )}
       onClick={handleClick}


### PR DESCRIPTION
**What changed? Why?**

| Before | After |
|--------|--------|
| ![DS 2025-02-26 at 14 31 53@2x](https://github.com/user-attachments/assets/eedcb51c-cd38-482a-9f88-adc17255893c) | ![DS 2025-02-26 at 14 32 30@2x](https://github.com/user-attachments/assets/8ca6e951-f070-4bc8-8bf0-d112620b710c) |

**Notes to reviewers**

**How has it been tested?**
