### PR TITLE
feat: add minikit provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
+    "@farcaster/frame-sdk": "^0.0.28",
+    "@farcaster/frame-wagmi-connector": "^0.0.16",
     "@tanstack/react-query": "^5",
     "clsx": "^2.1.1",
     "graphql": "^14 || ^15 || ^16",

--- a/src/DefaultOnchainKitProviders.test.tsx
+++ b/src/DefaultOnchainKitProviders.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, WagmiProvider, createConfig } from 'wagmi';
+import { DefaultOnchainKitProviders } from './DefaultOnchainKitProviders';
+import { useProviderDependencies } from './internal/hooks/useProviderDependencies';
+
+const queryClient = new QueryClient();
+const wagmiConfig = createConfig({
+  chains: [
+    {
+      id: 1,
+      name: 'Mock Chain',
+      nativeCurrency: { name: 'ETH', symbol: 'ETH', decimals: 18 },
+      rpcUrls: { default: { http: ['http://localhost'] } },
+    },
+  ],
+  connectors: [],
+  transports: { [1]: http() },
+});
+
+vi.mock('wagmi', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('wagmi')>();
+  return {
+    ...actual,
+    WagmiProvider: vi.fn(({ children }) => (
+      <div data-testid="wagmi-provider">{children}</div>
+    )),
+  };
+});
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+  return {
+    ...actual,
+    QueryClientProvider: vi.fn(({ children }) => (
+      <div data-testid="query-client-provider">{children}</div>
+    )),
+  };
+});
+
+vi.mock('./internal/hooks/useProviderDependencies', () => ({
+  useProviderDependencies: vi.fn(() => ({
+    providedWagmiConfig: vi.fn(),
+    providedQueryClient: vi.fn(),
+  })),
+}));
+
+describe('DefaultOnchainKitProviders', () => {
+  beforeEach(() => {
+    (useProviderDependencies as Mock).mockReturnValue({
+      providedWagmiConfig: false,
+      providedQueryClient: false,
+    });
+  });
+
+  it('should wrap children in default providers', () => {
+    render(
+      <DefaultOnchainKitProviders>
+        <div>Test Child</div>
+      </DefaultOnchainKitProviders>,
+    );
+
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+    expect(screen.queryAllByTestId('wagmi-provider')).toHaveLength(1);
+    expect(screen.queryAllByTestId('query-client-provider')).toHaveLength(1);
+  });
+
+  it('should not render duplicate default providers when a wagmi provider already exists', () => {
+    (useProviderDependencies as Mock).mockReturnValue({
+      providedWagmiConfig: wagmiConfig,
+      providedQueryClient: null,
+    });
+
+    render(
+      <WagmiProvider config={wagmiConfig}>
+        <DefaultOnchainKitProviders>
+          <div>Test Child</div>
+        </DefaultOnchainKitProviders>
+      </WagmiProvider>,
+    );
+
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+    expect(screen.queryAllByTestId('wagmi-provider')).toHaveLength(1);
+  });
+
+  it('should not render duplicate default providers when a query client already exists', () => {
+    (useProviderDependencies as Mock).mockReturnValue({
+      providedWagmiConfig: null,
+      providedQueryClient: queryClient,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <DefaultOnchainKitProviders>
+          <div>Test Child</div>
+        </DefaultOnchainKitProviders>
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByText('Test Child')).toBeInTheDocument();
+    expect(screen.queryAllByTestId('query-client-provider')).toHaveLength(1);
+  });
+});

--- a/src/DefaultOnchainKitProviders.tsx
+++ b/src/DefaultOnchainKitProviders.tsx
@@ -1,0 +1,59 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type PropsWithChildren, useMemo } from 'react';
+import { WagmiProvider } from 'wagmi';
+import { coinbaseWallet } from 'wagmi/connectors';
+import { createWagmiConfig } from './core/createWagmiConfig';
+import type { CreateWagmiConfigParams } from './core/types';
+import { useProviderDependencies } from './internal/hooks/useProviderDependencies';
+
+export function DefaultOnchainKitProviders({
+  apiKey,
+  appName,
+  appLogoUrl,
+  connectors = [
+    coinbaseWallet({
+      appName,
+      appLogoUrl,
+      preference: 'all',
+    }),
+  ],
+  children,
+}: PropsWithChildren<CreateWagmiConfigParams>) {
+  // Check the React context for WagmiProvider and QueryClientProvider
+  const { providedWagmiConfig, providedQueryClient } =
+    useProviderDependencies();
+
+  const defaultConfig = useMemo(() => {
+    // IMPORTANT: Don't create a new Wagmi configuration if one already exists
+    // This prevents the user-provided WagmiConfig from being overridden
+    return (
+      providedWagmiConfig ||
+      createWagmiConfig({
+        apiKey,
+        appName,
+        appLogoUrl,
+        connectors,
+      })
+    );
+  }, [apiKey, appName, appLogoUrl, connectors, providedWagmiConfig]);
+
+  const defaultQueryClient = useMemo(() => {
+    // IMPORTANT: Don't create a new QueryClient if one already exists
+    // This prevents the user-provided QueryClient from being overridden
+    return providedQueryClient || new QueryClient();
+  }, [providedQueryClient]);
+
+  // If both dependencies are missing, return a context with default parent providers
+  // If only one dependency is provided, expect the user to also provide the missing one
+  if (!providedWagmiConfig && !providedQueryClient) {
+    return (
+      <WagmiProvider config={defaultConfig}>
+        <QueryClientProvider client={defaultQueryClient}>
+          {children}
+        </QueryClientProvider>
+      </WagmiProvider>
+    );
+  }
+
+  return children;
+}

--- a/src/OnchainKitProvider.tsx
+++ b/src/OnchainKitProvider.tsx
@@ -4,15 +4,12 @@ import {
   ONCHAIN_KIT_CONFIG,
   setOnchainKitConfig,
 } from '@/core/OnchainKitConfig';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createContext, useMemo } from 'react';
-import { WagmiProvider } from 'wagmi';
+import { DefaultOnchainKitProviders } from './DefaultOnchainKitProviders';
 import OnchainKitProviderBoundary from './OnchainKitProviderBoundary';
 import { DEFAULT_PRIVACY_URL, DEFAULT_TERMS_URL } from './core/constants';
-import { createWagmiConfig } from './core/createWagmiConfig';
 import type { OnchainKitContextType } from './core/types';
 import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from './identity/constants';
-import { useProviderDependencies } from './internal/hooks/useProviderDependencies';
 import { checkHashLength } from './internal/utils/checkHashLength';
 import type { OnchainKitProviderReact } from './types';
 
@@ -85,50 +82,15 @@ export function OnchainKitProvider({
     sessionId,
   ]);
 
-  // Check the React context for WagmiProvider and QueryClientProvider
-  const { providedWagmiConfig, providedQueryClient } =
-    useProviderDependencies();
-
-  const defaultConfig = useMemo(() => {
-    // IMPORTANT: Don't create a new Wagmi configuration if one already exists
-    // This prevents the user-provided WagmiConfig from being overridden
-    return (
-      providedWagmiConfig ||
-      createWagmiConfig({
-        apiKey,
-        appName: value.config.appearance.name,
-        appLogoUrl: value.config.appearance.logo,
-      })
-    );
-  }, [
-    apiKey,
-    providedWagmiConfig,
-    value.config.appearance.name,
-    value.config.appearance.logo,
-  ]);
-  const defaultQueryClient = useMemo(() => {
-    // IMPORTANT: Don't create a new QueryClient if one already exists
-    // This prevents the user-provided QueryClient from being overridden
-    return providedQueryClient || new QueryClient();
-  }, [providedQueryClient]);
-
-  // If both dependencies are missing, return a context with default parent providers
-  // If only one dependency is provided, expect the user to also provide the missing one
-  if (!providedWagmiConfig && !providedQueryClient) {
-    return (
-      <WagmiProvider config={defaultConfig}>
-        <QueryClientProvider client={defaultQueryClient}>
-          <OnchainKitContext.Provider value={value}>
-            <OnchainKitProviderBoundary>{children}</OnchainKitProviderBoundary>
-          </OnchainKitContext.Provider>
-        </QueryClientProvider>
-      </WagmiProvider>
-    );
-  }
-
   return (
-    <OnchainKitContext.Provider value={value}>
-      <OnchainKitProviderBoundary>{children}</OnchainKitProviderBoundary>
-    </OnchainKitContext.Provider>
+    <DefaultOnchainKitProviders
+      apiKey={apiKey}
+      appName={value.config.appearance.name}
+      appLogoUrl={value.config.appearance.logo}
+    >
+      <OnchainKitContext.Provider value={value}>
+        <OnchainKitProviderBoundary>{children}</OnchainKitProviderBoundary>
+      </OnchainKitContext.Provider>
+    </DefaultOnchainKitProviders>
   );
 }

--- a/src/core/createWagmiConfig.ts
+++ b/src/core/createWagmiConfig.ts
@@ -11,16 +11,17 @@ export const createWagmiConfig = ({
   apiKey,
   appName,
   appLogoUrl,
+  connectors = [
+    coinbaseWallet({
+      appName,
+      appLogoUrl,
+      preference: 'all',
+    }),
+  ],
 }: CreateWagmiConfigParams) => {
   return createConfig({
     chains: [base, baseSepolia],
-    connectors: [
-      coinbaseWallet({
-        appName,
-        appLogoUrl,
-        preference: 'all',
-      }),
-    ],
+    connectors,
     storage: createStorage({
       storage: cookieStorage,
     }),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,6 @@
 import type { EASSchemaUid } from '@/identity/types';
 import type { Address, Chain } from 'viem';
+import type { CreateConnectorFn } from 'wagmi';
 
 /**
  * Note: exported as public Type
@@ -38,6 +39,8 @@ export type CreateWagmiConfigParams = {
   appName?: string;
   /** Application logo URL */
   appLogoUrl?: string;
+  /** Connectors to use, defaults to coinbaseWallet */
+  connectors?: CreateConnectorFn[];
 };
 
 /**

--- a/src/minikit/MiniKitProvider.test.tsx
+++ b/src/minikit/MiniKitProvider.test.tsx
@@ -1,0 +1,334 @@
+import sdk, { type Context } from '@farcaster/frame-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { act, useContext } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { http, WagmiProvider, createConfig } from 'wagmi';
+import { base } from 'wagmi/chains';
+import { MiniKitContext, MiniKitProvider } from './MiniKitProvider';
+import type { MiniKitContextType } from './types';
+
+vi.mock('@farcaster/frame-sdk', () => {
+  let listeners: Record<string, (data: object) => void> = {};
+
+  return {
+    default: {
+      emit: vi.fn((event: string, data: object) => {
+        if (listeners[event]) {
+          listeners[event](data);
+        }
+      }),
+      on: vi.fn((event, callback) => {
+        listeners[event] = callback;
+      }),
+      removeAllListeners: vi.fn(() => {
+        listeners = {};
+      }),
+      context: vi.fn(),
+    },
+  };
+});
+
+vi.mock('@farcaster/frame-wagmi-connector', () => ({
+  farcasterFrame: vi.fn(),
+}));
+
+const mockConfig = {
+  chains: [base],
+  connectors: [],
+  transports: { [base.id]: http() },
+} as const;
+
+const queryClient = new QueryClient();
+
+describe('MiniKitProvider', () => {
+  beforeEach(() => {
+    vi.mocked(sdk).context = Promise.resolve({
+      client: {
+        notificationDetails: null,
+        added: false,
+        safeAreaInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      },
+    }) as unknown as Promise<Context.FrameContext>;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should load context initially', async () => {
+    let contextValue: MiniKitContextType | undefined;
+
+    function TestComponent() {
+      contextValue = useContext(MiniKitContext);
+      return null;
+    }
+
+    render(
+      <WagmiProvider config={createConfig(mockConfig)}>
+        <QueryClientProvider client={queryClient}>
+          <MiniKitProvider
+            chain={mockConfig.chains[0]}
+            config={{
+              appearance: {
+                name: 'Test App',
+                logo: 'https://example.com/icon.png',
+              },
+            }}
+          >
+            <TestComponent />
+          </MiniKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    expect(contextValue?.context).toBeNull();
+    expect(contextValue?.notificationProxyUrl).toBe('/api/notify');
+    expect(typeof contextValue?.updateClientContext).toBe('function');
+
+    await act(() => Promise.resolve());
+
+    expect(contextValue?.context).not.toBeNull();
+  });
+
+  it('should handle rejected context', async () => {
+    let contextValue: MiniKitContextType | undefined;
+
+    function TestComponent() {
+      contextValue = useContext(MiniKitContext);
+      contextValue?.updateClientContext({
+        details: {
+          url: 'https://example.com',
+          token: '1234567890',
+        },
+      });
+      return null;
+    }
+
+    vi.mocked(sdk).context = Promise.reject();
+
+    await act(async () => {
+      render(
+        <WagmiProvider config={createConfig(mockConfig)}>
+          <QueryClientProvider client={queryClient}>
+            <MiniKitProvider chain={mockConfig.chains[0]}>
+              <TestComponent />
+            </MiniKitProvider>
+          </QueryClientProvider>
+        </WagmiProvider>,
+      );
+    });
+
+    expect(contextValue?.context).toBeNull();
+  });
+
+  it('should render children with safe area insets', async () => {
+    const { container } = render(
+      <WagmiProvider config={createConfig(mockConfig)}>
+        <QueryClientProvider client={queryClient}>
+          <MiniKitProvider chain={mockConfig.chains[0]}>
+            <div>Test Child</div>
+          </MiniKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    expect(container.querySelector('div')).toHaveStyle({
+      paddingTop: '0px',
+      paddingBottom: '0px',
+      paddingLeft: '0px',
+      paddingRight: '0px',
+    });
+  });
+
+  it('should set up frame event listeners', async () => {
+    render(
+      <WagmiProvider config={createConfig(mockConfig)}>
+        <QueryClientProvider client={queryClient}>
+          <MiniKitProvider chain={mockConfig.chains[0]}>
+            <div>Test Child</div>
+          </MiniKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    expect(sdk.on).toHaveBeenCalledWith('frameAdded', expect.any(Function));
+    expect(sdk.on).toHaveBeenCalledWith('frameRemoved', expect.any(Function));
+    expect(sdk.on).toHaveBeenCalledWith(
+      'notificationsEnabled',
+      expect.any(Function),
+    );
+    expect(sdk.on).toHaveBeenCalledWith(
+      'notificationsDisabled',
+      expect.any(Function),
+    );
+  });
+
+  it('should clean up listeners on unmount', async () => {
+    const { unmount } = render(
+      <WagmiProvider config={createConfig(mockConfig)}>
+        <QueryClientProvider client={queryClient}>
+          <MiniKitProvider chain={mockConfig.chains[0]}>
+            <div>Test Child</div>
+          </MiniKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    await act(() => Promise.resolve());
+    unmount();
+
+    expect(sdk.removeAllListeners).toHaveBeenCalled();
+  });
+
+  it('should update context when frame is added and removed', async () => {
+    let contextValue: MiniKitContextType | undefined;
+
+    function TestComponent() {
+      const context = useContext(MiniKitContext);
+      contextValue = context;
+      return null;
+    }
+
+    render(
+      <WagmiProvider config={createConfig(mockConfig)}>
+        <QueryClientProvider client={queryClient}>
+          <MiniKitProvider chain={mockConfig.chains[0]}>
+            <TestComponent />
+          </MiniKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    const notificationDetails = {
+      url: 'https://example.com',
+      token: '1234567890',
+    };
+
+    act(() => {
+      sdk.emit('frameAdded', {
+        notificationDetails,
+      });
+    });
+
+    expect(contextValue?.context?.client.notificationDetails).toEqual(
+      notificationDetails,
+    );
+    expect(contextValue?.context?.client.added).toBe(true);
+
+    act(() => {
+      sdk.emit('frameRemoved');
+    });
+
+    expect(contextValue?.context?.client.notificationDetails).toBeUndefined();
+    expect(contextValue?.context?.client.added).toBe(false);
+  });
+
+  it('should log an error when frameAddRejected is emitted', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(vi.fn());
+
+    render(
+      <WagmiProvider config={createConfig(mockConfig)}>
+        <QueryClientProvider client={queryClient}>
+          <MiniKitProvider chain={mockConfig.chains[0]}>
+            <div>Test Child</div>
+          </MiniKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    sdk.emit('frameAddRejected', {
+      reason: 'invalid_domain_manifest',
+    });
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'Frame add rejected',
+      'invalid_domain_manifest',
+    );
+  });
+
+  it('should update context when notifications are enabled and remove when disabled', async () => {
+    let contextValue: MiniKitContextType | undefined;
+
+    function TestComponent() {
+      const context = useContext(MiniKitContext);
+      contextValue = context;
+      return null;
+    }
+
+    render(
+      <WagmiProvider config={createConfig(mockConfig)}>
+        <QueryClientProvider client={queryClient}>
+          <MiniKitProvider chain={mockConfig.chains[0]}>
+            <TestComponent />
+          </MiniKitProvider>
+        </QueryClientProvider>
+      </WagmiProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    const notificationDetails = {
+      url: 'https://example.com',
+      token: '1234567890',
+    };
+
+    act(() => {
+      sdk.emit('notificationsEnabled', {
+        notificationDetails,
+      });
+    });
+
+    expect(contextValue?.context?.client.notificationDetails).toEqual(
+      notificationDetails,
+    );
+
+    act(() => {
+      sdk.emit('notificationsDisabled');
+    });
+
+    expect(contextValue?.context?.client.notificationDetails).toBeUndefined();
+  });
+
+  it('should handle context fetch error', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    vi.mocked(sdk).context = Promise.reject(new Error('Test error'));
+
+    let contextValue: MiniKitContextType | undefined;
+    function TestComponent() {
+      contextValue = useContext(MiniKitContext);
+      return null;
+    }
+
+    await act(async () => {
+      render(
+        <WagmiProvider config={createConfig(mockConfig)}>
+          <QueryClientProvider client={queryClient}>
+            <MiniKitProvider chain={mockConfig.chains[0]}>
+              <TestComponent />
+            </MiniKitProvider>
+          </QueryClientProvider>
+        </WagmiProvider>,
+      );
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error fetching context:',
+      expect.any(Error),
+    );
+    expect(contextValue?.context).toBeNull();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/minikit/MiniKitProvider.tsx
+++ b/src/minikit/MiniKitProvider.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { DefaultOnchainKitProviders } from '@/DefaultOnchainKitProviders';
+import { OnchainKitProvider } from '@/OnchainKitProvider';
+import type { OnchainKitProviderReact } from '@/types';
+import sdk, { type Context } from '@farcaster/frame-sdk';
+import { farcasterFrame } from '@farcaster/frame-wagmi-connector';
+import {
+  createContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { coinbaseWallet } from 'wagmi/connectors';
+import type {
+  MiniKitContextType,
+  MiniKitProviderReact,
+  UpdateClientContextParams,
+} from './types';
+
+export const emptyContext = {} as MiniKitContextType;
+
+export const MiniKitContext = createContext<MiniKitContextType>(emptyContext);
+
+/**
+ * Provides the MiniKit React Context to the app.
+ */
+export function MiniKitProvider({
+  children,
+  notificationProxyUrl = '/api/notify',
+  ...onchainKitProps
+}: MiniKitProviderReact & OnchainKitProviderReact) {
+  const [context, setContext] = useState<Context.FrameContext | null>(null);
+
+  useEffect(() => {
+    sdk.on('frameAdded', ({ notificationDetails }) => {
+      if (notificationDetails) {
+        updateClientContext({
+          details: notificationDetails,
+          frameAdded: true,
+        });
+      }
+    });
+
+    sdk.on('frameAddRejected', ({ reason }) => {
+      console.error('Frame add rejected', reason);
+    });
+
+    sdk.on('frameRemoved', () => {
+      updateClientContext({
+        details: undefined,
+        frameAdded: false,
+      });
+    });
+
+    sdk.on('notificationsEnabled', ({ notificationDetails }) => {
+      updateClientContext({
+        details: notificationDetails,
+      });
+    });
+
+    sdk.on('notificationsDisabled', () => {
+      updateClientContext({
+        details: undefined,
+      });
+    });
+
+    async function fetchContext() {
+      try {
+        // if not running in a frame, context resolves as undefined
+        const context = await sdk.context;
+        setContext(context);
+      } catch (error) {
+        console.error('Error fetching context:', error);
+      }
+    }
+
+    fetchContext();
+
+    return () => {
+      sdk.removeAllListeners();
+    };
+  }, []);
+
+  const updateClientContext = useCallback(
+    ({ details, frameAdded }: UpdateClientContextParams) => {
+      setContext((prevContext) => {
+        if (!prevContext) {
+          return null;
+        }
+        return {
+          ...prevContext,
+          client: {
+            ...prevContext.client,
+            notificationDetails: details ?? undefined,
+            added: frameAdded ?? prevContext.client.added,
+          },
+        };
+      });
+    },
+    [],
+  );
+
+  const connectors = useMemo(() => {
+    return [
+      context // if context is set, the app is running in a frame, use farcasterFrame connector
+        ? farcasterFrame()
+        : coinbaseWallet({
+            appName: process.env.NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME,
+            appLogoUrl: process.env.NEXT_PUBLIC_ICON_URL,
+            preference: 'all',
+          }),
+    ];
+  }, [context]);
+
+  const value = useMemo(() => {
+    return {
+      context,
+      updateClientContext,
+      notificationProxyUrl,
+    };
+  }, [updateClientContext, notificationProxyUrl, context]);
+
+  return (
+    <MiniKitContext.Provider value={value}>
+      <DefaultOnchainKitProviders
+        apiKey={onchainKitProps.apiKey}
+        appName={onchainKitProps.config?.appearance?.name ?? undefined}
+        appLogoUrl={onchainKitProps.config?.appearance?.logo ?? undefined}
+        connectors={connectors}
+      >
+        <OnchainKitProvider {...onchainKitProps}>
+          <div
+            style={{
+              paddingTop: context?.client.safeAreaInsets?.top ?? 0,
+              paddingBottom: context?.client.safeAreaInsets?.bottom ?? 0,
+              paddingLeft: context?.client.safeAreaInsets?.left ?? 0,
+              paddingRight: context?.client.safeAreaInsets?.right ?? 0,
+            }}
+          >
+            {children}
+          </div>
+        </OnchainKitProvider>
+      </DefaultOnchainKitProviders>
+    </MiniKitContext.Provider>
+  );
+}

--- a/src/minikit/index.ts
+++ b/src/minikit/index.ts
@@ -1,0 +1,2 @@
+export { MiniKitProvider } from './MiniKitProvider';
+export type { MiniKitProviderReact } from './types';

--- a/src/minikit/types.ts
+++ b/src/minikit/types.ts
@@ -1,0 +1,27 @@
+import type { Context, FrameNotificationDetails } from '@farcaster/frame-sdk';
+
+export type UpdateClientContextParams = {
+  details?: FrameNotificationDetails | null;
+  frameAdded?: boolean;
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type MiniKitProviderReact = {
+  children: React.ReactNode;
+  /*
+   * The URL of the notification proxy.
+   * Notifications are sent by posting a cross origin request to a url returned by
+   * the frames context.  This prop allows you to set a custom proxy route for MiniKits
+   * notification related hooks to use.
+   * @default `/api/notify`
+   */
+  notificationProxyUrl?: string;
+};
+
+export type MiniKitContextType = {
+  context: Context.FrameContext | null;
+  updateClientContext: (params: UpdateClientContextParams) => void;
+  notificationProxyUrl: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2037,6 +2037,8 @@ __metadata:
     "@biomejs/biome": "npm:1.8.3"
     "@changesets/cli": "npm:^2.27.10"
     "@chromatic-com/storybook": "npm:^1.7.0"
+    "@farcaster/frame-sdk": "npm:^0.0.28"
+    "@farcaster/frame-wagmi-connector": "npm:^0.0.16"
     "@storybook/addon-a11y": "npm:^8.2.9"
     "@storybook/addon-essentials": "npm:^8.2.9"
     "@storybook/addon-interactions": "npm:^8.2.9"
@@ -2526,6 +2528,39 @@ __metadata:
     ethereum-cryptography: "npm:^2.0.0"
     micro-ftch: "npm:^0.3.1"
   checksum: 4e6e0449236f66b53782bab3b387108f0ddc050835bfe1381c67a7c038fea27cb85ab38851d98b700957022f0acb6e455ca0c634249cfcce1a116bad76500160
+  languageName: node
+  linkType: hard
+
+"@farcaster/frame-core@npm:0.0.26":
+  version: 0.0.26
+  resolution: "@farcaster/frame-core@npm:0.0.26"
+  dependencies:
+    ox: "npm:^0.4.4"
+    zod: "npm:^3.24.1"
+  checksum: 4be35197af05ef13dbda9a836e2e64e00c1a99fea03dc72a6926a29831ac2c5f33c52b631672506e36a9b371a5d16027b28cd90d237f061c7fd979fc9f1147f0
+  languageName: node
+  linkType: hard
+
+"@farcaster/frame-sdk@npm:^0.0.28":
+  version: 0.0.28
+  resolution: "@farcaster/frame-sdk@npm:0.0.28"
+  dependencies:
+    "@farcaster/frame-core": "npm:0.0.26"
+    comlink: "npm:^4.4.2"
+    eventemitter3: "npm:^5.0.1"
+    ox: "npm:^0.4.4"
+  checksum: 541c0fce0b4195dc340a2c1d82ae4a9a371f700d37876e5e9d82dcf20d254ec011d20d4cd6cb335cd73128371d7f179bb267a1b809bace0684447a8279a8bea6
+  languageName: node
+  linkType: hard
+
+"@farcaster/frame-wagmi-connector@npm:^0.0.16":
+  version: 0.0.16
+  resolution: "@farcaster/frame-wagmi-connector@npm:0.0.16"
+  peerDependencies:
+    "@farcaster/frame-sdk": ^0.0.28
+    "@wagmi/core": ^2.14.1
+    viem: ^2.21.55
+  checksum: 830fd2125821dcb97ad821b9bd0a85eacd1cd0f964d18fbbe453f8454fd22a85ab60cfd03eb6f442e6b77bcd3c0c0c063d5429596034c6911bca99cec64e75d6
   languageName: node
   linkType: hard
 
@@ -6676,6 +6711,13 @@ __metadata:
   dependencies:
     delayed-stream: "npm:~1.0.0"
   checksum: 0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
+  languageName: node
+  linkType: hard
+
+"comlink@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "comlink@npm:4.4.2"
+  checksum: 38aa1f455cf08e94aaa8fc494fd203cc0ef02ece6c21404b7931ce17567e8a72deacddab98aa5650cfd78332ff24c34610586f6fb27fd19dc77e753ed1980deb
   languageName: node
   linkType: hard
 
@@ -11499,6 +11541,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ox@npm:^0.4.4":
+  version: 0.4.4
+  resolution: "ox@npm:0.4.4"
+  dependencies:
+    "@adraffy/ens-normalize": "npm:^1.10.1"
+    "@noble/curves": "npm:^1.6.0"
+    "@noble/hashes": "npm:^1.5.0"
+    "@scure/bip32": "npm:^1.5.0"
+    "@scure/bip39": "npm:^1.4.0"
+    abitype: "npm:^1.0.6"
+    eventemitter3: "npm:5.0.1"
+  peerDependencies:
+    typescript: ">=5.4.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: ce1539ec41c97f6d8386ea8f0cdd85d4af025d3b7a6762607aa1a6545f550ca637abba8c9be4b26f6bf2136f16ccd579454e6976ee06ddde7225ac8fcfd4254d
+  languageName: node
+  linkType: hard
+
 "p-defer@npm:^1.0.0":
   version: 1.0.0
   resolution: "p-defer@npm:1.0.0"
@@ -15267,6 +15329,13 @@ __metadata:
   dependencies:
     "@types/yoga-layout": "npm:1.9.2"
   checksum: e83b6b7078faf4d0472461b53e92bf9cae655de3d896aee5f79b5ba5a960e507bbf8e671b261db13137bf18711686969f19fd1d9c4669beb1d70754b83c5879d
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.24.1":
+  version: 3.24.1
+  resolution: "zod@npm:3.24.1"
+  checksum: 0223d21dbaa15d8928fe0da3b54696391d8e3e1e2d0283a1a070b5980a1dbba945ce631c2d1eccc088fdbad0f2dfa40155590bf83732d3ac4fcca2cc9237591b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What changed? Why?**
* Add MiniKitProvider
  * Provides global access to context 
  * Hooks up event listeners
  * Updates internal context state with notification details
  * Adds SafeAreaInsets
* Extract Default wagmi/query provider logic to DefaultOnchainKitProviders to reuse allowing consumers to wrap MiniKitProvider with their own wagmi/react-query

**Notes to reviewers**

**How has it been tested?**
