### PR TITLE
chore: fix onramp bug

### DIFF
--- a/playground/nextjs-app-router/components/demo/Buy.tsx
+++ b/playground/nextjs-app-router/components/demo/Buy.tsx
@@ -7,7 +7,6 @@ import type { TransactionReceipt } from 'viem';
 import { base } from 'viem/chains';
 import { degenToken } from '../../lib/constants';
 import { AppContext } from '../AppProvider';
-import { usdcToken } from '../../onchainkit/esm/token/constants';
 
 const FALLBACK_DEFAULT_MAX_SLIPPAGE = 3;
 
@@ -56,7 +55,7 @@ function BuyComponent() {
           maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
         }}
         isSponsored={isSponsored}
-        toToken={usdcToken}
+        toToken={degenToken}
       />
     </div>
   );

--- a/playground/nextjs-app-router/components/demo/Buy.tsx
+++ b/playground/nextjs-app-router/components/demo/Buy.tsx
@@ -7,6 +7,7 @@ import type { TransactionReceipt } from 'viem';
 import { base } from 'viem/chains';
 import { degenToken } from '../../lib/constants';
 import { AppContext } from '../AppProvider';
+import { usdcToken } from '../../onchainkit/esm/token/constants';
 
 const FALLBACK_DEFAULT_MAX_SLIPPAGE = 3;
 
@@ -55,7 +56,7 @@ function BuyComponent() {
           maxSlippage: defaultMaxSlippage || FALLBACK_DEFAULT_MAX_SLIPPAGE,
         }}
         isSponsored={isSponsored}
-        toToken={degenToken}
+        toToken={usdcToken}
       />
     </div>
   );

--- a/src/buy/components/BuyDropdown.tsx
+++ b/src/buy/components/BuyDropdown.tsx
@@ -111,7 +111,7 @@ export function BuyDropdown() {
             description={method.description}
             onClick={handleOnrampClick(method.id)}
             icon={method.icon}
-            amountUSDC={to?.amountUSD}
+            to={to}
           />
         );
       })}

--- a/src/buy/components/BuyOnrampItem.test.tsx
+++ b/src/buy/components/BuyOnrampItem.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BuyOnrampItem } from './BuyOnrampItem';
 import { useBuyContext } from './BuyProvider';
+import { Address } from 'viem';
 
 vi.mock('./BuyProvider', () => ({
   useBuyContext: vi.fn(),
@@ -18,7 +19,7 @@ vi.mock('../../internal/svg', () => ({
 const mockTo = {
   amountUSD: '5',
   amount: '5',
-  token: { symbol: 'USDC' },
+  token: { address: 'USDC' },
 };
 
 describe('BuyOnrampItem', () => {
@@ -108,7 +109,7 @@ describe('BuyOnrampItem', () => {
           {
             amount: '5',
             amountUSD: '4',
-            token: { symbol: 'DEGEN' } as Token,
+            token: { address: 'DEGEN' as Address } as Token,
           } as SwapUnit
         }
       />,

--- a/src/buy/components/BuyOnrampItem.test.tsx
+++ b/src/buy/components/BuyOnrampItem.test.tsx
@@ -1,10 +1,10 @@
 import type { SwapUnit } from '@/swap/types';
 import type { Token } from '@/token';
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { Address } from 'viem';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BuyOnrampItem } from './BuyOnrampItem';
 import { useBuyContext } from './BuyProvider';
-import { Address } from 'viem';
 
 vi.mock('./BuyProvider', () => ({
   useBuyContext: vi.fn(),

--- a/src/buy/components/BuyOnrampItem.test.tsx
+++ b/src/buy/components/BuyOnrampItem.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../../internal/svg', () => ({
 const mockTo = {
   amountUSD: '5',
   amount: '5',
-  token: { address: 'USDC' },
+  token: { address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' },
 };
 
 describe('BuyOnrampItem', () => {

--- a/src/buy/components/BuyOnrampItem.test.tsx
+++ b/src/buy/components/BuyOnrampItem.test.tsx
@@ -1,9 +1,9 @@
+import type { SwapUnit } from '@/swap/types';
+import type { Token } from '@/token';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BuyOnrampItem } from './BuyOnrampItem';
 import { useBuyContext } from './BuyProvider';
-import type { SwapUnit } from '@/swap/types';
-import type { Token } from '@/token';
 
 vi.mock('./BuyProvider', () => ({
   useBuyContext: vi.fn(),

--- a/src/buy/components/BuyOnrampItem.test.tsx
+++ b/src/buy/components/BuyOnrampItem.test.tsx
@@ -2,6 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BuyOnrampItem } from './BuyOnrampItem';
 import { useBuyContext } from './BuyProvider';
+import { SwapUnit } from '@/swap/types';
+import { Token } from '@/token';
 
 vi.mock('./BuyProvider', () => ({
   useBuyContext: vi.fn(),
@@ -12,6 +14,12 @@ vi.mock('../../internal/svg', () => ({
   cardSvg: <svg data-testid="cardSvg" />,
   coinbaseLogoSvg: <svg data-testid="coinbaseLogoSvg" />,
 }));
+
+const mockTo = {
+  amountUSD: '5',
+  amount: '5',
+  token: { symbol: 'USDC' },
+};
 
 describe('BuyOnrampItem', () => {
   const mockSetIsDropdownOpen = vi.fn();
@@ -31,7 +39,7 @@ describe('BuyOnrampItem', () => {
         description="Fast and secure payments."
         onClick={mockOnClick}
         icon="applePay"
-        amountUSDC="5"
+        to={mockTo as SwapUnit}
       />,
     );
 
@@ -48,7 +56,7 @@ describe('BuyOnrampItem', () => {
         description="Use your card to pay."
         onClick={mockOnClick}
         icon="creditCard"
-        amountUSDC="5"
+        to={mockTo as SwapUnit}
       />,
     );
 
@@ -62,7 +70,7 @@ describe('BuyOnrampItem', () => {
         description="Pay using your Coinbase account."
         onClick={mockOnClick}
         icon="coinbasePay"
-        amountUSDC="5"
+        to={mockTo as SwapUnit}
       />,
     );
 
@@ -80,7 +88,7 @@ describe('BuyOnrampItem', () => {
         description="Fast and secure payments."
         onClick={mockOnClick}
         icon="applePay"
-        amountUSDC="5"
+        to={mockTo as SwapUnit}
       />,
     );
 
@@ -96,7 +104,13 @@ describe('BuyOnrampItem', () => {
         description="Fast and secure payments."
         onClick={mockOnClick}
         icon="applePay"
-        amountUSDC=".4"
+        to={
+          {
+            amount: '5',
+            amountUSD: '4',
+            token: { symbol: 'DEGEN' } as Token,
+          } as SwapUnit
+        }
       />,
     );
 

--- a/src/buy/components/BuyOnrampItem.test.tsx
+++ b/src/buy/components/BuyOnrampItem.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BuyOnrampItem } from './BuyOnrampItem';
 import { useBuyContext } from './BuyProvider';
-import { SwapUnit } from '@/swap/types';
-import { Token } from '@/token';
+import type { SwapUnit } from '@/swap/types';
+import type { Token } from '@/token';
 
 vi.mock('./BuyProvider', () => ({
   useBuyContext: vi.fn(),

--- a/src/buy/components/BuyOnrampItem.tsx
+++ b/src/buy/components/BuyOnrampItem.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { SwapUnit } from '@/swap/types';
+import type { SwapUnit } from '@/swap/types';
 import { usdcToken } from '@/token/constants';
 import { useCallback, useMemo } from 'react';
 import { applePaySvg } from '../../internal/svg/applePaySvg';

--- a/src/buy/components/BuyOnrampItem.tsx
+++ b/src/buy/components/BuyOnrampItem.tsx
@@ -41,7 +41,7 @@ export function BuyOnrampItem({
     // if token is USDC the usd estimate
     // can be slightly off (4.9999999) so
     // use amount instead to prevent disabling of onramp
-    if (to?.token?.symbol === usdcToken?.symbol) {
+    if (to?.token?.address === usdcToken?.address) {
       return to?.amount;
     }
     return to?.amountUSD;

--- a/src/buy/components/BuyOnrampItem.tsx
+++ b/src/buy/components/BuyOnrampItem.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { SwapUnit } from '@/swap/types';
+import { usdcToken } from '@/token/constants';
 import { useCallback, useMemo } from 'react';
 import { applePaySvg } from '../../internal/svg/applePaySvg';
 import { cardSvg } from '../../internal/svg/cardSvg';
@@ -12,7 +14,7 @@ type OnrampItemReact = {
   onClick: () => void;
   svg?: React.ReactNode;
   icon: string;
-  amountUSDC?: string;
+  to?: SwapUnit;
 };
 
 const ONRAMP_ICON_MAP: Record<string, React.ReactNode> = {
@@ -26,7 +28,7 @@ export function BuyOnrampItem({
   description,
   onClick,
   icon,
-  amountUSDC,
+  to,
 }: OnrampItemReact) {
   const { setIsDropdownOpen } = useBuyContext();
 
@@ -35,9 +37,19 @@ export function BuyOnrampItem({
     onClick();
   }, [onClick, setIsDropdownOpen]);
 
+  const fiatAmount = useMemo(() => {
+    // if token is USDC the usd estimate
+    // can be slightly off (4.9999999) so
+    // use amount instead to prevent disabling of onramp
+    if (to?.token?.symbol === usdcToken?.symbol) {
+      return to?.amount;
+    }
+    return to?.amountUSD;
+  }, [to]);
+
   // Debit and Apple Pay have a minimum purchase amount of $5
   const isDisabled =
-    !amountUSDC || (Number.parseFloat(amountUSDC) < 5 && name !== 'Coinbase');
+    !fiatAmount || (Number.parseFloat(fiatAmount) < 5 && name !== 'Coinbase');
 
   const message = useMemo(() => {
     if (isDisabled) {

--- a/src/buy/components/BuyOnrampItem.tsx
+++ b/src/buy/components/BuyOnrampItem.tsx
@@ -41,7 +41,9 @@ export function BuyOnrampItem({
     // if token is USDC the usd estimate
     // can be slightly off (4.9999999) so
     // use amount instead to prevent disabling of onramp
-    if (to?.token?.address === usdcToken?.address) {
+    if (
+      to?.token?.address?.toLowerCase() === usdcToken?.address.toLowerCase()
+    ) {
       return to?.amount;
     }
     return to?.amountUSD;


### PR DESCRIPTION
**What changed? Why?**

The USD estimate for $5 of USDC is slightly off (4.9999). There is a minimum amount of $5 required for onramp options so this PR updates that check to use amount instead of amountUSD for USDC buys. We need to keep amountUSD for non-USDC tokens.

**Notes to reviewers**

**How has it been tested?**
