### PR TITLE
chore: Add Attestation caching

### DIFF
--- a/.changeset/petite-guests-itch.md
+++ b/.changeset/petite-guests-itch.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": minor
+---
+
+-**chore**: Add Attestation caching. By @cpcramer #2180

--- a/packages/onchainkit/src/identity/hooks/useAttestations.test.ts
+++ b/packages/onchainkit/src/identity/hooks/useAttestations.test.ts
@@ -42,18 +42,6 @@ describe('useAttestations', () => {
     mockUseQuery.mockClear();
   });
 
-  it('returns an empty array if no schemaId provided', async () => {
-    const address = '0xaddress';
-    const chain = base;
-    const schemaId = null;
-    const { result } = renderHook(() =>
-      useAttestations({ address, chain, schemaId }),
-    );
-    await waitFor(() => {
-      expect(result.current).toEqual([]);
-    });
-  });
-
   it('returns an empty array if no attestations found', async () => {
     (getAttestations as Mock).mockReturnValue([]);
 

--- a/packages/onchainkit/src/identity/hooks/useAttestations.test.ts
+++ b/packages/onchainkit/src/identity/hooks/useAttestations.test.ts
@@ -6,14 +6,40 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { base } from 'viem/chains';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAttestations } from './useAttestations';
+import { getNewReactQueryTestProvider } from './getNewReactQueryTestProvider';
 
 vi.mock('@/identity/utils/getAttestations', () => ({
   getAttestations: vi.fn(),
 }));
 
+const mockUseQuery = vi.fn();
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  type UseQueryType = <TData, _TError = Error>(options: {
+    queryKey: unknown[];
+    queryFn: () => Promise<TData>;
+    [key: string]: unknown;
+  }) => unknown;
+
+  return {
+    ...actual,
+    useQuery: <TData, TError = Error>(options: {
+      queryKey: unknown[];
+      queryFn: () => Promise<TData>;
+      [key: string]: unknown;
+    }) => {
+      mockUseQuery(options);
+      // Return an object with data property for the hook to extract
+      const result = (actual.useQuery as UseQueryType)<TData, TError>(options);
+      return result;
+    },
+  };
+});
+
 describe('useAttestations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseQuery.mockClear();
   });
 
   it('returns an empty array if no schemaId provided', async () => {
@@ -33,32 +59,186 @@ describe('useAttestations', () => {
 
     const address = '0xaddress';
     const chain = base;
-    const schemaId = '0xschema';
-    const { result } = renderHook(() =>
-      useAttestations({ address, chain, schemaId }),
+    const schemaId = '0xschema' as `0x${string}`;
+    const { result } = renderHook(
+      () => useAttestations({ address, chain, schemaId }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
     );
 
     await waitFor(() => {
       expect(result.current).toEqual([]);
     });
+
+    expect(getAttestations).toHaveBeenCalledWith(address, chain, {
+      schemas: [schemaId],
+    });
   });
 
   it('returns attestations if found', async () => {
-    (getAttestations as Mock).mockReturnValue([
+    const mockAttestations = [
       {
         schemaId: '0xschema',
       },
-    ]);
+    ];
+    (getAttestations as Mock).mockResolvedValue(mockAttestations);
 
     const address = '0xaddress';
     const chain = base;
-    const schemaId = '0xschema';
-    const { result } = renderHook(() =>
-      useAttestations({ address, chain, schemaId }),
+    const schemaId = '0xschema' as `0x${string}`;
+    const { result } = renderHook(
+      () => useAttestations({ address, chain, schemaId }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
     );
 
     await waitFor(() => {
-      expect(result.current).toEqual([{ schemaId: '0xschema' }]);
+      expect(result.current).toEqual(mockAttestations);
     });
+  });
+
+  it('is disabled when address or schemaId is not provided', async () => {
+    (getAttestations as Mock).mockImplementation(() => {
+      throw new Error('This should not be called');
+    });
+
+    const address = '0xaddress';
+    const chain = base;
+    const schemaId = '';
+
+    const { result } = renderHook(
+      () => useAttestations({ address, chain, schemaId: '' as any }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(getAttestations).not.toHaveBeenCalled();
+    expect(result.current).toEqual([]);
+  });
+
+  it('respects the enabled option in queryOptions', async () => {
+    const mockAttestations = [{ schemaId: '0xschema' }];
+    (getAttestations as Mock).mockResolvedValue(mockAttestations);
+
+    const address = '0xaddress';
+    const chain = base;
+    const schemaId = '0xschema' as `0x${string}`;
+
+    const { result } = renderHook(
+      () => useAttestations({ address, chain, schemaId }, { enabled: false }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(getAttestations).not.toHaveBeenCalled();
+    expect(result.current).toEqual([]);
+  });
+
+  it('merges custom queryOptions with default options', async () => {
+    const mockAttestations = [{ schemaId: '0xschema' }];
+    (getAttestations as Mock).mockResolvedValue(mockAttestations);
+
+    const address = '0xaddress';
+    const chain = base;
+    const schemaId = '0xschema' as `0x${string}`;
+    const customGcTime = 120000;
+
+    const { result } = renderHook(
+      () =>
+        useAttestations({ address, chain, schemaId }, { gcTime: customGcTime }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(mockAttestations);
+    });
+
+    expect(getAttestations).toHaveBeenCalled();
+  });
+
+  it('correctly maps cacheTime to gcTime for backwards compatibility', async () => {
+    const mockCacheTime = 60000;
+    const mockAttestations = [{ schemaId: '0xschema' }];
+
+    (getAttestations as Mock).mockResolvedValue(mockAttestations);
+
+    const address = '0xaddress';
+    const chain = base;
+    const schemaId = '0xschema' as `0x${string}`;
+
+    renderHook(
+      () =>
+        useAttestations(
+          { address, chain, schemaId },
+          { cacheTime: mockCacheTime },
+        ),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    expect(mockUseQuery).toHaveBeenCalled();
+    const optionsWithCacheTime = mockUseQuery.mock.calls[0][0];
+    expect(optionsWithCacheTime).toHaveProperty('gcTime', mockCacheTime);
+
+    const mockGcTime = 120000;
+    mockUseQuery.mockClear();
+
+    renderHook(
+      () =>
+        useAttestations(
+          { address, chain, schemaId },
+          { cacheTime: mockCacheTime, gcTime: mockGcTime },
+        ),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    expect(mockUseQuery).toHaveBeenCalled();
+    const optionsWithBoth = mockUseQuery.mock.calls[0][0];
+    expect(optionsWithBoth).toHaveProperty('gcTime', mockGcTime);
+  });
+
+  it('creates a stable query key based on address, chain, and schemaId', async () => {
+    const mockAttestations = [{ schemaId: '0xschema' }];
+    (getAttestations as Mock).mockResolvedValue(mockAttestations);
+
+    const address = '0xaddress';
+    const chain = base;
+    const schemaId = '0xschema' as `0x${string}`;
+
+    const { result, rerender } = renderHook(
+      (props: { address: string; schemaId: `0x${string}` }) =>
+        useAttestations({
+          address: props.address as `0x${string}`,
+          chain,
+          schemaId: props.schemaId,
+        }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+        initialProps: { address: address as `0x${string}`, schemaId },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual(mockAttestations);
+    });
+
+    vi.clearAllMocks();
+
+    rerender({ address: address as `0x${string}`, schemaId });
+
+    expect(getAttestations).not.toHaveBeenCalled();
   });
 });

--- a/packages/onchainkit/src/identity/hooks/useAttestations.test.ts
+++ b/packages/onchainkit/src/identity/hooks/useAttestations.test.ts
@@ -29,7 +29,6 @@ vi.mock('@tanstack/react-query', async () => {
       [key: string]: unknown;
     }) => {
       mockUseQuery(options);
-      // Return an object with data property for the hook to extract
       const result = (actual.useQuery as UseQueryType)<TData, TError>(options);
       return result;
     },

--- a/packages/onchainkit/src/identity/hooks/useAttestations.ts
+++ b/packages/onchainkit/src/identity/hooks/useAttestations.ts
@@ -14,16 +14,10 @@ export function useAttestations(
   { address, chain, schemaId }: UseAttestations,
   queryOptions?: UseQueryOptions<Attestation[]>,
 ): Attestation[] {
-  if (!schemaId) {
-    return [];
-  }
-
-  const queryKey = ['useAttestations', address, chain?.id, schemaId];
-
   const result = useQuery<Attestation[]>({
-    queryKey,
+    queryKey: ['useAttestations', address, chain?.id, schemaId],
     queryFn: async () => {
-      return getAttestations(address, chain, { schemas: [schemaId] });
+      return getAttestations(address, chain, { schemas: [schemaId!] });
     },
     enabled: !!address && !!schemaId,
     ...DEFAULT_QUERY_OPTIONS,

--- a/packages/onchainkit/src/identity/hooks/useAttestations.ts
+++ b/packages/onchainkit/src/identity/hooks/useAttestations.ts
@@ -1,29 +1,35 @@
-import type { Attestation, UseAttestations } from '@/identity/types';
+import type {
+  Attestation,
+  UseAttestations,
+  UseQueryOptions,
+} from '@/identity/types';
 import { getAttestations } from '@/identity/utils/getAttestations';
-import { useEffect, useState } from 'react';
+import { DEFAULT_QUERY_OPTIONS } from '@/internal/constants';
+import { useQuery } from '@tanstack/react-query';
 
 /**
  * Fetches EAS Attestations for a given address, chain, and schemaId.
  */
-export function useAttestations({
-  address,
-  chain,
-  schemaId,
-}: UseAttestations): Attestation[] {
+export function useAttestations(
+  { address, chain, schemaId }: UseAttestations,
+  queryOptions?: UseQueryOptions<Attestation[]>,
+): Attestation[] {
   if (!schemaId) {
     return [];
   }
-  const [attestations, setAttestations] = useState<Attestation[]>([]);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const foundAttestations = await getAttestations(address, chain, {
-        schemas: [schemaId],
-      });
-      setAttestations(foundAttestations);
-    };
-    fetchData();
-  }, [address, chain, schemaId]);
+  const queryKey = ['useAttestations', address, chain?.id, schemaId];
 
-  return attestations;
+  const result = useQuery<Attestation[]>({
+    queryKey,
+    queryFn: async () => {
+      return getAttestations(address, chain, { schemas: [schemaId] });
+    },
+    enabled: !!address && !!schemaId,
+    ...DEFAULT_QUERY_OPTIONS,
+    gcTime: queryOptions?.cacheTime,
+    ...queryOptions,
+  });
+
+  return result.data || [];
 }

--- a/packages/onchainkit/src/identity/utils/getAttestations.test.ts
+++ b/packages/onchainkit/src/identity/utils/getAttestations.test.ts
@@ -31,6 +31,16 @@ describe('getAttestations', () => {
     vi.clearAllMocks();
   });
 
+  it('returns an empty array if no address is provided', async () => {
+    const result = await getAttestations(
+      null as unknown as `0x${string}`,
+      base,
+      mockOptions,
+    );
+    expect(result).toEqual([]);
+    expect(getAttestationsByFilter).not.toHaveBeenCalled();
+  });
+
   it('should return and empty array for unsupported chains', async () => {
     const result = await getAttestations(
       mockAddress,

--- a/packages/onchainkit/src/identity/utils/getAttestations.ts
+++ b/packages/onchainkit/src/identity/utils/getAttestations.ts
@@ -12,6 +12,11 @@ export async function getAttestations(
   chain: Chain,
   options?: GetAttestationsOptions,
 ): Promise<Attestation[]> {
+  if (!address) {
+    console.log('Error in getAttestation: Address is not provided');
+    return [];
+  }
+
   if (!isChainSupported(chain)) {
     console.log('Error in getAttestation: Chain is not supported');
     return [];


### PR DESCRIPTION
**What changed? Why?**
Add caching to the `useAttestation` hook.

This saves us one network call on every render of the identity component - reducing network overhead and latency.

Removes:
<img width="1309" alt="Screenshot 2025-03-27 at 2 10 27 PM" src="https://github.com/user-attachments/assets/dd7f8711-fc4e-48b2-a8d0-d4b9bace6e90" />

**Notes to reviewers**


**How has it been tested?**
Tested in playground using logs and network tab.