### PR TITLE
chore: Enable eslint display-name rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,7 +52,6 @@ export default [
         { caseSensitive: true, natural: false, minKeys: 2 },
       ],
       'react-hooks/rules-of-hooks': 'off',
-      'react/display-name': 'off',
       'react/prop-types': 'off',
       'react-hooks/exhaustive-deps': 'off',
       '@typescript-eslint/no-explicit-any': 'off',

--- a/packages/onchainkit/src/appchain/bridge/components/AppchainBridgeWithdraw.test.tsx
+++ b/packages/onchainkit/src/appchain/bridge/components/AppchainBridgeWithdraw.test.tsx
@@ -42,6 +42,7 @@ describe('AppchainBridgeWithdraw', () => {
 
   it('renders the loading state correctly', () => {
     (useWithdrawButton as Mock).mockReturnValue({
+      isPending: true,
       isSuccess: false,
       buttonDisabled: false,
       buttonContent: 'Claim',

--- a/packages/onchainkit/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
+++ b/packages/onchainkit/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
@@ -3,7 +3,7 @@ import { Spinner } from '@/internal/components/Spinner';
 import { ErrorSvg } from '@/internal/svg/fullWidthErrorSvg';
 import { SuccessSvg } from '@/internal/svg/fullWidthSuccessSvg';
 import { border, cn, color, pressable, text } from '@/styles/theme';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useWithdrawButton } from '../hooks/useWithdrawButton';
 import { useAppchainBridgeContext } from './AppchainBridgeProvider';
 
@@ -49,9 +49,10 @@ export const AppchainBridgeWithdraw = () => {
       </div>
     </div>
   );
+  SuccessIcon.displayName = 'SuccessIcon';
 
-  const LoadingContent = useMemo(
-    () => () => (
+  function LoadingContent() {
+    return (
       <div className="flex h-full flex-col items-center justify-center gap-16">
         <Spinner className="!border-t-[var(--ock-bg-primary)] h-24 w-24" />
         <span className="px-4 text-center font-medium text-base">
@@ -60,12 +61,12 @@ export const AppchainBridgeWithdraw = () => {
           Please do not close this window.
         </span>
       </div>
-    ),
-    [],
-  );
+    );
+  }
+  LoadingContent.displayName = 'LoadingContent';
 
-  const ClaimContent = useMemo(
-    () => () => (
+  function ClaimContent() {
+    return (
       <div className="flex flex-col items-center gap-16">
         <SuccessIcon />
         <button
@@ -80,12 +81,12 @@ export const AppchainBridgeWithdraw = () => {
           </div>
         </button>
       </div>
-    ),
-    [buttonStyles, buttonDisabled, buttonContent, proveAndFinalizeWithdrawal],
-  );
+    );
+  }
+  ClaimContent.displayName = 'ClaimContent';
 
-  const ErrorContent = useMemo(
-    () => () => (
+  function ErrorContent() {
+    return (
       <div className="flex flex-col items-center gap-16">
         <div className="flex justify-center">
           <div className="h-20 w-20">
@@ -115,9 +116,9 @@ export const AppchainBridgeWithdraw = () => {
           </button>
         </div>
       </div>
-    ),
-    [handleResetState, buttonStyles],
-  );
+    );
+  }
+  ErrorContent.displayName = 'ErrorContent';
 
   const renderContent = () => {
     if (isError) {

--- a/packages/onchainkit/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
+++ b/packages/onchainkit/src/appchain/bridge/components/AppchainBridgeWithdraw.tsx
@@ -7,19 +7,25 @@ import { useEffect } from 'react';
 import { useWithdrawButton } from '../hooks/useWithdrawButton';
 import { useAppchainBridgeContext } from './AppchainBridgeProvider';
 
+const buttonStyles = cn(
+  pressable.primary,
+  border.radius,
+  'w-full rounded-xl',
+  'px-4 py-3 font-medium text-base text-white leading-6',
+  text.headline,
+);
+
 export const AppchainBridgeWithdraw = () => {
   const {
     withdrawStatus,
     waitForWithdrawal,
-    proveAndFinalizeWithdrawal,
     resumeWithdrawalTxHash,
     handleResetState,
   } = useAppchainBridgeContext();
 
-  const { buttonDisabled, buttonContent, shouldShowClaim, label, isError } =
-    useWithdrawButton({
-      withdrawStatus,
-    });
+  const { shouldShowClaim, label, isError, isPending } = useWithdrawButton({
+    withdrawStatus,
+  });
 
   useEffect(() => {
     (async () => {
@@ -34,99 +40,6 @@ export const AppchainBridgeWithdraw = () => {
     })();
   }, [withdrawStatus, waitForWithdrawal, resumeWithdrawalTxHash]);
 
-  const buttonStyles = cn(
-    pressable.primary,
-    border.radius,
-    'w-full rounded-xl',
-    'px-4 py-3 font-medium text-base text-white leading-6',
-    text.headline,
-  );
-
-  const SuccessIcon = () => (
-    <div className="flex justify-center">
-      <div className="h-20 w-20">
-        <SuccessSvg fill="var(--ock-bg-primary)" />
-      </div>
-    </div>
-  );
-  SuccessIcon.displayName = 'SuccessIcon';
-
-  function LoadingContent() {
-    return (
-      <div className="flex h-full flex-col items-center justify-center gap-16">
-        <Spinner className="!border-t-[var(--ock-bg-primary)] h-24 w-24" />
-        <span className="px-4 text-center font-medium text-base">
-          Waiting for claim to be ready...
-          <br />
-          Please do not close this window.
-        </span>
-      </div>
-    );
-  }
-  LoadingContent.displayName = 'LoadingContent';
-
-  function ClaimContent() {
-    return (
-      <div className="flex flex-col items-center gap-16">
-        <SuccessIcon />
-        <button
-          onClick={proveAndFinalizeWithdrawal}
-          className={cn(buttonStyles, buttonDisabled && pressable.disabled)}
-          type="button"
-        >
-          <div
-            className={cn(text.headline, color.inverse, 'flex justify-center')}
-          >
-            {buttonContent}
-          </div>
-        </button>
-      </div>
-    );
-  }
-  ClaimContent.displayName = 'ClaimContent';
-
-  function ErrorContent() {
-    return (
-      <div className="flex flex-col items-center gap-16">
-        <div className="flex justify-center">
-          <div className="h-20 w-20">
-            <ErrorSvg fill="var(--ock-bg-error)" />
-          </div>
-        </div>
-        <div className="flex flex-col items-center gap-4">
-          <span className="px-4 text-center font-medium text-base">
-            There was an error processing your withdrawal.
-            <br />
-            If the issue persists, please contact support.
-          </span>
-          <button
-            onClick={handleResetState}
-            className={buttonStyles}
-            type="button"
-          >
-            <div
-              className={cn(
-                text.headline,
-                color.inverse,
-                'flex justify-center',
-              )}
-            >
-              Back to bridge
-            </div>
-          </button>
-        </div>
-      </div>
-    );
-  }
-  ErrorContent.displayName = 'ErrorContent';
-
-  const renderContent = () => {
-    if (isError) {
-      return <ErrorContent />;
-    }
-    return shouldShowClaim ? <ClaimContent /> : <LoadingContent />;
-  };
-
   return (
     <div className="flex h-full w-full flex-col justify-between">
       <div>
@@ -137,7 +50,9 @@ export const AppchainBridgeWithdraw = () => {
         </div>
       </div>
       <div className="mt-16 px-4 pb-4">
-        {renderContent()}
+        {isError && <ErrorContent onBack={handleResetState} />}
+        {isPending && <LoadingContent />}
+        {shouldShowClaim && <ClaimContent />}
         {withdrawStatus === 'claimRejected' && (
           <div className={cn(text.label2, color.error, 'mt-2')}>
             Transaction denied
@@ -147,3 +62,72 @@ export const AppchainBridgeWithdraw = () => {
     </div>
   );
 };
+
+function LoadingContent() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-16">
+      <Spinner className="!border-t-[var(--ock-bg-primary)] h-24 w-24" />
+      <span className="px-4 text-center font-medium text-base">
+        Waiting for claim to be ready...
+        <br />
+        Please do not close this window.
+      </span>
+    </div>
+  );
+}
+
+function ErrorContent({ onBack }: { onBack: () => void }) {
+  return (
+    <div className="flex flex-col items-center gap-16">
+      <div className="flex justify-center">
+        <div className="h-20 w-20">
+          <ErrorSvg fill="var(--ock-bg-error)" />
+        </div>
+      </div>
+      <div className="flex flex-col items-center gap-4">
+        <span className="px-4 text-center font-medium text-base">
+          There was an error processing your withdrawal.
+          <br />
+          If the issue persists, please contact support.
+        </span>
+        <button onClick={onBack} className={buttonStyles} type="button">
+          <div
+            className={cn(text.headline, color.inverse, 'flex justify-center')}
+          >
+            Back to bridge
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ClaimContent() {
+  const { withdrawStatus, proveAndFinalizeWithdrawal } =
+    useAppchainBridgeContext();
+
+  const { buttonDisabled, buttonContent } = useWithdrawButton({
+    withdrawStatus,
+  });
+
+  return (
+    <div className="flex flex-col items-center gap-16">
+      <div className="flex justify-center">
+        <div className="h-20 w-20">
+          <SuccessSvg fill="var(--ock-bg-primary)" />
+        </div>
+      </div>
+      <button
+        onClick={proveAndFinalizeWithdrawal}
+        className={cn(buttonStyles, buttonDisabled && pressable.disabled)}
+        type="button"
+      >
+        <div
+          className={cn(text.headline, color.inverse, 'flex justify-center')}
+        >
+          {buttonContent}
+        </div>
+      </button>
+    </div>
+  );
+}

--- a/packages/onchainkit/src/fund/components/FundCardPaymentMethodSelectRow.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardPaymentMethodSelectRow.tsx
@@ -78,3 +78,5 @@ export const FundCardPaymentMethodSelectRow = memo(
     );
   },
 );
+
+FundCardPaymentMethodSelectRow.displayName = 'FundCardPaymentMethodSelectRow';

--- a/packages/onchainkit/src/fund/components/FundCardPaymentMethodSelectorToggle.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardPaymentMethodSelectorToggle.tsx
@@ -53,3 +53,6 @@ export const FundCardPaymentMethodSelectorToggle = forwardRef(
     );
   },
 );
+
+FundCardPaymentMethodSelectorToggle.displayName =
+  'FundCardPaymentMethodSelectorToggle';

--- a/packages/onchainkit/src/internal/components/TextInput.tsx
+++ b/packages/onchainkit/src/internal/components/TextInput.tsx
@@ -80,3 +80,5 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputReact>(
     );
   },
 );
+
+TextInput.displayName = 'TextInput';

--- a/packages/onchainkit/src/internal/components/amount-input/CurrencyLabel.tsx
+++ b/packages/onchainkit/src/internal/components/amount-input/CurrencyLabel.tsx
@@ -25,3 +25,5 @@ export const CurrencyLabel = forwardRef<HTMLSpanElement, CurrencyLabelProps>(
     );
   },
 );
+
+CurrencyLabel.displayName = 'CurrencyLabel';

--- a/packages/onchainkit/src/wallet/hooks/usePortfolio.test.tsx
+++ b/packages/onchainkit/src/wallet/hooks/usePortfolio.test.tsx
@@ -35,9 +35,11 @@ const createWrapper = () => {
       },
     },
   });
-  return ({ children }: { children: React.ReactNode }) => (
+  const TestWrapper = ({ children }: { children: React.ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
+  TestWrapper.displayName = 'TestWrapper';
+  return TestWrapper;
 };
 
 describe('usePortfolio', () => {


### PR DESCRIPTION
**What changed? Why?**
Enabling the eslint rule `display-name` and fixing or ignoring the flagged errors.

Why? This ensures the component appears properly labeled in all tooling, making development, debugging, and testing much more efficient. Adding the display name is considered a best practice in React development, especially for components created with forwardRef, memo, or other higher-order components.

**Notes to reviewers**

**How has it been tested?**
Unit tests.