### PR TITLE
chore(ONRAMP-5024):Make OnchainKit onramp utils usable without the OCK Provider (in non-React environments)

### DIFF
--- a/src/fund/utils/fetchOnrampConfig.test.ts
+++ b/src/fund/utils/fetchOnrampConfig.test.ts
@@ -46,6 +46,20 @@ describe('fetchOnrampConfig', () => {
     });
   });
 
+  it('should use provided apiKey when available', async () => {
+    const customApiKey = 'custom-api-key';
+    await fetchOnrampConfig(customApiKey);
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${ONRAMP_API_BASE_URL}/buy/config`,
+      expect.objectContaining({
+        headers: {
+          Authorization: `Bearer ${customApiKey}`,
+        },
+      }),
+    );
+  });
+
   it('should throw an error if the fetch fails', async () => {
     (fetch as Mock).mockImplementationOnce(() =>
       Promise.reject(new Error('Fetch failed')),

--- a/src/fund/utils/fetchOnrampConfig.ts
+++ b/src/fund/utils/fetchOnrampConfig.ts
@@ -6,12 +6,14 @@ import type { OnrampConfigResponseData } from '../types';
 /**
  * Returns list of countries supported by Coinbase Onramp, and the payment methods available in each country.
  */
-export async function fetchOnrampConfig(): Promise<OnrampConfigResponseData> {
-  const apiKey = getApiKey();
+export async function fetchOnrampConfig(
+  apiKey?: string,
+): Promise<OnrampConfigResponseData> {
+  const cpdApiKey = apiKey || getApiKey();
   const response = await fetch(`${ONRAMP_API_BASE_URL}/buy/config`, {
     method: 'GET',
     headers: {
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${cpdApiKey}`,
     },
   });
 

--- a/src/fund/utils/fetchOnrampOptions.test.ts
+++ b/src/fund/utils/fetchOnrampOptions.test.ts
@@ -53,6 +53,20 @@ describe('fetchOnrampOptions', () => {
     });
   });
 
+  it('should use provided apiKey when available', async () => {
+    const customApiKey = 'custom-api-key';
+    await fetchOnrampOptions({ country, subdivision, apiKey: customApiKey });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${ONRAMP_API_BASE_URL}/buy/options?country=${country}&subdivision=${subdivision}`,
+      expect.objectContaining({
+        headers: {
+          Authorization: `Bearer ${customApiKey}`,
+        },
+      }),
+    );
+  });
+
   it('should handle fetch errors', async () => {
     (global.fetch as Mock).mockRejectedValue(new Error('Fetch error'));
 

--- a/src/fund/utils/fetchOnrampOptions.ts
+++ b/src/fund/utils/fetchOnrampOptions.ts
@@ -12,11 +12,13 @@ import type { OnrampOptionsResponseData } from '../types';
 export async function fetchOnrampOptions({
   country,
   subdivision,
+  apiKey,
 }: {
   country: string;
   subdivision?: string;
+  apiKey?: string;
 }): Promise<OnrampOptionsResponseData> {
-  const apiKey = getApiKey();
+  const cpdApiKey = apiKey || getApiKey();
 
   let queryParams = `?country=${country}`;
 
@@ -29,7 +31,7 @@ export async function fetchOnrampOptions({
     {
       method: 'GET',
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${cpdApiKey}`,
       },
     },
   );

--- a/src/fund/utils/fetchOnrampQuote.test.ts
+++ b/src/fund/utils/fetchOnrampQuote.test.ts
@@ -72,6 +72,29 @@ describe('fetchOnrampQuote', () => {
     });
   });
 
+  it('should use provided apiKey when available', async () => {
+    const customApiKey = 'custom-api-key';
+    await fetchOnrampQuote({
+      purchaseCurrency: mockPurchaseCurrency,
+      purchaseNetwork: mockPurchaseNetwork,
+      paymentCurrency: mockPaymentCurrency,
+      paymentMethod: mockPaymentMethod,
+      paymentAmount: mockPaymentAmount,
+      country: mockCountry,
+      subdivision: mockSubdivision,
+      apiKey: customApiKey,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${ONRAMP_API_BASE_URL}/buy/quote`,
+      expect.objectContaining({
+        headers: {
+          Authorization: `Bearer ${customApiKey}`,
+        },
+      }),
+    );
+  });
+
   it('should throw an error if fetch fails', async () => {
     global.fetch = vi.fn(() =>
       Promise.reject(new Error('Fetch failed')),

--- a/src/fund/utils/fetchOnrampQuote.ts
+++ b/src/fund/utils/fetchOnrampQuote.ts
@@ -24,6 +24,7 @@ export async function fetchOnrampQuote({
   paymentAmount,
   country,
   subdivision,
+  apiKey,
 }: {
   purchaseCurrency: string;
   purchaseNetwork?: string;
@@ -32,8 +33,9 @@ export async function fetchOnrampQuote({
   paymentAmount: string;
   country: string;
   subdivision?: string;
+  apiKey?: string;
 }): Promise<OnrampQuoteResponseData> {
-  const apiKey = getApiKey();
+  const cpdApiKey = apiKey || getApiKey();
 
   const response = await fetch(`${ONRAMP_API_BASE_URL}/buy/quote`, {
     method: 'POST',
@@ -47,7 +49,7 @@ export async function fetchOnrampQuote({
       subdivision,
     }),
     headers: {
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${cpdApiKey}`,
     },
   });
 

--- a/src/fund/utils/fetchOnrampTransactionStatus.test.ts
+++ b/src/fund/utils/fetchOnrampTransactionStatus.test.ts
@@ -49,6 +49,25 @@ describe('fetchOnrampTransactionStatus', () => {
     });
   });
 
+  it('should use provided apiKey when available', async () => {
+    const customApiKey = 'custom-api-key';
+    await fetchOnrampTransactionStatus({
+      partnerUserId,
+      nextPageKey,
+      pageSize,
+      apiKey: customApiKey,
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${ONRAMP_API_BASE_URL}/buy/user/${partnerUserId}/transactions?page_key=${nextPageKey}&page_size=${pageSize}`,
+      expect.objectContaining({
+        headers: {
+          Authorization: `Bearer ${customApiKey}`,
+        },
+      }),
+    );
+  });
+
   it('should throw an error if fetch fails', async () => {
     global.fetch = vi.fn(() => Promise.reject(new Error('Fetch failed')));
 

--- a/src/fund/utils/fetchOnrampTransactionStatus.ts
+++ b/src/fund/utils/fetchOnrampTransactionStatus.ts
@@ -16,19 +16,21 @@ export async function fetchOnrampTransactionStatus({
   partnerUserId,
   nextPageKey,
   pageSize,
+  apiKey,
 }: {
   partnerUserId: string;
   nextPageKey: string;
   pageSize: string;
+  apiKey?: string;
 }): Promise<OnrampTransactionStatusResponseData> {
-  const apiKey = getApiKey();
+  const cpdApiKey = apiKey || getApiKey();
 
   const response = await fetch(
     `${ONRAMP_API_BASE_URL}/buy/user/${partnerUserId}/transactions?page_key=${nextPageKey}&page_size=${pageSize}`,
     {
       method: 'GET',
       headers: {
-        Authorization: `Bearer ${apiKey}`,
+        Authorization: `Bearer ${cpdApiKey}`,
       },
     },
   );


### PR DESCRIPTION

**What changed? Why?**
Updated Onramp utils to allow to be used in non-react JS environments and/or without having to set up Onchainkit Provider

**Notes to reviewers**

**How has it been tested?**
