### PR TITLE
fix: playground layout providers

### DIFF
--- a/packages/playground/app/layout.tsx
+++ b/packages/playground/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import '@coinbase/onchainkit/styles.css';
 import './globals.css';
-import OnchainProviders from '@/components/OnchainProviders';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -17,9 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>
-        <OnchainProviders>{children}</OnchainProviders>
-      </body>
+      <body className={inter.className}>{children}</body>
     </html>
   );
 }

--- a/packages/playground/app/page.tsx
+++ b/packages/playground/app/page.tsx
@@ -2,13 +2,16 @@
 
 import { AppProvider } from '@/components/AppProvider';
 import Demo from '@/components/Demo';
+import OnchainProviders from '@/components/OnchainProviders';
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen w-full bg-muted/40">
-      <AppProvider>
-        <Demo />
-      </AppProvider>
-    </main>
+    <OnchainProviders>
+      <main className="flex min-h-screen w-full bg-muted/40">
+        <AppProvider>
+          <Demo />
+        </AppProvider>
+      </main>
+    </OnchainProviders>
   );
 }


### PR DESCRIPTION
**What changed? Why?**
Move Ock providers to page so they aren't inherited by the minikit app

**Notes to reviewers**

**How has it been tested?**
