### PR TITLE
feat: signature

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,6 +190,12 @@
       "import": "./esm/nft/components/mint/index.js",
       "default": "./esm/nft/components/mint/index.js"
     },
+    "./signature": {
+      "types": "./esm/signature/index.d.ts",
+      "module": "./esm/signature/index.js",
+      "import": "./esm/signature/index.js",
+      "default": "./esm/signature/index.js"
+    },
     "./swap": {
       "types": "./esm/swap/index.d.ts",
       "module": "./esm/swap/index.js",

--- a/playground/nextjs-app-router/components/Demo.tsx
+++ b/playground/nextjs-app-router/components/Demo.tsx
@@ -16,6 +16,7 @@ import NFTCardDemo from './demo/NFTCard';
 import NFTCardDefaultDemo from './demo/NFTCardDefault';
 import NFTMintCardDemo from './demo/NFTMintCard';
 import NFTMintCardDefaultDemo from './demo/NFTMintCardDefault';
+import SignatureDemo from './demo/Signature';
 import SwapDemo from './demo/Swap';
 import SwapDefaultDemo from './demo/SwapDefault';
 import TransactionDemo from './demo/Transaction';
@@ -45,6 +46,7 @@ const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
   [OnchainKitComponent.NFTCardDefault]: NFTCardDefaultDemo,
   [OnchainKitComponent.IdentityCard]: IdentityCardDemo,
   [OnchainKitComponent.Earn]: EarnDemo,
+  [OnchainKitComponent.Signature]: SignatureDemo,
 };
 
 export default function Demo() {

--- a/playground/nextjs-app-router/components/DemoOptions.tsx
+++ b/playground/nextjs-app-router/components/DemoOptions.tsx
@@ -63,6 +63,7 @@ const COMPONENT_CONFIG: Partial<
     NFTOptions,
   ],
   [OnchainKitComponent.Earn]: [EarnOptions],
+  [OnchainKitComponent.Signature]: [Chain],
 };
 
 export default function DemoOptions({

--- a/playground/nextjs-app-router/components/demo/Signature.tsx
+++ b/playground/nextjs-app-router/components/demo/Signature.tsx
@@ -1,0 +1,79 @@
+import type { APIError } from '@coinbase/onchainkit/api';
+import {
+  type LifecycleStatus,
+  Signature,
+} from '@coinbase/onchainkit/signature';
+import { encodeAbiParameters } from 'viem';
+import { base } from 'viem/chains';
+
+const SCHEMA_UID =
+  '0xf58b8b212ef75ee8cd7e8d803c37c03e0519890502d5e99ee2412aae1456cafe';
+const EAS_CONTRACT = '0x4200000000000000000000000000000000000021';
+
+export default function Transaction() {
+  const domain = {
+    name: 'EAS Attestation',
+    version: '1.0.0',
+    chainId: base.id,
+    verifyingContract: EAS_CONTRACT,
+  } as const;
+
+  const types = {
+    Attest: [
+      { name: 'schema', type: 'bytes32' },
+      { name: 'recipient', type: 'address' },
+      { name: 'time', type: 'uint64' },
+      { name: 'revocable', type: 'bool' },
+      { name: 'refUID', type: 'bytes32' },
+      { name: 'data', type: 'bytes' },
+      { name: 'value', type: 'uint256' },
+    ],
+  } as const;
+
+  const message = {
+    schema: SCHEMA_UID,
+    recipient: '0x0000000000000000000000000000000000000000',
+    time: BigInt(0),
+    revocable: false,
+    refUID:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    data: encodeAbiParameters([{ type: 'string' }], ['test attestation']),
+    value: BigInt(0),
+  } as const;
+
+  const handleOnSuccess = (signature: string) => {
+    console.log(signature);
+  };
+
+  const handleOnStatus = (status: LifecycleStatus) => {
+    console.log(status);
+  };
+
+  const handleOnError = (error: APIError) => {
+    console.log(error);
+  };
+
+  return (
+    <div className="w-200">
+      <Signature
+        domain={domain}
+        types={types}
+        message={message}
+        primaryType="Attest"
+        label="EIP712"
+        onSuccess={handleOnSuccess}
+        onStatus={handleOnStatus}
+        onError={handleOnError}
+        resetAfter={1000}
+      />
+      <div className="mt-8" />
+      <Signature
+        message="test message"
+        label="personal_sign"
+        onSuccess={handleOnSuccess}
+        onStatus={handleOnStatus}
+        onError={handleOnError}
+      />
+    </div>
+  );
+}

--- a/playground/nextjs-app-router/components/form/active-component.tsx
+++ b/playground/nextjs-app-router/components/form/active-component.tsx
@@ -69,6 +69,9 @@ export function ActiveComponent() {
             NFT Mint Card Default
           </SelectItem>
           <SelectItem value={OnchainKitComponent.Earn}>Earn</SelectItem>
+          <SelectItem value={OnchainKitComponent.Signature}>
+            Signature
+          </SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/playground/nextjs-app-router/onchainkit/package.json
+++ b/playground/nextjs-app-router/onchainkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coinbase/onchainkit",
-  "version": "0.37.5",
+  "version": "0.37.7",
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",
@@ -35,6 +35,8 @@
     "react-dom": "^18 || ^19"
   },
   "dependencies": {
+    "@farcaster/frame-sdk": "^0.0.28",
+    "@farcaster/frame-wagmi-connector": "^0.0.16",
     "@tanstack/react-query": "^5",
     "clsx": "^2.1.1",
     "graphql": "^14 || ^15 || ^16",
@@ -164,6 +166,12 @@
       "import": "./esm/identity/index.js",
       "default": "./esm/identity/index.js"
     },
+    "./minikit": {
+      "types": "./esm/minikit/index.d.ts",
+      "module": "./esm/minikit/index.js",
+      "import": "./esm/minikit/index.js",
+      "default": "./esm/minikit/index.js"
+    },    
     "./nft": {
       "types": "./esm/nft/index.d.ts",
       "module": "./esm/nft/index.js",
@@ -181,6 +189,12 @@
       "module": "./esm/nft/components/mint/index.js",
       "import": "./esm/nft/components/mint/index.js",
       "default": "./esm/nft/components/mint/index.js"
+    },
+    "./signature": {
+      "types": "./esm/signature/index.d.ts",
+      "module": "./esm/signature/index.js",
+      "import": "./esm/signature/index.js",
+      "default": "./esm/signature/index.js"
     },
     "./swap": {
       "types": "./esm/swap/index.d.ts",

--- a/playground/nextjs-app-router/types/onchainkit.ts
+++ b/playground/nextjs-app-router/types/onchainkit.ts
@@ -18,6 +18,7 @@ export enum OnchainKitComponent {
   NFTMintCard = 'nft-mint-card',
   NFTMintCardDefault = 'nft-mint-card-default',
   Earn = 'earn',
+  Signature = 'signature',
 }
 
 export enum TransactionTypes {

--- a/src/internal/components/Toast.tsx
+++ b/src/internal/components/Toast.tsx
@@ -3,7 +3,7 @@ import { background, cn } from '../../styles/theme';
 import { CloseSvg } from '../svg/closeSvg';
 import { getToastPosition } from '../utils/getToastPosition';
 
-type ToastProps = {
+export type ToastProps = {
   className?: string;
   durationMs?: number;
   startTimeout?: boolean;

--- a/src/signature/components/Signature.test.tsx
+++ b/src/signature/components/Signature.test.tsx
@@ -1,0 +1,135 @@
+import { useIsMounted } from '@/internal/hooks/useIsMounted';
+import { render, screen } from '@testing-library/react';
+import { encodeAbiParameters } from 'viem';
+import { base } from 'viem/chains';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Signature } from './Signature';
+
+vi.mock('@/internal/hooks/useTheme', () => ({
+  useTheme: vi.fn(() => 'default-light'),
+}));
+vi.mock('@/internal/hooks/useIsMounted');
+vi.mock('./SignatureProvider', () => ({
+  SignatureProvider: vi.fn(({ children }) => (
+    <div data-testid="SignatureProvider">{children}</div>
+  )),
+}));
+vi.mock('./SignatureStatus', () => ({
+  SignatureStatus: vi.fn(() => <div>SignatureStatus</div>),
+}));
+vi.mock('./SignatureToast', () => ({
+  SignatureToast: vi.fn(() => <div>SignatureToast</div>),
+}));
+vi.mock('./SignatureButton', () => ({
+  SignatureButton: vi.fn(({ label, disabled }) => (
+    <button type="button" disabled={disabled}>
+      {label}
+    </button>
+  )),
+}));
+
+const SCHEMA_UID =
+  '0xf58b8b212ef75ee8cd7e8d803c37c03e0519890502d5e99ee2412aae1456cafe';
+const EAS_CONTRACT = '0x4200000000000000000000000000000000000021';
+
+const domain = {
+  name: 'EAS Attestation',
+  version: '1.0.0',
+  chainId: base.id,
+  verifyingContract: EAS_CONTRACT,
+} as const;
+
+const types = {
+  Attest: [
+    { name: 'schema', type: 'bytes32' },
+    { name: 'recipient', type: 'address' },
+    { name: 'time', type: 'uint64' },
+    { name: 'revocable', type: 'bool' },
+    { name: 'refUID', type: 'bytes32' },
+    { name: 'data', type: 'bytes' },
+    { name: 'value', type: 'uint256' },
+  ],
+} as const;
+
+const message = {
+  schema: SCHEMA_UID,
+  recipient: '0x0000000000000000000000000000000000000000',
+  time: BigInt(0),
+  revocable: false,
+  refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  data: encodeAbiParameters([{ type: 'string' }], ['test attestation']),
+  value: BigInt(0),
+} as const;
+
+describe('Signature', () => {
+  beforeEach(() => {
+    (useIsMounted as Mock).mockReturnValue(true);
+  });
+
+  it('should render an empty div if not mounted', () => {
+    (useIsMounted as Mock).mockReturnValue(false);
+
+    render(<Signature message="test" />);
+
+    expect(screen.queryByTestId('SignatureProvider')).not.toBeInTheDocument();
+  });
+
+  it('should render with valid EIP712 typed data', () => {
+    render(
+      <Signature
+        domain={domain}
+        types={types}
+        message={message}
+        primaryType="Attest"
+        label="EIP712"
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('EIP712')).toBeInTheDocument();
+  });
+
+  it('should render with valid signable message', () => {
+    render(
+      <Signature
+        message="test message"
+        label="personal_sign"
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('personal_sign')).toBeInTheDocument();
+  });
+
+  it('should render custom children instead of default button', () => {
+    render(
+      <Signature message="test message" onSuccess={vi.fn()}>
+        <button type="button">Custom Button</button>
+      </Signature>,
+    );
+
+    expect(screen.getByText('Custom Button')).toBeInTheDocument();
+  });
+
+  it('should apply a custom className', () => {
+    render(
+      <Signature
+        message="test message"
+        className="custom-class"
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('SignatureProvider').firstChild).toHaveClass(
+      'custom-class',
+    );
+  });
+
+  it('should disable the button when disabled prop is true', () => {
+    render(
+      <Signature message="test message" disabled={true} onSuccess={vi.fn()} />,
+    );
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/src/signature/components/Signature.tsx
+++ b/src/signature/components/Signature.tsx
@@ -1,0 +1,68 @@
+import { useIsMounted } from '@/internal/hooks/useIsMounted';
+import { useTheme } from '@/internal/hooks/useTheme';
+import { cn } from '@/styles/theme';
+import type { SignatureReact } from '../types';
+import { SignatureButton } from './SignatureButton';
+import { SignatureProvider } from './SignatureProvider';
+import { SignatureStatus } from './SignatureStatus';
+import { SignatureToast } from './SignatureToast';
+
+function SignatureDefaultContent({
+  label,
+  disabled,
+}: Pick<SignatureReact, 'label' | 'disabled'>) {
+  return (
+    <>
+      <SignatureButton label={label} disabled={disabled} />
+      <SignatureStatus />
+      <SignatureToast />
+    </>
+  );
+}
+
+export function Signature({
+  className,
+  domain,
+  types,
+  message,
+  primaryType,
+  children,
+  label,
+  disabled = false,
+  onSuccess,
+  onStatus,
+  onError,
+  resetAfter,
+}: SignatureReact) {
+  const isMounted = useIsMounted();
+  const componentTheme = useTheme();
+
+  if (!isMounted) {
+    return (
+      <div
+        className={cn(componentTheme, 'flex w-full flex-col gap-2', className)}
+      />
+    );
+  }
+
+  return (
+    <SignatureProvider
+      onSuccess={onSuccess}
+      onStatus={onStatus}
+      onError={onError}
+      domain={domain}
+      types={types}
+      message={message}
+      primaryType={primaryType}
+      resetAfter={resetAfter}
+    >
+      <div
+        className={cn(componentTheme, 'flex w-full flex-col gap-2', className)}
+      >
+        {children ?? (
+          <SignatureDefaultContent label={label} disabled={disabled} />
+        )}
+      </div>
+    </SignatureProvider>
+  );
+}

--- a/src/signature/components/SignatureButton.test.tsx
+++ b/src/signature/components/SignatureButton.test.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { useAccount } from 'wagmi';
+import { SignatureButton } from './SignatureButton';
+import { useSignatureContext } from './SignatureProvider';
+
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+}));
+
+vi.mock('./SignatureProvider', () => ({
+  useSignatureContext: vi.fn(),
+}));
+
+vi.mock('@/wallet/components/ConnectWallet', () => ({
+  ConnectWallet: vi.fn(({ children }) => (
+    <button type="button">{children}</button>
+  )),
+}));
+
+describe('SignatureButton', () => {
+  const mockHandleSign = vi.fn();
+
+  beforeEach(() => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'init',
+      },
+      handleSign: mockHandleSign,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render ConnectWallet when no address is connected', () => {
+    (useAccount as Mock).mockReturnValue({ address: undefined });
+
+    render(<SignatureButton />);
+    expect(screen.getByText('Connect Wallet')).toBeInTheDocument();
+  });
+
+  it('should render connect label when passed in', () => {
+    (useAccount as Mock).mockReturnValue({ address: undefined });
+
+    render(<SignatureButton connectLabel="Sign in please" />);
+    expect(screen.getByText('Sign in please')).toBeInTheDocument();
+  });
+
+  it('should render sign button when address is connected', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+
+    render(<SignatureButton label="Sign Message" />);
+    expect(screen.getByText('Sign Message')).toBeInTheDocument();
+  });
+
+  it('should render pending message when pending', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'pending',
+      },
+    });
+
+    render(<SignatureButton label="Sign Message" />);
+    expect(screen.getByText('Signing...')).toBeInTheDocument();
+  });
+
+  it('should render pending label when pending', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'pending',
+      },
+    });
+
+    render(<SignatureButton label="Sign Message" pendingLabel="Pending" />);
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('should render error message when error', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'error',
+      },
+    });
+
+    render(<SignatureButton label="Sign Message" />);
+    expect(screen.getByText('Try again')).toBeInTheDocument();
+  });
+
+  it('should render error label when error', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'error',
+      },
+    });
+
+    render(
+      <SignatureButton label="Sign Message" errorLabel="Try more things" />,
+    );
+    expect(screen.getByText('Try more things')).toBeInTheDocument();
+  });
+
+  it('should render success message when success', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+      },
+    });
+
+    render(<SignatureButton label="Sign Message" />);
+    expect(screen.getByText('Signed')).toBeInTheDocument();
+  });
+
+  it('should render success label when success', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+      },
+    });
+
+    render(<SignatureButton label="Sign Message" successLabel="done" />);
+    expect(screen.getByText('done')).toBeInTheDocument();
+  });
+
+  it('should call handleSign when clicked', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+
+    render(<SignatureButton label="Sign Message" />);
+    fireEvent.click(screen.getByText('Sign Message'));
+    expect(mockHandleSign).toHaveBeenCalled();
+  });
+
+  it('should apply custom className', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+
+    render(<SignatureButton label="Sign Message" className="custom-class" />);
+    expect(screen.getByRole('button')).toHaveClass('custom-class');
+  });
+
+  it('should disable button when disabled prop is true', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+
+    render(<SignatureButton label="Sign Message" disabled={true} />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('should use default label when none provided', () => {
+    (useAccount as Mock).mockReturnValue({ address: '0x123' });
+
+    render(<SignatureButton />);
+    expect(screen.getByText('Sign')).toBeInTheDocument();
+  });
+});

--- a/src/signature/components/SignatureButton.tsx
+++ b/src/signature/components/SignatureButton.tsx
@@ -1,0 +1,79 @@
+import { ConnectWallet } from '@/wallet/components/ConnectWallet';
+import { ConnectWalletText } from '@/wallet/components/ConnectWalletText';
+import { type ReactNode, useMemo } from 'react';
+import { useAccount } from 'wagmi';
+import { border, cn, color, pressable, text } from '../../styles/theme';
+import { useSignatureContext } from './SignatureProvider';
+
+type SignatureButtonProps = {
+  className?: string;
+  disabled?: boolean;
+  label?: ReactNode;
+  connectLabel?: ReactNode;
+  errorLabel?: ReactNode;
+  successLabel?: ReactNode;
+  pendingLabel?: ReactNode;
+};
+
+export function SignatureButton({
+  className,
+  disabled = false,
+  label = 'Sign',
+  connectLabel = 'Connect Wallet',
+  errorLabel = 'Try again',
+  successLabel = 'Signed',
+  pendingLabel = 'Signing...',
+}: SignatureButtonProps) {
+  const { handleSign, lifecycleStatus } = useSignatureContext();
+  const { address } = useAccount();
+
+  const buttonLabel = useMemo(() => {
+    if (lifecycleStatus.statusName === 'pending') {
+      return pendingLabel;
+    }
+
+    if (lifecycleStatus.statusName === 'error') {
+      return errorLabel;
+    }
+
+    if (lifecycleStatus.statusName === 'success') {
+      return successLabel;
+    }
+
+    return label;
+  }, [
+    lifecycleStatus.statusName,
+    label,
+    errorLabel,
+    successLabel,
+    pendingLabel,
+  ]);
+
+  if (!address) {
+    return (
+      <ConnectWallet className={cn('w-full', className)}>
+        <ConnectWalletText>{connectLabel}</ConnectWalletText>
+      </ConnectWallet>
+    );
+  }
+
+  return (
+    <button
+      className={cn(
+        pressable.primary,
+        border.radius,
+        'w-full rounded-xl',
+        'px-4 py-3 font-medium leading-6',
+        disabled && pressable.disabled,
+        text.headline,
+        color.inverse,
+        className,
+      )}
+      type="button"
+      onClick={handleSign}
+      disabled={disabled}
+    >
+      {buttonLabel}
+    </button>
+  );
+}

--- a/src/signature/components/SignatureIcon.test.tsx
+++ b/src/signature/components/SignatureIcon.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { type Mock, describe, expect, it, vi } from 'vitest';
+import { MessageType } from '../types';
+import { SignatureIcon } from './SignatureIcon';
+import { useSignatureContext } from './SignatureProvider';
+
+vi.mock('./SignatureProvider', () => ({
+  useSignatureContext: vi.fn(),
+}));
+vi.mock('../../internal/svg/errorSvg', () => ({
+  ErrorSvg: vi.fn(() => <div>ErrorSvg</div>),
+}));
+vi.mock('../../internal/svg/successSvg', () => ({
+  SuccessSvg: vi.fn(() => <div>SuccessSvg</div>),
+}));
+vi.mock('../../internal/components/Spinner', () => ({
+  Spinner: vi.fn(() => <div>Spinner</div>),
+}));
+
+describe('SignatureIcon', () => {
+  it('should render success icon', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+
+    render(<SignatureIcon />);
+    expect(screen.getByText('SuccessSvg')).toBeInTheDocument();
+  });
+
+  it('should render error icon', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'error',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+    render(<SignatureIcon />);
+    expect(screen.getByText('ErrorSvg')).toBeInTheDocument();
+  });
+
+  it('should render spinner icon', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'pending',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+    render(<SignatureIcon />);
+    expect(screen.getByText('Spinner')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+
+    render(<SignatureIcon className="custom-class" />);
+    expect(screen.getByText('SuccessSvg').parentElement).toHaveClass(
+      'custom-class',
+    );
+  });
+
+  it('should not render if no icon', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'init',
+        statusData: null,
+      },
+    });
+
+    render(<SignatureIcon />);
+    expect(screen.queryByTestId('ockSignatureIcon')).not.toBeInTheDocument();
+  });
+});

--- a/src/signature/components/SignatureIcon.tsx
+++ b/src/signature/components/SignatureIcon.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+import { Spinner } from '../../internal/components/Spinner';
+import { ErrorSvg } from '../../internal/svg/errorSvg';
+import { SuccessSvg } from '../../internal/svg/successSvg';
+import { cn, text } from '../../styles/theme';
+import { useSignatureContext } from './SignatureProvider';
+
+type SignatureIconProps = {
+  className?: string;
+};
+
+export function SignatureIcon({ className }: SignatureIconProps) {
+  const { lifecycleStatus } = useSignatureContext();
+
+  const icon = useMemo(() => {
+    if (lifecycleStatus.statusName === 'success') {
+      return <SuccessSvg />;
+    }
+    if (lifecycleStatus.statusName === 'error') {
+      return <ErrorSvg />;
+    }
+    if (lifecycleStatus.statusName === 'pending') {
+      return <Spinner className="px-1.5 py-1.5" />;
+    }
+    return null;
+  }, [lifecycleStatus.statusName]);
+
+  if (!icon) {
+    return null;
+  }
+
+  return (
+    <div className={cn(text.label2, className)} data-testid="ockSignatureIcon">
+      {icon}
+    </div>
+  );
+}

--- a/src/signature/components/SignatureLabel.test.tsx
+++ b/src/signature/components/SignatureLabel.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { type Mock, describe, expect, it, vi } from 'vitest';
+import { MessageType } from '../types';
+import { SignatureLabel } from './SignatureLabel';
+import { useSignatureContext } from './SignatureProvider';
+
+vi.mock('./SignatureProvider', () => ({
+  useSignatureContext: vi.fn(),
+}));
+
+describe('SignatureLabel', () => {
+  it('should render success message', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+
+    render(<SignatureLabel />);
+    expect(screen.getByText('Success')).toBeInTheDocument();
+  });
+
+  it('should render error message', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'error',
+        statusData: {
+          code: 'TEST01',
+          message: 'Test error message',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+    render(<SignatureLabel />);
+    expect(screen.getByText('Test error message')).toBeInTheDocument();
+  });
+
+  it('should render pending message', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'pending',
+        statusData: {
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+    render(<SignatureLabel />);
+    expect(screen.getByText('Confirm in wallet')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+
+    render(<SignatureLabel className="custom-class" />);
+    expect(screen.getByText('Success')).toHaveClass('custom-class');
+  });
+
+  it('should not render if no label', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'init',
+        statusData: null,
+      },
+    });
+
+    render(<SignatureLabel />);
+    expect(screen.queryByTestId('ockSignatureLabel')).not.toBeInTheDocument();
+  });
+});

--- a/src/signature/components/SignatureLabel.tsx
+++ b/src/signature/components/SignatureLabel.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import { cn, text } from '../../styles/theme';
+import { useSignatureContext } from './SignatureProvider';
+
+type SignatureLabelProps = {
+  className?: string;
+};
+
+export function SignatureLabel({ className }: SignatureLabelProps) {
+  const { lifecycleStatus } = useSignatureContext();
+
+  const label = useMemo(() => {
+    if (lifecycleStatus.statusName === 'success') {
+      return 'Success';
+    }
+    if (lifecycleStatus.statusName === 'error') {
+      return lifecycleStatus.statusData.message;
+    }
+    if (lifecycleStatus.statusName === 'pending') {
+      return 'Confirm in wallet';
+    }
+    return null;
+  }, [lifecycleStatus.statusName, lifecycleStatus.statusData]);
+
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <div className={cn(text.label2, className)} data-testid="ockSignatureLabel">
+      {label}
+    </div>
+  );
+}

--- a/src/signature/components/SignatureProvider.test.tsx
+++ b/src/signature/components/SignatureProvider.test.tsx
@@ -1,0 +1,254 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  type Mock,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+import { useSignMessage, useSignTypedData } from 'wagmi';
+import { SignatureProvider, useSignatureContext } from './SignatureProvider';
+
+vi.mock('wagmi', () => ({
+  useSignMessage: vi.fn(),
+  useSignTypedData: vi.fn(),
+}));
+
+const TestComponent = () => {
+  const context = useSignatureContext();
+
+  const handleSign = () => {
+    context.handleSign();
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={handleSign}>
+        sign
+      </button>
+      <div data-testid="lifecycle-status">
+        {context.lifecycleStatus.statusName}
+      </div>
+    </div>
+  );
+};
+
+describe('SignatureProvider', () => {
+  let mockOnError: Mock;
+  let mockOnStatus: Mock;
+  let mockOnSuccess: Mock;
+  let mockSignMessage: Mock;
+  let mockSignTypedData: Mock;
+
+  beforeEach(() => {
+    mockOnError = vi.fn();
+    mockOnStatus = vi.fn();
+    mockOnSuccess = vi.fn();
+    mockSignMessage = vi.fn();
+    mockSignTypedData = vi.fn();
+
+    (useSignMessage as Mock).mockReturnValue({
+      signMessageAsync: mockSignMessage,
+      reset: vi.fn(),
+    });
+    (useSignTypedData as Mock).mockReturnValue({
+      signTypedDataAsync: mockSignTypedData,
+      reset: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should throw error if useSignatureContext is used outside provider', () => {
+    const consoleError = console.error;
+    console.error = vi.fn();
+
+    expect(() => {
+      render(<TestComponent />);
+    }).toThrow('useSignatureContext must be used within a SignatureProvider');
+
+    console.error = consoleError;
+  });
+
+  it('should handle successful signature for typed data', async () => {
+    mockSignTypedData.mockResolvedValue('0x123');
+
+    render(
+      <SignatureProvider
+        domain={{ name: 'Test', version: '1' }}
+        types={{ Test: [{ name: 'test', type: 'string' }] }}
+        message={{ test: 'test' }}
+        primaryType="Test"
+        onSuccess={mockOnSuccess}
+        onStatus={mockOnStatus}
+      >
+        <TestComponent />
+      </SignatureProvider>,
+    );
+
+    fireEvent.click(screen.getByText('sign'));
+
+    expect(mockSignTypedData).toHaveBeenCalled();
+    expect(mockOnStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusName: 'pending',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith('0x123');
+      expect(mockOnStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusName: 'success',
+        }),
+      );
+    });
+  });
+
+  it('should handle successful signature for message', async () => {
+    mockSignMessage.mockResolvedValue('0x456');
+
+    render(
+      <SignatureProvider
+        message="Test message"
+        onSuccess={mockOnSuccess}
+        onStatus={mockOnStatus}
+      >
+        <TestComponent />
+      </SignatureProvider>,
+    );
+
+    fireEvent.click(screen.getByText('sign'));
+
+    expect(mockSignMessage).toHaveBeenCalled();
+    expect(mockOnStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusName: 'pending',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith('0x456');
+      expect(mockOnStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusName: 'success',
+        }),
+      );
+    });
+  });
+
+  it('should handle reset after', async () => {
+    mockSignMessage.mockResolvedValue('0x456');
+
+    render(
+      <SignatureProvider
+        message="Test message"
+        onSuccess={mockOnSuccess}
+        resetAfter={10}
+      >
+        <TestComponent />
+      </SignatureProvider>,
+    );
+
+    fireEvent.click(screen.getByText('sign'));
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith('0x456');
+    });
+
+    await waitFor(() => {
+      expect(useSignMessage().reset).toHaveBeenCalled();
+      expect(useSignTypedData().reset).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle invalid message data', async () => {
+    mockSignTypedData.mockRejectedValue('Invalid message data');
+
+    render(
+      /* @ts-expect-error */
+      <SignatureProvider
+        domain={{ name: 'Test', version: '1' }}
+        types={{ Test: [{ name: 'test', type: 'string' }] }}
+        primaryType="Test"
+        onError={mockOnError}
+        onStatus={mockOnStatus}
+      >
+        <TestComponent />
+      </SignatureProvider>,
+    );
+
+    fireEvent.click(screen.getByText('sign'));
+
+    await waitFor(() => {
+      expect(mockOnError).toHaveBeenCalled();
+      expect(mockOnStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusName: 'error',
+        }),
+      );
+    });
+  });
+
+  it('should handle user rejected request error', async () => {
+    const error = { cause: { name: 'UserRejectedRequestError' } };
+    mockSignTypedData.mockRejectedValue(error);
+
+    render(
+      <SignatureProvider
+        domain={{ name: 'Test', version: '1' }}
+        types={{ Test: [{ name: 'test', type: 'string' }] }}
+        message={{ test: 'test' }}
+        primaryType="Test"
+        onError={mockOnError}
+        onStatus={mockOnStatus}
+      >
+        <TestComponent />
+      </SignatureProvider>,
+    );
+
+    fireEvent.click(screen.getByText('sign'));
+
+    await waitFor(() => {
+      expect(mockOnError).toHaveBeenCalled();
+      expect(mockOnStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusName: 'error',
+        }),
+      );
+    });
+  });
+
+  it('should handle signature error', async () => {
+    const error = new Error('User rejected');
+    mockSignTypedData.mockRejectedValue(error);
+
+    render(
+      <SignatureProvider
+        domain={{ name: 'Test', version: '1' }}
+        types={{ Test: [{ name: 'test', type: 'string' }] }}
+        message={{ test: 'test' }}
+        primaryType="Test"
+        onError={mockOnError}
+        onStatus={mockOnStatus}
+      >
+        <TestComponent />
+      </SignatureProvider>,
+    );
+
+    fireEvent.click(screen.getByText('sign'));
+
+    await waitFor(() => {
+      expect(mockOnError).toHaveBeenCalled();
+      expect(mockOnStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusName: 'error',
+        }),
+      );
+    });
+  });
+});

--- a/src/signature/components/SignatureProvider.tsx
+++ b/src/signature/components/SignatureProvider.tsx
@@ -1,0 +1,161 @@
+import type { APIError } from '@/api/types';
+import { useLifecycleStatus } from '@/internal/hooks/useLifecycleStatus';
+import { useValue } from '@/internal/hooks/useValue';
+import { GENERIC_ERROR_MESSAGE } from '@/transaction/constants';
+import { isUserRejectedRequestError } from '@/transaction/utils/isUserRejectedRequestError';
+import { createContext, useContext, useEffect } from 'react';
+import { useSignMessage, useSignTypedData } from 'wagmi';
+import type {
+  SignMessageParameters,
+  SignTypedDataParameters,
+} from 'wagmi/actions';
+import {
+  type LifecycleStatus,
+  MessageType,
+  type SignatureProviderProps,
+} from '../types';
+import { validateMessage } from '../utils/validateMessage';
+
+type SignatureContextType = {
+  lifecycleStatus: LifecycleStatus;
+  handleSign: () => Promise<void>;
+};
+
+const EMPTY_CONTEXT = {} as SignatureContextType;
+
+const SignatureContext = createContext<SignatureContextType>(EMPTY_CONTEXT);
+
+export function useSignatureContext() {
+  const context = useContext(SignatureContext);
+  if (context === EMPTY_CONTEXT) {
+    throw new Error(
+      'useSignatureContext must be used within a SignatureProvider',
+    );
+  }
+  return context;
+}
+
+export function SignatureProvider({
+  children,
+  onSuccess,
+  onError,
+  onStatus,
+  domain,
+  types,
+  message,
+  primaryType,
+  resetAfter,
+}: SignatureProviderProps) {
+  const { signTypedDataAsync, reset: resetSignTypedData } = useSignTypedData();
+  const { signMessageAsync, reset: resetSignMessage } = useSignMessage();
+  const [lifecycleStatus, updateLifecycleStatus] =
+    useLifecycleStatus<LifecycleStatus>({
+      statusName: 'init',
+      statusData: null,
+    });
+
+  useEffect(() => {
+    onStatus?.(lifecycleStatus);
+  }, [lifecycleStatus, onStatus]);
+
+  useEffect(() => {
+    if (lifecycleStatus.statusName === 'success' && resetAfter) {
+      setTimeout(() => {
+        resetSignMessage();
+        resetSignTypedData();
+        updateLifecycleStatus({
+          statusName: 'init',
+          statusData: null,
+        });
+      }, resetAfter);
+    }
+  }, [
+    updateLifecycleStatus,
+    lifecycleStatus,
+    resetAfter,
+    resetSignMessage,
+    resetSignTypedData,
+  ]);
+
+  async function handleSignTypedData({
+    domain,
+    types,
+    message,
+    primaryType,
+  }: SignTypedDataParameters) {
+    const signature = await signTypedDataAsync({
+      domain,
+      types,
+      message,
+      primaryType,
+    });
+    updateLifecycleStatus({
+      statusName: 'success',
+      statusData: {
+        signature,
+      },
+    });
+    onSuccess?.(signature);
+  }
+
+  async function handleSignMessage({ message }: SignMessageParameters) {
+    const signature = await signMessageAsync({ message });
+    updateLifecycleStatus({
+      statusName: 'success',
+      statusData: {
+        signature,
+      },
+    });
+    onSuccess?.(signature);
+  }
+
+  function handleError(err: unknown) {
+    const errorMessage = isUserRejectedRequestError(err)
+      ? 'Request denied.'
+      : GENERIC_ERROR_MESSAGE;
+    updateLifecycleStatus({
+      statusName: 'error',
+      statusData: {
+        code: 'SmSPc01', // Signature module SignatureProvider component 01 error
+        error: JSON.stringify(err),
+        message: errorMessage,
+      },
+    });
+    onError?.(err as APIError);
+  }
+
+  async function handleSign() {
+    updateLifecycleStatus({
+      statusName: 'pending',
+    });
+
+    try {
+      const validatedMessage = validateMessage({
+        domain,
+        types,
+        message,
+        primaryType,
+      });
+      if (validatedMessage.type === MessageType.TYPED_DATA) {
+        await handleSignTypedData(validatedMessage.data);
+      } else if (validatedMessage.type === MessageType.SIGNABLE_MESSAGE) {
+        await handleSignMessage(validatedMessage.data);
+      } else if (validatedMessage.type === MessageType.INVALID) {
+        throw new Error('Invalid message data');
+      }
+    } catch (err) {
+      handleError(err);
+    }
+  }
+
+  const value = useValue({
+    lifecycleStatus,
+    handleSign,
+  });
+
+  return (
+    <SignatureContext.Provider value={value}>
+      {children}
+    </SignatureContext.Provider>
+  );
+}

--- a/src/signature/components/SignatureStatus.test.tsx
+++ b/src/signature/components/SignatureStatus.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSignatureContext } from './SignatureProvider';
+import { SignatureStatus } from './SignatureStatus';
+
+vi.mock('./SignatureProvider', () => ({
+  useSignatureContext: vi.fn(),
+}));
+vi.mock('./SignatureLabel', () => ({
+  SignatureLabel: vi.fn(() => <div>SignatureLabel</div>),
+}));
+
+describe('SignatureStatus', () => {
+  beforeEach(() => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'init',
+      },
+    });
+  });
+
+  it('should render default children', () => {
+    render(<SignatureStatus />);
+    expect(screen.getByText('SignatureLabel')).toBeInTheDocument();
+  });
+
+  it('should render passed in children', () => {
+    render(
+      <SignatureStatus>
+        <div>Custom Child</div>
+      </SignatureStatus>,
+    );
+    expect(screen.getByText('Custom Child')).toBeInTheDocument();
+  });
+
+  it('should render error className', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'error',
+      },
+    });
+    render(<SignatureStatus />);
+    expect(screen.getByText('SignatureLabel').parentElement).toHaveClass(
+      'ock-text-error',
+    );
+  });
+
+  it('should set custom className', () => {
+    render(<SignatureStatus className="custom-class" />);
+    expect(screen.getByText('SignatureLabel').parentElement).toHaveClass(
+      'custom-class',
+    );
+  });
+});

--- a/src/signature/components/SignatureStatus.tsx
+++ b/src/signature/components/SignatureStatus.tsx
@@ -1,0 +1,29 @@
+import { cn, color } from '../../styles/theme';
+import { SignatureLabel } from './SignatureLabel';
+import { useSignatureContext } from './SignatureProvider';
+
+const DEFAULT_CHILDREN = <SignatureLabel />;
+
+type SignatureStatusProps = {
+  children?: React.ReactNode;
+  className?: string;
+};
+
+export function SignatureStatus({
+  children = DEFAULT_CHILDREN,
+  className,
+}: SignatureStatusProps) {
+  const { lifecycleStatus } = useSignatureContext();
+  return (
+    <div
+      className={cn(
+        'flex justify-between',
+        color.foregroundMuted,
+        { [color.error]: lifecycleStatus.statusName === 'error' },
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/signature/components/SignatureToast.test.tsx
+++ b/src/signature/components/SignatureToast.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type Mock, describe, expect, it, vi } from 'vitest';
+import { MessageType } from '../types';
+import { useSignatureContext } from './SignatureProvider';
+import { SignatureToast } from './SignatureToast';
+
+vi.mock('./SignatureProvider', () => ({
+  useSignatureContext: vi.fn(),
+}));
+
+vi.mock('./SignatureIcon', () => ({
+  SignatureIcon: vi.fn(() => <div>SignatureIcon</div>),
+}));
+vi.mock('./SignatureLabel', () => ({
+  SignatureLabel: vi.fn(() => <div>SignatureLabel</div>),
+}));
+
+describe('SignatureToast', () => {
+  it('should render if status it not init', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+
+    render(<SignatureToast />);
+    expect(screen.getByTestId('ockToast')).toBeInTheDocument();
+  });
+
+  it('should not render in init status', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'init',
+        statusData: null,
+      },
+    });
+
+    render(<SignatureToast />);
+    expect(screen.queryByTestId('ockToast')).not.toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+
+    render(<SignatureToast className="custom-class" />);
+    expect(screen.getByTestId('ockToast')).toHaveClass('custom-class');
+  });
+
+  it('should hide toast onClose', () => {
+    (useSignatureContext as Mock).mockReturnValue({
+      lifecycleStatus: {
+        statusName: 'success',
+        statusData: {
+          signature: '0x123',
+          type: MessageType.TYPED_DATA,
+        },
+      },
+    });
+
+    render(<SignatureToast />);
+
+    expect(screen.queryByTestId('ockToast')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('ockCloseButton'));
+
+    expect(screen.queryByTestId('ockToast')).not.toBeInTheDocument();
+  });
+
+  it('should render default children', () => {
+    render(<SignatureToast />);
+    expect(screen.getByText('SignatureIcon')).toBeInTheDocument();
+    expect(screen.getByText('SignatureLabel')).toBeInTheDocument();
+  });
+
+  it('should render passed in children', () => {
+    render(
+      <SignatureToast>
+        <div>Custom Child</div>
+      </SignatureToast>,
+    );
+    expect(screen.getByText('Custom Child')).toBeInTheDocument();
+  });
+});

--- a/src/signature/components/SignatureToast.tsx
+++ b/src/signature/components/SignatureToast.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Toast, type ToastProps } from '../../internal/components/Toast';
+import { SignatureIcon } from './SignatureIcon';
+import { SignatureLabel } from './SignatureLabel';
+import { useSignatureContext } from './SignatureProvider';
+
+const DEFAULT_CHILDREN = (
+  <>
+    <SignatureIcon />
+    <SignatureLabel />
+  </>
+);
+
+type SignatureToastProps = {
+  children?: React.ReactNode;
+  className?: string;
+  durationMs?: ToastProps['durationMs'];
+  position?: ToastProps['position'];
+};
+
+export function SignatureToast({
+  children = DEFAULT_CHILDREN,
+  className,
+  durationMs = 5000,
+  position = 'bottom-center',
+}: SignatureToastProps) {
+  const { lifecycleStatus } = useSignatureContext();
+  const [isToastVisible, setIsToastVisible] = useState(false);
+
+  useEffect(() => {
+    if (lifecycleStatus.statusName !== 'init') {
+      setIsToastVisible(true);
+    }
+  }, [lifecycleStatus]);
+
+  const closeToast = useCallback(() => {
+    setIsToastVisible(false);
+  }, []);
+
+  return (
+    <Toast
+      position={position}
+      className={className}
+      durationMs={durationMs}
+      isVisible={isToastVisible}
+      onClose={closeToast}
+      startTimeout={
+        lifecycleStatus.statusName === 'error' ||
+        lifecycleStatus.statusName === 'success'
+      }
+    >
+      {children}
+    </Toast>
+  );
+}

--- a/src/signature/index.ts
+++ b/src/signature/index.ts
@@ -1,0 +1,9 @@
+export { Signature } from './components/Signature';
+export { SignatureButton } from './components/SignatureButton';
+export { SignatureToast } from './components/SignatureToast';
+export { SignatureStatus } from './components/SignatureStatus';
+export { SignatureIcon } from './components/SignatureIcon';
+export { SignatureLabel } from './components/SignatureLabel';
+export { SignatureProvider } from './components/SignatureProvider';
+export { useSignatureContext } from './components/SignatureProvider';
+export type { LifecycleStatus, SignatureReact } from './types';

--- a/src/signature/types.ts
+++ b/src/signature/types.ts
@@ -1,0 +1,103 @@
+import type {
+  SignMessageParameters,
+  SignTypedDataParameters,
+} from 'wagmi/actions';
+import type { APIError } from '../api/types';
+
+export enum MessageType {
+  SIGNABLE_MESSAGE = 'signable_message',
+  TYPED_DATA = 'typed_data',
+  INVALID = 'invalid',
+}
+
+export type ValidateMessageResult =
+  | { type: MessageType.TYPED_DATA; data: SignTypedDataParameters }
+  | { type: MessageType.SIGNABLE_MESSAGE; data: SignMessageParameters }
+  | { type: MessageType.INVALID; data: null };
+
+export type MessageData = {
+  domain?: SignTypedDataParameters['domain'];
+  types?: SignTypedDataParameters['types'];
+  message:
+    | SignTypedDataParameters['message']
+    | SignMessageParameters['message'];
+  primaryType?: SignTypedDataParameters['primaryType'];
+};
+
+export type SignatureProviderProps = {
+  children: React.ReactNode;
+  onSuccess?: (signature: string) => void;
+  onError?: (error: APIError) => void;
+  onStatus?: (status: LifecycleStatus) => void;
+  resetAfter?: number;
+} & MessageData;
+
+/**
+ * Note: exported as public Type
+ */
+export type SignatureReact = {
+  chainId?: number;
+  className?: string;
+  onSuccess?: (signature: string) => void;
+  onStatus?: (status: LifecycleStatus) => void;
+  onError?: (error: APIError) => void;
+  resetAfter?: number;
+} & (
+  | {
+      domain?: SignTypedDataParameters['domain'];
+      types: SignTypedDataParameters['types'];
+      message: SignTypedDataParameters['message'];
+      primaryType: SignTypedDataParameters['primaryType'];
+    }
+  | {
+      message: SignMessageParameters['message'];
+      domain?: never;
+      types?: never;
+      primaryType?: never;
+    }
+) &
+  (
+    | {
+        children: React.ReactNode;
+        label?: never;
+        disabled?: never;
+      }
+    | {
+        children?: never;
+        label?: React.ReactNode;
+        disabled?: boolean;
+      }
+  );
+
+/**
+ * List of Signature lifecycle statuses.
+ * The order of the statuses follows the Signature lifecycle.
+ *
+ * Note: exported as public Type
+ */
+export type LifecycleStatus =
+  | {
+      statusName: 'init';
+      statusData: null;
+    }
+  | {
+      statusName: 'error';
+      statusData: APIError;
+    }
+  | {
+      statusName: 'pending';
+      statusData: {
+        type: MessageType;
+      };
+    }
+  | {
+      statusName: 'success';
+      statusData: {
+        signature: `0x${string}`;
+        type: MessageType;
+      };
+    }
+  | {
+      statusName: 'reset';
+      statusData: null;
+    };

--- a/src/signature/utils/validateMessage.test.ts
+++ b/src/signature/utils/validateMessage.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { MessageType } from '../types';
+import { validateMessage } from './validateMessage';
+
+describe('validateMessage', () => {
+  it('should validate typed data message', () => {
+    const typedData = {
+      domain: { name: 'Test', version: '1' },
+      types: { Test: [{ name: 'test', type: 'string' }] },
+      message: { test: 'test' },
+      primaryType: 'Test',
+    };
+
+    const result = validateMessage(typedData);
+    expect(result).toEqual({
+      type: MessageType.TYPED_DATA,
+      data: typedData,
+    });
+  });
+
+  it('should validate signable message', () => {
+    const messageData = {
+      message: 'Test message',
+    };
+
+    const result = validateMessage(messageData);
+    expect(result).toEqual({
+      type: MessageType.SIGNABLE_MESSAGE,
+      data: messageData,
+    });
+  });
+
+  it('should validate string message', () => {
+    const result = validateMessage({ message: 'Test message' });
+    expect(result).toEqual({
+      type: MessageType.SIGNABLE_MESSAGE,
+      data: { message: 'Test message' },
+    });
+  });
+
+  it('should validate hex raw message', () => {
+    const result = validateMessage({
+      message: { raw: '0x1234' },
+    });
+    expect(result).toEqual({
+      type: MessageType.SIGNABLE_MESSAGE,
+      data: { message: { raw: '0x1234' } },
+    });
+  });
+
+  it('should validate ByteArray raw message', () => {
+    const result = validateMessage({
+      message: { raw: new Uint8Array([1, 2, 3, 4]) },
+    });
+    expect(result).toEqual({
+      type: MessageType.SIGNABLE_MESSAGE,
+      data: { message: { raw: new Uint8Array([1, 2, 3, 4]) } },
+    });
+  });
+
+  it('should return invalid for incomplete typed data', () => {
+    const invalidTypedData = {
+      domain: { name: 'Test', version: '1' },
+      types: { Test: [{ name: 'test', type: 'string' }] },
+      // missing message and primaryType
+    };
+
+    // @ts-expect-error testing invalid input
+    const result = validateMessage(invalidTypedData);
+    expect(result).toEqual({
+      type: MessageType.INVALID,
+      data: null,
+    });
+  });
+
+  it('should return invalid for empty message data', () => {
+    // @ts-expect-error testing invalid input
+    const result = validateMessage({});
+    expect(result).toEqual({
+      type: MessageType.INVALID,
+      data: null,
+    });
+  });
+
+  it('should return invalid for null message data', () => {
+    // @ts-expect-error testing invalid input
+    const result = validateMessage(null);
+    expect(result).toEqual({
+      type: MessageType.INVALID,
+      data: null,
+    });
+  });
+});

--- a/src/signature/utils/validateMessage.ts
+++ b/src/signature/utils/validateMessage.ts
@@ -1,0 +1,54 @@
+import type {
+  SignMessageParameters,
+  SignTypedDataParameters,
+} from 'wagmi/actions';
+import {
+  type MessageData,
+  MessageType,
+  type ValidateMessageResult,
+} from '../types';
+
+export function isTypedData(
+  params: MessageData,
+): params is SignTypedDataParameters {
+  return !!(
+    params?.types &&
+    params?.primaryType &&
+    typeof params?.message === 'object'
+  );
+}
+
+export function isSignableMessage(
+  params: MessageData,
+): params is SignMessageParameters {
+  return (
+    typeof params?.message === 'string' ||
+    (typeof params?.message === 'object' &&
+      'raw' in params.message &&
+      (typeof params.message.raw === 'string' ||
+        params.message.raw instanceof Uint8Array))
+  );
+}
+
+export function validateMessage(
+  messageData: MessageData,
+): ValidateMessageResult {
+  if (isTypedData(messageData)) {
+    return {
+      type: MessageType.TYPED_DATA,
+      data: messageData,
+    };
+  }
+
+  if (isSignableMessage(messageData)) {
+    return {
+      type: MessageType.SIGNABLE_MESSAGE,
+      data: messageData,
+    };
+  }
+
+  return {
+    type: MessageType.INVALID,
+    data: null,
+  };
+}


### PR DESCRIPTION
**What changed? Why?**
Adding Signature component which utilizes wagmi signTypedData (EIP 712) and signMessage (personal_sign falling back to eth_sign) to sign data

**Notes to reviewers**

**How has it been tested?**
