### PR TITLE
Feat/getPriceQuote

### DIFF
--- a/src/api/getPriceQuote.test.ts
+++ b/src/api/getPriceQuote.test.ts
@@ -1,0 +1,107 @@
+
+import { RequestContext } from '@/core/network/constants';
+import { CDP_GET_PRICE_QUOTE } from '@/core/network/definitions/wallet';
+import { sendRequest } from '@/core/network/request';
+import { type Mock, describe, expect, it, vi } from 'vitest';
+import { getPriceQuote } from './getPriceQuote';
+import type {
+  GetPriceQuoteParams,
+  GetPriceQuoteResponse,
+  PriceQuoteToken,
+} from './types';
+
+vi.mock('@/core/network/request', () => ({
+  sendRequest: vi.fn(),
+}));
+
+const mockTokens: PriceQuoteToken[] = [
+  'ETH',
+  '0x1234567890123456789012345678901234567890',
+];
+
+const mockParams: GetPriceQuoteParams = {
+  tokens: mockTokens,
+};
+
+const mockSuccessResponse: GetPriceQuoteResponse = {
+  priceQuote: [
+    {
+      name: 'Ethereum',
+      symbol: 'ETH',
+      contractAddress: '',
+      price: '2400',
+      timestamp: 1714761600,
+    },
+    {
+      name: 'Test Token',
+      symbol: 'TEST',
+      contractAddress: '0x1234567890123456789012345678901234567890',
+      price: '3.14',
+      timestamp: 1714761600,
+    },
+  ],
+};
+
+describe('getPriceQuote', () => {
+  const mockSendRequest = sendRequest as Mock;
+
+  it('should return the price quote for a successful request', async () => {
+    mockSendRequest.mockResolvedValueOnce({
+      result: mockSuccessResponse,
+    });
+
+    const result = await getPriceQuote(mockParams);
+
+    expect(result).toEqual(mockSuccessResponse);
+    expect(mockSendRequest).toHaveBeenCalledWith(
+      CDP_GET_PRICE_QUOTE,
+      [mockParams],
+      RequestContext.API,
+    );
+  });
+
+  it('should return an error if no tokens are provided', async () => {
+    const result = await getPriceQuote({
+      tokens: [],
+    });
+
+    expect(result).toEqual({
+      code: 'INVALID_INPUT',
+      error: 'Invalid input: tokens must be an array of at least one token',
+      message: '',
+    });
+  });
+
+  it('should handle API error response', async () => {
+    const mockError = {
+      code: 500,
+      error: 'Internal Server Error',
+      message: 'Internal Server Error',
+    };
+
+    mockSendRequest.mockResolvedValueOnce({
+      error: mockError,
+    });
+
+    const result = await getPriceQuote(mockParams);
+
+    expect(result).toEqual({
+      code: `${mockError.code}`,
+      error: 'Error fetching price quote',
+      message: mockError.message,
+    });
+  });
+
+  it('should handle unexpected errors', async () => {
+    const errorMessage = 'Network Error';
+    mockSendRequest.mockRejectedValueOnce(new Error(errorMessage));
+
+    const result = await getPriceQuote(mockParams);
+
+    expect(result).toEqual({
+      code: 'UNCAUGHT_PRICE_QUOTE_ERROR',
+      error: 'Something went wrong',
+      message: `Error fetching price quote: Error: ${errorMessage}`,
+    });
+  });
+});

--- a/src/api/getPriceQuote.test.ts
+++ b/src/api/getPriceQuote.test.ts
@@ -1,4 +1,3 @@
-
 import { RequestContext } from '@/core/network/constants';
 import { CDP_GET_PRICE_QUOTE } from '@/core/network/definitions/wallet';
 import { sendRequest } from '@/core/network/request';

--- a/src/api/getPriceQuote.ts
+++ b/src/api/getPriceQuote.ts
@@ -1,0 +1,59 @@
+import { RequestContext } from '@/core/network/constants';
+import { CDP_GET_PRICE_QUOTE } from '@/core/network/definitions/wallet';
+import { sendRequest } from '@/core/network/request';
+
+import type { GetPriceQuoteParams, GetPriceQuoteResponse } from './types';
+
+/**
+ * Retrieves a price quote for a token
+ *
+ * @param params - The parameters for the price quote. The property `tokens`
+ * must be an array of contract addresses or 'ETH'.
+ * @param _context - The context in which the price quote is retrieved
+ * @returns The price quote for the token
+ */
+export async function getPriceQuote(
+  params: GetPriceQuoteParams,
+  _context: RequestContext = RequestContext.API,
+): Promise<GetPriceQuoteResponse> {
+  const apiParams = validateGetPriceQuoteParams(params);
+  if ('error' in apiParams) {
+    return apiParams;
+  }
+
+  try {
+    const res = await sendRequest<GetPriceQuoteParams, GetPriceQuoteResponse>(
+      CDP_GET_PRICE_QUOTE,
+      [apiParams],
+      _context,
+    );
+    if (res.error) {
+      return {
+        code: `${res.error.code}`,
+        error: 'Error fetching price quote',
+        message: res.error.message,
+      };
+    }
+    return res.result;
+  } catch (error) {
+    return {
+      code: 'UNCAUGHT_PRICE_QUOTE_ERROR',
+      error: 'Something went wrong',
+      message: `Error fetching price quote: ${error}`,
+    };
+  }
+}
+
+function validateGetPriceQuoteParams(params: GetPriceQuoteParams) {
+  const { tokens } = params;
+
+  if (!tokens || tokens.length === 0) {
+    return {
+      code: 'INVALID_INPUT',
+      error: 'Invalid input: tokens must be an array of at least one token',
+      message: '',
+    };
+  }
+
+  return params;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,7 @@ export { getSwapQuote } from './getSwapQuote';
 export { getTokenDetails } from './getTokenDetails';
 export { getTokens } from './getTokens';
 export { getPortfolios } from './getPortfolios';
+export { getPriceQuote } from './getPriceQuote';
 export type {
   APIError,
   BuildMintTransactionParams,
@@ -18,6 +19,8 @@ export type {
   BuildSwapTransactionResponse,
   GetMintDetailsParams,
   GetMintDetailsResponse,
+  GetPriceQuoteParams,
+  GetPriceQuoteResponse,
   GetSwapQuoteParams,
   GetSwapQuoteResponse,
   GetTokenDetailsParams,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -384,3 +384,36 @@ export type BuildSendTransactionParams = {
  * Note: exported as public Type
  */
 export type BuildSendTransactionResponse = Call | APIError;
+
+export type PriceQuoteToken = Address | 'ETH';
+
+/**
+ * Note: exported as public Type
+ */
+export type GetPriceQuoteParams = {
+  /** The token to get the price quote for */
+  tokens: PriceQuoteToken[];
+};
+
+type PriceQuote = {
+  /** The name of the token */
+  name: string | '';
+  /** The symbol of the token */
+  symbol: string | '';
+  /** The contract address of the token */
+  contractAddress: Address | '';
+  /** The price of the token */
+  price: string | '';
+  /** The timestamp of the price quote */
+  timestamp: number | 0;
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type GetPriceQuoteResponse =
+  | {
+      /** The array of price quotes for the tokens */
+      priceQuote: PriceQuote[];
+    }
+  | APIError;

--- a/src/core/network/definitions/wallet.ts
+++ b/src/core/network/definitions/wallet.ts
@@ -1,1 +1,2 @@
 export const CDP_GET_PORTFOLIO_TOKEN_BALANCES = 'cdp_getTokensForAddresses';
+export const CDP_GET_PRICE_QUOTE = 'cdp_getPriceQuote';

--- a/src/internal/hooks/useExchangeRate.tsx
+++ b/src/internal/hooks/useExchangeRate.tsx
@@ -1,12 +1,11 @@
-import { getSwapQuote } from '@/api';
+import { getPriceQuote } from '@/api';
+import type { PriceQuoteToken } from '@/api/types';
 import { RequestContext } from '@/core/network/constants';
 import { isApiError } from '@/internal/utils/isApiResponseError';
-import type { Token } from '@/token';
-import { usdcToken } from '@/token/constants';
 import type { Dispatch, SetStateAction } from 'react';
 
 type UseExchangeRateParams = {
-  token: Token;
+  token: PriceQuoteToken;
   selectedInputType: 'crypto' | 'fiat';
   setExchangeRate: Dispatch<SetStateAction<number>>;
   setExchangeRateLoading?: Dispatch<SetStateAction<boolean>>;
@@ -22,37 +21,27 @@ export async function useExchangeRate({
     return;
   }
 
-  if (token.address === usdcToken.address) {
-    setExchangeRate(1);
-    return;
-  }
-
   setExchangeRateLoading?.(true);
 
-  const fromToken = selectedInputType === 'crypto' ? token : usdcToken;
-  const toToken = selectedInputType === 'crypto' ? usdcToken : token;
-
   try {
-    const response = await getSwapQuote(
-      {
-        amount: '1', // hardcoded amount of 1 because we only need the exchange rate
-        from: fromToken,
-        to: toToken,
-        useAggregator: false,
-      },
+    const response = await getPriceQuote(
+      { tokens: [token] },
       RequestContext.Wallet,
     );
     if (isApiError(response)) {
-      console.error('Error fetching exchange rate:', response.error);
+      console.error('Error fetching price quote:', response.error);
       return;
     }
+    const priceQuote = response.priceQuote[0];
+
     const rate =
       selectedInputType === 'crypto'
-        ? 1 / Number(response.fromAmountUSD)
-        : Number(response.toAmount) / 10 ** response.to.decimals;
+        ? 1 / Number(priceQuote.price)
+        : Number(priceQuote.price);
+
     setExchangeRate(rate);
   } catch (error) {
-    console.error('Uncaught error fetching exchange rate:', error);
+    console.error('Uncaught error fetching price quote:', error);
   } finally {
     setExchangeRateLoading?.(false);
   }


### PR DESCRIPTION
**What changed? Why?**
* added API endpoint `getPriceQuote`
  * `getPriceQuote` fetches price quotes for the provided token contract addresses and/or ETH
  * `getPriceQuote` is available only on Base mainnet

*`getPriceQuote` interface*

Request
```
type GetPriceQuoteParams = {
  tokens: PriceQuoteToken[];
};
```
Response
```
type GetPriceQuoteResponse =
  | {
      priceQuote: PriceQuote[];
    }
  | APIError;

type PriceQuote = {
  name: string | '';
  symbol: string | '';
  contractAddress: Address | '';
  price: string | '';
  timestamp: number | 0;
};
```
Usage
```
const response = getPriceQuote({ tokens: ["ETH", "0x123...ABC"] });
if (response.error) {
  throw New Error(priceQuotes.error)
}

const tokenPrice = response.priceQuotes[0].price;
```

**Notes to reviewers**

**How has it been tested?**
