### PR TITLE
chore: Refactor WalletModal init event

### DIFF
--- a/src/core/analytics/types.ts
+++ b/src/core/analytics/types.ts
@@ -172,7 +172,6 @@ export type WalletEventData = {
   };
   [WalletEvent.ConnectSuccess]: CommonAnalyticsData & {
     address: string;
-    walletProvider: string;
   };
   [WalletEvent.Disconnect]: CommonAnalyticsData & {
     component: string;

--- a/src/wallet/components/ConnectWallet.test.tsx
+++ b/src/wallet/components/ConnectWallet.test.tsx
@@ -148,7 +148,7 @@ describe('ConnectWallet', () => {
       WalletEvent.ConnectInitiated,
       {
         component: 'ConnectWallet',
-        walletProvider: 'TestConnector',
+        walletProvider: 'Coinbase',
       },
     );
 
@@ -610,7 +610,7 @@ describe('ConnectWallet', () => {
         WalletEvent.ConnectInitiated,
         {
           component: 'ConnectWallet',
-          walletProvider: 'TestConnector',
+          walletProvider: 'Coinbase',
         },
       );
     });

--- a/src/wallet/components/ConnectWallet.test.tsx
+++ b/src/wallet/components/ConnectWallet.test.tsx
@@ -163,7 +163,6 @@ describe('ConnectWallet', () => {
     connectMock.mock.calls[0][1].onSuccess();
     expect(mockSendAnalytics).toHaveBeenCalledWith(WalletEvent.ConnectSuccess, {
       address: '',
-      walletProvider: 'TestConnector',
     });
 
     const error = new Error('Test error');
@@ -594,31 +593,6 @@ describe('ConnectWallet', () => {
   });
 
   describe('analytics', () => {
-    it('should send analytics when connect button is clicked in modal mode', () => {
-      vi.mocked(useOnchainKit).mockReturnValue({
-        config: { wallet: { display: 'modal' } },
-      });
-
-      vi.mocked(useConnect).mockReturnValue({
-        connectors: [{ name: 'TestConnector', id: 'mockConnector' }],
-        connect: vi.fn(),
-        status: 'idle',
-      });
-
-      render(<ConnectWallet text="Connect Wallet" />);
-
-      const button = screen.getByTestId('ockConnectButton');
-      fireEvent.click(button);
-
-      expect(mockSendAnalytics).toHaveBeenCalledWith(
-        WalletEvent.ConnectInitiated,
-        {
-          component: 'WalletModal',
-          walletProvider: 'TestConnector',
-        },
-      );
-    });
-
     it('should send analytics when direct connect is initiated', () => {
       const connectMock = vi.fn();
       vi.mocked(useConnect).mockReturnValue({
@@ -660,7 +634,6 @@ describe('ConnectWallet', () => {
         WalletEvent.ConnectSuccess,
         {
           address: '',
-          walletProvider: 'TestConnector',
         },
       );
     });
@@ -708,7 +681,6 @@ describe('ConnectWallet', () => {
         WalletEvent.ConnectSuccess,
         {
           address: '0x123',
-          walletProvider: 'TestConnector',
         },
       );
     });

--- a/src/wallet/components/ConnectWallet.tsx
+++ b/src/wallet/components/ConnectWallet.tsx
@@ -92,9 +92,9 @@ export function ConnectWallet({
   }, [setIsConnectModalOpen]);
 
   const handleAnalyticsInitiated = useCallback(
-    (connectorName: string, component = 'ConnectWallet') => {
+    (connectorName: string) => {
       sendAnalytics(WalletEvent.ConnectInitiated, {
-        component,
+        component: 'ConnectWallet',
         walletProvider: connectorName,
       });
     },

--- a/src/wallet/components/ConnectWallet.tsx
+++ b/src/wallet/components/ConnectWallet.tsx
@@ -91,15 +91,12 @@ export function ConnectWallet({
     setHasClickedConnect(true);
   }, [setIsConnectModalOpen]);
 
-  const handleAnalyticsInitiated = useCallback(
-    (connectorName: string) => {
-      sendAnalytics(WalletEvent.ConnectInitiated, {
-        component: 'ConnectWallet',
-        walletProvider: connectorName,
-      });
-    },
-    [sendAnalytics],
-  );
+  const handleAnalyticsInitiated = useCallback(() => {
+    sendAnalytics(WalletEvent.ConnectInitiated, {
+      component: 'ConnectWallet',
+      walletProvider: 'Coinbase',
+    });
+  }, [sendAnalytics]);
 
   const handleAnalyticsSuccess = useCallback(
     (walletAddress: string | undefined) => {
@@ -160,7 +157,7 @@ export function ConnectWallet({
           className={className}
           connectWalletText={connectWalletText}
           onClick={() => {
-            handleAnalyticsInitiated(connector.name);
+            handleAnalyticsInitiated();
 
             connect(
               { connector },

--- a/src/wallet/components/ConnectWallet.tsx
+++ b/src/wallet/components/ConnectWallet.tsx
@@ -92,7 +92,7 @@ export function ConnectWallet({
   }, [setIsConnectModalOpen]);
 
   const handleAnalyticsInitiated = useCallback(
-    (connectorName: string, component: string) => {
+    (connectorName: string, component = 'ConnectWallet') => {
       sendAnalytics(WalletEvent.ConnectInitiated, {
         component,
         walletProvider: connectorName,
@@ -102,10 +102,9 @@ export function ConnectWallet({
   );
 
   const handleAnalyticsSuccess = useCallback(
-    (connectorName: string, walletAddress: string | undefined) => {
+    (walletAddress: string | undefined) => {
       sendAnalytics(WalletEvent.ConnectSuccess, {
         address: walletAddress ?? '',
-        walletProvider: connectorName,
       });
     },
     [sendAnalytics],
@@ -134,7 +133,7 @@ export function ConnectWallet({
 
   useEffect(() => {
     if (status === 'connected' && accountAddress && connector) {
-      handleAnalyticsSuccess(connector.name, accountAddress);
+      handleAnalyticsSuccess(accountAddress);
     }
   }, [status, accountAddress, connector, handleAnalyticsSuccess]);
 
@@ -148,7 +147,6 @@ export function ConnectWallet({
             onClick={() => {
               handleOpenConnectModal();
               setHasClickedConnect(true);
-              handleAnalyticsInitiated(connector.name, 'WalletModal');
             }}
             text={text}
           />
@@ -162,14 +160,14 @@ export function ConnectWallet({
           className={className}
           connectWalletText={connectWalletText}
           onClick={() => {
-            handleAnalyticsInitiated(connector.name, 'ConnectWallet');
+            handleAnalyticsInitiated(connector.name);
 
             connect(
               { connector },
               {
                 onSuccess: () => {
                   onConnect?.();
-                  handleAnalyticsSuccess(connector.name, accountAddress);
+                  handleAnalyticsSuccess(accountAddress);
                 },
                 onError: (error) => {
                   handleAnalyticsError(

--- a/src/wallet/components/WalletModal.tsx
+++ b/src/wallet/components/WalletModal.tsx
@@ -64,7 +64,7 @@ export function WalletModal({
         );
       }
     }
-  }, [appName, appLogo, connect, onClose, onError, handleAnalyticsInitiated]);
+  }, [appName, appLogo, connect, onClose, onError]);
 
   const handleMetaMaskConnection = useCallback(() => {
     try {
@@ -85,7 +85,7 @@ export function WalletModal({
         error instanceof Error ? error : new Error('Failed to connect wallet'),
       );
     }
-  }, [connect, onClose, onError, appName, appLogo, handleAnalyticsInitiated]);
+  }, [connect, onClose, onError, appName, appLogo]);
 
   const handlePhantomConnection = useCallback(() => {
     try {
@@ -102,7 +102,7 @@ export function WalletModal({
         error instanceof Error ? error : new Error('Failed to connect wallet'),
       );
     }
-  }, [connect, onClose, onError, handleAnalyticsInitiated]);
+  }, [connect, onClose, onError]);
 
   return (
     <Dialog isOpen={isOpen} onClose={onClose} aria-label="Connect Wallet">

--- a/src/wallet/components/WalletModal.tsx
+++ b/src/wallet/components/WalletModal.tsx
@@ -37,12 +37,15 @@ export function WalletModal({
   const privacyPolicyUrl = config?.wallet?.privacyUrl ?? undefined;
   const termsOfServiceUrl = config?.wallet?.termsUrl ?? undefined;
 
-  const handleAnalyticsInitiated = (connectorName: string) => {
-    sendAnalytics(WalletEvent.ConnectInitiated, {
-      component: 'WalletModal',
-      walletProvider: connectorName,
-    });
-  };
+  const handleAnalyticsInitiated = useCallback(
+    (connectorName: string) => {
+      sendAnalytics(WalletEvent.ConnectInitiated, {
+        component: 'WalletModal',
+        walletProvider: connectorName,
+      });
+    },
+    [sendAnalytics],
+  );
 
   const handleCoinbaseWalletConnection = useCallback(() => {
     try {
@@ -64,7 +67,7 @@ export function WalletModal({
         );
       }
     }
-  }, [appName, appLogo, connect, onClose, onError]);
+  }, [appName, appLogo, connect, onClose, onError, handleAnalyticsInitiated]);
 
   const handleMetaMaskConnection = useCallback(() => {
     try {
@@ -85,7 +88,7 @@ export function WalletModal({
         error instanceof Error ? error : new Error('Failed to connect wallet'),
       );
     }
-  }, [connect, onClose, onError, appName, appLogo]);
+  }, [connect, onClose, onError, appName, appLogo, handleAnalyticsInitiated]);
 
   const handlePhantomConnection = useCallback(() => {
     try {
@@ -102,7 +105,7 @@ export function WalletModal({
         error instanceof Error ? error : new Error('Failed to connect wallet'),
       );
     }
-  }, [connect, onClose, onError]);
+  }, [connect, onClose, onError, handleAnalyticsInitiated]);
 
   return (
     <Dialog isOpen={isOpen} onClose={onClose} aria-label="Connect Wallet">


### PR DESCRIPTION
**What changed? Why?**
We weren't logging the Wallet Provider in our connect wallet events as expected. Rather than having connectWallet and WalletModal share a single handleConnectInitiated call, this creates a new handler inside WalletModal making it easier to pass the provider used. 

- Removed the walletProvider in the ConnectSuccess call. The provider is already being tracked in the initiation event, and can be tied to a successful connecting using the sessionID

**Notes to reviewers**

**How has it been tested?**
WalletModal with Phantom connector: 
<img width="879" alt="Screenshot 2025-03-03 at 12 07 00 PM" src="https://github.com/user-attachments/assets/48eb18cb-35fe-4e04-9c01-1935f559b198" />

<img width="886" alt="Screenshot 2025-03-03 at 12 07 11 PM" src="https://github.com/user-attachments/assets/15c5702c-f2dd-4d99-99b6-9c652b10d87d" />

ConnectWallet: 
<img width="883" alt="Screenshot 2025-03-03 at 12 11 24 PM" src="https://github.com/user-attachments/assets/bda9fddb-84d7-4fd6-8328-052c836dd7b2" />

<img width="843" alt="Screenshot 2025-03-03 at 12 10 59 PM" src="https://github.com/user-attachments/assets/f8958205-1f2b-4cc3-82af-f33fd0aad9b2" />
