### PR TITLE
fix: signature provider unmount reset

### DIFF
--- a/packages/onchainkit/src/signature/components/SignatureProvider.tsx
+++ b/packages/onchainkit/src/signature/components/SignatureProvider.tsx
@@ -60,7 +60,7 @@ export function SignatureProvider({
 
   useEffect(() => {
     if (lifecycleStatus.statusName === 'success' && resetAfter) {
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         resetSignMessage();
         resetSignTypedData();
         updateLifecycleStatus({
@@ -68,6 +68,8 @@ export function SignatureProvider({
           statusData: null,
         });
       }, resetAfter);
+
+      return () => clearTimeout(timeoutId);
     }
   }, [
     updateLifecycleStatus,


### PR DESCRIPTION
**What changed? Why?**

Added proper cleanup of SignatureProvider on unmount. Currently, if the component unmounts within 1000ms after a successful action, state mutation happens on an unmounted component.

**Notes to reviewers**

**How has it been tested?**
