### PR TITLE
feat: Add Base light and dark theme

### DIFF
--- a/.changeset/fluffy-icons-rhyme.md
+++ b/.changeset/fluffy-icons-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: Added base-light and base-dark theme. By @cpcramer #000

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -89,7 +89,8 @@ export type ComponentTheme =
  * Internal theme options, including light/dark variants for 'default'
  */
 export type UseThemeReact =
-  | 'base'
+  | 'base-light'
+  | 'base-dark'
   | 'cyberpunk'
   | 'default'
   | 'hacker'

--- a/src/internal/hooks/useTheme.test.ts
+++ b/src/internal/hooks/useTheme.test.ts
@@ -27,7 +27,6 @@ describe('useTheme', () => {
 
   it.each([
     ['cyberpunk', 'auto', 'light', 'cyberpunk'],
-    ['base', 'dark', 'dark', 'base'],
     ['hacker', 'light', 'light', 'hacker'],
   ] as const)(
     'should return %s theme when set, regardless of mode or system preference',
@@ -44,6 +43,10 @@ describe('useTheme', () => {
     ['default', 'auto', 'dark', 'default-dark'],
     ['default', 'light', 'dark', 'default-light'],
     ['default', 'dark', 'light', 'default-dark'],
+    ['base', 'auto', 'light', 'base-light'],
+    ['base', 'auto', 'dark', 'base-dark'],
+    ['base', 'light', 'dark', 'base-light'],
+    ['base', 'dark', 'light', 'base-dark'],
     ['custom', 'auto', 'light', 'custom-light'],
     ['custom', 'auto', 'dark', 'custom-dark'],
   ] as const)(
@@ -59,6 +62,8 @@ describe('useTheme', () => {
   it.each([
     ['default', undefined, 'light', 'default-light'],
     ['default', undefined, 'dark', 'default-dark'],
+    ['base', undefined, 'light', 'base-light'],
+    ['base', undefined, 'dark', 'base-dark'],
     ['custom', undefined, 'light', 'custom-light'],
     ['custom', undefined, 'dark', 'custom-dark'],
   ] as const)(
@@ -88,14 +93,15 @@ describe('useTheme', () => {
   it('should handle all possible return types of UseThemeReact', () => {
     const allThemes: UseThemeReact[] = [
       'cyberpunk',
-      'base',
       'hacker',
       'default-light',
       'default-dark',
+      'base-light',
+      'base-dark',
     ];
 
     for (const theme of allThemes) {
-      if (theme === 'cyberpunk' || theme === 'base' || theme === 'hacker') {
+      if (theme === 'cyberpunk' || theme === 'hacker') {
         mockUseOnchainKit(theme, 'auto');
       } else {
         const [baseTheme, mode] = theme.split('-');

--- a/src/internal/hooks/useTheme.ts
+++ b/src/internal/hooks/useTheme.ts
@@ -4,12 +4,10 @@ import { usePreferredColorScheme } from './usePreferredColorScheme';
 
 export function useTheme(): UseThemeReact {
   const preferredMode = usePreferredColorScheme();
-  const {
-    config: { appearance } = {},
-  } = useOnchainKit();
+  const { config: { appearance } = {} } = useOnchainKit();
   const { theme = 'default', mode = 'auto' } = appearance || {};
 
-  if (theme === 'cyberpunk' || theme === 'base' || theme === 'hacker') {
+  if (theme === 'cyberpunk' || theme === 'hacker') {
     return theme;
   }
 

--- a/src/internal/hooks/useTheme.ts
+++ b/src/internal/hooks/useTheme.ts
@@ -4,7 +4,9 @@ import { usePreferredColorScheme } from './usePreferredColorScheme';
 
 export function useTheme(): UseThemeReact {
   const preferredMode = usePreferredColorScheme();
-  const { config: { appearance } = {} } = useOnchainKit();
+  const {
+    config: { appearance } = {},
+  } = useOnchainKit();
   const { theme = 'default', mode = 'auto' } = appearance || {};
 
   if (theme === 'cyberpunk' || theme === 'hacker') {

--- a/src/styles/tailwind-base.css
+++ b/src/styles/tailwind-base.css
@@ -102,7 +102,56 @@
     --ock-line-inverse: theme(colors.gray.300);
   }
 
-  .base {
+  .base-light {
+    --ock-font-family: 'DM Sans', sans-serif;
+    --ock-border-radius: 0.5rem;
+    --ock-border-radius-inner: 0.25rem;
+    --ock-text-inverse: theme(colors.gray.50);
+    --ock-text-foreground: theme(colors.gray.950);
+    --ock-text-foreground-muted: theme(colors.gray.600);
+    --ock-text-error: theme(colors.rose.600);
+    --ock-text-primary: #0052ff;
+    --ock-text-success: theme(colors.lime.600);
+    --ock-text-warning: theme(colors.orange.600);
+    --ock-text-disabled: theme(colors.gray.400);
+
+    --ock-bg-default: theme(colors.gray.50);
+    --ock-bg-default-hover: theme(colors.gray.200);
+    --ock-bg-default-active: theme(colors.gray.300);
+    --ock-bg-alternate: theme(colors.gray.200);
+    --ock-bg-alternate-hover: theme(colors.gray.300);
+    --ock-bg-alternate-active: theme(colors.gray.400);
+    --ock-bg-inverse: theme(colors.gray.100);
+    --ock-bg-inverse-hover: theme(colors.gray.200);
+    --ock-bg-inverse-active: theme(colors.gray.300);
+    --ock-bg-primary: #0052ff;
+    --ock-bg-primary-hover: #014ceb;
+    --ock-bg-primary-active: #0148dc;
+    --ock-bg-primary-washed: #b2cbff;
+    --ock-bg-primary-disabled: #9dbcfe;
+    --ock-bg-secondary: theme(colors.slate.200);
+    --ock-bg-secondary-hover: theme(colors.slate.300);
+    --ock-bg-secondary-active: theme(colors.slate.400);
+    --ock-bg-error: theme(colors.rose.600);
+    --ock-bg-warning: theme(colors.orange.600);
+    --ock-bg-success: theme(colors.lime.300);
+    --ock-bg-default-reverse: theme(colors.gray.950);
+
+    --ock-icon-color-primary: #0052ff;
+    --ock-icon-color-foreground: theme(colors.gray.950);
+    --ock-icon-color-foreground-muted: theme(colors.gray.600);
+    --ock-icon-color-inverse: theme(colors.gray.50);
+    --ock-icon-color-error: theme(colors.rose.600);
+    --ock-icon-color-success: theme(colors.lime.600);
+    --ock-icon-color-warning: theme(colors.orange.600);
+
+    --ock-line-primary: #0052ff;
+    --ock-line-default: theme(colors.gray.300);
+    --ock-line-heavy: theme(colors.gray.500);
+    --ock-line-inverse: theme(colors.gray.700);
+  }
+
+  .base-dark {
     --ock-font-family: 'DM Sans', sans-serif;
     --ock-border-radius: 0.5rem;
     --ock-border-radius-inner: 0.25rem;
@@ -110,7 +159,7 @@
     --ock-text-foreground: theme(colors.gray.50);
     --ock-text-foreground-muted: theme(colors.gray.400);
     --ock-text-error: theme(colors.rose.400);
-    --ock-text-primary: #0052ff;
+    --ock-text-primary: #578bfa;
     --ock-text-success: theme(colors.lime.400);
     --ock-text-warning: theme(colors.orange.400);
     --ock-text-disabled: theme(colors.gray.600);
@@ -124,11 +173,11 @@
     --ock-bg-inverse: theme(colors.gray.900);
     --ock-bg-inverse-hover: theme(colors.gray.800);
     --ock-bg-inverse-active: theme(colors.gray.700);
-    --ock-bg-primary: #0052ff;
-    --ock-bg-primary-hover: #014ceb;
-    --ock-bg-primary-active: #0148dc;
-    --ock-bg-primary-washed: #b2cbff;
-    --ock-bg-primary-disabled: #80a8ff;
+    --ock-text-primary: #578bfa;
+    --ock-bg-primary-hover: #477ef5;
+    --ock-bg-primary-active: #5386f5;
+    --ock-bg-primary-washed: #051537;
+    --ock-bg-primary-disabled: #1b3365;
     --ock-bg-secondary: theme(colors.slate.800);
     --ock-bg-secondary-hover: theme(colors.slate.700);
     --ock-bg-secondary-active: theme(colors.slate.600);
@@ -137,7 +186,7 @@
     --ock-bg-success: theme(colors.lime.700);
     --ock-bg-default-reverse: theme(colors.gray.50);
 
-    --ock-icon-color-primary: #0052ff;
+    --ock-icon-color-primary: #578bfa;
     --ock-icon-color-foreground: theme(colors.gray.50);
     --ock-icon-color-foreground-muted: theme(colors.gray.400);
     --ock-icon-color-inverse: theme(colors.gray.950);
@@ -145,7 +194,7 @@
     --ock-icon-color-success: theme(colors.lime.400);
     --ock-icon-color-warning: theme(colors.orange.400);
 
-    --ock-line-primary: #0052ff;
+    --ock-line-primary: #578bfa;
     --ock-line-default: theme(colors.gray.700);
     --ock-line-heavy: theme(colors.gray.500);
     --ock-line-inverse: theme(colors.gray.300);

--- a/src/styles/tailwind-base.css
+++ b/src/styles/tailwind-base.css
@@ -173,7 +173,7 @@
     --ock-bg-inverse: theme(colors.gray.900);
     --ock-bg-inverse-hover: theme(colors.gray.800);
     --ock-bg-inverse-active: theme(colors.gray.700);
-    --ock-text-primary: #578bfa;
+    --ock-bg-primary: #578bfa;
     --ock-bg-primary-hover: #477ef5;
     --ock-bg-primary-active: #5386f5;
     --ock-bg-primary-washed: #051537;


### PR DESCRIPTION
**What changed? Why?**
Add `base-light` and `base-dark` theme support. 

**Notes to reviewers**

**How has it been tested?**

<img width="448" alt="Screenshot 2025-03-19 at 4 23 08 PM" src="https://github.com/user-attachments/assets/a44e9e1b-cc2a-4e3d-a8ff-40a448a38b52" />

<img width="451" alt="Screenshot 2025-03-19 at 4 23 18 PM" src="https://github.com/user-attachments/assets/0ed317fe-6874-46a0-bdfb-0f326c42deef" />
