### PR TITLE
feat: allow AmountInput to use TextInput's delayMs prop

### DIFF
--- a/src/internal/components/amount-input/AmountInput.tsx
+++ b/src/internal/components/amount-input/AmountInput.tsx
@@ -15,6 +15,7 @@ type AmountInputProps = {
   setFiatAmount: (value: string) => void;
   setCryptoAmount: (value: string) => void;
   exchangeRate: string;
+  delayMs?: number;
   className?: string;
   textClassName?: string;
 };
@@ -28,6 +29,7 @@ export function AmountInput({
   setFiatAmount,
   setCryptoAmount,
   exchangeRate,
+  delayMs,
   className,
   textClassName,
 }: AmountInputProps) {
@@ -111,6 +113,7 @@ export function AmountInput({
               )}
               value={value}
               onChange={handleAmountChange}
+              delayMs={delayMs}
               inputValidator={isValidAmount}
               ref={inputRef}
               inputMode="decimal"


### PR DESCRIPTION
**What changed? Why?**
* TextInput supports a `delayMs` prop for debouncing
* AmountInput implements TextInput. Previously it had not supported `delayMs`
* This PR adds `delayMs` as a supported prop that's passed to TextInput

**Notes to reviewers**

**How has it been tested?**
* locally, in playground