### PR TITLE
Replace `htmlFor="chain"` nft-options.tsx

### DIFF
--- a/playground/nextjs-app-router/components/form/nft-options.tsx
+++ b/playground/nextjs-app-router/components/form/nft-options.tsx
@@ -8,7 +8,7 @@ export function NFTOptions() {
 
   return (
     <div className="grid gap-2">
-      <Label htmlFor="chain">NFT contract:tokenId</Label>
+      <Label htmlFor="nftToken">NFT contract:tokenId</Label>
       <Input
         id="nftToken"
         placeholder="Enter contractAddress:tokenId"


### PR DESCRIPTION
**What changed? Why?**

Replace `htmlFor="chain"` with `htmlFor="nftToken"` to ensure the label properly references the corresponding input. This improves accessibility and helps screen readers identify the correct field.
