### PR TITLE
fix: Remove unused @coinbase/onchainkit/core export + enable alpha releases

### DIFF
--- a/.changeset/nice-spoons-kiss.md
+++ b/.changeset/nice-spoons-kiss.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+Removes unused @coinbase/onchainkit/core export

--- a/.changeset/nice-spoons-kiss.md
+++ b/.changeset/nice-spoons-kiss.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-Removes unused @coinbase/onchainkit/core export
+Removes unused \@coinbase/onchainkit/core export

--- a/.changeset/nice-spoons-kiss.md
+++ b/.changeset/nice-spoons-kiss.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-Removes unused \@coinbase/onchainkit/core export
+fix: Removes unused \@coinbase/onchainkit/core export

--- a/.changeset/nice-spoons-kiss.md
+++ b/.changeset/nice-spoons-kiss.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
-fix: Removes unused \@coinbase/onchainkit/core export
+**fix**: Removed unused \@coinbase/onchainkit/core export. By @dgca #2211

--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -145,12 +145,6 @@
       "import": "./esm/checkout/index.js",
       "default": "./esm/checkout/index.js"
     },
-    "./core": {
-      "types": "./esm/core/index.d.ts",
-      "module": "./esm/core/index.js",
-      "import": "./esm/core/index.js",
-      "default": "./esm/core/index.js"
-    },
     "./earn": {
       "types": "./esm/earn/index.d.ts",
       "module": "./esm/earn/index.js",

--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -20,7 +20,6 @@
     "ci:lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.tsx --fix",
-    "lint:no-fix": "eslint . --ext .ts,.tsx",
     "lint:unsafe": "eslint . --ext .ts,.tsx --fix --max-warnings=0",
     "storybook:dev": "storybook dev -p 6006",
     "storybook:build": "storybook build",

--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -20,6 +20,7 @@
     "ci:lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "format": "prettier --write .",
     "lint": "eslint . --ext .ts,.tsx --fix",
+    "lint:no-fix": "eslint . --ext .ts,.tsx",
     "lint:unsafe": "eslint . --ext .ts,.tsx --fix --max-warnings=0",
     "storybook:dev": "storybook dev -p 6006",
     "storybook:build": "storybook build",

--- a/packages/onchainkit/scripts/publish-alpha.js
+++ b/packages/onchainkit/scripts/publish-alpha.js
@@ -95,7 +95,7 @@ export function publishAlphaRelease(nextAlphaVersion) {
     JSON.stringify(packageJson, null, 2) + '\n',
   );
 
-  execSync(`pnpm publish --tag ${ALPHA_TAG} --no-git-checks --dry-run`);
+  execSync(`pnpm publish --tag ${ALPHA_TAG} --no-git-checks`);
 }
 
 main();

--- a/packages/onchainkit/scripts/publish-alpha.test.ts
+++ b/packages/onchainkit/scripts/publish-alpha.test.ts
@@ -123,7 +123,7 @@ describe('publish-alpha-release script', () => {
 
       // Verify publish command was executed
       expect(execSync).toHaveBeenCalledWith(
-        `pnpm publish --tag ${ALPHA_TAG} --no-git-checks --dry-run`,
+        `pnpm publish --tag ${ALPHA_TAG} --no-git-checks`,
       );
     });
   });
@@ -160,7 +160,7 @@ describe('publish-alpha-release script', () => {
 
       // Verify the next alpha version was calculated and published
       expect(execSync).toHaveBeenCalledWith(
-        `pnpm publish --tag ${ALPHA_TAG} --no-git-checks --dry-run`,
+        `pnpm publish --tag ${ALPHA_TAG} --no-git-checks`,
       );
     });
 


### PR DESCRIPTION
**What changed? Why?**

- Removes \@coinbase/onchainkit/core export from package.json that's not included in the build
- Removes --dry-run from alpha release script

**Notes to reviewers**

Figured this change would be a good minor but testable change to test alpha releases with.

**How has it been tested?**

Manually