### PR TITLE
chore: update ConnectWallet and add default children

### DIFF
--- a/packages/onchainkit/src/buy/components/Buy.test.tsx
+++ b/packages/onchainkit/src/buy/components/Buy.test.tsx
@@ -23,6 +23,10 @@ vi.mock('./BuyDropdown', () => ({
   BuyDropdown: () => <div data-testid="mock-BuyDropdown">BuyDropdown</div>,
 }));
 
+vi.mock('./BuyButton', () => ({
+  BuyButton: () => <div data-testid="mock-BuyButton">Buy</div>,
+}));
+
 vi.mock('@/internal/hooks/useTheme', () => ({
   useTheme: vi.fn(),
 }));

--- a/packages/onchainkit/src/signature/components/SignatureButton.test.tsx
+++ b/packages/onchainkit/src/signature/components/SignatureButton.test.tsx
@@ -8,28 +8,29 @@ import {
   it,
   vi,
 } from 'vitest';
-import { useAccount } from 'wagmi';
+import { useAccount, useConnect } from 'wagmi';
 import { SignatureButton } from './SignatureButton';
 import { useSignatureContext } from './SignatureProvider';
 
 vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
+  useConnect: vi.fn(),
+  useConnectors: vi.fn(() => ({ connectors: [{ id: 'mockConnector' }] })),
 }));
 
 vi.mock('./SignatureProvider', () => ({
   useSignatureContext: vi.fn(),
 }));
 
-vi.mock('@/wallet/components/ConnectWallet', () => ({
-  ConnectWallet: vi.fn(({ children }) => (
-    <button type="button">{children}</button>
-  )),
-}));
-
 describe('SignatureButton', () => {
   const mockHandleSign = vi.fn();
 
   beforeEach(() => {
+    (useConnect as Mock).mockReturnValue({
+      connectors: [{ id: 'mockConnector' }],
+      connect: vi.fn(),
+      status: 'idle',
+    });
     (useSignatureContext as Mock).mockReturnValue({
       lifecycleStatus: {
         statusName: 'init',
@@ -43,14 +44,20 @@ describe('SignatureButton', () => {
   });
 
   it('should render ConnectWallet when no address is connected', () => {
-    (useAccount as Mock).mockReturnValue({ address: undefined });
+    (useAccount as Mock).mockReturnValue({
+      address: undefined,
+      status: 'disconnected',
+    });
 
     render(<SignatureButton />);
     expect(screen.getByText('Connect Wallet')).toBeInTheDocument();
   });
 
   it('should render connect label when passed in', () => {
-    (useAccount as Mock).mockReturnValue({ address: undefined });
+    (useAccount as Mock).mockReturnValue({
+      address: undefined,
+      status: 'disconnected',
+    });
 
     render(<SignatureButton connectLabel="Sign in please" />);
     expect(screen.getByText('Sign in please')).toBeInTheDocument();

--- a/packages/onchainkit/src/signature/components/SignatureButton.tsx
+++ b/packages/onchainkit/src/signature/components/SignatureButton.tsx
@@ -1,5 +1,4 @@
 import { ConnectWallet } from '@/wallet/components/ConnectWallet';
-import { ConnectWalletText } from '@/wallet/components/ConnectWalletText';
 import { type ReactNode, useMemo } from 'react';
 import { useAccount } from 'wagmi';
 import { border, cn, color, pressable, text } from '../../styles/theme';
@@ -51,9 +50,10 @@ export function SignatureButton({
 
   if (!address) {
     return (
-      <ConnectWallet className={cn('w-full', className)}>
-        <ConnectWalletText>{connectLabel}</ConnectWalletText>
-      </ConnectWallet>
+      <ConnectWallet
+        className={cn('w-full', className)}
+        disconnectedLabel={connectLabel}
+      />
     );
   }
 

--- a/packages/onchainkit/src/wallet/components/ConnectWallet.test.tsx
+++ b/packages/onchainkit/src/wallet/components/ConnectWallet.test.tsx
@@ -31,6 +31,11 @@ vi.mock('./WalletProvider', () => ({
   ),
 }));
 
+vi.mock('@/identity', () => ({
+  Name: () => <div data-testid="ockName">Name</div>,
+  Avatar: () => <div data-testid="ockAvatar">Avatar</div>,
+}));
+
 vi.mock('@rainbow-me/rainbowkit', () => ({
   ConnectButton: {
     Custom: ({

--- a/packages/onchainkit/src/wallet/components/ConnectWallet.tsx
+++ b/packages/onchainkit/src/wallet/components/ConnectWallet.tsx
@@ -24,7 +24,7 @@ import { ConnectWalletText } from './ConnectWalletText';
 import { WalletModal } from './WalletModal';
 import { useWalletContext } from './WalletProvider';
 
-const connectWalletDefaultchildren = (
+const connectWalletDefaultChildren = (
   <>
     <Avatar className="h-6 w-6" />
     <Name />
@@ -231,7 +231,7 @@ export function ConnectWallet({
           onClick={handleToggle}
         >
           <div className="flex items-center justify-center gap-2">
-            {childrenWithoutConnectWalletText || connectWalletDefaultchildren}
+            {childrenWithoutConnectWalletText || connectWalletDefaultChildren}
           </div>
         </button>
       </div>

--- a/packages/onchainkit/src/wallet/components/ConnectWalletText.tsx
+++ b/packages/onchainkit/src/wallet/components/ConnectWalletText.tsx
@@ -1,6 +1,9 @@
 import { cn, color, text as dsText } from '../../styles/theme';
 import type { ConnectWalletTextReact } from '../types';
 
+/**
+ * @deprecated Use the `disconnectedLabel` prop on `ConnectWallet` instead.
+ */
 export function ConnectWalletText({
   children,
   className,

--- a/packages/onchainkit/src/wallet/components/Wallet.tsx
+++ b/packages/onchainkit/src/wallet/components/Wallet.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Avatar, Name } from '@/identity';
 import { Draggable } from '@/internal/components/Draggable/Draggable';
 import { useIsMounted } from '@/internal/hooks/useIsMounted';
 import { useOutsideClick } from '@/internal/hooks/useOutsideClick';
@@ -23,10 +22,7 @@ import { WalletProvider, useWalletContext } from './WalletProvider';
 
 const defaultWalletChildren = (
   <>
-    <ConnectWallet>
-      <Avatar className="h-6 w-6" key="avatar" />
-      <Name key="name" />
-    </ConnectWallet>
+    <ConnectWallet />
     <WalletDropdown />
   </>
 );

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedDefault.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedDefault.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import { Avatar, Name } from '@/identity';
 import { ConnectWallet } from './ConnectWallet';
-import { ConnectWalletText } from './ConnectWalletText';
 import { Wallet } from './Wallet';
 import { WalletAdvancedAddressDetails } from './WalletAdvancedAddressDetails';
 import { WalletAdvancedTokenHoldings } from './WalletAdvancedTokenHoldings';
@@ -13,11 +11,7 @@ import { WalletDropdown } from './WalletDropdown';
 export function WalletAdvancedDefault() {
   return (
     <Wallet>
-      <ConnectWallet>
-        <ConnectWalletText>Connect Wallet</ConnectWalletText>
-        <Avatar className="h-6 w-6" />
-        <Name />
-      </ConnectWallet>
+      <ConnectWallet />
       <WalletDropdown>
         <WalletAdvancedWalletActions />
         <WalletAdvancedAddressDetails />

--- a/packages/onchainkit/src/wallet/components/WalletIsland.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletIsland.tsx
@@ -2,10 +2,8 @@
 
 import { Avatar } from '@/identity';
 import { portfolioSvg } from '@/internal/svg/portfolioSvg';
-import { useAccount } from 'wagmi';
 import { getDefaultDraggableStartingPosition } from '../utils/getDefaultDraggableStartingPosition';
 import { ConnectWallet } from './ConnectWallet';
-import { ConnectWalletText } from './ConnectWalletText';
 import { Wallet } from './Wallet';
 import { WalletAdvancedAddressDetails } from './WalletAdvancedAddressDetails';
 import { WalletAdvancedTokenHoldings } from './WalletAdvancedTokenHoldings';
@@ -18,19 +16,13 @@ export function WalletIsland({
 }: {
   startingPosition?: { x: number; y: number };
 }) {
-  const { status } = useAccount();
-
   return (
     <Wallet draggable={true} draggableStartingPosition={startingPosition}>
-      <ConnectWallet className="!rounded-full m-0 flex h-14 w-14 min-w-14 flex-col items-center justify-center p-0">
-        <ConnectWalletText>
-          <div className="h-5 w-5">{portfolioSvg}</div>
-        </ConnectWalletText>
-        {status === 'connected' ? (
-          <Avatar className="pointer-events-none h-14 w-14" />
-        ) : (
-          <div className="h-5 w-5">{portfolioSvg}</div>
-        )}
+      <ConnectWallet
+        className="!rounded-full m-0 flex h-14 w-14 min-w-14 flex-col items-center justify-center p-0"
+        disconnectedLabel={<div className="h-5 w-5">{portfolioSvg}</div>}
+      >
+        <Avatar className="pointer-events-none h-14 w-14" />
       </ConnectWallet>
       <WalletDropdown>
         <WalletAdvancedWalletActions />

--- a/packages/onchainkit/src/wallet/types.ts
+++ b/packages/onchainkit/src/wallet/types.ts
@@ -31,6 +31,8 @@ export type ConnectWalletReact = {
   text?: string;
   /** Optional callback function to execute when the wallet is connected. */
   onConnect?: () => void;
+  /** Optional disconnected display override */
+  disconnectedLabel?: React.ReactNode;
 };
 
 /**

--- a/packages/playground/components/demo/Wallet.tsx
+++ b/packages/playground/components/demo/Wallet.tsx
@@ -6,7 +6,7 @@ import {
   Name,
   Socials,
 } from '@coinbase/onchainkit/identity';
-import { color } from '@coinbase/onchainkit/theme';
+import { cn, color } from '@coinbase/onchainkit/theme';
 import {
   ConnectWallet,
   Wallet,
@@ -24,7 +24,9 @@ function WalletComponent() {
   return (
     <div className="flex justify-end">
       <Wallet>
-        <ConnectWallet text="Connect Wallet">
+        <ConnectWallet
+          disconnectedLabel={<span className={cn(color.inverse)}>Connect</span>}
+        >
           <Avatar address={address} className="h-6 w-6" />
           <Name />
         </ConnectWallet>


### PR DESCRIPTION
**What changed? Why?**
- implement default children for `<ConnectWallet />`
- refactor ConnectWallet logic
- introduce new prop `disconnectedLabel` on ConnectWallet that enables devs to customize disconnected state (children will represent connected state)
- deprecate `ConnectWalletText` component

**Notes to reviewers**

**How has it been tested?**
