### PR TITLE
refactor: improve WalletAdvanced sub-component handling

### DIFF
--- a/src/wallet/components/WalletAdvancedContent.test.tsx
+++ b/src/wallet/components/WalletAdvancedContent.test.tsx
@@ -56,10 +56,8 @@ describe('WalletAdvancedContent', () => {
   >;
 
   const defaultMockUseWalletAdvancedContext = {
-    showSwap: false,
-    isSwapClosing: false,
-    showQr: false,
-    isQrClosing: false,
+    activeFeature: null,
+    isActiveFeatureClosing: false,
     tokenHoldings: [],
     animations: {
       container: '',
@@ -250,10 +248,10 @@ describe('WalletAdvancedContent', () => {
     expect(setIsSubComponentClosing).toHaveBeenCalledWith(false);
   });
 
-  it('renders WalletAdvancedQrReceive when showQr is true', () => {
+  it('renders WalletAdvancedQrReceive when activeFeature is qr', () => {
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: true,
+      activeFeature: 'qr',
     });
 
     render(
@@ -271,10 +269,10 @@ describe('WalletAdvancedContent', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders WalletAdvancedSwap when showSwap is true', () => {
+  it('renders WalletAdvancedSwap when activeFeature is swap', () => {
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showSwap: true,
+      activeFeature: 'swap',
     });
 
     render(
@@ -312,7 +310,7 @@ describe('WalletAdvancedContent', () => {
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showSwap: true,
+      activeFeature: 'swap',
       tokenBalances: mockTokenBalances,
     });
 
@@ -349,8 +347,7 @@ describe('WalletAdvancedContent', () => {
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: true,
-      showSwap: false,
+      activeFeature: 'qr',
     });
 
     const customClassNames = {
@@ -380,8 +377,7 @@ describe('WalletAdvancedContent', () => {
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: false,
-      showSwap: true,
+      activeFeature: 'swap',
     });
 
     rerender(
@@ -419,8 +415,7 @@ describe('WalletAdvancedContent', () => {
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: true,
-      showSwap: false,
+      activeFeature: 'qr',
     });
 
     const customClassNames = {

--- a/src/wallet/components/WalletAdvancedContent.tsx
+++ b/src/wallet/components/WalletAdvancedContent.tsx
@@ -23,7 +23,7 @@ export function WalletAdvancedContent({
     breakpoint,
   } = useWalletContext();
 
-  const { showQr, showSwap, tokenBalances, animations } =
+  const { activeFeature, tokenBalances, animations } =
     useWalletAdvancedContext();
 
   const handleBottomSheetClose = useCallback(() => {
@@ -38,7 +38,7 @@ export function WalletAdvancedContent({
   }, [isSubComponentClosing, setIsSubComponentOpen, setIsSubComponentClosing]);
 
   const content = useMemo(() => {
-    if (showQr) {
+    if (activeFeature === 'qr') {
       return (
         <ContentWrapper>
           <WalletAdvancedQrReceive classNames={classNames?.qr} />
@@ -46,7 +46,7 @@ export function WalletAdvancedContent({
       );
     }
 
-    if (showSwap) {
+    if (activeFeature === 'swap') {
       return (
         <ContentWrapper>
           <WalletAdvancedSwap
@@ -75,7 +75,7 @@ export function WalletAdvancedContent({
     }
 
     return <ContentWrapper className="px-4 py-3">{children}</ContentWrapper>;
-  }, [showQr, showSwap, swappableTokens, tokenBalances, children, classNames]);
+  }, [activeFeature, swappableTokens, tokenBalances, children, classNames]);
 
   if (breakpoint === 'sm') {
     return (

--- a/src/wallet/components/WalletAdvancedProvider.test.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.test.tsx
@@ -57,14 +57,10 @@ describe('useWalletAdvancedContext', () => {
     });
 
     expect(result.current).toEqual({
-      showSwap: false,
-      setShowSwap: expect.any(Function),
-      isSwapClosing: false,
-      setIsSwapClosing: expect.any(Function),
-      showQr: false,
-      setShowQr: expect.any(Function),
-      isQrClosing: false,
-      setIsQrClosing: expect.any(Function),
+      activeFeature: null,
+      setActiveFeature: expect.any(Function),
+      isActiveFeatureClosing: false,
+      setIsActiveFeatureClosing: expect.any(Function),
       tokenBalances: expect.any(Array),
       portfolioFiatValue: expect.any(Number),
       refetchPortfolioData: expect.any(Function),

--- a/src/wallet/components/WalletAdvancedProvider.tsx
+++ b/src/wallet/components/WalletAdvancedProvider.tsx
@@ -2,7 +2,10 @@ import { RequestContext } from '@/core/network/constants';
 import { useValue } from '@/internal/hooks/useValue';
 import { usePortfolio } from '@/wallet/hooks/usePortfolio';
 import { type ReactNode, createContext, useContext, useState } from 'react';
-import type { WalletAdvancedContextType } from '../types';
+import type {
+  WalletAdvancedContextType,
+  WalletAdvancedFeature,
+} from '../types';
 import { useWalletContext } from './WalletProvider';
 
 type WalletAdvancedProviderReact = {
@@ -29,10 +32,9 @@ export function WalletAdvancedProvider({
 }: WalletAdvancedProviderReact) {
   const { address, isSubComponentClosing, showSubComponentAbove } =
     useWalletContext();
-  const [showSwap, setShowSwap] = useState(false);
-  const [isSwapClosing, setIsSwapClosing] = useState(false);
-  const [showQr, setShowQr] = useState(false);
-  const [isQrClosing, setIsQrClosing] = useState(false);
+  const [activeFeature, setActiveFeature] =
+    useState<WalletAdvancedFeature | null>(null);
+  const [isActiveFeatureClosing, setIsActiveFeatureClosing] = useState(false);
   const {
     data: portfolioData,
     refetch: refetchPortfolioData,
@@ -49,14 +51,10 @@ export function WalletAdvancedProvider({
   );
 
   const value = useValue({
-    showSwap,
-    setShowSwap,
-    isSwapClosing,
-    setIsSwapClosing,
-    showQr,
-    setShowQr,
-    isQrClosing,
-    setIsQrClosing,
+    activeFeature,
+    setActiveFeature,
+    isActiveFeatureClosing,
+    setIsActiveFeatureClosing,
     tokenBalances,
     portfolioFiatValue,
     isFetchingPortfolioData,

--- a/src/wallet/components/WalletAdvancedQrReceive.test.tsx
+++ b/src/wallet/components/WalletAdvancedQrReceive.test.tsx
@@ -56,8 +56,10 @@ describe('WalletAdvancedQrReceive', () => {
   >;
 
   const defaultMockUseWalletAdvancedContext = {
-    showQr: false,
-    setShowQr: vi.fn(),
+    activeFeature: null,
+    setActiveFeature: vi.fn(),
+    isActiveFeatureClosing: false,
+    setIsActiveFeatureClosing: vi.fn(),
     animationClasses: {
       qr: 'animate-slideInFromLeft',
     },
@@ -79,7 +81,7 @@ describe('WalletAdvancedQrReceive', () => {
 
   it('should render correctly based on isQrClosing state', () => {
     mockUseWalletAdvancedContext.mockReturnValue({
-      isQrClosing: false,
+      isActiveFeatureClosing: false,
     });
 
     const { rerender } = render(<WalletAdvancedQrReceive />);
@@ -91,7 +93,7 @@ describe('WalletAdvancedQrReceive', () => {
     );
 
     mockUseWalletAdvancedContext.mockReturnValue({
-      isQrClosing: true,
+      isActiveFeatureClosing: true,
     });
     rerender(<WalletAdvancedQrReceive />);
     expect(screen.getByTestId('ockWalletAdvancedQrReceive')).toHaveClass(
@@ -100,27 +102,23 @@ describe('WalletAdvancedQrReceive', () => {
   });
 
   it('should close when back button is clicked', () => {
-    const mockSetShowQr = vi.fn();
-    const mockSetIsQrClosing = vi.fn();
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: true,
-      setShowQr: mockSetShowQr,
-      setIsQrClosing: mockSetIsQrClosing,
+      activeFeature: 'qr',
     });
 
     const { rerender } = render(<WalletAdvancedQrReceive />);
 
     const backButton = screen.getByRole('button', { name: /back button/i });
     fireEvent.click(backButton);
-    expect(mockSetIsQrClosing).toHaveBeenCalledWith(true);
+    expect(
+      defaultMockUseWalletAdvancedContext.setIsActiveFeatureClosing,
+    ).toHaveBeenCalledWith(true);
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: true,
-      setShowQr: mockSetShowQr,
-      setIsQrClosing: mockSetIsQrClosing,
-      isQrClosing: true,
+      activeFeature: 'qr',
+      isActiveFeatureClosing: true,
     });
 
     rerender(<WalletAdvancedQrReceive />);
@@ -128,8 +126,12 @@ describe('WalletAdvancedQrReceive', () => {
     const qrContainer = screen.getByTestId('ockWalletAdvancedQrReceive');
     fireEvent.animationEnd(qrContainer);
 
-    expect(mockSetShowQr).toHaveBeenCalledWith(false);
-    expect(mockSetIsQrClosing).toHaveBeenCalledWith(false);
+    expect(
+      defaultMockUseWalletAdvancedContext.setActiveFeature,
+    ).toHaveBeenCalledWith(null);
+    expect(
+      defaultMockUseWalletAdvancedContext.setIsActiveFeatureClosing,
+    ).toHaveBeenCalledWith(false);
   });
 
   it('should copy address when the copy icon is clicked', async () => {
@@ -143,7 +145,7 @@ describe('WalletAdvancedQrReceive', () => {
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: true,
+      activeFeature: 'qr',
     });
 
     render(<WalletAdvancedQrReceive />);
@@ -185,7 +187,7 @@ describe('WalletAdvancedQrReceive', () => {
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: true,
+      activeFeature: 'qr',
     });
 
     render(<WalletAdvancedQrReceive />);
@@ -227,7 +229,7 @@ describe('WalletAdvancedQrReceive', () => {
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showQr: true,
+      activeFeature: 'qr',
     });
 
     render(<WalletAdvancedQrReceive />);

--- a/src/wallet/components/WalletAdvancedQrReceive.tsx
+++ b/src/wallet/components/WalletAdvancedQrReceive.tsx
@@ -16,20 +16,24 @@ export function WalletAdvancedQrReceive({
   classNames,
 }: WalletAdvancedQrReceiveProps) {
   const { address } = useWalletContext();
-  const { setShowQr, isQrClosing, setIsQrClosing } = useWalletAdvancedContext();
+  const {
+    setActiveFeature,
+    isActiveFeatureClosing,
+    setIsActiveFeatureClosing,
+  } = useWalletAdvancedContext();
   const [copyText, setCopyText] = useState('Copy');
   const [copyButtonText, setCopyButtonText] = useState('Copy address');
 
   const handleCloseQr = useCallback(() => {
-    setIsQrClosing(true);
-  }, [setIsQrClosing]);
+    setIsActiveFeatureClosing(true);
+  }, [setIsActiveFeatureClosing]);
 
   const handleAnimationEnd = useCallback(() => {
-    if (isQrClosing) {
-      setShowQr(false);
-      setIsQrClosing(false);
+    if (isActiveFeatureClosing) {
+      setActiveFeature(null);
+      setIsActiveFeatureClosing(false);
     }
-  }, [isQrClosing, setShowQr, setIsQrClosing]);
+  }, [isActiveFeatureClosing, setActiveFeature, setIsActiveFeatureClosing]);
 
   const resetAffordanceText = useCallback(() => {
     setTimeout(() => {
@@ -68,7 +72,7 @@ export function WalletAdvancedQrReceive({
         'flex flex-col items-center justify-between',
         'h-full w-full',
         'px-4 pt-3 pb-4',
-        isQrClosing
+        isActiveFeatureClosing
           ? 'fade-out slide-out-to-left-5 animate-out fill-mode-forwards ease-in-out'
           : 'fade-in slide-in-from-left-5 linear animate-in duration-150',
         classNames?.container,

--- a/src/wallet/components/WalletAdvancedSwap.test.tsx
+++ b/src/wallet/components/WalletAdvancedSwap.test.tsx
@@ -84,9 +84,10 @@ describe('WalletAdvancedSwap', () => {
   const mockUseAccount = useAccount as ReturnType<typeof vi.fn>;
 
   const defaultMockUseWalletAdvancedContext = {
-    showSwap: false,
-    setShowSwap: vi.fn(),
-    setIsSwapClosing: vi.fn(),
+    activeFeature: null,
+    setActiveFeature: vi.fn(),
+    isActiveFeatureClosing: false,
+    setIsActiveFeatureClosing: vi.fn(),
     animationClasses: {
       swap: 'animate-slideInFromLeft',
     },
@@ -145,7 +146,7 @@ describe('WalletAdvancedSwap', () => {
   it('should render correctly', () => {
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showSwap: true,
+      activeFeature: 'swap',
     });
 
     render(
@@ -163,7 +164,7 @@ describe('WalletAdvancedSwap', () => {
 
   it('should render correctly based on isSwapClosing state', () => {
     mockUseWalletAdvancedContext.mockReturnValue({
-      isSwapClosing: false,
+      isActiveFeatureClosing: false,
     });
 
     const { rerender } = render(
@@ -182,7 +183,7 @@ describe('WalletAdvancedSwap', () => {
     );
 
     mockUseWalletAdvancedContext.mockReturnValue({
-      isSwapClosing: true,
+      isActiveFeatureClosing: true,
     });
     rerender(
       <WalletAdvancedSwap
@@ -200,14 +201,10 @@ describe('WalletAdvancedSwap', () => {
   });
 
   it('should close swap when back button is clicked', () => {
-    const mockSetShowSwap = vi.fn();
-    const mockSetIsSwapClosing = vi.fn();
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showSwap: true,
+      activeFeature: 'swap',
       tokenHoldings: [tokens],
-      setShowSwap: mockSetShowSwap,
-      setIsSwapClosing: mockSetIsSwapClosing,
     });
 
     const { rerender } = render(
@@ -223,14 +220,14 @@ describe('WalletAdvancedSwap', () => {
 
     const backButton = screen.getByRole('button', { name: /back button/i });
     fireEvent.click(backButton);
-    expect(mockSetIsSwapClosing).toHaveBeenCalledWith(true);
+    expect(
+      defaultMockUseWalletAdvancedContext.setIsActiveFeatureClosing,
+    ).toHaveBeenCalledWith(true);
 
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
       tokenHoldings: [tokens],
-      setShowSwap: mockSetShowSwap,
-      setIsSwapClosing: mockSetIsSwapClosing,
-      isSwapClosing: true,
+      isActiveFeatureClosing: true,
     });
 
     rerender(
@@ -247,14 +244,18 @@ describe('WalletAdvancedSwap', () => {
     const swapContainer = screen.getByTestId('ockWalletAdvancedSwap');
     fireEvent.animationEnd(swapContainer);
 
-    expect(mockSetShowSwap).toHaveBeenCalledWith(false);
-    expect(mockSetIsSwapClosing).toHaveBeenCalledWith(false);
+    expect(
+      defaultMockUseWalletAdvancedContext.setActiveFeature,
+    ).toHaveBeenCalledWith(null);
+    expect(
+      defaultMockUseWalletAdvancedContext.setIsActiveFeatureClosing,
+    ).toHaveBeenCalledWith(false);
   });
 
   it('should apply custom classNames to all elements', () => {
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      showSwap: true,
+      activeFeature: 'swap',
     });
 
     const customClassNames = {

--- a/src/wallet/components/WalletAdvancedSwap.tsx
+++ b/src/wallet/components/WalletAdvancedSwap.tsx
@@ -30,19 +30,22 @@ export function WalletAdvancedSwap({
   title,
   to,
 }: WalletAdvancedSwapProps) {
-  const { setShowSwap, isSwapClosing, setIsSwapClosing } =
-    useWalletAdvancedContext();
+  const {
+    setActiveFeature,
+    isActiveFeatureClosing,
+    setIsActiveFeatureClosing,
+  } = useWalletAdvancedContext();
 
   const handleCloseSwap = useCallback(() => {
-    setIsSwapClosing(true);
-  }, [setIsSwapClosing]);
+    setIsActiveFeatureClosing(true);
+  }, [setIsActiveFeatureClosing]);
 
   const handleAnimationEnd = useCallback(() => {
-    if (isSwapClosing) {
-      setShowSwap(false);
-      setIsSwapClosing(false);
+    if (isActiveFeatureClosing) {
+      setActiveFeature(null);
+      setIsActiveFeatureClosing(false);
     }
-  }, [isSwapClosing, setShowSwap, setIsSwapClosing]);
+  }, [isActiveFeatureClosing, setActiveFeature, setIsActiveFeatureClosing]);
 
   const backButton = (
     <PressableIcon ariaLabel="Back button" onClick={handleCloseSwap}>
@@ -55,7 +58,7 @@ export function WalletAdvancedSwap({
       className={cn(
         'h-full',
         border.radius,
-        isSwapClosing
+        isActiveFeatureClosing
           ? 'fade-out slide-out-to-right-5 animate-out fill-mode-forwards ease-in-out'
           : 'fade-in slide-in-from-right-5 linear animate-in duration-150',
         'relative',

--- a/src/wallet/components/WalletAdvancedTokenHoldings.test.tsx
+++ b/src/wallet/components/WalletAdvancedTokenHoldings.test.tsx
@@ -65,8 +65,8 @@ describe('WalletAdvancedTokenHoldings', () => {
             'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
           chainId: 8453,
         },
-        balance: 0.42,
-        valueInFiat: 1386,
+        cryptoBalance: 420000000000000,
+        fiatBalance: 1386,
       },
       {
         token: {
@@ -78,8 +78,8 @@ describe('WalletAdvancedTokenHoldings', () => {
             'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/44/2b/442b80bd16af0c0d9b22e03a16753823fe826e5bfd457292b55fa0ba8c1ba213-ZWUzYjJmZGUtMDYxNy00NDcyLTg0NjQtMWI4OGEwYjBiODE2',
           chainId: 8453,
         },
-        balance: 69,
-        valueInFiat: 69,
+        cryptoBalance: 69000000,
+        fiatBalance: 69,
       },
       {
         token: {
@@ -91,8 +91,8 @@ describe('WalletAdvancedTokenHoldings', () => {
             'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
           chainId: 8453,
         },
-        balance: 0.42,
-        valueInFiat: 1386,
+        cryptoBalance: 420000000000000,
+        fiatBalance: 1386,
       },
     ];
 

--- a/src/wallet/components/WalletAdvancedTokenHoldings.tsx
+++ b/src/wallet/components/WalletAdvancedTokenHoldings.tsx
@@ -2,6 +2,7 @@
 
 import { cn, color, text } from '@/styles/theme';
 import { type Token, TokenImage } from '@/token';
+import { formatUnits } from 'viem';
 import { useWalletAdvancedContext } from './WalletAdvancedProvider';
 
 type WalletAdvancedTokenDetailsProps = {
@@ -62,10 +63,12 @@ export function WalletAdvancedTokenHoldings({
             name: tokenBalance.name,
             symbol: tokenBalance.symbol,
           }}
-          balance={
-            Number(tokenBalance.cryptoBalance) /
-            10 ** Number(tokenBalance.decimals)
-          }
+          balance={Number(
+            formatUnits(
+              BigInt(tokenBalance.cryptoBalance),
+              tokenBalance.decimals,
+            ),
+          )}
           valueInFiat={Number(tokenBalance.fiatBalance)}
           classNames={classNames?.tokenDetails}
         />

--- a/src/wallet/components/WalletAdvancedTransactionActions.test.tsx
+++ b/src/wallet/components/WalletAdvancedTransactionActions.test.tsx
@@ -38,7 +38,7 @@ describe('WalletAdvancedTransactionActons', () => {
   const mockUseWalletContext = useWalletContext as ReturnType<typeof vi.fn>;
 
   const defaultMockUseWalletAdvancedContext = {
-    setShowSwap: vi.fn(),
+    setActiveFeature: vi.fn(),
     animations: {
       content: '',
     },
@@ -142,32 +142,34 @@ describe('WalletAdvancedTransactionActons', () => {
     expect(window.open).not.toHaveBeenCalled();
   });
 
-  it('opens the send page when the send button is clicked', () => {
+  it('sets activeFeature to send when the send button is clicked', () => {
+    mockUseWalletAdvancedContext.mockReturnValue(
+      defaultMockUseWalletAdvancedContext,
+    );
+
     render(<WalletAdvancedTransactionActions />);
 
     const sendButton = screen.getByRole('button', { name: 'Send' });
     fireEvent.click(sendButton);
 
-    expect(window.open).toHaveBeenCalledWith(
-      'https://wallet.coinbase.com',
-      '_blank',
-    );
+    expect(
+      defaultMockUseWalletAdvancedContext.setActiveFeature,
+    ).toHaveBeenCalledWith('send');
   });
 
-  it('sets showSwap to true when the swap button is clicked', () => {
-    const setShowSwapMock = vi.fn();
-
-    mockUseWalletAdvancedContext.mockReturnValue({
-      ...defaultMockUseWalletAdvancedContext,
-      setShowSwap: setShowSwapMock,
-    });
+  it('sets activeFeature to swap when the swap button is clicked', () => {
+    mockUseWalletAdvancedContext.mockReturnValue(
+      defaultMockUseWalletAdvancedContext,
+    );
 
     render(<WalletAdvancedTransactionActions />);
 
     const swapButton = screen.getByRole('button', { name: 'Swap' });
     fireEvent.click(swapButton);
 
-    expect(setShowSwapMock).toHaveBeenCalledWith(true);
+    expect(
+      defaultMockUseWalletAdvancedContext.setActiveFeature,
+    ).toHaveBeenCalledWith('swap');
   });
 
   it('renders a placeholder when fetcher is loading', () => {
@@ -178,9 +180,7 @@ describe('WalletAdvancedTransactionActons', () => {
 
     render(<WalletAdvancedTransactionActions />);
 
-    const placeholder = screen.getByTestId(
-      'ockWalletAdvanced_LoadingPlaceholder',
-    );
+    const placeholder = screen.getByTestId('ockSkeleton');
     expect(placeholder).toHaveClass('my-3 h-16 w-80');
   });
 

--- a/src/wallet/components/WalletAdvancedTransactionActions.test.tsx
+++ b/src/wallet/components/WalletAdvancedTransactionActions.test.tsx
@@ -142,19 +142,16 @@ describe('WalletAdvancedTransactionActons', () => {
     expect(window.open).not.toHaveBeenCalled();
   });
 
-  it('sets activeFeature to send when the send button is clicked', () => {
-    mockUseWalletAdvancedContext.mockReturnValue(
-      defaultMockUseWalletAdvancedContext,
-    );
-
+  it('opens the send page when the send button is clicked', () => {
     render(<WalletAdvancedTransactionActions />);
 
     const sendButton = screen.getByRole('button', { name: 'Send' });
     fireEvent.click(sendButton);
 
-    expect(
-      defaultMockUseWalletAdvancedContext.setActiveFeature,
-    ).toHaveBeenCalledWith('send');
+    expect(window.open).toHaveBeenCalledWith(
+      'https://wallet.coinbase.com',
+      '_blank',
+    );
   });
 
   it('sets activeFeature to swap when the swap button is clicked', () => {

--- a/src/wallet/components/WalletAdvancedTransactionActions.tsx
+++ b/src/wallet/components/WalletAdvancedTransactionActions.tsx
@@ -2,6 +2,7 @@
 
 import { useAnalytics } from '@/core/analytics/hooks/useAnalytics';
 import { WalletEvent, WalletOption } from '@/core/analytics/types';
+import { Skeleton } from '@/internal/components/Skeleton';
 import { addSvgForeground } from '@/internal/svg/addForegroundSvg';
 import { arrowUpRightSvg } from '@/internal/svg/arrowUpRightSvg';
 import { toggleSvg } from '@/internal/svg/toggleSvg';
@@ -36,7 +37,7 @@ export function WalletAdvancedTransactionActions({
 }: WalletAdvancedTransactionActionsProps) {
   const { address, chain } = useWalletContext();
   const { projectId } = useOnchainKit();
-  const { isFetchingPortfolioData, setShowSwap, animations } =
+  const { isFetchingPortfolioData, setActiveFeature, animations } =
     useWalletAdvancedContext();
   const { sendAnalytics } = useAnalytics();
 
@@ -84,16 +85,11 @@ export function WalletAdvancedTransactionActions({
 
   const handleSwap = useCallback(() => {
     handleAnalyticsOptionSelected(WalletOption.Swap);
-    setShowSwap(true);
-  }, [setShowSwap, handleAnalyticsOptionSelected]);
+    setActiveFeature('swap');
+  }, [setActiveFeature, handleAnalyticsOptionSelected]);
 
   if (isFetchingPortfolioData) {
-    return (
-      <div
-        data-testid="ockWalletAdvanced_LoadingPlaceholder"
-        className="my-3 h-16 w-80"
-      />
-    ); // Prevent layout shift
+    return <Skeleton className="my-3 h-16 w-80" />;
   }
 
   return (

--- a/src/wallet/components/WalletAdvancedWalletActions.test.tsx
+++ b/src/wallet/components/WalletAdvancedWalletActions.test.tsx
@@ -43,6 +43,8 @@ describe('WalletAdvancedWalletActions', () => {
   const mockSendAnalytics = vi.fn();
 
   const defaultMockUseWalletAdvancedContext = {
+    setActiveFeature: vi.fn(),
+    refetchPortfolioData: vi.fn(),
     animations: {
       content: '',
     },
@@ -62,12 +64,6 @@ describe('WalletAdvancedWalletActions', () => {
   it('renders the WalletAdvancedWalletActions component', () => {
     const handleCloseMock = vi.fn();
     mockUseWalletContext.mockReturnValue({ handleClose: handleCloseMock });
-
-    const setShowQrMock = vi.fn();
-    mockUseWalletAdvancedContext.mockReturnValue({
-      ...defaultMockUseWalletAdvancedContext,
-      setShowQr: setShowQrMock,
-    });
 
     (useDisconnect as Mock).mockReturnValue({
       disconnect: vi.fn(),
@@ -93,12 +89,6 @@ describe('WalletAdvancedWalletActions', () => {
       handleClose: handleCloseMock,
     });
 
-    const setShowQrMock = vi.fn();
-    mockUseWalletAdvancedContext.mockReturnValue({
-      ...defaultMockUseWalletAdvancedContext,
-      setShowQr: setShowQrMock,
-    });
-
     const disconnectMock = vi.fn();
     (useDisconnect as Mock).mockReturnValue({
       disconnect: disconnectMock,
@@ -117,10 +107,8 @@ describe('WalletAdvancedWalletActions', () => {
   });
 
   it('sets showQr to true when qr button is clicked', () => {
-    const setShowQrMock = vi.fn();
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      setShowQr: setShowQrMock,
     });
 
     render(<WalletAdvancedWalletActions />);
@@ -128,14 +116,14 @@ describe('WalletAdvancedWalletActions', () => {
     const qrButton = screen.getByTestId('ockWalletAdvanced_QrButton');
     fireEvent.click(qrButton);
 
-    expect(setShowQrMock).toHaveBeenCalled();
+    expect(
+      defaultMockUseWalletAdvancedContext.setActiveFeature,
+    ).toHaveBeenCalledWith('qr');
   });
 
   it('refreshes portfolio data when refresh button is clicked', () => {
-    const refetchPortfolioDataMock = vi.fn();
     mockUseWalletAdvancedContext.mockReturnValue({
       ...defaultMockUseWalletAdvancedContext,
-      refetchPortfolioData: refetchPortfolioDataMock,
     });
 
     render(<WalletAdvancedWalletActions />);
@@ -143,7 +131,9 @@ describe('WalletAdvancedWalletActions', () => {
     const refreshButton = screen.getByTestId('ockWalletAdvanced_RefreshButton');
     fireEvent.click(refreshButton);
 
-    expect(refetchPortfolioDataMock).toHaveBeenCalled();
+    expect(
+      defaultMockUseWalletAdvancedContext.refetchPortfolioData,
+    ).toHaveBeenCalled();
   });
 
   it('opens transaction history when transactions button is clicked', () => {
@@ -250,10 +240,8 @@ describe('WalletAdvancedWalletActions', () => {
     });
 
     it('sends analytics when QR button is clicked', () => {
-      const setShowQrMock = vi.fn();
       mockUseWalletAdvancedContext.mockReturnValue({
         ...defaultMockUseWalletAdvancedContext,
-        setShowQr: setShowQrMock,
       });
 
       render(<WalletAdvancedWalletActions />);
@@ -270,10 +258,8 @@ describe('WalletAdvancedWalletActions', () => {
     });
 
     it('sends analytics when refresh button is clicked', () => {
-      const refetchPortfolioDataMock = vi.fn();
       mockUseWalletAdvancedContext.mockReturnValue({
         ...defaultMockUseWalletAdvancedContext,
-        refetchPortfolioData: refetchPortfolioDataMock,
       });
 
       render(<WalletAdvancedWalletActions />);

--- a/src/wallet/components/WalletAdvancedWalletActions.tsx
+++ b/src/wallet/components/WalletAdvancedWalletActions.tsx
@@ -27,7 +27,7 @@ export function WalletAdvancedWalletActions({
   classNames,
 }: WalletAdvancedWalletActionsProps) {
   const { address, handleClose } = useWalletContext();
-  const { setShowQr, refetchPortfolioData, animations } =
+  const { setActiveFeature, refetchPortfolioData, animations } =
     useWalletAdvancedContext();
   const { disconnect, connectors } = useDisconnect();
   const { sendAnalytics } = useAnalytics();
@@ -68,8 +68,8 @@ export function WalletAdvancedWalletActions({
 
   const handleQr = useCallback(() => {
     handleAnalyticsOptionSelected(WalletOption.QR);
-    setShowQr(true);
-  }, [setShowQr, handleAnalyticsOptionSelected]);
+    setActiveFeature('qr');
+  }, [setActiveFeature, handleAnalyticsOptionSelected]);
 
   const handleRefreshPortfolioData = useCallback(async () => {
     handleAnalyticsOptionSelected(WalletOption.Refresh);

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -214,18 +214,16 @@ export type WalletAdvancedReact = {
   };
 };
 
+export type WalletAdvancedFeature = 'qr' | 'swap';
+
 /**
  * Note: exported as public Type
  */
 export type WalletAdvancedContextType = {
-  showSwap: boolean;
-  setShowSwap: Dispatch<SetStateAction<boolean>>;
-  isSwapClosing: boolean;
-  setIsSwapClosing: Dispatch<SetStateAction<boolean>>;
-  showQr: boolean;
-  setShowQr: Dispatch<SetStateAction<boolean>>;
-  isQrClosing: boolean;
-  setIsQrClosing: Dispatch<SetStateAction<boolean>>;
+  activeFeature: WalletAdvancedFeature | null;
+  setActiveFeature: Dispatch<SetStateAction<WalletAdvancedFeature | null>>;
+  isActiveFeatureClosing: boolean;
+  setIsActiveFeatureClosing: Dispatch<SetStateAction<boolean>>;
   tokenBalances: PortfolioTokenWithFiatValue[] | undefined;
   portfolioFiatValue: number | undefined;
   isFetchingPortfolioData: boolean;


### PR DESCRIPTION
**What changed? Why?**
* previously, we had state for the two sub-components: QR and Swap. 
* in preparation for the addition of Send, I refactored how WalletAdvanced handles sub-components
* instead of separate state for each sub-component, there is one state: `activeFeature`. this simplifies the devex for controlling which feature is displayed

**Notes to reviewers**

**How has it been tested?**
test coverage and in playground