### PR TITLE
feat: add useConnectModal hook

### DIFF
--- a/packages/onchainkit/.prettierignore
+++ b/packages/onchainkit/.prettierignore
@@ -1,0 +1,2 @@
+dist
+esm

--- a/packages/onchainkit/CHANGELOG.md
+++ b/packages/onchainkit/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Patch Changes
 
-  - **feat**: Add iconUrl to OnrampPaymentCurrency type. By @rustam-cb #2165
-  - **fix**: Fix bug that would disable onramp due to USDC price fluctuations. By @abcrane123 #2171
-  - **chore**: Remove site code from onchainkit repository. By @cpcramer #2136
+- **feat**: Add iconUrl to OnrampPaymentCurrency type. By @rustam-cb #2165
+- **fix**: Fix bug that would disable onramp due to USDC price fluctuations. By @abcrane123 #2171
+- **chore**: Remove site code from onchainkit repository. By @cpcramer #2136
 
 ## 0.38.1
 

--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -86,6 +86,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tscpaths": "^0.0.9",
     "tsup": "^8.3.5",
+    "usehooks-ts": "^3.1.0",
     "vite": "^5.3.3",
     "vitest": "^3.0.5"
   },

--- a/packages/onchainkit/src/styles/index-with-tailwind.css
+++ b/packages/onchainkit/src/styles/index-with-tailwind.css
@@ -1,9 +1,8 @@
-@import url("https://fonts.googleapis.com/css2?family=Inter&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz@0,9..40;1,9..40&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,700;1,9..40,700&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Oxanium:wght@200..800&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz@0,9..40;1,9..40&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,700;1,9..40,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Oxanium:wght@200..800&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100..900&display=swap');
-@import url("./tailwind-base.css");
-@import url("./index.css");
-
+@import url('./tailwind-base.css');
+@import url('./index.css');

--- a/packages/onchainkit/src/styles/index.css
+++ b/packages/onchainkit/src/styles/index.css
@@ -181,4 +181,3 @@
 .ock-bg-primary-disabled {
   background-color: var(--ock-bg-primary-disabled);
 }
-

--- a/packages/onchainkit/src/wallet/hooks/useConnectModal.test.tsx
+++ b/packages/onchainkit/src/wallet/hooks/useConnectModal.test.tsx
@@ -1,0 +1,37 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useConnectModal } from './useConnectModal';
+
+describe('useConnectModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return the correct values on initial render', () => {
+    const { result } = renderHook(() => useConnectModal());
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.openConnectModal).toBeInstanceOf(Function);
+    expect(result.current.closeConnectModal).toBeInstanceOf(Function);
+  });
+
+  it('should update isOpen state when openConnectModal is called', () => {
+    const { result } = renderHook(() => useConnectModal());
+    expect(result.current.isOpen).toBe(false);
+    act(() => {
+      result.current.openConnectModal();
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('should update isOpen state when closeConnectModal is called', () => {
+    const { result } = renderHook(() => useConnectModal());
+    act(() => {
+      result.current.openConnectModal();
+    });
+    expect(result.current.isOpen).toBe(true);
+    act(() => {
+      result.current.closeConnectModal();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+});

--- a/packages/onchainkit/src/wallet/hooks/useConnectModal.test.tsx
+++ b/packages/onchainkit/src/wallet/hooks/useConnectModal.test.tsx
@@ -10,11 +10,13 @@ describe('useConnectModal', () => {
   it('should return the correct values on initial render', () => {
     const { result } = renderHook(() => useConnectModal());
     expect(result.current.isOpen).toBe(false);
+    expect(result.current.setIsOpen).toBeInstanceOf(Function);
     expect(result.current.openConnectModal).toBeInstanceOf(Function);
     expect(result.current.closeConnectModal).toBeInstanceOf(Function);
+    expect(result.current.toggleConnectModal).toBeInstanceOf(Function);
   });
 
-  it('should update isOpen state when openConnectModal is called', () => {
+  it('should set isOpen state to true when openConnectModal is called', () => {
     const { result } = renderHook(() => useConnectModal());
     expect(result.current.isOpen).toBe(false);
     act(() => {
@@ -23,7 +25,7 @@ describe('useConnectModal', () => {
     expect(result.current.isOpen).toBe(true);
   });
 
-  it('should update isOpen state when closeConnectModal is called', () => {
+  it('should set isOpen state to false when closeConnectModal is called', () => {
     const { result } = renderHook(() => useConnectModal());
     act(() => {
       result.current.openConnectModal();
@@ -33,5 +35,35 @@ describe('useConnectModal', () => {
       result.current.closeConnectModal();
     });
     expect(result.current.isOpen).toBe(false);
+  });
+
+  it('should toggle isOpen state when toggleConnectModal is called', () => {
+    const { result } = renderHook(() => useConnectModal());
+    expect(result.current.isOpen).toBe(false);
+    act(() => {
+      result.current.toggleConnectModal();
+    });
+    expect(result.current.isOpen).toBe(true);
+    act(() => {
+      result.current.toggleConnectModal();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('should set isOpen state to false when setIsOpen is called with false', () => {
+    const { result } = renderHook(() => useConnectModal());
+    expect(result.current.isOpen).toBe(false);
+    act(() => {
+      result.current.setIsOpen(false);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('should set isOpen state to true when setIsOpen is called with true', () => {
+    const { result } = renderHook(() => useConnectModal());
+    expect(result.current.isOpen).toBe(false);
+    act(() => {
+      result.current.setIsOpen(true);
+    });
   });
 });

--- a/packages/onchainkit/src/wallet/hooks/useConnectModal.tsx
+++ b/packages/onchainkit/src/wallet/hooks/useConnectModal.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react';
+import { useBoolean } from 'usehooks-ts';
 
 type ConnectModalState = {
   /** Boolean value indicating if the connect modal is open */
   isOpen: boolean;
+  /** Function to set the connect modal state */
+  setIsOpen: (isOpen: boolean) => void;
   /** Function to open the connect modal */
   openConnectModal: () => void;
   /** Function to close the connect modal */
   closeConnectModal: () => void;
+  /** Function to toggle the connect modal */
+  toggleConnectModal: () => void;
 };
 
 /**
@@ -14,11 +18,19 @@ type ConnectModalState = {
  * @returns an object containing the isOpen state and the openConnectModal and closeConnectModal functions
  */
 export function useConnectModal(): ConnectModalState {
-  const [isOpen, setIsOpen] = useState(false);
+  const {
+    value: isOpen,
+    setValue: setIsOpen,
+    setTrue: openConnectModal,
+    setFalse: closeConnectModal,
+    toggle: toggleConnectModal,
+  } = useBoolean(false);
 
   return {
     isOpen,
-    openConnectModal: () => setIsOpen(true),
-    closeConnectModal: () => setIsOpen(false),
+    setIsOpen,
+    openConnectModal,
+    closeConnectModal,
+    toggleConnectModal,
   };
 }

--- a/packages/onchainkit/src/wallet/hooks/useConnectModal.tsx
+++ b/packages/onchainkit/src/wallet/hooks/useConnectModal.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+type ConnectModalState = {
+  /** Boolean value indicating if the connect modal is open */
+  isOpen: boolean;
+  /** Function to open the connect modal */
+  openConnectModal: () => void;
+  /** Function to close the connect modal */
+  closeConnectModal: () => void;
+};
+
+/**
+ * Hook to manage the connect modal state
+ * @returns an object containing the isOpen state and the openConnectModal and closeConnectModal functions
+ */
+export function useConnectModal(): ConnectModalState {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return {
+    isOpen,
+    openConnectModal: () => setIsOpen(true),
+    closeConnectModal: () => setIsOpen(false),
+  };
+}

--- a/packages/onchainkit/src/wallet/index.ts
+++ b/packages/onchainkit/src/wallet/index.ts
@@ -25,6 +25,9 @@ export { WalletProvider } from './components/WalletProvider';
 export { isValidAAEntrypoint } from './utils/isValidAAEntrypoint';
 export { isWalletACoinbaseSmartWallet } from './utils/isWalletACoinbaseSmartWallet';
 
+// Hooks
+export { useConnectModal } from './hooks/useConnectModal';
+
 // Types
 export type {
   ConnectWalletReact,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       tsup:
         specifier: ^8.3.5
         version: 8.4.0(@swc/core@1.11.11(@swc/helpers@0.5.15))(jiti@1.21.7)(postcss@8.5.3)(typescript@5.8.2)(yaml@2.7.0)
+      usehooks-ts:
+        specifier: ^3.1.0
+        version: 3.1.1(react@18.3.1)
       vite:
         specifier: ^5.3.3
         version: 5.4.14(@types/node@22.13.10)
@@ -7444,6 +7447,12 @@ packages:
   use@3.1.1:
     resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==}
     engines: {node: '>=0.10.0'}
+
+  usehooks-ts@3.1.1:
+    resolution: {integrity: sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==}
+    engines: {node: '>=16.15.0'}
+    peerDependencies:
+      react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   utf-8-validate@5.0.10:
     resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
@@ -16503,6 +16512,11 @@ snapshots:
       react: 18.3.1
 
   use@3.1.1: {}
+
+  usehooks-ts@3.1.1(react@18.3.1):
+    dependencies:
+      lodash.debounce: 4.0.8
+      react: 18.3.1
 
   utf-8-validate@5.0.10:
     dependencies:


### PR DESCRIPTION
**What changed? Why?**
What:
* added a hook, `useConnectModal`
* this hook controls modal state, with fns for opening and closing

Why
* makes it easier to interface with `WalletModal` vs rewriting state handlers every time

**Notes to reviewers**
Example usage:
```
import {
  WalletIsland,
  useConnectModal,
  WalletModal,
} from '@coinbase/onchainkit/wallet';
import { useAccount } from 'wagmi';

export default function WalletIslandDemo() {
  const { address } = useAccount();
  const { isOpen, openConnectModal, closeConnectModal } = useConnectModal();

  const handleClick = () => {
    if (!address) {
      openConnectModal();
      return;
    }
    console.log('submitting transaction');
  };

  return (
    <>
      <WalletIsland />
      <button
        onClick={handleClick}
        className="bg-green-500 text-white p-2 rounded-md"
      >
        {address ? 'Submit' : 'Connect'}
      </button>
      <WalletModal isOpen={isOpen} onClose={closeConnectModal} />
    </>
  );
}
```

https://github.com/user-attachments/assets/9c63e5d1-b8f3-4157-a8a3-3ac6b8f68232

**How has it been tested?**
* test coverage, playground