### PR TITLE
fix: pass in notification details when available

### DIFF
--- a/src/minikit/hooks/useNotification.test.tsx
+++ b/src/minikit/hooks/useNotification.test.tsx
@@ -65,6 +65,55 @@ describe('useNotification', () => {
         notificationId: expect.any(String),
         title: 'test',
         body: 'test',
+        notificationDetails: null,
+      },
+    });
+  });
+
+  it('should allow notificationDetails to be passed in from context', async () => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ success: true }),
+      }),
+    );
+
+    (useMiniKit as Mock).mockReturnValue({
+      context: {
+        user: {
+          fid: 123,
+        },
+        client: {
+          notificationDetails: {
+            token: '123',
+            url: 'https://example.com',
+          },
+        },
+      },
+      notificationProxyUrl: '/api/notification',
+    });
+
+    const { result } = renderHook(() => useNotification());
+
+    const response = await act(async () => {
+      return await result.current({
+        title: 'test',
+        body: 'test',
+      });
+    });
+
+    expect(response).toBe(true);
+    const calledBody = JSON.parse((global.fetch as Mock).mock.calls[0][1].body);
+    expect(calledBody).toEqual({
+      fid: 123,
+      notification: {
+        notificationId: expect.any(String),
+        title: 'test',
+        body: 'test',
+        notificationDetails: {
+          token: '123',
+          url: 'https://example.com',
+        },
       },
     });
   });

--- a/src/minikit/hooks/useNotification.ts
+++ b/src/minikit/hooks/useNotification.ts
@@ -26,6 +26,7 @@ export function useNotification() {
             fid: context.user.fid,
             notification: {
               notificationId: crypto.randomUUID(),
+              notificationDetails: context.client?.notificationDetails ?? null,
               title,
               body,
             },


### PR DESCRIPTION
**What changed? Why?**
Pass in notification details from frontend context when available to allow in-app notifications to be sent without a database.

**Notes to reviewers**

**How has it been tested?**
