### PR TITLE
fix(wallet): Export WalletModal to allow custom opening

### DIFF
--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -18,7 +18,7 @@ export { WalletAdvancedTokenHoldings } from './components/WalletAdvancedTokenHol
 export { WalletAdvancedQrReceive } from './components/WalletAdvancedQrReceive';
 export { WalletAdvancedSwap } from './components/WalletAdvancedSwap';
 export { WalletAdvancedWalletActions } from './components/WalletAdvancedWalletActions';
-export { WalletModal } from "./components/WalletModal";
+export { WalletModal } from './components/WalletModal';
 
 // Utils
 export { isValidAAEntrypoint } from './utils/isValidAAEntrypoint';

--- a/src/wallet/index.ts
+++ b/src/wallet/index.ts
@@ -18,6 +18,7 @@ export { WalletAdvancedTokenHoldings } from './components/WalletAdvancedTokenHol
 export { WalletAdvancedQrReceive } from './components/WalletAdvancedQrReceive';
 export { WalletAdvancedSwap } from './components/WalletAdvancedSwap';
 export { WalletAdvancedWalletActions } from './components/WalletAdvancedWalletActions';
+export { WalletModal } from "./components/WalletModal";
 
 // Utils
 export { isValidAAEntrypoint } from './utils/isValidAAEntrypoint';


### PR DESCRIPTION
### **What changed? Why?**
Added an export of the `WalletModal` component to allow opening it from custom connect buttons instead of the generic UI.
Spotted during ETH Denver, it was useful for our case as we have multiple login providers, including OnchainKit, and don't want to use the big "Connect" button, but instead our own button that will open the modal.

Using the wagmi connector directly wasn't possible as it only exposes Coinbase Wallet, not the Metamask / Phantom options also provided in this modal

### **Notes to reviewers**
/

### **How has it been tested?**
Straightforward change that shouldn't require testing, but we tested and integrated in our project 