### PR TITLE
feat: Add Badge tooltip display

### DIFF
--- a/.changeset/eight-crabs-tan.md
+++ b/.changeset/eight-crabs-tan.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-- **feat**: Add Badge tooltip display. By @cpcramer #2140
+- **feat**: Added `Badge` tooltip display. By @cpcramer #2140

--- a/.changeset/eight-crabs-tan.md
+++ b/.changeset/eight-crabs-tan.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: Add Badge tooltip display. By @cpcramer #2140

--- a/src/identity/components/Badge.test.tsx
+++ b/src/identity/components/Badge.test.tsx
@@ -66,7 +66,7 @@ describe('Badge Component', () => {
     expect(screen.queryByTestId('ockBadgeTooltip')).not.toBeInTheDocument();
   });
 
-  it('should show tooltip when hovered and tooltip is true', async () => {
+  it('should show tooltip with default content when tooltip is true', async () => {
     render(<Badge tooltip={true} />);
 
     const badge = await screen.findByTestId('ockBadge');
@@ -76,8 +76,8 @@ describe('Badge Component', () => {
     expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent('Verified');
   });
 
-  it('should show tooltipText when provided', async () => {
-    render(<Badge tooltipText="Custom tooltip" />);
+  it('should show tooltip with custom text when tooltip is a string', async () => {
+    render(<Badge tooltip="Custom tooltip" />);
 
     const badge = await screen.findByTestId('ockBadge');
     fireEvent.mouseEnter(badge);
@@ -106,21 +106,7 @@ describe('Badge Component', () => {
     expect(badge).toHaveClass('custom-class');
   });
 
-  it('should automatically enable tooltip when tooltipText is provided', async () => {
-    render(<Badge tooltip={false} tooltipText="Auto-enabled" />);
-
-    const badge = await screen.findByTestId('ockBadge');
-
-    expect(badge).toHaveClass('cursor-pointer');
-
-    fireEvent.mouseEnter(badge);
-    expect(screen.getByTestId('ockBadgeTooltip')).toBeInTheDocument();
-    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent(
-      'Auto-enabled',
-    );
-  });
-
-  it('should use attestation name when available', async () => {
+  it('should use attestation name when available and tooltip is true', async () => {
     vi.mocked(useAttestations).mockReturnValue([
       {
         decodedDataJson: JSON.stringify({ attestation: 'Coinbase Verified' }),

--- a/src/identity/components/Badge.test.tsx
+++ b/src/identity/components/Badge.test.tsx
@@ -218,7 +218,7 @@ describe('Badge Component', () => {
     expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent('Verified');
   });
 
-  it('should use context schemaId if available', async () => {
+  it('should use context schemaId if tooltip is enabled', async () => {
     vi.mocked(useIdentityContext).mockReturnValue({
       address: '0x123',
       schemaId: '0xcontextSchema',
@@ -237,7 +237,7 @@ describe('Badge Component', () => {
       },
     });
 
-    render(<Badge />);
+    render(<Badge tooltip={true} />);
 
     expect(useAttestations).toHaveBeenCalledWith({
       address: '0x123',
@@ -246,7 +246,35 @@ describe('Badge Component', () => {
     });
   });
 
-  it('should fall back to kit schemaId if context schemaId is not available', async () => {
+  it('should pass null schemaId when tooltip is disabled', async () => {
+    vi.mocked(useIdentityContext).mockReturnValue({
+      address: '0x123',
+      schemaId: '0xcontextSchema',
+    });
+
+    vi.mocked(useOnchainKit).mockReturnValue({
+      address: null,
+      apiKey: null,
+      chain: base,
+      rpcUrl: null,
+      schemaId: '0xkitSchema',
+      projectId: null,
+      sessionId: null,
+      config: {
+        appearance: {},
+      },
+    });
+
+    render(<Badge tooltip={false} />);
+
+    expect(useAttestations).toHaveBeenCalledWith({
+      address: '0x123',
+      chain: base,
+      schemaId: null,
+    });
+  });
+
+  it('should fall back to kit schemaId if context schemaId is not available and tooltip is enabled', async () => {
     vi.mocked(useIdentityContext).mockReturnValue({
       address: '0x123',
       schemaId: null,
@@ -265,7 +293,7 @@ describe('Badge Component', () => {
       },
     });
 
-    render(<Badge />);
+    render(<Badge tooltip={true} />);
 
     expect(useAttestations).toHaveBeenCalledWith({
       address: '0x123',

--- a/src/identity/components/Badge.test.tsx
+++ b/src/identity/components/Badge.test.tsx
@@ -275,7 +275,6 @@ describe('Badge Component', () => {
   });
 
   it('should display default "Verified" text when no attestation is available', async () => {
-    // Test with empty attestations array
     vi.mocked(useAttestations).mockReturnValue([]);
 
     render(<Badge tooltip={true} />);

--- a/src/identity/components/Badge.test.tsx
+++ b/src/identity/components/Badge.test.tsx
@@ -7,7 +7,6 @@ import { useOnchainKit } from '../../useOnchainKit';
 import { Badge } from './Badge';
 import { useIdentityContext } from './IdentityProvider';
 
-// Mock the hooks
 vi.mock('@/identity/hooks/useAttestations');
 vi.mock('./IdentityProvider');
 vi.mock('../../useOnchainKit');
@@ -112,7 +111,6 @@ describe('Badge Component', () => {
 
     const badge = await screen.findByTestId('ockBadge');
 
-    // Should have cursor-pointer when tooltipText is provided
     expect(badge).toHaveClass('cursor-pointer');
 
     fireEvent.mouseEnter(badge);

--- a/src/identity/components/Badge.test.tsx
+++ b/src/identity/components/Badge.test.tsx
@@ -287,4 +287,16 @@ describe('Badge Component', () => {
       schemaId: '0xkitSchema',
     });
   });
+
+  it('should display default "Verified" text when no attestation is available', async () => {
+    // Test with empty attestations array
+    vi.mocked(useAttestations).mockReturnValue([]);
+
+    render(<Badge tooltip={true} />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+
+    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent('Verified');
+  });
 });

--- a/src/identity/components/Badge.test.tsx
+++ b/src/identity/components/Badge.test.tsx
@@ -1,10 +1,42 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, expect, it } from 'vitest';
+import { useAttestations } from '@/identity/hooks/useAttestations';
+import { base } from 'viem/chains';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useOnchainKit } from '../../useOnchainKit';
 import { Badge } from './Badge';
+import { useIdentityContext } from './IdentityProvider';
+
+// Mock the hooks
+vi.mock('@/identity/hooks/useAttestations');
+vi.mock('./IdentityProvider');
+vi.mock('../../useOnchainKit');
 
 describe('Badge Component', () => {
   const badgeStyle = 'height: 12px; width: 12px';
+
+  beforeEach(() => {
+    vi.mocked(useIdentityContext).mockReturnValue({
+      address: '0x123',
+      schemaId: '0xschema',
+    });
+
+    vi.mocked(useOnchainKit).mockReturnValue({
+      address: null,
+      apiKey: null,
+      chain: base,
+      rpcUrl: null,
+      schemaId: null,
+      projectId: null,
+      sessionId: null,
+      config: {
+        appearance: {},
+      },
+    });
+
+    vi.mocked(useAttestations).mockReturnValue([]);
+  });
+
   it('should render the svg', async () => {
     render(<Badge />);
 
@@ -23,6 +55,238 @@ describe('Badge Component', () => {
       expect(badge).toHaveClass('ock-bg-primary');
       const ticker = screen.queryByTestId('ock-badgeSvg');
       expect(ticker).toHaveClass('ock-icon-color-inverse');
+    });
+  });
+
+  it('should not show tooltip when tooltip is false', async () => {
+    render(<Badge tooltip={false} />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+
+    expect(screen.queryByTestId('ockBadgeTooltip')).not.toBeInTheDocument();
+  });
+
+  it('should show tooltip when hovered and tooltip is true', async () => {
+    render(<Badge tooltip={true} />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+
+    expect(screen.getByTestId('ockBadgeTooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent('Verified');
+  });
+
+  it('should show tooltipText when provided', async () => {
+    render(<Badge tooltipText="Custom tooltip" />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+
+    expect(screen.getByTestId('ockBadgeTooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent(
+      'Custom tooltip',
+    );
+  });
+
+  it('should not show tooltip when mouse leaves', async () => {
+    render(<Badge tooltip={true} />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+    expect(screen.getByTestId('ockBadgeTooltip')).toBeInTheDocument();
+
+    fireEvent.mouseLeave(badge);
+    expect(screen.queryByTestId('ockBadgeTooltip')).not.toBeInTheDocument();
+  });
+
+  it('should apply custom className', async () => {
+    render(<Badge className="custom-class" />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    expect(badge).toHaveClass('custom-class');
+  });
+
+  it('should automatically enable tooltip when tooltipText is provided', async () => {
+    render(<Badge tooltip={false} tooltipText="Auto-enabled" />);
+
+    const badge = await screen.findByTestId('ockBadge');
+
+    // Should have cursor-pointer when tooltipText is provided
+    expect(badge).toHaveClass('cursor-pointer');
+
+    fireEvent.mouseEnter(badge);
+    expect(screen.getByTestId('ockBadgeTooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent(
+      'Auto-enabled',
+    );
+  });
+
+  it('should use attestation name when available', async () => {
+    vi.mocked(useAttestations).mockReturnValue([
+      {
+        decodedDataJson: JSON.stringify({ attestation: 'Coinbase Verified' }),
+        id: '1',
+        attester: '0x456',
+        expirationTime: 0,
+        recipient: '0x123',
+        revocationTime: 0,
+        revoked: false,
+        schemaId: '0xschema',
+        time: 123456789,
+      },
+    ]);
+
+    render(<Badge tooltip={true} />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+
+    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent(
+      'Coinbase Verified',
+    );
+  });
+
+  it('should handle complex attestation data structure', async () => {
+    vi.mocked(useAttestations).mockReturnValue([
+      {
+        decodedDataJson: JSON.stringify({
+          verification: {
+            name: 'verification',
+            type: 'string',
+            signature: 'xyz',
+            value: 'Base Verified',
+          },
+        }),
+        id: '1',
+        attester: '0x456',
+        expirationTime: 0,
+        recipient: '0x123',
+        revocationTime: 0,
+        revoked: false,
+        schemaId: '0xschema',
+        time: 123456789,
+      },
+    ]);
+
+    render(<Badge tooltip={true} />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+
+    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent(
+      'Base Verified',
+    );
+  });
+
+  it('should handle array-formatted attestation data', async () => {
+    vi.mocked(useAttestations).mockReturnValue([
+      {
+        decodedDataJson: JSON.stringify([
+          {
+            name: 'Array Attestation',
+            type: 'string',
+            signature: 'abc',
+            value: 'Value not used',
+          },
+        ]),
+        id: '1',
+        attester: '0x789',
+        expirationTime: 0,
+        recipient: '0x123',
+        revocationTime: 0,
+        revoked: false,
+        schemaId: '0xschema',
+        time: 123456789,
+      },
+    ]);
+
+    render(<Badge tooltip={true} />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+
+    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent(
+      'Array Attestation',
+    );
+  });
+
+  it('should handle JSON parsing errors gracefully', async () => {
+    vi.mocked(useAttestations).mockReturnValue([
+      {
+        decodedDataJson: 'invalid-json',
+        id: '1',
+        attester: '0x456',
+        expirationTime: 0,
+        recipient: '0x123',
+        revocationTime: 0,
+        revoked: false,
+        schemaId: '0xschema',
+        time: 123456789,
+      },
+    ]);
+
+    render(<Badge tooltip={true} />);
+
+    const badge = await screen.findByTestId('ockBadge');
+    fireEvent.mouseEnter(badge);
+
+    expect(screen.getByTestId('ockBadgeTooltip')).toHaveTextContent('Verified');
+  });
+
+  it('should use context schemaId if available', async () => {
+    vi.mocked(useIdentityContext).mockReturnValue({
+      address: '0x123',
+      schemaId: '0xcontextSchema',
+    });
+
+    vi.mocked(useOnchainKit).mockReturnValue({
+      address: null,
+      apiKey: null,
+      chain: base,
+      rpcUrl: null,
+      schemaId: '0xkitSchema',
+      projectId: null,
+      sessionId: null,
+      config: {
+        appearance: {},
+      },
+    });
+
+    render(<Badge />);
+
+    expect(useAttestations).toHaveBeenCalledWith({
+      address: '0x123',
+      chain: base,
+      schemaId: '0xcontextSchema',
+    });
+  });
+
+  it('should fall back to kit schemaId if context schemaId is not available', async () => {
+    vi.mocked(useIdentityContext).mockReturnValue({
+      address: '0x123',
+      schemaId: null,
+    });
+
+    vi.mocked(useOnchainKit).mockReturnValue({
+      address: null,
+      apiKey: null,
+      chain: base,
+      rpcUrl: null,
+      schemaId: '0xkitSchema',
+      projectId: null,
+      sessionId: null,
+      config: {
+        appearance: {},
+      },
+    });
+
+    render(<Badge />);
+
+    expect(useAttestations).toHaveBeenCalledWith({
+      address: '0x123',
+      chain: base,
+      schemaId: '0xkitSchema',
     });
   });
 });

--- a/src/identity/components/Badge.tsx
+++ b/src/identity/components/Badge.tsx
@@ -28,14 +28,14 @@ export function Badge({ className, tooltip = false }: BadgeReact) {
   const { address, schemaId: contextSchemaId } = useIdentityContext();
   const { chain, schemaId: kitSchemaId } = useOnchainKit();
 
+  // Only enable tooltip if tooltip is true or a string
+  const showTooltipFeature = Boolean(tooltip);
+
   const attestations = useAttestations({
     address,
     chain,
-    schemaId: contextSchemaId ?? kitSchemaId,
+    schemaId: showTooltipFeature ? contextSchemaId ?? kitSchemaId : null,
   });
-
-  // Only enable tooltip if tooltip is true or a string
-  const showTooltipFeature = Boolean(tooltip);
 
   // Get tooltip text from tooltip prop or attestation
   const displayText = useMemo(() => {

--- a/src/identity/components/Badge.tsx
+++ b/src/identity/components/Badge.tsx
@@ -8,6 +8,18 @@ import { useState } from 'react';
 import { useOnchainKit } from '../../useOnchainKit';
 import { useIdentityContext } from './IdentityProvider';
 
+type extractAttestationNameParams = {
+  decodedDataJson?: string;
+  id?: string;
+  attester?: string;
+  expirationTime?: number;
+  recipient?: string;
+  revocationTime?: number;
+  revoked?: boolean;
+  schemaId?: string;
+  time?: number;
+};
+
 /**
  * Badge component.
  */
@@ -63,7 +75,7 @@ export function Badge({ className, tooltip = false, tooltipText }: BadgeReact) {
             text.legal,
             color.foreground,
             zIndex.tooltip,
-            'absolute bottom-full left-1/2 mb-1 -translate-x-1/2 transform',
+            '-translate-x-1/2 absolute bottom-full left-1/2 mb-1 transform',
             'whitespace-nowrap px-1.5 py-0.5',
           )}
           data-testid="ockBadgeTooltip"
@@ -71,7 +83,7 @@ export function Badge({ className, tooltip = false, tooltipText }: BadgeReact) {
           {displayText}
           <div
             className={cn(
-              'absolute left-1/2 top-full -translate-x-1/2 transform',
+              '-translate-x-1/2 absolute top-full left-1/2 transform',
             )}
           />
         </div>
@@ -83,7 +95,9 @@ export function Badge({ className, tooltip = false, tooltipText }: BadgeReact) {
 /**
  * Extracts the attestation name from an attestation object
  */
-function extractAttestationName(attestation?: any): string {
+function extractAttestationName(
+  attestation?: extractAttestationNameParams,
+): string {
   if (!attestation?.decodedDataJson) {
     return 'Verified';
   }

--- a/src/identity/components/Badge.tsx
+++ b/src/identity/components/Badge.tsx
@@ -1,30 +1,95 @@
 'use client';
+import { useAttestations } from '@/identity/hooks/useAttestations';
 import type { BadgeReact } from '@/identity/types';
+import { Popover } from '@/internal/components/Popover';
 import { badgeSvg } from '@/internal/svg/badgeSvg';
 import { background, cn } from '@/styles/theme';
+import { border, color, pressable, text } from '@/styles/theme';
+import { useOnchainKit } from '@/useOnchainKit';
+import { useCallback, useRef, useState } from 'react';
+import { useIdentityContext } from './IdentityProvider';
 
 /**
  * Badge component.
  */
-export function Badge({ className }: BadgeReact) {
+export function Badge({
+  className,
+  tooltipText,
+  tooltip = !!tooltipText, // Default to true if tooltipText exists
+}: BadgeReact) {
   // TODO: Implement the Badge component as span and CSS without an SVG element.
-  const badgeSize = '12px';
+  const badgeRef = useRef<HTMLSpanElement>(null);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const { chain, schemaId } = useOnchainKit();
+  const { schemaId: contextSchemaId, address: contextAddress } =
+    useIdentityContext();
+
+  const attestations = useAttestations({
+    address: contextAddress,
+    chain,
+    schemaId: contextSchemaId ?? schemaId,
+  });
+
+  const handleMouseEnter = useCallback(() => {
+    if (tooltip) {
+      setIsTooltipOpen(true);
+    }
+  }, [tooltip]);
+
+  const handleMouseLeave = useCallback(() => {
+    setIsTooltipOpen(false);
+  }, []);
+
+  // Use tooltipText if provided, otherwise fall back to the attestation name
+  const displayText =
+    tooltipText ??
+    (attestations[0]?.decodedDataJson
+      ? JSON.parse(attestations[0].decodedDataJson)[0]?.name
+      : null);
+
   return (
-    <span
-      className={cn(
-        background.primary,
-        'rounded-full border border-transparent',
-        className,
+    <div className="relative inline-block">
+      <span
+        ref={badgeRef}
+        className={cn(
+          background.primary,
+          'h-3 w-3 max-h-3 max-w-3',
+          'rounded-full border border-transparent inline-block',
+          tooltip && 'cursor-default group',
+          className,
+        )}
+        data-testid="ockBadge"
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      >
+        {badgeSvg}
+      </span>
+      {tooltip && displayText && (
+        <Popover
+          anchor={badgeRef.current}
+          isOpen={isTooltipOpen}
+          onClose={() => setIsTooltipOpen(false)}
+          position="top"
+          align="center"
+          offset={4}
+          trigger={badgeRef}
+        >
+          <div
+            className={cn(
+              pressable.alternate,
+              text.legal,
+              color.foreground,
+              border.default,
+              border.radius,
+              'rounded-md bg-gray-900 px-2 py-1 text-xs text-white whitespace-nowrap',
+            )}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
+          >
+            {displayText}
+          </div>
+        </Popover>
       )}
-      data-testid="ockBadge"
-      style={{
-        height: badgeSize,
-        width: badgeSize,
-        maxHeight: badgeSize,
-        maxWidth: badgeSize,
-      }}
-    >
-      {badgeSvg}
-    </span>
+    </div>
   );
 }

--- a/src/identity/components/Badge.tsx
+++ b/src/identity/components/Badge.tsx
@@ -28,13 +28,10 @@ export function Badge({ className, tooltip = false }: BadgeReact) {
   const { address, schemaId: contextSchemaId } = useIdentityContext();
   const { chain, schemaId: kitSchemaId } = useOnchainKit();
 
-  // Only enable tooltip if tooltip is true or a string
-  const showTooltipFeature = Boolean(tooltip);
-
   const attestations = useAttestations({
     address,
     chain,
-    schemaId: showTooltipFeature ? contextSchemaId ?? kitSchemaId : null,
+    schemaId: tooltip ? contextSchemaId ?? kitSchemaId : null,
   });
 
   // Get tooltip text from tooltip prop or attestation
@@ -57,7 +54,7 @@ export function Badge({ className, tooltip = false }: BadgeReact) {
           background.primary,
           border.default,
           border.radius,
-          showTooltipFeature && 'cursor-pointer',
+          tooltip && 'cursor-pointer',
           className,
         )}
         style={{
@@ -67,14 +64,14 @@ export function Badge({ className, tooltip = false }: BadgeReact) {
           maxWidth: badgeSize,
         }}
         data-testid="ockBadge"
-        {...(showTooltipFeature && {
+        {...(tooltip && {
           onMouseEnter: () => setShowTooltip(true),
           onMouseLeave: () => setShowTooltip(false),
         })}
       >
         {badgeSvg}
       </span>
-      {showTooltip && showTooltipFeature && (
+      {showTooltip && tooltip && (
         <div
           className={cn(
             border.radius,

--- a/src/identity/components/IdentityCard.test.tsx
+++ b/src/identity/components/IdentityCard.test.tsx
@@ -170,4 +170,26 @@ describe('IdentityCard', () => {
       chain: goerli,
     });
   });
+
+  it('passes boolean tooltip prop to Badge component', () => {
+    renderWithProvider(
+      <IdentityCard address={mockAddress} badgeTooltip={true} />,
+    );
+
+    // Verify that the Badge component receives the tooltip prop
+    // Since we're mocking the Name component and checking its children,
+    // we can verify that it contains the Badge with the correct props
+    expect(screen.getByTestId('ockIdentity_Text')).toBeInTheDocument();
+  });
+
+  it('passes string tooltip prop to Badge component', () => {
+    renderWithProvider(
+      <IdentityCard address={mockAddress} badgeTooltip="Custom Tooltip" />,
+    );
+
+    // Verify that the Badge component receives the tooltip prop
+    // Since we're mocking the Name component and checking its children,
+    // we can verify that it contains the Badge with the correct props
+    expect(screen.getByTestId('ockIdentity_Text')).toBeInTheDocument();
+  });
 });

--- a/src/identity/components/IdentityCard.test.tsx
+++ b/src/identity/components/IdentityCard.test.tsx
@@ -175,10 +175,6 @@ describe('IdentityCard', () => {
     renderWithProvider(
       <IdentityCard address={mockAddress} badgeTooltip={true} />,
     );
-
-    // Verify that the Badge component receives the tooltip prop
-    // Since we're mocking the Name component and checking its children,
-    // we can verify that it contains the Badge with the correct props
     expect(screen.getByTestId('ockIdentity_Text')).toBeInTheDocument();
   });
 
@@ -186,10 +182,6 @@ describe('IdentityCard', () => {
     renderWithProvider(
       <IdentityCard address={mockAddress} badgeTooltip="Custom Tooltip" />,
     );
-
-    // Verify that the Badge component receives the tooltip prop
-    // Since we're mocking the Name component and checking its children,
-    // we can verify that it contains the Badge with the correct props
     expect(screen.getByTestId('ockIdentity_Text')).toBeInTheDocument();
   });
 });

--- a/src/identity/components/IdentityCard.tsx
+++ b/src/identity/components/IdentityCard.tsx
@@ -14,7 +14,7 @@ type IdentityCardReact = {
   chain?: Chain;
   className?: string;
   schemaId?: Address | null;
-  /** Controls whether the badge shows a tooltip on hover. When a string is provided, it shows that text in the tooltip. Defaults to false. */
+  /** Controls whether the badge shows a tooltip on hover. When true, the tooltip displays the attestation's name. When a string is provided, it overrides the default and shows that text in the tooltip. Defaults to false. */
   badgeTooltip?: boolean | string;
 };
 

--- a/src/identity/components/IdentityCard.tsx
+++ b/src/identity/components/IdentityCard.tsx
@@ -14,10 +14,8 @@ type IdentityCardReact = {
   chain?: Chain;
   className?: string;
   schemaId?: Address | null;
-  /** Controls whether the badge shows a tooltip on hover. Defaults to false. */
-  badgeTooltip?: boolean;
-  /** Custom text to display in the badge tooltip. Defaults to the attestation name if not provided. */
-  badgeTooltipText?: string;
+  /** Controls whether the badge shows a tooltip on hover. When a string is provided, it shows that text in the tooltip. Defaults to false. */
+  badgeTooltip?: boolean | string;
 };
 
 export function IdentityCard({
@@ -26,7 +24,6 @@ export function IdentityCard({
   className = '',
   schemaId,
   badgeTooltip,
-  badgeTooltipText,
 }: IdentityCardReact) {
   return (
     <Identity
@@ -43,7 +40,7 @@ export function IdentityCard({
     >
       <Avatar />
       <Name>
-        <Badge tooltip={badgeTooltip} tooltipText={badgeTooltipText} />
+        <Badge tooltip={badgeTooltip} />
       </Name>
       <AddressComponent />
       <Socials />

--- a/src/identity/components/IdentityCard.tsx
+++ b/src/identity/components/IdentityCard.tsx
@@ -14,7 +14,7 @@ type IdentityCardReact = {
   chain?: Chain;
   className?: string;
   schemaId?: Address | null;
-  /** Controls whether the badge shows a tooltip on hover. When true, the tooltip displays the attestation's name. When a string is provided, it overrides the default and shows that text in the tooltip. Defaults to false. */
+  /** Controls whether the badge shows a tooltip on hover. When true, the tooltip displays the attestation's name. When a string is provided, that text overrides the default display. Defaults to false. */
   badgeTooltip?: boolean | string;
 };
 

--- a/src/identity/components/IdentityCard.tsx
+++ b/src/identity/components/IdentityCard.tsx
@@ -14,6 +14,10 @@ type IdentityCardReact = {
   chain?: Chain;
   className?: string;
   schemaId?: Address | null;
+  /** Controls whether the badge shows a tooltip on hover. Defaults to false. */
+  badgeTooltip?: boolean;
+  /** Custom text to display in the badge tooltip. Defaults to the attestation name if not provided. */
+  badgeTooltipText?: string;
 };
 
 export function IdentityCard({
@@ -21,6 +25,8 @@ export function IdentityCard({
   chain,
   className = '',
   schemaId,
+  badgeTooltip,
+  badgeTooltipText,
 }: IdentityCardReact) {
   return (
     <Identity
@@ -37,7 +43,7 @@ export function IdentityCard({
     >
       <Avatar />
       <Name>
-        <Badge />
+        <Badge tooltip={badgeTooltip} tooltipText={badgeTooltipText} />
       </Name>
       <AddressComponent />
       <Socials />

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -67,7 +67,7 @@ export type AvatarReact = {
 export type BadgeReact = {
   /** Optional className override for top span element. */
   className?: string;
-  /** Controls whether the badge shows a tooltip on hover. When true, the tooltip displays the attestation's name. When a string is provided, it overrides the default and shows that text in the tooltip. Defaults to false. */
+  /** Controls whether the badge shows a tooltip on hover. When true, the tooltip displays the attestation's name. When a string is provided, that text overrides the default display. Defaults to false. */
   tooltip?: boolean | string;
 };
 

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -67,7 +67,7 @@ export type AvatarReact = {
 export type BadgeReact = {
   /** Optional className override for top span element. */
   className?: string;
-  /** Controls whether the badge shows a tooltip on hover. Defaults to true. */
+  /** Controls whether the badge shows a tooltip on hover. Defaults to false. */
   tooltip?: boolean;
   /** Custom text to display in the badge tooltip. Defaults to the attestation name if not provided. */
   tooltipText?: string;

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -67,6 +67,10 @@ export type AvatarReact = {
 export type BadgeReact = {
   /** Optional className override for top span element. */
   className?: string;
+  /** Controls whether the badge shows a tooltip on hover. Defaults to true. */
+  tooltip?: boolean;
+  /** Custom text to display in the badge tooltip. Defaults to the attestation name if not provided. */
+  tooltipText?: string;
 };
 
 /**

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -67,7 +67,7 @@ export type AvatarReact = {
 export type BadgeReact = {
   /** Optional className override for top span element. */
   className?: string;
-  /** Controls whether the badge shows a tooltip on hover. When a string is provided, it shows that text in the tooltip. Defaults to false. */
+  /** Controls whether the badge shows a tooltip on hover. When true, the tooltip displays the attestation's name. When a string is provided, it overrides the default and shows that text in the tooltip. Defaults to false. */
   tooltip?: boolean | string;
 };
 

--- a/src/identity/types.ts
+++ b/src/identity/types.ts
@@ -67,10 +67,8 @@ export type AvatarReact = {
 export type BadgeReact = {
   /** Optional className override for top span element. */
   className?: string;
-  /** Controls whether the badge shows a tooltip on hover. Defaults to false. */
-  tooltip?: boolean;
-  /** Custom text to display in the badge tooltip. Defaults to the attestation name if not provided. */
-  tooltipText?: string;
+  /** Controls whether the badge shows a tooltip on hover. When a string is provided, it shows that text in the tooltip. Defaults to false. */
+  tooltip?: boolean | string;
 };
 
 /**


### PR DESCRIPTION
**What changed? Why?**
The attestation badge can be confusing, it's simply a checkmark that displays next to the users wallet name or address. This tooltip will make it clear what the Badge represents. It will also allow the developer to customize the message.
**Notes to reviewers**

**How has it been tested?**

`<IdentityCard /> // No tooltip.` 

`<IdentityCard badgeTooltip={true} /> // Tooltip with attestation name` 
<img width="626" alt="Screenshot 2025-03-18 at 2 51 33 PM" src="https://github.com/user-attachments/assets/95e1cb71-0ba6-4b0d-98cb-2686c49f4ff7" />

`<IdentityCard badgeTooltipText="Custom text" /> // Tooltip with "Custom text"`
<img width="630" alt="Screenshot 2025-03-18 at 2 52 52 PM" src="https://github.com/user-attachments/assets/7b84fa3a-7001-455e-9bdd-eab8ae24223b" />

```
<Identity>
       <Badge /> // No tooltip
</Identity>
```

```
<Identity>
       <Badge tooltip={true} /> // Tooltip with attestation name
</Identity>
```

```
<Identity>
       <Badge tooltipText="Custom text" /> // Tooltip with "Custom text
</Identity>
```

With themes:
<img width="477" alt="Screenshot 2025-03-19 at 11 24 00 AM" src="https://github.com/user-attachments/assets/94e412fb-93a2-4b63-9f9f-63baddda087a" />