### PR TITLE
feat: NFTCard default children prop

### DIFF
--- a/src/nft/components/NFTCard.test.tsx
+++ b/src/nft/components/NFTCard.test.tsx
@@ -24,6 +24,13 @@ vi.mock('@/internal/hooks/useIsMounted');
 vi.mock('@/nft/components/NFTProvider', () => ({
   NFTProvider: vi.fn(({ children }) => <div>{children}</div>),
 }));
+vi.mock('./view', () => ({
+  NFTMedia: () => <div data-testid="nft-media" />,
+  NFTTitle: () => <div data-testid="nft-title" />,
+  NFTOwner: () => <div data-testid="nft-owner" />,
+  NFTLastSoldPrice: () => <div data-testid="nft-last-sold-price" />,
+  NFTNetwork: () => <div data-testid="nft-network" />,
+}));
 
 describe('NFTView', () => {
   beforeEach(() => {
@@ -57,6 +64,17 @@ describe('NFTView', () => {
     );
 
     expect(queryByTestId('ockNFTCard_Container')).not.toBeInTheDocument();
+  });
+
+  it('should render default content when no children are provided', () => {
+    const { getByTestId } = render(
+      <NFTCard contractAddress="0x123" tokenId="1" />,
+    );
+    expect(getByTestId('nft-media')).toBeInTheDocument();
+    expect(getByTestId('nft-title')).toBeInTheDocument();
+    expect(getByTestId('nft-owner')).toBeInTheDocument();
+    expect(getByTestId('nft-last-sold-price')).toBeInTheDocument();
+    expect(getByTestId('nft-network')).toBeInTheDocument();
   });
 
   it('should pass contractAddress and tokenId to NFTProvider', () => {

--- a/src/nft/components/NFTCard.tsx
+++ b/src/nft/components/NFTCard.tsx
@@ -10,9 +10,28 @@ import { useAccount } from 'wagmi';
 import { border, cn, color, pressable } from '../../styles/theme';
 import NFTErrorBoundary from './NFTErrorBoundary';
 import { NFTErrorFallback } from './NFTErrorFallback';
+import {
+  NFTLastSoldPrice,
+  NFTMedia,
+  NFTNetwork,
+  NFTOwner,
+  NFTTitle,
+} from './view';
+
+function NFTCardDefaultContent() {
+  return (
+    <>
+      <NFTMedia />
+      <NFTTitle />
+      <NFTOwner />
+      <NFTLastSoldPrice />
+      <NFTNetwork />
+    </>
+  );
+}
 
 export function NFTCard({
-  children,
+  children = <NFTCardDefaultContent />,
   className,
   contractAddress,
   tokenId,

--- a/src/nft/components/NFTCardDefault.tsx
+++ b/src/nft/components/NFTCardDefault.tsx
@@ -9,6 +9,9 @@ import {
   NFTTitle,
 } from './view';
 
+/**
+ * @deprecated Use the `NFTCard` component instead with no 'children' props.
+ */
 export function NFTCardDefault({
   contractAddress,
   tokenId,

--- a/src/nft/types.ts
+++ b/src/nft/types.ts
@@ -164,7 +164,7 @@ export type NFTReact = {
  * Note: exported as public Type
  */
 export type NFTCardReact = {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   /** Optional className override for top div element. */
   className?: string;
   /** Contract address of the NFT */


### PR DESCRIPTION
**What changed? Why?**

- Adds default value for NFTCard's children prop
- Adds deprecated tag to NFTCardDefault component

**Notes to reviewers**

The default children I added are same as what was in `<NFTCardDefault />`. I noticed that the playground demo includes the `<NFTMintDate />` as well, which is not included in `<NFTCardDefault />`. I left this off intentionally, though.

**How has it been tested?**

In the playground and via component tests