### PR TITLE
fix: Changeset version script

### DIFF
--- a/packages/onchainkit/scripts/get-next-version.js
+++ b/packages/onchainkit/scripts/get-next-version.js
@@ -36,7 +36,7 @@ function getNextVersion() {
 
     if (!nextVersion) throw new Error('No onchainkit version found');
   } catch (error) {
-    console.error('Error checking changeset status:\n', error);
+    console.error('Error checking changeset status:\n', error.message);
   }
 
   if (!nextVersion) {
@@ -46,7 +46,7 @@ function getNextVersion() {
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
       nextVersion = packageJson.version;
     } catch (error) {
-      console.error('Error falling back to package.json:\n', error);
+      console.error('Error falling back to package.json:\n', error.message);
 
       process.exit(1);
     }

--- a/packages/onchainkit/scripts/get-next-version.js
+++ b/packages/onchainkit/scripts/get-next-version.js
@@ -3,14 +3,13 @@ import process from 'process';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { dirname } from 'path';
 
 const packageName = '@coinbase/onchainkit';
 const onchainkitPath = 'packages/onchainkit';
 
 function getNextVersion() {
   const currentFilePath = fileURLToPath(import.meta.url);
-  const currentDir = dirname(currentFilePath);
+  const currentDir = path.dirname(currentFilePath);
 
   // Move to monorepo root
   const monorepoRoot = path.resolve(currentDir, '../../..');

--- a/packages/onchainkit/scripts/get-next-version.js
+++ b/packages/onchainkit/scripts/get-next-version.js
@@ -2,13 +2,19 @@ import { execSync } from 'child_process';
 import process from 'process';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 
 const packageName = '@coinbase/onchainkit';
 const onchainkitPath = 'packages/onchainkit';
 
 function getNextVersion() {
+  const currentFilePath = fileURLToPath(import.meta.url);
+  const currentDir = dirname(currentFilePath);
+
   // Move to monorepo root
-  process.chdir('../..');
+  const monorepoRoot = path.resolve(currentDir, '../../..');
+  process.chdir(monorepoRoot);
 
   let nextVersion = '';
 
@@ -30,10 +36,7 @@ function getNextVersion() {
 
     if (!nextVersion) throw new Error('No onchainkit version found');
   } catch (error) {
-    console.error(
-      'Error checking changeset status:\n',
-      error instanceof Error ? error.message : error,
-    );
+    console.error('Error checking changeset status:\n', error);
   }
 
   if (!nextVersion) {
@@ -43,10 +46,7 @@ function getNextVersion() {
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
       nextVersion = packageJson.version;
     } catch (error) {
-      console.error(
-        'Error falling back to package.json:\n',
-        error instanceof Error ? error.message : error,
-      );
+      console.error('Error falling back to package.json:\n', error);
 
       process.exit(1);
     }

--- a/packages/onchainkit/scripts/get-next-version.js
+++ b/packages/onchainkit/scripts/get-next-version.js
@@ -4,35 +4,57 @@ import fs from 'fs';
 import path from 'path';
 
 const packageName = '@coinbase/onchainkit';
+const onchainkitPath = 'packages/onchainkit';
 
 function getNextVersion() {
+  // Move to monorepo root
+  process.chdir('../..');
+
+  let nextVersion = '';
+
   try {
-    process.chdir('../..');
-    const output = execSync(
-      'pnpm changeset status --verbose --since=origin/main',
-      {
-        encoding: 'utf-8',
-      },
-    );
+    // This throws an error if there are no changes in any packages
+    const output = execSync('pnpm changeset status --verbose', {
+      encoding: 'utf-8',
+    });
 
     const lines = output.split('\n');
     const onchainkitVersionLine = lines.find((line) =>
       line.includes(packageName),
     );
 
-    if (!onchainkitVersionLine) return;
+    if (!onchainkitVersionLine)
+      throw new Error('No onchainkit version line found');
 
-    const nextVersion = onchainkitVersionLine.split(packageName)[1].trim();
+    nextVersion = onchainkitVersionLine.split(packageName)[1].trim();
 
-    // Write version to dist/version.txt, adjusting for the directory change
-    const versionPath = path.join('packages/onchainkit/dist/version.txt');
-    fs.writeFileSync(versionPath, nextVersion);
-
-    return nextVersion;
+    if (!nextVersion) throw new Error('No onchainkit version found');
   } catch (error) {
-    console.error('Error checking changeset status:', error.message);
-    process.exit(1);
+    console.error(
+      'Error checking changeset status:\n',
+      error instanceof Error ? error.message : error,
+    );
   }
+
+  if (!nextVersion) {
+    try {
+      // If changeset check fails, fall back to current version from package.json
+      const packageJsonPath = path.join(onchainkitPath, 'package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      nextVersion = packageJson.version;
+    } catch (error) {
+      console.error(
+        'Error falling back to package.json:\n',
+        error instanceof Error ? error.message : error,
+      );
+
+      process.exit(1);
+    }
+  }
+
+  // Write version to dist/version.txt, adjusting for the directory change
+  const versionPath = path.join(onchainkitPath, 'dist/version.txt');
+  fs.writeFileSync(versionPath, nextVersion);
 }
 
 getNextVersion();

--- a/packages/onchainkit/scripts/get-next-version.test.ts
+++ b/packages/onchainkit/scripts/get-next-version.test.ts
@@ -2,16 +2,25 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
 // Mock the modules
 vi.mock('child_process');
 vi.mock('fs');
 vi.mock('path');
+vi.mock('url');
 
 describe('get-next-version script', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+
+    // Mock fileURLToPath and path operations
+    vi.mocked(fileURLToPath).mockReturnValue('/mocked/path/to/script.js');
+    vi.mocked(path.resolve).mockReturnValue('/mocked/monorepo/root');
+
+    // Mock process.chdir to prevent actual directory changes
+    vi.spyOn(process, 'chdir').mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -33,14 +42,16 @@ describe('get-next-version script', () => {
       'packages/onchainkit/dist/version.txt',
     );
 
-    // Import the script (this needs to happen after mocks are set up)
+    // Import the script
     await import('./get-next-version.js');
 
+    // Verify process.chdir was called with the mocked root
+    expect(process.chdir).toHaveBeenCalledWith('/mocked/monorepo/root');
+
     // Verify execSync was called with correct arguments
-    expect(execSync).toHaveBeenCalledWith(
-      'pnpm changeset status --verbose --since=origin/main',
-      { encoding: 'utf-8' },
-    );
+    expect(execSync).toHaveBeenCalledWith('pnpm changeset status --verbose', {
+      encoding: 'utf-8',
+    });
 
     // Verify the version was written to the file
     expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -49,10 +60,41 @@ describe('get-next-version script', () => {
     );
   });
 
-  it('should exit with error code 1 when execSync throws', async () => {
+  it('should fall back to package.json version when changeset check fails', async () => {
     // Mock execSync to throw an error
     vi.mocked(execSync).mockImplementation(() => {
       throw new Error('Command failed');
+    });
+
+    // Mock fs.readFileSync to return package.json content
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ version: '1.1.0' }),
+    );
+
+    // Mock path.join for both package.json and version.txt paths
+    vi.mocked(path.join)
+      .mockReturnValueOnce('packages/onchainkit/package.json')
+      .mockReturnValueOnce('packages/onchainkit/dist/version.txt');
+
+    // Import the script
+    await import('./get-next-version.js');
+
+    // Verify the fallback version was written to the file
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      'packages/onchainkit/dist/version.txt',
+      '1.1.0',
+    );
+  });
+
+  it('should exit with error code 1 when both changeset and package.json fallback fail', async () => {
+    // Mock execSync to throw an error
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('Command failed');
+    });
+
+    // Mock fs.readFileSync to throw an error
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error('File not found');
     });
 
     // Mock process.exit
@@ -70,8 +112,12 @@ describe('get-next-version script', () => {
 
     // Verify error handling
     expect(mockConsoleError).toHaveBeenCalledWith(
-      'Error checking changeset status:',
+      'Error checking changeset status:\n',
       'Command failed',
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Error falling back to package.json:\n',
+      'File not found',
     );
     expect(mockExit).toHaveBeenCalledWith(1);
   });
@@ -86,10 +132,83 @@ some-other-package  1.0.0  patch  No changelog entry found
 `;
     vi.mocked(execSync).mockReturnValue(mockChangesetOutput);
 
+    // Mock fs.readFileSync to return package.json content for fallback
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ version: '1.1.0' }),
+    );
+
+    // Mock path.join for both package.json and version.txt paths
+    vi.mocked(path.join)
+      .mockReturnValueOnce('packages/onchainkit/package.json')
+      .mockReturnValueOnce('packages/onchainkit/dist/version.txt');
+
     // Import the script
     await import('./get-next-version.js');
 
-    // Verify fs.writeFileSync was not called
-    expect(fs.writeFileSync).not.toHaveBeenCalled();
+    // Verify fs.writeFileSync was called with the fallback version
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      'packages/onchainkit/dist/version.txt',
+      '1.1.0',
+    );
+  });
+
+  it('should handle case where onchainkit version line is not found in changeset', async () => {
+    // Mock execSync to return output with no onchainkit line
+    const mockChangesetOutput = `
+🦋  warning no packages have been published
+---
+some-other-package  1.0.0  patch  No changelog entry found
+---
+`;
+    vi.mocked(execSync).mockReturnValue(mockChangesetOutput);
+
+    // Mock fs.readFileSync to return package.json content for fallback
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ version: '1.1.0' }),
+    );
+
+    // Mock path.join for both package.json and version.txt paths
+    vi.mocked(path.join)
+      .mockReturnValueOnce('packages/onchainkit/package.json')
+      .mockReturnValueOnce('packages/onchainkit/dist/version.txt');
+
+    // Import the script
+    await import('./get-next-version.js');
+
+    // Verify the fallback version was written to the file
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      'packages/onchainkit/dist/version.txt',
+      '1.1.0',
+    );
+  });
+
+  it('should handle case where onchainkit version is empty in changeset', async () => {
+    // Mock execSync to return output with empty version
+    const mockChangesetOutput = `
+🦋  warning no packages have been published
+---
+@coinbase/onchainkit
+---
+`;
+    vi.mocked(execSync).mockReturnValue(mockChangesetOutput);
+
+    // Mock fs.readFileSync to return package.json content for fallback
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ version: '1.1.0' }),
+    );
+
+    // Mock path.join for both package.json and version.txt paths
+    vi.mocked(path.join)
+      .mockReturnValueOnce('packages/onchainkit/package.json')
+      .mockReturnValueOnce('packages/onchainkit/dist/version.txt');
+
+    // Import the script
+    await import('./get-next-version.js');
+
+    // Verify the fallback version was written to the file
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      'packages/onchainkit/dist/version.txt',
+      '1.1.0',
+    );
   });
 });


### PR DESCRIPTION
**What changed? Why?**

- Removed `--since=origin/main` flag in the changeset script which was causing it to not report a version
- Fall back to package.json if changeset doesn't produce a version change
- More robust error handling

**Notes to reviewers**

**How has it been tested?**

- Manually