### PR TITLE
Docs/vercel deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ pnpm f:play dev:watch
 
 Then, you can view the playground at [http://localhost:3000](http://localhost:3000).
 
+ ### Deployment 
+ Want to explore a working example instantly? 
+ Click below to deploy a demo to Vercel in one click:
+ 
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcoinbase%2Fonchainkit%23)
 
 ## 🌁 Team and Community
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ pnpm f:play dev:watch
 Then, you can view the playground at [http://localhost:3000](http://localhost:3000).
 
  ### Deployment 
+ 
  Want to explore a working example instantly? 
  Click below to deploy a demo to Vercel in one click:
- 
+
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcoinbase%2Fonchainkit%23)
 
 ## 🌁 Team and Community


### PR DESCRIPTION
**What changed? Why?**
Added Vercel Depoy button in the README.MD

