### PR TITLE
chore: Export Fund SuccessEventData type

### DIFF
--- a/packages/onchainkit/src/fund/index.ts
+++ b/packages/onchainkit/src/fund/index.ts
@@ -38,4 +38,5 @@ export type {
   OnrampPurchaseCurrency,
   OnrampQuoteResponseData,
   OnrampTransactionStatusName,
+  SuccessEventData,
 } from './types';

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -190,6 +190,9 @@ export type SuccessEvent = {
   data?: SuccessEventData;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type SuccessEventData = {
   assetImageUrl: string;
   assetName: string;
@@ -202,6 +205,9 @@ export type RequestOpenUrlEvent = {
   url: string;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type EventMetadata =
   | OpenEvent
   | TransitionViewEvent
@@ -210,6 +216,9 @@ export type EventMetadata =
   | SuccessEvent
   | RequestOpenUrlEvent;
 
+/**
+ * Note: exported as public Type
+ */
 export type OnrampError = {
   errorType:
     | 'internal_error'
@@ -220,6 +229,9 @@ export type OnrampError = {
   debugMessage?: string;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type OnrampTransactionStatusName =
   | 'ONRAMP_TRANSACTION_STATUS_UNSPECIFIED'
   | 'ONRAMP_TRANSACTION_STATUS_CREATED'
@@ -227,6 +239,9 @@ export type OnrampTransactionStatusName =
   | 'ONRAMP_TRANSACTION_STATUS_SUCCESS'
   | 'ONRAMP_TRANSACTION_STATUS_FAILED';
 
+/**
+ * Note: exported as public Type
+ */
 export type OnrampAmount = {
   value: string;
   currency: string;
@@ -250,10 +265,16 @@ export type OnrampTransaction = {
   transactionId: string;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type OnrampPaymentMethod = {
   id: string;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type OnrampPaymentMethodLimit = {
   id: string;
   min: string;
@@ -267,6 +288,9 @@ type OnrampNetwork = {
   contractAddress: string;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type OnrampOptionsResponseData = {
   /**
    * List of supported fiat currencies that can be exchanged for crypto on Onramp in the given location.
@@ -279,6 +303,9 @@ export type OnrampOptionsResponseData = {
   purchaseCurrencies: OnrampPurchaseCurrency[];
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type OnrampPurchaseCurrency = {
   id: string;
   name: string;
@@ -328,6 +355,9 @@ export type FundCardCurrencyLabelPropsReact = {
   label: string;
 };
 
+/**
+ * Note: exported as public Type
+ */
 export type FundCardPropsReact = {
   children?: ReactNode;
   assetSymbol: string;
@@ -423,16 +453,25 @@ export type PresetAmountInputItemPropsReact = {
  */
 export type PresetAmountInputs = readonly [string, string, string];
 
-export type OnrampConfigResponseData = {
-  countries: OnrampConfigCountry[];
-};
-
+/**
+ * Note: exported as public Type
+ */
 export type OnrampConfigCountry = {
   id: string;
   subdivisions: string[];
   paymentMethods: OnrampPaymentMethod[];
 };
 
+/**
+ * Note: exported as public Type
+ */
+export type OnrampConfigResponseData = {
+  countries: OnrampConfigCountry[];
+};
+
+/**
+ * Note: exported as public Type
+ */
 export type OnrampQuoteResponseData = {
   /**
    * Object with amount and currency of the total fiat payment required to complete the purchase, inclusive of any fees.
@@ -456,7 +495,7 @@ export type OnrampQuoteResponseData = {
    */
   coinbaseFee: OnrampAmount;
   /**
-   * Object with amount and currency of the network fee required to send the purchased crypto to the user’s wallet.
+   * Object with amount and currency of the network fee required to send the purchased crypto to the user's wallet.
    * The currency will match the `paymentCurrency`.
    */
   networkFee: OnrampAmount;


### PR DESCRIPTION
**What changed? Why?**
Exporting missing type - `SuccessEventData` for the Fund component. 

This type should be exported. It is currently[ erroring in the Fund setup-onramp-event-listeners docs page.](https://docs.base.org/builderkits/onchainkit/fund/setup-onramp-event-listeners) 
<img width="701" alt="Screenshot 2025-04-03 at 9 42 53 AM" src="https://github.com/user-attachments/assets/9f8c2c23-5b12-4756-8e45-f7f8a51cf3c0" />

**Notes to reviewers**

**How has it been tested?**
