### PR TITLE
chore: Refactor WalletProvider event to use connector from useAccount

### DIFF
--- a/src/core/analytics/types.ts
+++ b/src/core/analytics/types.ts
@@ -163,8 +163,6 @@ export type WalletEventData = {
   [WalletEvent.ConnectInitiated]: CommonAnalyticsData & {
     /** Component used to connect wallet */
     component: string;
-    /** Coinbase, Metamask, Phantom, etc. */
-    walletProvider: string;
   };
   [WalletEvent.ConnectError]: CommonAnalyticsData & {
     error: string;
@@ -172,6 +170,7 @@ export type WalletEventData = {
   };
   [WalletEvent.ConnectSuccess]: CommonAnalyticsData & {
     address: string;
+    /** Coinbase, Metamask, Phantom, etc. */
     walletProvider: string;
   };
   [WalletEvent.Disconnect]: CommonAnalyticsData & {

--- a/src/wallet/components/ConnectWallet.test.tsx
+++ b/src/wallet/components/ConnectWallet.test.tsx
@@ -148,7 +148,6 @@ describe('ConnectWallet', () => {
       WalletEvent.ConnectInitiated,
       {
         component: 'ConnectWallet',
-        walletProvider: 'TestConnector',
       },
     );
 
@@ -614,7 +613,6 @@ describe('ConnectWallet', () => {
         WalletEvent.ConnectInitiated,
         {
           component: 'WalletModal',
-          walletProvider: 'TestConnector',
         },
       );
     });
@@ -636,7 +634,6 @@ describe('ConnectWallet', () => {
         WalletEvent.ConnectInitiated,
         {
           component: 'ConnectWallet',
-          walletProvider: 'TestConnector',
         },
       );
     });

--- a/src/wallet/components/ConnectWallet.tsx
+++ b/src/wallet/components/ConnectWallet.tsx
@@ -153,7 +153,7 @@ export function ConnectWallet({
             onClick={() => {
               handleOpenConnectModal();
               setHasClickedConnect(true);
-              handleAnalyticsInitiated('modal');
+              handleAnalyticsInitiated('WalletModal');
             }}
             text={text}
           />
@@ -167,7 +167,7 @@ export function ConnectWallet({
           className={className}
           connectWalletText={connectWalletText}
           onClick={() => {
-            handleAnalyticsInitiated('direct');
+            handleAnalyticsInitiated('ConnectWallet');
 
             connect(
               { connector },


### PR DESCRIPTION
**What changed? Why?**
Refactor our wallet connector events to use the connector from `useAccount()` to determine and pass the WalletProvider in our analytics events. 
<img width="662" alt="Screenshot 2025-03-03 at 3 23 31 PM" src="https://github.com/user-attachments/assets/b308ad11-accb-45f8-9982-12c17e2ab054" />


**Notes to reviewers**

**How has it been tested?**
<img width="911" alt="Screenshot 2025-03-03 at 1 58 09 PM" src="https://github.com/user-attachments/assets/23d4ece4-cc5f-4dd8-911e-ed2f10ae3e1e" />

<img width="860" alt="Screenshot 2025-03-03 at 1 58 22 PM" src="https://github.com/user-attachments/assets/57e02a98-ddd0-4461-b408-6707cea5e07e" />

<img width="879" alt="Screenshot 2025-03-03 at 1 58 35 PM" src="https://github.com/user-attachments/assets/36bb7512-6c27-4618-bee6-fde488ee8e04" />
