### PR TITLE
fix: Make TokenRow text-overflow: ellipsis work correctly

### DIFF
--- a/src/token/components/TokenRow.tsx
+++ b/src/token/components/TokenRow.tsx
@@ -29,13 +29,13 @@ export const TokenRow = memo(function TokenRow({
       )}
       onClick={() => onClick?.(token)}
     >
-      <span className="flex items-center gap-3">
+      <span className="flex items-center gap-3 max-w-full">
         {!hideImage && <TokenImage token={token} size={28} />}
-        <span className="flex flex-col items-start">
+        <span className="flex flex-col items-start min-w-0">
           <span
             className={cn(
               text.headline,
-              'overflow-hidden text-ellipsis whitespace-nowrap text-left',
+              'overflow-hidden text-ellipsis whitespace-nowrap text-left max-w-full',
             )}
           >
             {token.name.trim()}


### PR DESCRIPTION
**What changed? Why?**

Fixes the styling in the TokenRow component so that text-overflow ellipsis works as intended. Currently, a token with a long name will cause the container to be horizontally scrollable and the text will overflow out of its container.

<img width="300" alt="Screenshot 2025-03-15 at 3 37 48 PM" src="https://github.com/user-attachments/assets/e17732bb-d939-4311-940d-0010b9c474f6" />

**Notes to reviewers**

n/a

**How has it been tested?**

Manually in the playground app