### PR TITLE
chore: Enable eslint prop-types rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,7 +52,6 @@ export default [
         { caseSensitive: true, natural: false, minKeys: 2 },
       ],
       'react-hooks/rules-of-hooks': 'off',
-      'react/display-name': 'off',
       'react-hooks/exhaustive-deps': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,7 +52,7 @@ export default [
         { caseSensitive: true, natural: false, minKeys: 2 },
       ],
       'react-hooks/rules-of-hooks': 'off',
-      'react/prop-types': 'off',
+      'react/display-name': 'off',
       'react-hooks/exhaustive-deps': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
     },

--- a/packages/onchainkit/src/internal/components/TextInput.test.tsx
+++ b/packages/onchainkit/src/internal/components/TextInput.test.tsx
@@ -6,6 +6,17 @@ import { TextInput } from './TextInput';
 
 const DELAY_MS = 100;
 
+type RenderTestProps = {
+  className?: string;
+  delayMs?: number;
+  onChange?: (s: string) => void;
+  placeholder?: string;
+  setValue?: (s: string) => void;
+  value?: string;
+  disabled?: boolean;
+  inputMode?: React.InputHTMLAttributes<HTMLInputElement>['inputMode'];
+};
+
 const RenderTest = ({
   className = 'custom-class',
   delayMs = DELAY_MS,
@@ -14,7 +25,7 @@ const RenderTest = ({
   setValue = vi.fn(),
   value = 'test',
   ...props
-}) => (
+}: RenderTestProps) => (
   <TextInput
     className={className}
     delayMs={delayMs}

--- a/packages/onchainkit/src/internal/svg/addSvg.tsx
+++ b/packages/onchainkit/src/internal/svg/addSvg.tsx
@@ -1,6 +1,10 @@
 import { cn, icon } from '../../styles/theme';
 
-export const AddSvg = ({ className = cn(icon.inverse) }) => (
+type AddSvgProps = {
+  className?: string;
+};
+
+export const AddSvg = ({ className = cn(icon.inverse) }: AddSvgProps) => (
   <svg
     data-testid="ock-addSvg"
     role="img"

--- a/packages/onchainkit/src/internal/svg/errorSvg.tsx
+++ b/packages/onchainkit/src/internal/svg/errorSvg.tsx
@@ -1,4 +1,8 @@
-export const ErrorSvg = ({ fill = '#E11D48' }) => (
+type ErrorSvgProps = {
+  fill?: string;
+};
+
+export const ErrorSvg = ({ fill = '#E11D48' }: ErrorSvgProps) => (
   <svg
     aria-label="ock-errorSvg"
     width="16"

--- a/packages/onchainkit/src/internal/svg/fullWidthErrorSvg.tsx
+++ b/packages/onchainkit/src/internal/svg/fullWidthErrorSvg.tsx
@@ -1,4 +1,8 @@
-export const ErrorSvg = ({ fill = '#E11D48' }) => (
+type ErrorSvgProps = {
+  fill?: string;
+};
+
+export const ErrorSvg = ({ fill = '#E11D48' }: ErrorSvgProps) => (
   <svg
     aria-label="ock-errorSvg"
     width="100%"

--- a/packages/onchainkit/src/internal/svg/fullWidthSuccessSvg.tsx
+++ b/packages/onchainkit/src/internal/svg/fullWidthSuccessSvg.tsx
@@ -1,4 +1,8 @@
-export const SuccessSvg = ({ fill = '#65A30D' }) => (
+type SuccessSvgProps = {
+  fill?: string;
+};
+
+export const SuccessSvg = ({ fill = '#65A30D' }: SuccessSvgProps) => (
   <svg
     aria-label="ock-successSvg"
     width="100%"

--- a/packages/onchainkit/src/internal/svg/successSvg.tsx
+++ b/packages/onchainkit/src/internal/svg/successSvg.tsx
@@ -1,4 +1,8 @@
-export const SuccessSvg = ({ fill = '#65A30D' }) => (
+type SuccessSvgProps = {
+  fill?: string;
+};
+
+export const SuccessSvg = ({ fill = '#65A30D' }: SuccessSvgProps) => (
   <svg
     aria-label="ock-successSvg"
     width="16"


### PR DESCRIPTION
**What changed? Why?**
Enabling the eslint rule `prop-types` and fixing or ignoring the flagged errors.

This enforces the use of PropTypes for React component props validation. It checks that any component that receives props has proper prop validation defined.

**Notes to reviewers**

**How has it been tested?**
Unit tests.