### PR TITLE
fix: `getPriceQuote` type

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -414,6 +414,6 @@ type PriceQuote = {
 export type GetPriceQuoteResponse =
   | {
       /** The array of price quotes for the tokens */
-      priceQuote: PriceQuote[];
+      priceQuotes: PriceQuote[];
     }
   | APIError;

--- a/src/internal/hooks/useExchangeRate.test.tsx
+++ b/src/internal/hooks/useExchangeRate.test.tsx
@@ -35,7 +35,7 @@ describe('useExchangeRate', () => {
     const mockSetExchangeRateLoading = vi.fn();
 
     (getPriceQuote as Mock).mockResolvedValue({
-      priceQuote: [
+      priceQuotes: [
         {
           name: 'ETH',
           symbol: 'ETH',
@@ -65,7 +65,7 @@ describe('useExchangeRate', () => {
     const mockSetExchangeRateLoading = vi.fn();
 
     (getPriceQuote as Mock).mockResolvedValue({
-      priceQuote: [
+      priceQuotes: [
         {
           name: 'ETH',
           symbol: 'ETH',
@@ -147,7 +147,7 @@ describe('useExchangeRate', () => {
     const mockSetExchangeRateLoading = vi.fn();
 
     (getPriceQuote as Mock).mockResolvedValue({
-      priceQuote: [
+      priceQuotes: [
         {
           name: 'ETH',
           symbol: 'ETH',

--- a/src/internal/hooks/useExchangeRate.tsx
+++ b/src/internal/hooks/useExchangeRate.tsx
@@ -32,7 +32,7 @@ export async function useExchangeRate({
       console.error('Error fetching price quote:', response.error);
       return;
     }
-    const priceQuote = response.priceQuote[0];
+    const priceQuote = response.priceQuotes[0];
 
     const rate =
       selectedInputType === 'crypto'


### PR DESCRIPTION
**What changed? Why?**
* fix incorrect `getPriceQuote` type. the api returns an object with `priceQuotes` plural. the key previously was singular

**Notes to reviewers**

**How has it been tested?**
in local playground

API response
![image](https://github.com/user-attachments/assets/59573470-2946-4368-9047-e0c0a7ce0be1)

Send demo
![image](https://github.com/user-attachments/assets/f98b4266-7912-4068-8139-e4a017f86139)
