### PR TITLE
fix: Flaky Appchain unit test

### DIFF
--- a/packages/onchainkit/src/appchain/bridge/components/AppchainBridgeProvider.test.tsx
+++ b/packages/onchainkit/src/appchain/bridge/components/AppchainBridgeProvider.test.tsx
@@ -214,13 +214,13 @@ describe('AppchainBridgeProvider', () => {
   it('should handle address modal state changes', async () => {
     await waitFor(async () => {
       result.current.setIsAddressModalOpen(true);
+      expect(result.current.isAddressModalOpen).toBe(true);
     });
-    expect(result.current.isAddressModalOpen).toBe(true);
 
     await waitFor(async () => {
       result.current.handleAddressSelect('0x456' as `0x${string}`);
+      expect(result.current.bridgeParams.recipient).toBe('0x456');
     });
-    expect(result.current.bridgeParams.recipient).toBe('0x456');
   });
 
   it('should call deposit function when handleDeposit is called', async () => {


### PR DESCRIPTION
**What changed? Why?**
Attempting to fix the flaky unit test - _should handle address modal state changes_.

 This fix moves the assertion inside the waitFor callback, ensuring the test waits for the state update to complete before making the assertion.

<img width="489" alt="Screenshot 2025-04-01 at 10 07 54 AM" src="https://github.com/user-attachments/assets/2f935be3-900c-452e-9dbf-cd71634ce216" />

<img width="1503" alt="Screenshot 2025-04-01 at 10 08 08 AM" src="https://github.com/user-attachments/assets/0c335408-f68d-4410-b0a6-1649a2b07e0d" />

**Notes to reviewers**

**How has it been tested?**
