### PR TITLE
fix: use `chain.id` instead

### DIFF
--- a/src/appchain/bridge/components/AppchainBridgeProvider.tsx
+++ b/src/appchain/bridge/components/AppchainBridgeProvider.tsx
@@ -228,13 +228,18 @@ export const AppchainBridgeProvider = ({
   }, []);
 
   const handleOpenExplorer = useCallback(() => {
-    const blockExplorerUrl = getChainExplorer(from.id);
+    const blockExplorerUrl = getChainExplorer(chain.id);
     const txHash =
       depositStatus === 'depositSuccess'
         ? depositTransactionHash
         : finalizedWithdrawalTxHash;
     window.open(`${blockExplorerUrl}/tx/${txHash}`, '_blank');
-  }, [from, depositStatus, depositTransactionHash, finalizedWithdrawalTxHash]);
+  }, [
+    chain.id,
+    depositStatus,
+    depositTransactionHash,
+    finalizedWithdrawalTxHash,
+  ]);
 
   const handleDeposit = useCallback(async () => {
     await deposit({


### PR DESCRIPTION
**What changed? Why?**
explorer should always open using `chain.id` (Base or Base Sepolia) instead of `from.id`, `getExplorer` will return Basescan since for withdrawals `from` is the appchain ID

**Notes to reviewers**

**How has it been tested?**
