### PR TITLE
chore: Enable eslint rule no-explicit-any 

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,7 +51,6 @@ export default [
         'asc',
         { caseSensitive: true, natural: false, minKeys: 2 },
       ],
-      '@typescript-eslint/no-explicit-any': 'off',
     },
   },
 ];

--- a/packages/onchainkit/src/core/network/attestations.ts
+++ b/packages/onchainkit/src/core/network/attestations.ts
@@ -33,6 +33,7 @@ export type GetAttestationsByFilterOptions =
 export type AttestationsQueryVariables = {
   distinct: string[];
   take: number;
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   where: Record<string, any>;
 };
 
@@ -83,6 +84,7 @@ export function getAttestationQueryVariables(
   filters: GetAttestationQueryVariablesFilters,
 ): AttestationsQueryVariables {
   const checksummedAddress = getAddress(address);
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   const conditions: Record<string, any> = {
     recipient: { equals: checksummedAddress },
     revoked: { equals: filters.revoked },

--- a/packages/onchainkit/src/fund/utils/subscribeToWindowMessage.test.ts
+++ b/packages/onchainkit/src/fund/utils/subscribeToWindowMessage.test.ts
@@ -7,8 +7,7 @@ import {
 describe('subscribeToWindowMessage', () => {
   let unsubscribe: () => void;
   const DEFAULT_ORIGIN = 'https://default.origin';
-
-  const mockMessageEvent = (data: any, origin = DEFAULT_ORIGIN) =>
+  const mockMessageEvent = (data: unknown, origin = DEFAULT_ORIGIN) =>
     new MessageEvent('message', { data, origin });
 
   beforeEach(() => {

--- a/packages/onchainkit/src/identity/hooks/useAttestations.test.ts
+++ b/packages/onchainkit/src/identity/hooks/useAttestations.test.ts
@@ -96,7 +96,7 @@ describe('useAttestations', () => {
     const chain = base;
 
     const { result } = renderHook(
-      () => useAttestations({ address, chain, schemaId: '' as any }),
+      () => useAttestations({ address, chain, schemaId: '' as `0x${string}` }),
       {
         wrapper: getNewReactQueryTestProvider(),
       },

--- a/packages/onchainkit/src/internal/hooks/useDebounce.ts
+++ b/packages/onchainkit/src/internal/hooks/useDebounce.ts
@@ -1,5 +1,6 @@
 import { useLayoutEffect, useMemo, useRef } from 'react';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export const useDebounce = (
   callback: (...args: any[]) => void,
   delay: number,

--- a/packages/onchainkit/src/internal/types.ts
+++ b/packages/onchainkit/src/internal/types.ts
@@ -10,6 +10,7 @@ type GenericStatus<T> = {
   statusData: T;
 };
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export type AbstractLifecycleStatus = ErrorStatus | GenericStatus<any>;
 
 export type UseLifecycleStatusReturn<T extends AbstractLifecycleStatus> = [

--- a/packages/onchainkit/src/internal/utils/formatFiatAmount.test.ts
+++ b/packages/onchainkit/src/internal/utils/formatFiatAmount.test.ts
@@ -108,6 +108,7 @@ describe('formatFiatAmount', () => {
     expect(() => formatFiatAmount({ amount: 'invalid' })).not.toThrow();
     expect(formatFiatAmount({ amount: 'invalid' })).toBe('$0.00');
     expect(formatFiatAmount({ amount: Number.NaN })).toBe('$0.00');
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     expect(formatFiatAmount({ amount: undefined as any })).toBe('$0.00');
   });
 });

--- a/packages/onchainkit/src/swap/types.ts
+++ b/packages/onchainkit/src/swap/types.ts
@@ -23,6 +23,7 @@ export type SendSwapTransactionParams = {
   config: Config;
   isSponsored?: boolean; // Whether the swap is sponsored (default: false)
   paymaster?: string; // OnchainKit config paymaster RPC url
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   sendCallsAsync: any;
   sendTransactionAsync: SendTransactionMutateAsync<Config, unknown>;
   transactions: SwapTransaction[]; // A list of transactions to execute

--- a/packages/onchainkit/src/transaction/hooks/useWriteContracts.test.ts
+++ b/packages/onchainkit/src/transaction/hooks/useWriteContracts.test.ts
@@ -10,6 +10,7 @@ vi.mock('wagmi/experimental', () => ({
 
 interface UseWriteContractsConfig {
   mutation: {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
     onError?: (error: any) => void;
     onSuccess?: (id: string) => void;
   };

--- a/packages/onchainkit/src/transaction/types.ts
+++ b/packages/onchainkit/src/transaction/types.ts
@@ -129,6 +129,7 @@ type PaymasterService = {
 
 export type SendBatchedTransactionsParams = {
   capabilities?: WalletCapabilities;
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   sendCallsAsync: any;
   transactions?: Array<Call | ContractFunctionParameters>;
 };
@@ -329,6 +330,7 @@ export type UseSendCallsParams = {
 
 export type UseSendWalletTransactionsParams = {
   capabilities?: WalletCapabilities;
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   sendCallsAsync: any;
   sendCallAsync: SendTransactionMutateAsync<Config, unknown> | (() => void);
   walletCapabilities: ViemWalletCapabilities;

--- a/packages/onchainkit/src/wallet/components/ConnectWallet.test.tsx
+++ b/packages/onchainkit/src/wallet/components/ConnectWallet.test.tsx
@@ -9,6 +9,8 @@ import { ConnectWallet } from './ConnectWallet';
 import { ConnectWalletText } from './ConnectWalletText';
 import { useWalletContext } from './WalletProvider';
 import type { Connector } from 'wagmi';
+import type { UseAccountReturnType, UseConnectReturnType, Config } from 'wagmi';
+import type { WalletContextType } from '../types';
 
 const openConnectModalMock = vi.fn();
 
@@ -83,7 +85,7 @@ describe('ConnectWallet', () => {
       chain: undefined,
       chainId: undefined,
       connector: undefined,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     vi.mocked(useConnect).mockReturnValue({
       connectors: [
@@ -100,7 +102,7 @@ describe('ConnectWallet', () => {
       ],
       connect: vi.fn(),
       status: 'idle',
-    } as any);
+    } as unknown as UseConnectReturnType<Config, unknown>);
 
     vi.mocked(useWalletContext).mockReturnValue({
       isSubComponentOpen: false,
@@ -113,7 +115,7 @@ describe('ConnectWallet', () => {
       isMobile: false,
       isConnecting: false,
       walletOpen: false,
-    } as any);
+    } as unknown as WalletContextType);
 
     vi.mocked(useOnchainKit).mockReturnValue({
       config: {
@@ -126,7 +128,7 @@ describe('ConnectWallet', () => {
         projectId: '1',
         appMetadata: { name: 'Test App' },
       },
-    } as any);
+    } as unknown as ReturnType<typeof useOnchainKit>);
 
     vi.mocked(useAnalytics).mockReturnValue({
       sendAnalytics: mockSendAnalytics,
@@ -156,7 +158,7 @@ describe('ConnectWallet', () => {
       ],
       connect: vi.fn(),
       status: 'pending',
-    } as any);
+    } as unknown as UseConnectReturnType<Config, unknown>);
 
     vi.mocked(useAccount).mockReturnValue({
       address: '0x0' as `0x${string}`,
@@ -169,7 +171,7 @@ describe('ConnectWallet', () => {
       chain: undefined,
       chainId: undefined,
       connector: undefined,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     render(<ConnectWallet text="Connect Wallet" />);
     const spinner = screen.getByTestId('ockSpinner');
@@ -191,7 +193,7 @@ describe('ConnectWallet', () => {
         id: 'mockConnector',
         name: 'MockConnector',
       } as unknown as Connector,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     render(
       <ConnectWallet text="Connect Wallet">
@@ -221,7 +223,7 @@ describe('ConnectWallet', () => {
       ],
       connect: connectMock,
       status: 'idle',
-    } as any);
+    } as unknown as UseConnectReturnType<Config, unknown>);
 
     vi.mocked(useAnalytics).mockReturnValue({
       sendAnalytics: mockSendAnalytics,
@@ -289,7 +291,7 @@ describe('ConnectWallet', () => {
         id: 'mockConnector',
         name: 'MockConnector',
       } as unknown as Connector,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     vi.mocked(useWalletContext).mockReturnValue({
       isSubComponentOpen: false,
@@ -302,7 +304,7 @@ describe('ConnectWallet', () => {
       isMobile: false,
       isConnecting: false,
       walletOpen: false,
-    } as any);
+    } as unknown as WalletContextType);
 
     const { rerender } = render(
       <ConnectWallet text="Connect Wallet">
@@ -324,7 +326,7 @@ describe('ConnectWallet', () => {
       isMobile: false,
       isConnecting: false,
       walletOpen: false,
-    } as any);
+    } as unknown as WalletContextType);
 
     rerender(
       <ConnectWallet text="Connect Wallet">
@@ -348,7 +350,7 @@ describe('ConnectWallet', () => {
       isMobile: false,
       isConnecting: false,
       walletOpen: false,
-    } as any);
+    } as unknown as WalletContextType);
 
     vi.mocked(useAccount).mockReturnValue({
       address: '0x123' as `0x${string}`,
@@ -364,7 +366,7 @@ describe('ConnectWallet', () => {
         id: 'mockConnector',
         name: 'MockConnector',
       } as unknown as Connector,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     vi.mocked(useConnect).mockReturnValue({
       connectors: [
@@ -381,7 +383,7 @@ describe('ConnectWallet', () => {
       ],
       connect: vi.fn(),
       status: 'idle',
-    } as any);
+    } as unknown as UseConnectReturnType<Config, unknown>);
 
     render(
       <ConnectWallet>
@@ -407,7 +409,7 @@ describe('ConnectWallet', () => {
         id: 'mockConnector',
         name: 'MockConnector',
       } as unknown as Connector,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     render(
       <ConnectWallet>
@@ -436,7 +438,7 @@ describe('ConnectWallet', () => {
       chain: undefined,
       chainId: undefined,
       connector: undefined,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     vi.mocked(useConnect).mockReturnValue({
       connectors: [
@@ -453,7 +455,7 @@ describe('ConnectWallet', () => {
       ],
       connect: connectMock,
       status: 'idle',
-    } as any);
+    } as unknown as UseConnectReturnType<Config, unknown>);
 
     render(<ConnectWallet text="Connect Wallet" onConnect={onConnectMock} />);
 
@@ -476,7 +478,7 @@ describe('ConnectWallet', () => {
         id: 'mockConnector',
         name: 'MockConnector',
       } as unknown as Connector,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     render(<ConnectWallet text="Connect Wallet" onConnect={onConnectMock} />);
 
@@ -499,7 +501,7 @@ describe('ConnectWallet', () => {
         id: 'mockConnector',
         name: 'MockConnector',
       } as unknown as Connector,
-    } as any);
+    } as unknown as UseAccountReturnType<Config>);
 
     const onConnectMock = vi.fn();
     render(<ConnectWallet text="Connect Wallet" onConnect={onConnectMock} />);
@@ -520,7 +522,7 @@ describe('ConnectWallet', () => {
           projectId: '1',
           appMetadata: { name: 'Test App' },
         },
-      } as any);
+      } as unknown as ReturnType<typeof useOnchainKit>);
 
       vi.mocked(useAccount).mockReturnValue({
         address: '0x0' as `0x${string}`,
@@ -533,7 +535,7 @@ describe('ConnectWallet', () => {
         chain: undefined,
         chainId: undefined,
         connector: undefined,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       vi.mocked(useConnect).mockReturnValue({
         connectors: [
@@ -550,7 +552,7 @@ describe('ConnectWallet', () => {
         ],
         connect: vi.fn(),
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       const setIsConnectModalOpenMock = vi.fn();
       vi.mocked(useWalletContext).mockReturnValue({
@@ -564,7 +566,7 @@ describe('ConnectWallet', () => {
         isConnecting: false,
         walletOpen: false,
         handleClose: vi.fn(),
-      } as any);
+      } as unknown as WalletContextType);
 
       render(<ConnectWallet text="Connect Wallet" />);
 
@@ -592,7 +594,7 @@ describe('ConnectWallet', () => {
         ],
         connect: connectMock,
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       render(<ConnectWallet text="Connect Wallet" />);
 
@@ -628,7 +630,7 @@ describe('ConnectWallet', () => {
         chain: undefined,
         chainId: undefined,
         connector: undefined,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       render(
         <ConnectWallet>
@@ -659,7 +661,7 @@ describe('ConnectWallet', () => {
         ],
         connect: connectMock,
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       vi.mocked(useAccount).mockReturnValue({
         address: '0x0' as `0x${string}`,
@@ -672,7 +674,7 @@ describe('ConnectWallet', () => {
         chain: undefined,
         chainId: undefined,
         connector: undefined,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       vi.mocked(useWalletContext).mockReturnValue({
         isConnectModalOpen: true,
@@ -685,7 +687,7 @@ describe('ConnectWallet', () => {
         isConnecting: false,
         walletOpen: false,
         handleClose: vi.fn(),
-      } as any);
+      } as unknown as WalletContextType);
 
       render(<ConnectWallet text="Connect" onConnect={onConnectMock} />);
 
@@ -708,7 +710,7 @@ describe('ConnectWallet', () => {
           id: 'mockConnector',
           name: 'MockConnector',
         } as unknown as Connector,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       expect(onConnectMock).toHaveBeenCalledTimes(1);
     });
@@ -727,7 +729,7 @@ describe('ConnectWallet', () => {
           projectId: '1',
           appMetadata: { name: 'Test App' },
         },
-      } as any);
+      } as unknown as ReturnType<typeof useOnchainKit>);
 
       vi.mocked(useAccount).mockReturnValue({
         address: '0x0' as `0x${string}`,
@@ -740,7 +742,7 @@ describe('ConnectWallet', () => {
         chain: undefined,
         chainId: undefined,
         connector: undefined,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       const setIsConnectModalOpenMock = vi.fn();
       vi.mocked(useWalletContext).mockReturnValue({
@@ -754,7 +756,7 @@ describe('ConnectWallet', () => {
         isConnecting: false,
         walletOpen: false,
         handleClose: vi.fn(),
-      } as any);
+      } as unknown as WalletContextType);
 
       render(<ConnectWallet text="Connect Wallet" />);
 
@@ -785,7 +787,7 @@ describe('ConnectWallet', () => {
         chain: undefined,
         chainId: undefined,
         connector: undefined,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       vi.mocked(useConnect).mockReturnValue({
         connectors: [
@@ -802,7 +804,7 @@ describe('ConnectWallet', () => {
         ],
         connect: connectMock,
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       const { rerender } = render(
         <ConnectWallet text="Connect Wallet" onConnect={onConnectMock} />,
@@ -828,7 +830,7 @@ describe('ConnectWallet', () => {
           id: 'mockConnector',
           name: 'MockConnector',
         } as unknown as Connector,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       rerender(
         <ConnectWallet text="Connect Wallet" onConnect={onConnectMock} />,
@@ -861,7 +863,7 @@ describe('ConnectWallet', () => {
         ],
         connect: connectMock,
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       vi.mocked(useAccount).mockReturnValue({
         address: '0x0' as `0x${string}`,
@@ -874,7 +876,7 @@ describe('ConnectWallet', () => {
         chain: undefined,
         chainId: undefined,
         connector: undefined,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       vi.mocked(useWalletContext).mockReturnValue({
         isConnectModalOpen: true,
@@ -887,7 +889,7 @@ describe('ConnectWallet', () => {
         isConnecting: false,
         walletOpen: false,
         handleClose: vi.fn(),
-      } as any);
+      } as unknown as WalletContextType);
 
       render(<ConnectWallet text="Connect" onConnect={onConnectMock} />);
 
@@ -910,7 +912,7 @@ describe('ConnectWallet', () => {
           id: 'mockConnector',
           name: 'MockConnector',
         } as unknown as Connector,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       expect(onConnectMock).toHaveBeenCalledTimes(1);
     });
@@ -934,7 +936,7 @@ describe('ConnectWallet', () => {
         ],
         connect: connectMock,
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       vi.mocked(useAccount).mockReturnValue({
         address: '0x0' as `0x${string}`,
@@ -947,7 +949,7 @@ describe('ConnectWallet', () => {
         chain: undefined,
         chainId: undefined,
         connector: undefined,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       vi.mocked(useWalletContext).mockReturnValue({
         isConnectModalOpen: true,
@@ -960,7 +962,7 @@ describe('ConnectWallet', () => {
         isConnecting: false,
         walletOpen: false,
         handleClose: vi.fn(),
-      } as any);
+      } as unknown as WalletContextType);
 
       const { rerender } = render(
         <ConnectWallet text="Connect" onConnect={onConnectMock} />,
@@ -985,7 +987,7 @@ describe('ConnectWallet', () => {
           id: 'mockConnector',
           name: 'MockConnector',
         } as unknown as Connector,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       rerender(
         <ConnectWallet text="Connect Wallet" onConnect={onConnectMock} />,
@@ -1010,7 +1012,7 @@ describe('ConnectWallet', () => {
           projectId: '1',
           appMetadata: { name: 'Test App' },
         },
-      } as any);
+      } as unknown as ReturnType<typeof useOnchainKit>);
 
       vi.mocked(useWalletContext).mockReturnValue({
         isConnectModalOpen: true,
@@ -1023,7 +1025,7 @@ describe('ConnectWallet', () => {
         isConnecting: false,
         walletOpen: false,
         handleClose: vi.fn(),
-      } as any);
+      } as unknown as WalletContextType);
 
       mockUseAccount.mockReturnValue({
         address: undefined,
@@ -1036,7 +1038,7 @@ describe('ConnectWallet', () => {
         chain: undefined,
         chainId: undefined,
         connector: undefined,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       const { rerender } = render(
         <ConnectWallet text="Connect Wallet" onConnect={onConnectMock} />,
@@ -1060,7 +1062,7 @@ describe('ConnectWallet', () => {
           id: 'mockConnector',
           name: 'MockConnector',
         } as unknown as Connector,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       rerender(
         <ConnectWallet text="Connect Wallet" onConnect={onConnectMock} />,
@@ -1088,7 +1090,7 @@ describe('ConnectWallet', () => {
           projectId: '1',
           appMetadata: { name: 'Test App' },
         },
-      } as any);
+      } as unknown as ReturnType<typeof useOnchainKit>);
 
       vi.mocked(useConnect).mockReturnValue({
         connectors: [
@@ -1105,7 +1107,7 @@ describe('ConnectWallet', () => {
         ],
         connect: vi.fn(),
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       render(<ConnectWallet text="Connect Wallet" />);
 
@@ -1137,7 +1139,7 @@ describe('ConnectWallet', () => {
         ],
         connect: connectMock,
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       render(<ConnectWallet text="Connect Wallet" />);
 
@@ -1169,7 +1171,7 @@ describe('ConnectWallet', () => {
         ],
         connect: connectMock,
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       render(<ConnectWallet text="Connect Wallet" />);
 
@@ -1203,7 +1205,7 @@ describe('ConnectWallet', () => {
         ],
         connect: connectMock,
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       render(<ConnectWallet text="Connect Wallet" />);
 
@@ -1238,7 +1240,7 @@ describe('ConnectWallet', () => {
         ],
         connect: vi.fn(),
         status: 'idle',
-      } as any);
+      } as unknown as UseConnectReturnType<Config, unknown>);
 
       mockUseAccount.mockReturnValue({
         address: '0x123' as `0x${string}`,
@@ -1254,7 +1256,7 @@ describe('ConnectWallet', () => {
           id: 'mockConnector',
           name: 'TestConnector',
         } as unknown as Connector,
-      } as any);
+      } as unknown as UseAccountReturnType<Config>);
 
       render(<ConnectWallet text="Connect Wallet" />);
 


### PR DESCRIPTION
**What changed? Why?**
Enable eslint `no-explicit-any` and explicitly ignore the flagged errors.


**Notes to reviewers**

**How has it been tested?**
