### PR TITLE
fix: useFundCardSetupOnrampEventListeners unmount reset

### DIFF
--- a/packages/onchainkit/src/fund/hooks/useFundCardSetupOnrampEventListeners.test.tsx
+++ b/packages/onchainkit/src/fund/hooks/useFundCardSetupOnrampEventListeners.test.tsx
@@ -1,5 +1,12 @@
+import { ComponentType, useState } from 'react';
 import { setOnchainKitConfig } from '@/core/OnchainKitConfig';
-import { act, renderHook } from '@testing-library/react';
+import {
+  act,
+  renderHook,
+  render,
+  fireEvent,
+  screen,
+} from '@testing-library/react';
 import {
   type Mock,
   afterEach,
@@ -9,7 +16,10 @@ import {
   it,
   vi,
 } from 'vitest';
-import { FundCardProvider } from '../components/FundCardProvider';
+import {
+  FundCardProvider,
+  useFundContext,
+} from '../components/FundCardProvider';
 import { FUND_BUTTON_RESET_TIMEOUT } from '../constants';
 import type { EventMetadata, OnrampError } from '../types';
 import { fetchOnrampQuote } from '../utils/fetchOnrampQuote';
@@ -59,6 +69,27 @@ describe('useFundCardSetupOnrampEventListeners', () => {
     onSuccess = vi.fn(),
   } = {}) => {
     return renderHook(() => useFundCardSetupOnrampEventListeners(), {
+      wrapper: ({ children }) => (
+        <FundCardProvider
+          asset="ETH"
+          country="US"
+          onError={onError}
+          onStatus={onStatus}
+          onSuccess={onSuccess}
+        >
+          {children}
+        </FundCardProvider>
+      ),
+    });
+  };
+
+  const renderComponentWithProvider = ({
+    Component = (() => null) as ComponentType,
+    onError = vi.fn(),
+    onStatus = vi.fn(),
+    onSuccess = vi.fn(),
+  } = {}) => {
+    return render(<Component />, {
       wrapper: ({ children }) => (
         <FundCardProvider
           asset="ETH"
@@ -175,6 +206,57 @@ describe('useFundCardSetupOnrampEventListeners', () => {
     unmount();
 
     expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('clears fund button reset timeout on unmount', () => {
+    vi.useFakeTimers();
+    let eventHandler: (event: EventMetadata) => void = () => {};
+
+    (setupOnrampEventListeners as Mock).mockImplementation(({ onEvent }) => {
+      eventHandler = onEvent;
+      return () => {};
+    });
+
+    const Child = () => {
+      useFundCardSetupOnrampEventListeners();
+      return null;
+    };
+
+    const Component = () => {
+      const { submitButtonState } = useFundContext();
+      const [isUnmounted, setIsUnmounted] = useState(false);
+      return (
+        <>
+          <button role="button" onClick={() => setIsUnmounted(true)} />
+          {!isUnmounted && <Child />}
+          <span data-status={submitButtonState}>{submitButtonState}</span>
+        </>
+      );
+    };
+
+    renderComponentWithProvider({ Component });
+
+    act(() => {
+      eventHandler({
+        eventName: 'error',
+        error: {
+          errorType: 'network_error',
+          code: 'ERROR_CODE',
+          debugMessage: 'Error message',
+        },
+      });
+    });
+
+    fireEvent.click(screen.getByRole('button'));
+
+    act(() => {
+      vi.advanceTimersByTime(FUND_BUTTON_RESET_TIMEOUT + 100);
+    });
+
+    // The submitButtonState should not reset because the component is unmounted
+    expect(screen.queryByText('default')).not.toBeInTheDocument();
+
+    vi.useRealTimers();
   });
 
   it('handles transition_view event correctly', () => {

--- a/packages/onchainkit/src/fund/hooks/useFundCardSetupOnrampEventListeners.ts
+++ b/packages/onchainkit/src/fund/hooks/useFundCardSetupOnrampEventListeners.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useFundContext } from '../components/FundCardProvider';
 import { FUND_BUTTON_RESET_TIMEOUT } from '../constants';
 import type { EventMetadata, SuccessEventData } from '../types';
@@ -6,6 +6,13 @@ import { setupOnrampEventListeners } from '../utils/setupOnrampEventListeners';
 
 export const useFundCardSetupOnrampEventListeners = () => {
   const { setSubmitButtonState, updateLifecycleStatus } = useFundContext();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const scheduleFundButtonReset = useCallback(() => {
+    timeoutRef.current = setTimeout(() => {
+      setSubmitButtonState('default');
+    }, FUND_BUTTON_RESET_TIMEOUT);
+  }, [setSubmitButtonState]);
 
   const handleOnrampEvent = useCallback(
     (data: EventMetadata) => {
@@ -21,9 +28,7 @@ export const useFundCardSetupOnrampEventListeners = () => {
         });
 
         setSubmitButtonState('error');
-        setTimeout(() => {
-          setSubmitButtonState('default');
-        }, FUND_BUTTON_RESET_TIMEOUT);
+        scheduleFundButtonReset();
       }
     },
     [updateLifecycleStatus, setSubmitButtonState],
@@ -37,10 +42,7 @@ export const useFundCardSetupOnrampEventListeners = () => {
       });
 
       setSubmitButtonState('success');
-
-      setTimeout(() => {
-        setSubmitButtonState('default');
-      }, FUND_BUTTON_RESET_TIMEOUT);
+      scheduleFundButtonReset();
     },
     [updateLifecycleStatus, setSubmitButtonState],
   );
@@ -64,6 +66,10 @@ export const useFundCardSetupOnrampEventListeners = () => {
 
     return () => {
       unsubscribe();
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
     };
   }, []);
 };


### PR DESCRIPTION
**What changed? Why?**

Updated cleanup of useFundCardSetupOnrampEventListeners on unmount. Currently, if the provider unmounts within 3000ms after an action, state mutation happens on an unmounted provider.

**Notes to reviewers**

**How has it been tested?**
