### PR TITLE
chore: Add canceled event type

### DIFF
--- a/src/core/analytics/constants.ts
+++ b/src/core/analytics/constants.ts
@@ -9,13 +9,13 @@ export const ANALYTICS_EVENTS = {
   BUY_INITIATED: 'buyInitiated',
   BUY_OPTION_SELECTED: 'buyOptionSelected',
   BUY_SUCCESS: 'buySuccess',
-  BUY_CANCELLED: 'buyCancelled',
+  BUY_CANCELED: 'buyCanceled',
 
   // Checkout events
   CHECKOUT_FAILURE: 'checkoutFailure',
   CHECKOUT_INITIATED: 'checkoutInitiated',
   CHECKOUT_SUCCESS: 'checkoutSuccess',
-  CHECKOUT_CANCELLED: 'checkoutCancelled',
+  CHECKOUT_CANCELED: 'checkoutCanceled',
 
   // Error events
   COMPONENT_ERROR: 'componentError',
@@ -26,14 +26,14 @@ export const ANALYTICS_EVENTS = {
   FUND_INITIATED: 'fundInitiated',
   FUND_OPTION_SELECTED: 'fundOptionSelected',
   FUND_SUCCESS: 'fundSuccess',
-  FUND_CANCELLED: 'fundCancelled',
+  FUND_CANCELED: 'fundCanceled',
 
   // Mint events
   MINT_FAILURE: 'mintFailure',
   MINT_INITIATED: 'mintInitiated',
   MINT_QUANTITY_CHANGED: 'mintQuantityChanged',
   MINT_SUCCESS: 'mintSuccess',
-  MINT_CANCELLED: 'mintCancelled',
+  MINT_CANCELED: 'mintCanceled',
 
   // Swap events
   SWAP_FAILURE: 'swapFailure',
@@ -41,13 +41,13 @@ export const ANALYTICS_EVENTS = {
   SWAP_SLIPPAGE_CHANGED: 'swapSlippageChanged',
   SWAP_SUCCESS: 'swapSuccess',
   SWAP_TOKEN_SELECTED: 'swapTokenSelected',
-  SWAP_CANCELLED: 'swapCancelled',
+  SWAP_CANCELED: 'swapCanceled',
 
   // Transaction events
   TRANSACTION_FAILURE: 'transactionFailure',
   TRANSACTION_INITIATED: 'transactionInitiated',
   TRANSACTION_SUCCESS: 'transactionSuccess',
-  TRANSACTION_CANCELLED: 'transactionCancelled',
+  TRANSACTION_CANCELED: 'transactionCanceled',
 
   // Wallet events
   WALLET_CONNECT_ERROR: 'walletConnectError',
@@ -55,17 +55,17 @@ export const ANALYTICS_EVENTS = {
   WALLET_CONNECT_SUCCESS: 'walletConnectSuccess',
   WALLET_DISCONNECT: 'walletDisconnect',
   WALLET_OPTION_SELECTED: 'walletOptionSelected',
-  WALLET_CONNECT_CANCELLED: 'walletConnectCancelled',
+  WALLET_CONNECT_CANCELED: 'walletConnectCanceled',
 
   // Earn events
   EARN_DEPOSIT_INITIATED: 'earnDepositInitiated',
   EARN_DEPOSIT_SUCCESS: 'earnDepositSuccess',
   EARN_DEPOSIT_FAILURE: 'earnDepositFailure',
-  EARN_DEPOSIT_CANCELLED: 'earnDepositCancelled',
+  EARN_DEPOSIT_CANCELED: 'earnDepositCanceled',
   EARN_WITHDRAW_INITIATED: 'earnWithdrawInitiated',
   EARN_WITHDRAW_SUCCESS: 'earnWithdrawSuccess',
   EARN_WITHDRAW_FAILURE: 'earnWithdrawFailure',
-  EARN_WITHDRAW_CANCELLED: 'earnWithdrawCancelled',
+  EARN_WITHDRAW_CANCELED: 'earnWithdrawCanceled',
 } as const;
 
 /**

--- a/src/core/analytics/constants.ts
+++ b/src/core/analytics/constants.ts
@@ -9,11 +9,13 @@ export const ANALYTICS_EVENTS = {
   BUY_INITIATED: 'buyInitiated',
   BUY_OPTION_SELECTED: 'buyOptionSelected',
   BUY_SUCCESS: 'buySuccess',
+  BUY_CANCELLED: 'buyCancelled',
 
   // Checkout events
   CHECKOUT_FAILURE: 'checkoutFailure',
   CHECKOUT_INITIATED: 'checkoutInitiated',
   CHECKOUT_SUCCESS: 'checkoutSuccess',
+  CHECKOUT_CANCELLED: 'checkoutCancelled',
 
   // Error events
   COMPONENT_ERROR: 'componentError',
@@ -24,12 +26,14 @@ export const ANALYTICS_EVENTS = {
   FUND_INITIATED: 'fundInitiated',
   FUND_OPTION_SELECTED: 'fundOptionSelected',
   FUND_SUCCESS: 'fundSuccess',
+  FUND_CANCELLED: 'fundCancelled',
 
   // Mint events
   MINT_FAILURE: 'mintFailure',
   MINT_INITIATED: 'mintInitiated',
   MINT_QUANTITY_CHANGED: 'mintQuantityChanged',
   MINT_SUCCESS: 'mintSuccess',
+  MINT_CANCELLED: 'mintCancelled',
 
   // Swap events
   SWAP_FAILURE: 'swapFailure',
@@ -37,11 +41,13 @@ export const ANALYTICS_EVENTS = {
   SWAP_SLIPPAGE_CHANGED: 'swapSlippageChanged',
   SWAP_SUCCESS: 'swapSuccess',
   SWAP_TOKEN_SELECTED: 'swapTokenSelected',
+  SWAP_CANCELLED: 'swapCancelled',
 
   // Transaction events
   TRANSACTION_FAILURE: 'transactionFailure',
   TRANSACTION_INITIATED: 'transactionInitiated',
   TRANSACTION_SUCCESS: 'transactionSuccess',
+  TRANSACTION_CANCELLED: 'transactionCancelled',
 
   // Wallet events
   WALLET_CONNECT_ERROR: 'walletConnectError',
@@ -49,14 +55,17 @@ export const ANALYTICS_EVENTS = {
   WALLET_CONNECT_SUCCESS: 'walletConnectSuccess',
   WALLET_DISCONNECT: 'walletDisconnect',
   WALLET_OPTION_SELECTED: 'walletOptionSelected',
+  WALLET_CONNECT_CANCELLED: 'walletConnectCancelled',
 
   // Earn events
   EARN_DEPOSIT_INITIATED: 'earnDepositInitiated',
   EARN_DEPOSIT_SUCCESS: 'earnDepositSuccess',
   EARN_DEPOSIT_FAILURE: 'earnDepositFailure',
+  EARN_DEPOSIT_CANCELLED: 'earnDepositCancelled',
   EARN_WITHDRAW_INITIATED: 'earnWithdrawInitiated',
   EARN_WITHDRAW_SUCCESS: 'earnWithdrawSuccess',
   EARN_WITHDRAW_FAILURE: 'earnWithdrawFailure',
+  EARN_WITHDRAW_CANCELLED: 'earnWithdrawCancelled',
 } as const;
 
 /**

--- a/src/core/analytics/types.ts
+++ b/src/core/analytics/types.ts
@@ -279,12 +279,7 @@ export type MintEventData = {
     isSponsored: boolean;
     tokenId: string;
   };
-  [MintEvent.MintCancelled]: CommonAnalyticsData & {
-    contractAddress: string | undefined;
-    quantity: number | undefined;
-    tokenId: string | undefined;
-    reason: string | undefined;
-  };
+  [MintEvent.MintCancelled]: CommonAnalyticsData;
 };
 
 /**

--- a/src/core/analytics/types.ts
+++ b/src/core/analytics/types.ts
@@ -18,7 +18,7 @@ export enum WalletEvent {
   /** User selects a wallet option */
   OptionSelected = 'walletOptionSelected',
   /** User cancels wallet connection */
-  ConnectCancelled = 'walletConnectCancelled',
+  ConnectCanceled = 'walletConnectCanceled',
 }
 
 /**
@@ -43,7 +43,7 @@ export enum SwapEvent {
   SwapSuccess = 'swapSuccess',
   SwapInitiated = 'swapInitiated',
   SwapFailure = 'swapFailure',
-  SwapCancelled = 'swapCancelled',
+  SwapCanceled = 'swapCanceled',
 }
 
 /**
@@ -66,7 +66,7 @@ export enum BuyEvent {
   BuyInitiated = 'buyInitiated',
   BuyOptionSelected = 'buyOptionSelected',
   BuySuccess = 'buySuccess',
-  BuyCancelled = 'buyCancelled',
+  BuyCanceled = 'buyCanceled',
 }
 
 /**
@@ -76,7 +76,7 @@ export enum CheckoutEvent {
   CheckoutFailure = 'checkoutFailure',
   CheckoutInitiated = 'checkoutInitiated',
   CheckoutSuccess = 'checkoutSuccess',
-  CheckoutCancelled = 'checkoutCancelled',
+  CheckoutCanceled = 'checkoutCanceled',
 }
 
 /**
@@ -87,7 +87,7 @@ export enum MintEvent {
   MintInitiated = 'mintInitiated',
   MintQuantityChanged = 'mintQuantityChanged',
   MintSuccess = 'mintSuccess',
-  MintCancelled = 'mintCancelled',
+  MintCanceled = 'mintCanceled',
 }
 
 /**
@@ -97,7 +97,7 @@ export enum TransactionEvent {
   TransactionFailure = 'transactionFailure',
   TransactionInitiated = 'transactionInitiated',
   TransactionSuccess = 'transactionSuccess',
-  TransactionCancelled = 'transactionCancelled',
+  TransactionCanceled = 'transactionCanceled',
 }
 
 /**
@@ -109,7 +109,7 @@ export enum FundEvent {
   FundInitiated = 'fundInitiated',
   FundOptionSelected = 'fundOptionSelected',
   FundSuccess = 'fundSuccess',
-  FundCancelled = 'fundCancelled',
+  FundCanceled = 'fundCanceled',
 }
 
 /**
@@ -119,11 +119,11 @@ export enum EarnEvent {
   EarnDepositInitiated = 'earnDepositInitiated',
   EarnDepositSuccess = 'earnDepositSuccess',
   EarnDepositFailure = 'earnDepositFailure',
-  EarnDepositCancelled = 'earnDepositCancelled',
+  EarnDepositCanceled = 'earnDepositCanceled',
   EarnWithdrawInitiated = 'earnWithdrawInitiated',
   EarnWithdrawSuccess = 'earnWithdrawSuccess',
   EarnWithdrawFailure = 'earnWithdrawFailure',
-  EarnWithdrawCancelled = 'earnWithdrawCancelled',
+  EarnWithdrawCanceled = 'earnWithdrawCanceled',
 }
 
 /**
@@ -181,7 +181,7 @@ export type WalletEventData = {
   [WalletEvent.OptionSelected]: CommonAnalyticsData & {
     option: WalletOption;
   };
-  [WalletEvent.ConnectCancelled]: CommonAnalyticsData;
+  [WalletEvent.ConnectCanceled]: CommonAnalyticsData;
 };
 
 export type SwapEventData = {
@@ -207,7 +207,7 @@ export type SwapEventData = {
   [SwapEvent.SwapInitiated]: CommonAnalyticsData & {
     amount: number;
   };
-  [SwapEvent.SwapCancelled]: CommonAnalyticsData;
+  [SwapEvent.SwapCanceled]: CommonAnalyticsData;
 };
 
 export type BuyEventData = {
@@ -230,7 +230,7 @@ export type BuyEventData = {
     to: string;
     transactionHash: string;
   };
-  [BuyEvent.BuyCancelled]: CommonAnalyticsData;
+  [BuyEvent.BuyCanceled]: CommonAnalyticsData;
 };
 
 /**
@@ -253,7 +253,7 @@ export type CheckoutEventData = {
     amount: number;
     productId: string;
   };
-  [CheckoutEvent.CheckoutCancelled]: CommonAnalyticsData;
+  [CheckoutEvent.CheckoutCanceled]: CommonAnalyticsData;
 };
 
 /**
@@ -279,7 +279,7 @@ export type MintEventData = {
     isSponsored: boolean;
     tokenId: string;
   };
-  [MintEvent.MintCancelled]: CommonAnalyticsData;
+  [MintEvent.MintCanceled]: CommonAnalyticsData;
 };
 
 /**
@@ -298,7 +298,7 @@ export type TransactionEventData = {
     address: string | undefined;
     transactionHash: string | undefined;
   };
-  [TransactionEvent.TransactionCancelled]: CommonAnalyticsData;
+  [TransactionEvent.TransactionCanceled]: CommonAnalyticsData;
 };
 
 /**
@@ -325,7 +325,7 @@ export type FundEventData = {
     currency: string;
     transactionHash: string;
   };
-  [FundEvent.FundCancelled]: CommonAnalyticsData;
+  [FundEvent.FundCanceled]: CommonAnalyticsData;
 };
 
 /**
@@ -350,7 +350,7 @@ export type EarnEventData = {
     tokenAddress: string;
     vaultAddress: string;
   };
-  [EarnEvent.EarnDepositCancelled]: CommonAnalyticsData;
+  [EarnEvent.EarnDepositCanceled]: CommonAnalyticsData;
   [EarnEvent.EarnWithdrawInitiated]: CommonAnalyticsData & {
     amount: number;
     address: string;
@@ -369,7 +369,7 @@ export type EarnEventData = {
     tokenAddress: string;
     vaultAddress: string;
   };
-  [EarnEvent.EarnWithdrawCancelled]: CommonAnalyticsData;
+  [EarnEvent.EarnWithdrawCanceled]: CommonAnalyticsData;
 };
 
 // Update main AnalyticsEventData type to include all component events
@@ -382,7 +382,7 @@ export type AnalyticsEventData = {
   [WalletEvent.OptionSelected]: CommonAnalyticsData & {
     option: WalletOption;
   };
-  [WalletEvent.ConnectCancelled]: WalletEventData[WalletEvent.ConnectCancelled];
+  [WalletEvent.ConnectCanceled]: WalletEventData[WalletEvent.ConnectCanceled];
 
   // Swap events
   [SwapEvent.SlippageChanged]: SwapEventData[SwapEvent.SlippageChanged];
@@ -390,33 +390,33 @@ export type AnalyticsEventData = {
   [SwapEvent.SwapSuccess]: SwapEventData[SwapEvent.SwapSuccess];
   [SwapEvent.SwapFailure]: SwapEventData[SwapEvent.SwapFailure];
   [SwapEvent.SwapInitiated]: SwapEventData[SwapEvent.SwapInitiated];
-  [SwapEvent.SwapCancelled]: SwapEventData[SwapEvent.SwapCancelled];
+  [SwapEvent.SwapCanceled]: SwapEventData[SwapEvent.SwapCanceled];
 
   // Buy events
   [BuyEvent.BuyFailure]: BuyEventData[BuyEvent.BuyFailure];
   [BuyEvent.BuyInitiated]: BuyEventData[BuyEvent.BuyInitiated];
   [BuyEvent.BuyOptionSelected]: BuyEventData[BuyEvent.BuyOptionSelected];
   [BuyEvent.BuySuccess]: BuyEventData[BuyEvent.BuySuccess];
-  [BuyEvent.BuyCancelled]: BuyEventData[BuyEvent.BuyCancelled];
+  [BuyEvent.BuyCanceled]: BuyEventData[BuyEvent.BuyCanceled];
 
   // Checkout events
   [CheckoutEvent.CheckoutFailure]: CheckoutEventData[CheckoutEvent.CheckoutFailure];
   [CheckoutEvent.CheckoutInitiated]: CheckoutEventData[CheckoutEvent.CheckoutInitiated];
   [CheckoutEvent.CheckoutSuccess]: CheckoutEventData[CheckoutEvent.CheckoutSuccess];
-  [CheckoutEvent.CheckoutCancelled]: CheckoutEventData[CheckoutEvent.CheckoutCancelled];
+  [CheckoutEvent.CheckoutCanceled]: CheckoutEventData[CheckoutEvent.CheckoutCanceled];
 
   // Mint events
   [MintEvent.MintFailure]: MintEventData[MintEvent.MintFailure];
   [MintEvent.MintInitiated]: MintEventData[MintEvent.MintInitiated];
   [MintEvent.MintQuantityChanged]: MintEventData[MintEvent.MintQuantityChanged];
   [MintEvent.MintSuccess]: MintEventData[MintEvent.MintSuccess];
-  [MintEvent.MintCancelled]: MintEventData[MintEvent.MintCancelled];
+  [MintEvent.MintCanceled]: MintEventData[MintEvent.MintCanceled];
 
   // Transaction events
   [TransactionEvent.TransactionFailure]: TransactionEventData[TransactionEvent.TransactionFailure];
   [TransactionEvent.TransactionInitiated]: TransactionEventData[TransactionEvent.TransactionInitiated];
   [TransactionEvent.TransactionSuccess]: TransactionEventData[TransactionEvent.TransactionSuccess];
-  [TransactionEvent.TransactionCancelled]: TransactionEventData[TransactionEvent.TransactionCancelled];
+  [TransactionEvent.TransactionCanceled]: TransactionEventData[TransactionEvent.TransactionCanceled];
 
   // Fund events
   [FundEvent.FundAmountChanged]: FundEventData[FundEvent.FundAmountChanged];
@@ -424,17 +424,17 @@ export type AnalyticsEventData = {
   [FundEvent.FundInitiated]: FundEventData[FundEvent.FundInitiated];
   [FundEvent.FundOptionSelected]: FundEventData[FundEvent.FundOptionSelected];
   [FundEvent.FundSuccess]: FundEventData[FundEvent.FundSuccess];
-  [FundEvent.FundCancelled]: FundEventData[FundEvent.FundCancelled];
+  [FundEvent.FundCanceled]: FundEventData[FundEvent.FundCanceled];
 
   // Earn events
   [EarnEvent.EarnDepositInitiated]: EarnEventData[EarnEvent.EarnDepositInitiated];
   [EarnEvent.EarnDepositSuccess]: EarnEventData[EarnEvent.EarnDepositSuccess];
   [EarnEvent.EarnDepositFailure]: EarnEventData[EarnEvent.EarnDepositFailure];
-  [EarnEvent.EarnDepositCancelled]: EarnEventData[EarnEvent.EarnDepositCancelled];
+  [EarnEvent.EarnDepositCanceled]: EarnEventData[EarnEvent.EarnDepositCanceled];
   [EarnEvent.EarnWithdrawInitiated]: EarnEventData[EarnEvent.EarnWithdrawInitiated];
   [EarnEvent.EarnWithdrawSuccess]: EarnEventData[EarnEvent.EarnWithdrawSuccess];
   [EarnEvent.EarnWithdrawFailure]: EarnEventData[EarnEvent.EarnWithdrawFailure];
-  [EarnEvent.EarnWithdrawCancelled]: EarnEventData[EarnEvent.EarnWithdrawCancelled];
+  [EarnEvent.EarnWithdrawCanceled]: EarnEventData[EarnEvent.EarnWithdrawCanceled];
 
   // Error events
   [ErrorEvent.ComponentError]: CommonAnalyticsData & {

--- a/src/core/analytics/types.ts
+++ b/src/core/analytics/types.ts
@@ -17,6 +17,8 @@ export enum WalletEvent {
   Disconnect = 'walletDisconnect',
   /** User selects a wallet option */
   OptionSelected = 'walletOptionSelected',
+  /** User cancels wallet connection */
+  ConnectCancelled = 'walletConnectCancelled',
 }
 
 /**
@@ -41,6 +43,7 @@ export enum SwapEvent {
   SwapSuccess = 'swapSuccess',
   SwapInitiated = 'swapInitiated',
   SwapFailure = 'swapFailure',
+  SwapCancelled = 'swapCancelled',
 }
 
 /**
@@ -63,6 +66,7 @@ export enum BuyEvent {
   BuyInitiated = 'buyInitiated',
   BuyOptionSelected = 'buyOptionSelected',
   BuySuccess = 'buySuccess',
+  BuyCancelled = 'buyCancelled',
 }
 
 /**
@@ -72,6 +76,7 @@ export enum CheckoutEvent {
   CheckoutFailure = 'checkoutFailure',
   CheckoutInitiated = 'checkoutInitiated',
   CheckoutSuccess = 'checkoutSuccess',
+  CheckoutCancelled = 'checkoutCancelled',
 }
 
 /**
@@ -82,6 +87,7 @@ export enum MintEvent {
   MintInitiated = 'mintInitiated',
   MintQuantityChanged = 'mintQuantityChanged',
   MintSuccess = 'mintSuccess',
+  MintCancelled = 'mintCancelled',
 }
 
 /**
@@ -91,6 +97,7 @@ export enum TransactionEvent {
   TransactionFailure = 'transactionFailure',
   TransactionInitiated = 'transactionInitiated',
   TransactionSuccess = 'transactionSuccess',
+  TransactionCancelled = 'transactionCancelled',
 }
 
 /**
@@ -102,6 +109,7 @@ export enum FundEvent {
   FundInitiated = 'fundInitiated',
   FundOptionSelected = 'fundOptionSelected',
   FundSuccess = 'fundSuccess',
+  FundCancelled = 'fundCancelled',
 }
 
 /**
@@ -111,9 +119,11 @@ export enum EarnEvent {
   EarnDepositInitiated = 'earnDepositInitiated',
   EarnDepositSuccess = 'earnDepositSuccess',
   EarnDepositFailure = 'earnDepositFailure',
+  EarnDepositCancelled = 'earnDepositCancelled',
   EarnWithdrawInitiated = 'earnWithdrawInitiated',
   EarnWithdrawSuccess = 'earnWithdrawSuccess',
   EarnWithdrawFailure = 'earnWithdrawFailure',
+  EarnWithdrawCancelled = 'earnWithdrawCancelled',
 }
 
 /**
@@ -171,6 +181,7 @@ export type WalletEventData = {
   [WalletEvent.OptionSelected]: CommonAnalyticsData & {
     option: WalletOption;
   };
+  [WalletEvent.ConnectCancelled]: CommonAnalyticsData;
 };
 
 export type SwapEventData = {
@@ -196,6 +207,7 @@ export type SwapEventData = {
   [SwapEvent.SwapInitiated]: CommonAnalyticsData & {
     amount: number;
   };
+  [SwapEvent.SwapCancelled]: CommonAnalyticsData;
 };
 
 export type BuyEventData = {
@@ -218,6 +230,7 @@ export type BuyEventData = {
     to: string;
     transactionHash: string;
   };
+  [BuyEvent.BuyCancelled]: CommonAnalyticsData;
 };
 
 /**
@@ -240,6 +253,7 @@ export type CheckoutEventData = {
     amount: number;
     productId: string;
   };
+  [CheckoutEvent.CheckoutCancelled]: CommonAnalyticsData;
 };
 
 /**
@@ -265,6 +279,12 @@ export type MintEventData = {
     isSponsored: boolean;
     tokenId: string;
   };
+  [MintEvent.MintCancelled]: CommonAnalyticsData & {
+    contractAddress: string | undefined;
+    quantity: number | undefined;
+    tokenId: string | undefined;
+    reason: string | undefined;
+  };
 };
 
 /**
@@ -283,6 +303,7 @@ export type TransactionEventData = {
     address: string | undefined;
     transactionHash: string | undefined;
   };
+  [TransactionEvent.TransactionCancelled]: CommonAnalyticsData;
 };
 
 /**
@@ -309,6 +330,7 @@ export type FundEventData = {
     currency: string;
     transactionHash: string;
   };
+  [FundEvent.FundCancelled]: CommonAnalyticsData;
 };
 
 /**
@@ -333,6 +355,7 @@ export type EarnEventData = {
     tokenAddress: string;
     vaultAddress: string;
   };
+  [EarnEvent.EarnDepositCancelled]: CommonAnalyticsData;
   [EarnEvent.EarnWithdrawInitiated]: CommonAnalyticsData & {
     amount: number;
     address: string;
@@ -351,6 +374,7 @@ export type EarnEventData = {
     tokenAddress: string;
     vaultAddress: string;
   };
+  [EarnEvent.EarnWithdrawCancelled]: CommonAnalyticsData;
 };
 
 // Update main AnalyticsEventData type to include all component events
@@ -363,6 +387,7 @@ export type AnalyticsEventData = {
   [WalletEvent.OptionSelected]: CommonAnalyticsData & {
     option: WalletOption;
   };
+  [WalletEvent.ConnectCancelled]: WalletEventData[WalletEvent.ConnectCancelled];
 
   // Swap events
   [SwapEvent.SlippageChanged]: SwapEventData[SwapEvent.SlippageChanged];
@@ -370,28 +395,33 @@ export type AnalyticsEventData = {
   [SwapEvent.SwapSuccess]: SwapEventData[SwapEvent.SwapSuccess];
   [SwapEvent.SwapFailure]: SwapEventData[SwapEvent.SwapFailure];
   [SwapEvent.SwapInitiated]: SwapEventData[SwapEvent.SwapInitiated];
+  [SwapEvent.SwapCancelled]: SwapEventData[SwapEvent.SwapCancelled];
 
   // Buy events
   [BuyEvent.BuyFailure]: BuyEventData[BuyEvent.BuyFailure];
   [BuyEvent.BuyInitiated]: BuyEventData[BuyEvent.BuyInitiated];
   [BuyEvent.BuyOptionSelected]: BuyEventData[BuyEvent.BuyOptionSelected];
   [BuyEvent.BuySuccess]: BuyEventData[BuyEvent.BuySuccess];
+  [BuyEvent.BuyCancelled]: BuyEventData[BuyEvent.BuyCancelled];
 
   // Checkout events
   [CheckoutEvent.CheckoutFailure]: CheckoutEventData[CheckoutEvent.CheckoutFailure];
   [CheckoutEvent.CheckoutInitiated]: CheckoutEventData[CheckoutEvent.CheckoutInitiated];
   [CheckoutEvent.CheckoutSuccess]: CheckoutEventData[CheckoutEvent.CheckoutSuccess];
+  [CheckoutEvent.CheckoutCancelled]: CheckoutEventData[CheckoutEvent.CheckoutCancelled];
 
   // Mint events
   [MintEvent.MintFailure]: MintEventData[MintEvent.MintFailure];
   [MintEvent.MintInitiated]: MintEventData[MintEvent.MintInitiated];
   [MintEvent.MintQuantityChanged]: MintEventData[MintEvent.MintQuantityChanged];
   [MintEvent.MintSuccess]: MintEventData[MintEvent.MintSuccess];
+  [MintEvent.MintCancelled]: MintEventData[MintEvent.MintCancelled];
 
   // Transaction events
   [TransactionEvent.TransactionFailure]: TransactionEventData[TransactionEvent.TransactionFailure];
   [TransactionEvent.TransactionInitiated]: TransactionEventData[TransactionEvent.TransactionInitiated];
   [TransactionEvent.TransactionSuccess]: TransactionEventData[TransactionEvent.TransactionSuccess];
+  [TransactionEvent.TransactionCancelled]: TransactionEventData[TransactionEvent.TransactionCancelled];
 
   // Fund events
   [FundEvent.FundAmountChanged]: FundEventData[FundEvent.FundAmountChanged];
@@ -399,14 +429,17 @@ export type AnalyticsEventData = {
   [FundEvent.FundInitiated]: FundEventData[FundEvent.FundInitiated];
   [FundEvent.FundOptionSelected]: FundEventData[FundEvent.FundOptionSelected];
   [FundEvent.FundSuccess]: FundEventData[FundEvent.FundSuccess];
+  [FundEvent.FundCancelled]: FundEventData[FundEvent.FundCancelled];
 
   // Earn events
   [EarnEvent.EarnDepositInitiated]: EarnEventData[EarnEvent.EarnDepositInitiated];
   [EarnEvent.EarnDepositSuccess]: EarnEventData[EarnEvent.EarnDepositSuccess];
   [EarnEvent.EarnDepositFailure]: EarnEventData[EarnEvent.EarnDepositFailure];
+  [EarnEvent.EarnDepositCancelled]: EarnEventData[EarnEvent.EarnDepositCancelled];
   [EarnEvent.EarnWithdrawInitiated]: EarnEventData[EarnEvent.EarnWithdrawInitiated];
   [EarnEvent.EarnWithdrawSuccess]: EarnEventData[EarnEvent.EarnWithdrawSuccess];
   [EarnEvent.EarnWithdrawFailure]: EarnEventData[EarnEvent.EarnWithdrawFailure];
+  [EarnEvent.EarnWithdrawCancelled]: EarnEventData[EarnEvent.EarnWithdrawCancelled];
 
   // Error events
   [ErrorEvent.ComponentError]: CommonAnalyticsData & {


### PR DESCRIPTION
**What changed? Why?**
Add a new analytics event to track when users manually cancel actions in OnchainKit components. `SwapCanceled`, `checkoutCanceled`, etc. 

**Notes to reviewers**

**How has it been tested?**
