### PR TITLE
chore: add supported networks documentation for getPortfolios

### DIFF
--- a/site/docs/pages/api/get-portfolios.mdx
+++ b/site/docs/pages/api/get-portfolios.mdx
@@ -10,6 +10,11 @@ Before using this endpoint, make sure to obtain a [Client API Key](https://porta
 from Coinbase Developer Platform.
 :::
 
+:::info
+Please note: `getPortfolios` is only available for Base mainnet and Ethereum mainnet.
+You can control the network in the `OnchainKitProvider` by setting the `chain` prop.
+:::
+
 ## Usage
 
 :::code-group

--- a/src/api/getPortfolios.ts
+++ b/src/api/getPortfolios.ts
@@ -9,6 +9,7 @@ import type {
 
 /**
  * Retrieves the portfolios for the provided addresses
+ * Supported networks: Base mainnet and Ethereum mainnet
  */
 export async function getPortfolios(
   params: GetPortfoliosParams,


### PR DESCRIPTION
**What changed? Why?**
* Added supported network info to `getPortolios`

**Notes to reviewers**

**How has it been tested?**
