### PR TITLE
fix(WalletDropdownLinkReact): icon type allow ReactNode

### DIFF
--- a/src/wallet/components/WalletDropdownLink.test.tsx
+++ b/src/wallet/components/WalletDropdownLink.test.tsx
@@ -33,8 +33,6 @@ describe('WalletDropdownLink', () => {
   it('renders correctly with custom icon element', () => {
     const customIcon = <svg aria-label="custom-icon" />;
     render(
-      // TODO: remove this once we fix WalletDropdownLinkReact type
-      // @ts-expect-error -- will fix later, don't want to update types in this PR
       <WalletDropdownLink icon={customIcon} href="https://example.com">
         Link Text
       </WalletDropdownLink>,

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -195,8 +195,7 @@ export type WalletDropdownLinkReact = {
   /** Optional className override for the element */
   className?: string;
   href: string;
-  // TODO: fix this type - should be 'wallet' | ReactNode
-  icon?: 'wallet' & ReactNode;
+  icon?: 'wallet' | ReactNode;
   rel?: string;
   target?: string;
 };


### PR DESCRIPTION
**What changed? Why?**
Fixed `WalletDropdownLinkReact` type to allow `ReactNode` in `icon` property

**How has it been tested?**
When sending a `ReactNode` in the `icon` property is already working well.

**Code screenshots**

```tsx
<WalletDropdownLink icon={<Bot />} href="/deployed-agents">
  My agents
</WalletDropdownLink>
```

![Screenshot 2025-02-28 at 18 58 01](https://github.com/user-attachments/assets/02ee0686-83be-4981-bcbf-124fa724ba11)
