### PR TITLE
refactor: remove swap findChildren

### DIFF
--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -103,108 +103,45 @@ function SwapComponent() {
         </div>
       ) : null}
 
-      <div className="relative flex flex-col gap-6">
-        <h2>Swap Default</h2>
-        <Swap
-          className="w-full border sm:w-[500px]"
-          to={[...swappableTokens].reverse()}
-          from={swappableTokens}
-          onStatus={handleOnStatus}
-          onSuccess={handleOnSuccess}
-          onError={handleOnError}
-          config={{
-            maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
-          }}
-          isSponsored={isSponsored}
-          headerLeftContent={<div>test</div>}
+      <Swap
+        className="w-full border sm:w-[500px]"
+        onStatus={handleOnStatus}
+        onSuccess={handleOnSuccess}
+        onError={handleOnError}
+        config={{
+          maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
+        }}
+        isSponsored={isSponsored}
+      >
+        <SwapSettings>
+          <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
+          <SwapSettingsSlippageDescription>
+            Your swap will revert if the prices change by more than the selected
+            percentage.
+          </SwapSettingsSlippageDescription>
+          <SwapSettingsSlippageInput />
+        </SwapSettings>
+        <SwapAmountInput
+          label="Sell"
+          swappableTokens={swappableTokens}
+          token={ethToken}
+          type="from"
         />
-
-        <h2>Swap with Children</h2>
-        <Swap
-          className="w-full border sm:w-[500px]"
-          onStatus={handleOnStatus}
-          onSuccess={handleOnSuccess}
-          onError={handleOnError}
-          config={{
-            maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
-          }}
-          isSponsored={isSponsored}
-          headerLeftContent={<div>test</div>}
-        >
-          <SwapSettings>
-            <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
-            <SwapSettingsSlippageDescription>
-              Your swap will revert if the prices change by more than the
-              selected percentage.
-            </SwapSettingsSlippageDescription>
-            <SwapSettingsSlippageInput />
-          </SwapSettings>
-          <SwapAmountInput
-            label="Sell"
-            swappableTokens={swappableTokens}
-            token={ethToken}
-            type="from"
-          />
-          <SwapToggleButton />
-          <SwapAmountInput
-            label="Buy"
-            swappableTokens={swappableTokens}
-            token={usdcToken}
-            type="to"
-          />
-          <SwapButton
-            disabled={
-              ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] === 'production'
-            }
-          />
-          <SwapMessage />
-          <SwapToast />
-        </Swap>
-
-        <h2>Swap with extra Children</h2>
-        <Swap
-          className="w-full border sm:w-[500px]"
-          onStatus={handleOnStatus}
-          onSuccess={handleOnSuccess}
-          onError={handleOnError}
-          config={{
-            maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
-          }}
-          isSponsored={isSponsored}
-          headerLeftContent={<div>test</div>}
-        >
-          <SwapSettings>
-            <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
-            <SwapSettingsSlippageDescription>
-              Your swap will revert if the prices change by more than the
-              selected percentage.
-            </SwapSettingsSlippageDescription>
-            <SwapSettingsSlippageInput />
-          </SwapSettings>
-          <div className="pb-4">Buy my MemeCoin!!!</div>
-          <SwapAmountInput
-            label="Sell"
-            swappableTokens={swappableTokens}
-            token={ethToken}
-            type="from"
-          />
-          <SwapToggleButton />
-          <SwapAmountInput
-            label="Buy"
-            swappableTokens={swappableTokens}
-            token={usdcToken}
-            type="to"
-          />
-          <div className="pt-4">DO IT!!!</div>
-          <SwapButton
-            disabled={
-              ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] === 'production'
-            }
-          />
-          <SwapMessage />
-          <SwapToast />
-        </Swap>
-      </div>
+        <SwapToggleButton />
+        <SwapAmountInput
+          label="Buy"
+          swappableTokens={swappableTokens}
+          token={usdcToken}
+          type="to"
+        />
+        <SwapButton
+          disabled={
+            ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] === 'production'
+          }
+        />
+        <SwapMessage />
+        <SwapToast />
+      </Swap>
     </div>
   );
 }

--- a/playground/nextjs-app-router/components/demo/Swap.tsx
+++ b/playground/nextjs-app-router/components/demo/Swap.tsx
@@ -103,45 +103,108 @@ function SwapComponent() {
         </div>
       ) : null}
 
-      <Swap
-        className="w-full border sm:w-[500px]"
-        onStatus={handleOnStatus}
-        onSuccess={handleOnSuccess}
-        onError={handleOnError}
-        config={{
-          maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
-        }}
-        isSponsored={isSponsored}
-      >
-        <SwapSettings>
-          <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
-          <SwapSettingsSlippageDescription>
-            Your swap will revert if the prices change by more than the selected
-            percentage.
-          </SwapSettingsSlippageDescription>
-          <SwapSettingsSlippageInput />
-        </SwapSettings>
-        <SwapAmountInput
-          label="Sell"
-          swappableTokens={swappableTokens}
-          token={ethToken}
-          type="from"
+      <div className="relative flex flex-col gap-6">
+        <h2>Swap Default</h2>
+        <Swap
+          className="w-full border sm:w-[500px]"
+          to={[...swappableTokens].reverse()}
+          from={swappableTokens}
+          onStatus={handleOnStatus}
+          onSuccess={handleOnSuccess}
+          onError={handleOnError}
+          config={{
+            maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
+          }}
+          isSponsored={isSponsored}
+          headerLeftContent={<div>test</div>}
         />
-        <SwapToggleButton />
-        <SwapAmountInput
-          label="Buy"
-          swappableTokens={swappableTokens}
-          token={usdcToken}
-          type="to"
-        />
-        <SwapButton
-          disabled={
-            ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] === 'production'
-          }
-        />
-        <SwapMessage />
-        <SwapToast />
-      </Swap>
+
+        <h2>Swap with Children</h2>
+        <Swap
+          className="w-full border sm:w-[500px]"
+          onStatus={handleOnStatus}
+          onSuccess={handleOnSuccess}
+          onError={handleOnError}
+          config={{
+            maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
+          }}
+          isSponsored={isSponsored}
+          headerLeftContent={<div>test</div>}
+        >
+          <SwapSettings>
+            <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
+            <SwapSettingsSlippageDescription>
+              Your swap will revert if the prices change by more than the
+              selected percentage.
+            </SwapSettingsSlippageDescription>
+            <SwapSettingsSlippageInput />
+          </SwapSettings>
+          <SwapAmountInput
+            label="Sell"
+            swappableTokens={swappableTokens}
+            token={ethToken}
+            type="from"
+          />
+          <SwapToggleButton />
+          <SwapAmountInput
+            label="Buy"
+            swappableTokens={swappableTokens}
+            token={usdcToken}
+            type="to"
+          />
+          <SwapButton
+            disabled={
+              ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] === 'production'
+            }
+          />
+          <SwapMessage />
+          <SwapToast />
+        </Swap>
+
+        <h2>Swap with extra Children</h2>
+        <Swap
+          className="w-full border sm:w-[500px]"
+          onStatus={handleOnStatus}
+          onSuccess={handleOnSuccess}
+          onError={handleOnError}
+          config={{
+            maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
+          }}
+          isSponsored={isSponsored}
+          headerLeftContent={<div>test</div>}
+        >
+          <SwapSettings>
+            <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
+            <SwapSettingsSlippageDescription>
+              Your swap will revert if the prices change by more than the
+              selected percentage.
+            </SwapSettingsSlippageDescription>
+            <SwapSettingsSlippageInput />
+          </SwapSettings>
+          <div className="pb-4">Buy my MemeCoin!!!</div>
+          <SwapAmountInput
+            label="Sell"
+            swappableTokens={swappableTokens}
+            token={ethToken}
+            type="from"
+          />
+          <SwapToggleButton />
+          <SwapAmountInput
+            label="Buy"
+            swappableTokens={swappableTokens}
+            token={usdcToken}
+            type="to"
+          />
+          <div className="pt-4">DO IT!!!</div>
+          <SwapButton
+            disabled={
+              ENVIRONMENT_VARIABLES[ENVIRONMENT.ENVIRONMENT] === 'production'
+            }
+          />
+          <SwapMessage />
+          <SwapToast />
+        </Swap>
+      </div>
     </div>
   );
 }

--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.37.4",
+  "version": "0.37.5",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",

--- a/src/swap/components/Swap.test.tsx
+++ b/src/swap/components/Swap.test.tsx
@@ -2,11 +2,52 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { Swap } from './Swap';
 
+vi.mock('wagmi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    useAccount: vi.fn().mockReturnValue({
+      address: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+      chainId: 1,
+    }),
+    useConfig: vi.fn(),
+    useSwitchChain: vi.fn(),
+    useWriteContract: vi.fn(),
+  };
+});
+
+vi.mock('@/internal/hooks/useBreakpoints', () => ({
+  useBreakpoints: vi.fn().mockReturnValue('md'),
+}));
+
 vi.mock('./SwapProvider', () => ({
   SwapProvider: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="mock-SwapProvider">{children}</div>
   ),
-  useSwapContext: vi.fn(),
+  useSwapContext: vi.fn().mockReturnValue({
+    address: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+    config: {
+      maxSlippage: 10,
+    },
+    from: {
+      amount: '100',
+    },
+    to: {
+      amount: '100',
+    },
+    lifecycleStatus: {
+      statusName: 'init',
+      statusData: {
+        isMissingRequiredField: true,
+        maxSlippage: 10,
+      },
+    },
+    handleAmountChange: vi.fn(),
+    handleSubmit: vi.fn(),
+    handleToggle: vi.fn(),
+    updateLifecycleStatus: vi.fn(),
+    isToastVisible: false,
+  }),
 }));
 
 vi.mock('@/internal/svg/closeSvg', () => ({
@@ -45,5 +86,38 @@ describe('Swap Component', () => {
 
     const container = screen.getByTestId('ockSwap_Container');
     expect(container).toHaveClass('custom-class');
+  });
+
+  it('should render children', () => {
+    render(
+      <Swap>
+        <div>Test Child</div>
+      </Swap>,
+    );
+
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+  });
+
+  it('should render children when to, from, and disabled are provided', () => {
+    const toToken = {
+      address: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+      chainId: 1,
+      decimals: 18,
+      image: 'https://example.com/image.png',
+      name: 'toToken',
+      symbol: 'toToken',
+    };
+    const fromToken = {
+      address: '0x0000000000000000000000000000000000000001' as `0x${string}`,
+      chainId: 1,
+      decimals: 18,
+      image: 'https://example.com/image.png',
+      name: 'fromToken',
+      symbol: 'fromToken',
+    };
+    render(<Swap to={[toToken]} from={[fromToken]} disabled={true} />);
+
+    expect(screen.getByText('Buy')).toBeInTheDocument();
+    expect(screen.getByText('Sell')).toBeInTheDocument();
   });
 });

--- a/src/swap/components/SwapAmountInput.tsx
+++ b/src/swap/components/SwapAmountInput.tsx
@@ -104,13 +104,19 @@ export function SwapAmountInput({
       className={cn(
         background.secondary,
         border.radius,
-        'box-border flex h-[148px] w-full flex-col items-start p-4',
+        'my-0.5 box-border flex h-[148px] w-full flex-col items-start p-4',
         className,
       )}
       data-testid="ockSwapAmountInput_Container"
     >
-      <div className="flex w-full items-center justify-between">
-        <span className={cn(text.label2, color.foregroundMuted)}>{label}</span>
+      <div
+        className={cn(
+          text.label2,
+          color.foregroundMuted,
+          'flex w-full items-center justify-between',
+        )}
+      >
+        {label}
       </div>
       <div className="flex w-full items-center justify-between">
         <TextInput
@@ -139,27 +145,32 @@ export function SwapAmountInput({
           )
         )}
       </div>
-      <div className="mt-4 flex w-full justify-between">
-        <div className="flex items-center">
-          <span className={cn(text.label2, color.foregroundMuted)}>
-            {formatUSD(source.amountUSD)}
-          </span>
+      <div className="mt-4 flex w-full items-center justify-between">
+        <div className={cn(text.label2, color.foregroundMuted)}>
+          {formatUSD(source.amountUSD)}
         </div>
-        <span className={cn(text.label2, color.foregroundMuted)}>{''}</span>
-        <div className="flex items-center">
+        <div
+          className={cn(
+            text.label2,
+            color.foregroundMuted,
+            'flex grow items-center justify-end',
+          )}
+        >
           {source.balance && (
-            <span
-              className={cn(text.label2, color.foregroundMuted)}
-            >{`Balance: ${getRoundedAmount(source.balance, 8)}`}</span>
+            <span>{`Balance: ${getRoundedAmount(source.balance, 8)}`}</span>
           )}
           {type === 'from' && address && (
             <button
               type="button"
-              className="flex cursor-pointer items-center justify-center px-2 py-1"
+              className={cn(
+                text.label1,
+                color.primary,
+                'flex cursor-pointer items-center justify-center px-2 py-1',
+              )}
               data-testid="ockSwapAmountInput_MaxButton"
               onClick={handleMaxButtonClick}
             >
-              <span className={cn(text.label1, color.primary)}>Max</span>
+              Max
             </button>
           )}
         </div>

--- a/src/swap/components/SwapButton.tsx
+++ b/src/swap/components/SwapButton.tsx
@@ -5,7 +5,11 @@ import { ConnectWallet } from '@/wallet/components/ConnectWallet';
 import type { SwapButtonReact } from '../types';
 import { useSwapContext } from './SwapProvider';
 
-export function SwapButton({ className, disabled = false }: SwapButtonReact) {
+export function SwapButton({
+  className,
+  label = 'Swap',
+  disabled = false,
+}: SwapButtonReact) {
   const {
     address,
     to,
@@ -33,7 +37,7 @@ export function SwapButton({ className, disabled = false }: SwapButtonReact) {
 
   // prompt user to connect wallet
   if (!isDisabled && !address) {
-    return <ConnectWallet className="mt-4 w-full" />;
+    return <ConnectWallet className={cn('mt-4 w-full', className)} />;
   }
 
   return (
@@ -55,7 +59,7 @@ export function SwapButton({ className, disabled = false }: SwapButtonReact) {
       {isLoading ? (
         <Spinner />
       ) : (
-        <span className={cn(text.headline, color.inverse)}>Swap</span>
+        <span className={cn(text.headline, color.inverse)}>{label}</span>
       )}
     </button>
   );

--- a/src/swap/components/SwapDefault.tsx
+++ b/src/swap/components/SwapDefault.tsx
@@ -1,16 +1,10 @@
 'use client';
 import type { SwapDefaultReact } from '../types';
 import { Swap } from './Swap';
-import { SwapAmountInput } from './SwapAmountInput';
-import { SwapButton } from './SwapButton';
-import { SwapMessage } from './SwapMessage';
-import { SwapSettings } from './SwapSettings';
-import { SwapSettingsSlippageDescription } from './SwapSettingsSlippageDescription';
-import { SwapSettingsSlippageInput } from './SwapSettingsSlippageInput';
-import { SwapSettingsSlippageTitle } from './SwapSettingsSlippageTitle';
-import { SwapToast } from './SwapToast';
-import { SwapToggleButton } from './SwapToggleButton';
 
+/**
+ * @deprecated Use the `Swap` component instead with no 'children' props.
+ */
 export function SwapDefault({
   config,
   className,
@@ -34,31 +28,9 @@ export function SwapDefault({
       isSponsored={isSponsored}
       title={title}
       experimental={experimental}
-    >
-      <SwapSettings>
-        <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
-        <SwapSettingsSlippageDescription>
-          Your swap will revert if the prices change by more than the selected
-          percentage.
-        </SwapSettingsSlippageDescription>
-        <SwapSettingsSlippageInput />
-      </SwapSettings>
-      <SwapAmountInput
-        label="Sell"
-        swappableTokens={from}
-        token={from?.[0]}
-        type="from"
-      />
-      <SwapToggleButton />
-      <SwapAmountInput
-        label="Buy"
-        swappableTokens={to}
-        token={to?.[0]}
-        type="to"
-      />
-      <SwapButton disabled={disabled} />
-      <SwapMessage />
-      <SwapToast />
-    </Swap>
+      to={to}
+      from={from}
+      disabled={disabled}
+    />
   );
 }

--- a/src/swap/components/SwapSettings.tsx
+++ b/src/swap/components/SwapSettings.tsx
@@ -6,11 +6,25 @@ import { useIcon } from '@/internal/hooks/useIcon';
 import { background, border, cn, pressable, text } from '@/styles/theme';
 import { useCallback, useRef, useState } from 'react';
 import type { SwapSettingsReact } from '../types';
+import { SwapSettingsSlippageDescription } from './SwapSettingsSlippageDescription';
+import { SwapSettingsSlippageInput } from './SwapSettingsSlippageInput';
 import { SwapSettingsSlippageLayout } from './SwapSettingsSlippageLayout';
 import { SwapSettingsSlippageLayoutBottomSheet } from './SwapSettingsSlippageLayoutBottomSheet';
+import { SwapSettingsSlippageTitle } from './SwapSettingsSlippageTitle';
+
+const DEFAULT_CHILDREN = (
+  <>
+    <SwapSettingsSlippageTitle>Max. slippage</SwapSettingsSlippageTitle>
+    <SwapSettingsSlippageDescription>
+      Your swap will revert if the prices change by more than the selected
+      percentage.
+    </SwapSettingsSlippageDescription>
+    <SwapSettingsSlippageInput />,
+  </>
+);
 
 export function SwapSettings({
-  children,
+  children = DEFAULT_CHILDREN,
   className,
   icon = 'swapSettings',
   text: buttonText = '',
@@ -34,7 +48,7 @@ export function SwapSettings({
   return (
     <div
       className={cn(
-        'flex w-auto items-center justify-end space-x-1',
+        'flex w-auto items-center justify-end space-x-1 pb-4',
         className,
       )}
       data-testid="ockSwapSettings_Settings"

--- a/src/swap/components/SwapToggleButton.tsx
+++ b/src/swap/components/SwapToggleButton.tsx
@@ -13,7 +13,7 @@ export function SwapToggleButton({ className }: SwapToggleButtonReact) {
       className={cn(
         pressable.alternate,
         border.default,
-        '-translate-x-2/4 -translate-y-2/4 absolute top-2/4 left-2/4',
+        '-my-6 relative mx-auto',
         'flex h-12 w-12 items-center justify-center',
         'rounded-lg border-4 border-solid',
         className,

--- a/src/swap/types.ts
+++ b/src/swap/types.ts
@@ -185,6 +185,8 @@ export type SwapButtonReact = {
   className?: string;
   /** Disables swap button */
   disabled?: boolean;
+  /** Label for the swap button */
+  label?: ReactNode;
 };
 
 export type SwapConfig = {
@@ -291,8 +293,6 @@ export type SwapProviderReact = {
  * Note: exported as public Type
  */
 export type SwapReact = {
-  /** React children */
-  children: ReactNode;
   /** Optional className override for top div element */
   className?: string;
   /** Configuration options */
@@ -314,7 +314,31 @@ export type SwapReact = {
   title?: ReactNode;
   /** Header left content for the Swap component (eg. back button) */
   headerLeftContent?: ReactNode;
-};
+} & (
+  | {
+      /** When React children are provided
+       * swappableTokens, toToken, and fromToken should be passed to the SwapAmountInput component
+       * disabled should be passed to the SwapButton component
+       **/
+      children: ReactNode;
+      /** To token */
+      to?: never;
+      /** From token */
+      from?: never;
+      /** Disables swap button */
+      disabled?: never;
+    }
+  | {
+      /** When React Children are undefined, swappableTokens, toToken, and fromToken are required */
+      children?: never;
+      /** To token */
+      to: Token[];
+      /** From token */
+      from: Token[];
+      /** Disables swap button */
+      disabled?: boolean;
+    }
+);
 
 /**
  * Note: exported as public Type
@@ -332,7 +356,7 @@ export type SwapDefaultReact = {
  * Note: exported as public Type
  */
 export type SwapSettingsReact = {
-  children: ReactNode;
+  children?: ReactNode;
   /** Optional className override for top div element */
   className?: string;
   /** Optional icon override */


### PR DESCRIPTION
**What changed? Why?**
Update Swap and SwapSettings components to have default children.  Added toToken, fromToken, swappableTokens as top level props when children is undefined.  Interface is unchanged when children are passed in.

* Remove findChildren
* Add default children
* SwappableTokens, toToken, fromToken to Swap component, required when children is undefined

| swap default | swap with children | swap with extra |
| ------------- | -------------------| ---------------- |
| ![image](https://github.com/user-attachments/assets/a7edbfbb-d634-4686-b609-d788f3a3f7e3) | ![image](https://github.com/user-attachments/assets/b3234125-0fd7-4cbc-be31-e4e94fef44d5) | ![image](https://github.com/user-attachments/assets/800d7cc9-e8ce-4dce-af14-8efefe3a4308) |

**Notes to reviewers**

**How has it been tested?**
