### PR TITLE
chore: Add script to validate that the package includes all exports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
       - name: 'Setup'
         uses: ./.github/actions/setup
 
-      - name: Validate build
-        run: |
-          pnpm f:ock validate-build
-
       - name: Build
         run: |
           pnpm f:ock build
+
+      - name: Validate build
+        run: |
+          pnpm f:ock validate-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
       - name: 'Setup'
         uses: ./.github/actions/setup
 
+      - name: Validate build
+        run: |
+          pnpm f:ock validate-build
+
       - name: Build
         run: |
           pnpm f:ock build

--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -32,7 +32,7 @@
     "watch:tailwind": "tailwind -i ./src/styles/index.css -o ./src/tailwind.css --watch",
     "get-next-version": "node ./scripts/get-next-version.js",
     "publish-alpha": "node ./scripts/publish-alpha.js",
-    "validate-build": "pnpm pack && node ./scripts/validate-build.js"
+    "validate-build": "node ./scripts/validate-build.js"
   },
   "peerDependencies": {
     "@types/react": "^18 || ^19",

--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -31,7 +31,8 @@
     "watch": "tailwind -i ./src/styles/index-with-tailwind.css -o ./src/styles.css --watch",
     "watch:tailwind": "tailwind -i ./src/styles/index.css -o ./src/tailwind.css --watch",
     "get-next-version": "node ./scripts/get-next-version.js",
-    "publish-alpha": "node ./scripts/publish-alpha.js"
+    "publish-alpha": "node ./scripts/publish-alpha.js",
+    "validate-build": "pnpm pack && node ./scripts/validate-build.js"
   },
   "peerDependencies": {
     "@types/react": "^18 || ^19",

--- a/packages/onchainkit/scripts/validate-build.js
+++ b/packages/onchainkit/scripts/validate-build.js
@@ -46,7 +46,11 @@ function validateBuild() {
     );
 
     if (missingFiles.length > 0) {
-      throw new Error('Missing files in the tarball:', missingFiles.join('\n'));
+      console.error(
+        'Failed to find the following files:\n',
+        missingFiles.join('\n'),
+      );
+      throw new Error('Missing files in the tarball.');
     }
   } catch (err) {
     console.error('Something went wrong during build validation:');

--- a/packages/onchainkit/scripts/validate-build.js
+++ b/packages/onchainkit/scripts/validate-build.js
@@ -37,12 +37,12 @@ function validateBuild() {
     );
     const tarballContentsArr = lines
       .slice(tarballContentsStart, tarballContentsEnd)
-      .map((line) => './' + /(?<path>\S+$)/.exec(line)?.groups?.path);
+      .map((line) => './' + /(?<path>\S+$)/.exec(line)?.groups?.path?.trim());
     const tarballContents = new Set(tarballContentsArr);
 
-    console.log(lines.slice(0, 20));
-
-    console.log(tarballContentsArr.slice(0, 20));
+    console.log(lines.slice(0, 30));
+    console.log('---');
+    console.log(tarballContentsArr.slice(0, 30));
 
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),

--- a/packages/onchainkit/scripts/validate-build.js
+++ b/packages/onchainkit/scripts/validate-build.js
@@ -32,7 +32,7 @@ function validateBuild() {
     const tarballContents = new Set(tarballContentsArr);
 
     console.log(packageRoot);
-    console.log(tarballContentsArr.slice(0, 10));
+    console.log(lines);
 
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),

--- a/packages/onchainkit/scripts/validate-build.js
+++ b/packages/onchainkit/scripts/validate-build.js
@@ -1,0 +1,5 @@
+function validateBuild() {
+  console.log('Validating build...');
+}
+
+validateBuild();

--- a/packages/onchainkit/scripts/validate-build.js
+++ b/packages/onchainkit/scripts/validate-build.js
@@ -40,6 +40,10 @@ function validateBuild() {
       .map((line) => './' + /(?<path>\S+$)/.exec(line)?.groups?.path);
     const tarballContents = new Set(tarballContentsArr);
 
+    console.log(lines.slice(0, 20));
+
+    console.log(tarballContentsArr.slice(0, 20));
+
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
     );

--- a/packages/onchainkit/scripts/validate-build.js
+++ b/packages/onchainkit/scripts/validate-build.js
@@ -1,5 +1,82 @@
+// @ts-check
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import process from 'process';
+import { spawnSync } from 'child_process';
+
 function validateBuild() {
-  console.log('Validating build...');
+  try {
+    const currentDir = path.dirname(fileURLToPath(import.meta.url));
+    const packageRoot = path.resolve(currentDir, '..');
+    process.chdir(packageRoot);
+
+    const { stdout, stderr } = spawnSync(
+      'pnpm',
+      ['publish', '--dry-run', '--force', '--no-git-checks'],
+      {
+        cwd: packageRoot,
+        shell: true,
+        encoding: 'utf-8',
+        stdio: ['inherit', 'pipe', 'pipe'],
+      },
+    );
+
+    const lines = (stdout + stderr).split('\n');
+    const tarballContentsStart =
+      lines.indexOf('npm notice Tarball Contents') + 1;
+    const tarballContentsEnd = lines.indexOf('npm notice Tarball Details');
+    const tarballContentsArr = lines
+      .slice(tarballContentsStart, tarballContentsEnd)
+      .map((line) => './' + /(?<path>\S+$)/.exec(line)?.groups?.path);
+    const tarballContents = new Set(tarballContentsArr);
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
+    );
+
+    const missingFiles = getMissingFiles(
+      {
+        main: packageJson.main,
+        types: packageJson.types,
+        module: packageJson.module,
+        exports: packageJson.exports,
+      },
+      tarballContents,
+    );
+
+    if (missingFiles.length > 0) {
+      throw new Error('Missing files in the tarball:', missingFiles.join('\n'));
+    }
+  } catch (err) {
+    console.error('Something went wrong during build validation:');
+    console.error(err);
+    process.exit(1);
+  }
+
+  console.log('Build validation successful');
+  process.exit(0);
+}
+
+/**
+ * Validates package.json fields against the tarball content
+ * @param {Object.<string, string|Object.<string, string|Object>>} fields - Package.json fields to validate
+ * @param {Set<string>} tarballContents - Set of files in the tarball
+ */
+function getMissingFiles(fields, tarballContents) {
+  const missingFiles = [];
+
+  for (const value of Object.values(fields)) {
+    if (typeof value === 'string') {
+      if (!tarballContents.has(value)) {
+        missingFiles.push(value);
+      }
+    } else {
+      missingFiles.push(...getMissingFiles(value, tarballContents));
+    }
+  }
+
+  return missingFiles;
 }
 
 validateBuild();

--- a/packages/onchainkit/scripts/validate-build.js
+++ b/packages/onchainkit/scripts/validate-build.js
@@ -32,12 +32,14 @@ function validateBuild() {
     const lines = (stdout + stderr).split('\n');
     const tarballContentsStart =
       lines.findIndex((line) => TARBALL_CONTENTS_START_REGEX.test(line)) + 1;
+    console.log({ tarballContentsStart });
     const tarballContentsEnd = lines.findIndex((line) =>
       TARBALL_CONTENTS_END_REGEX.test(line),
     );
+    console.log({ tarballContentsEnd });
     const tarballContentsArr = lines
       .slice(tarballContentsStart, tarballContentsEnd)
-      .map((line) => './' + /(?<path>\S+$)/.exec(line)?.groups?.path?.trim());
+      .map((line) => './' + /(?<path>\S+$)/.exec(line.trim())?.groups?.path);
     const tarballContents = new Set(tarballContentsArr);
 
     console.log(lines.slice(0, 30));

--- a/packages/onchainkit/scripts/validate-build.js
+++ b/packages/onchainkit/scripts/validate-build.js
@@ -31,6 +31,9 @@ function validateBuild() {
       .map((line) => './' + /(?<path>\S+$)/.exec(line)?.groups?.path);
     const tarballContents = new Set(tarballContentsArr);
 
+    console.log(packageRoot);
+    console.log(tarballContentsArr.slice(0, 10));
+
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'),
     );

--- a/packages/onchainkit/scripts/validate-build.test.ts
+++ b/packages/onchainkit/scripts/validate-build.test.ts
@@ -1,0 +1,366 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  MockInstance,
+} from 'vitest';
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import process from 'process';
+
+// Mock the modules
+vi.mock('child_process');
+vi.mock('fs');
+vi.mock('path');
+vi.mock('url');
+vi.mock('process');
+
+describe('validate-build script', () => {
+  let mockConsoleLog: MockInstance;
+  let mockConsoleError: MockInstance;
+  let mockProcessExit: MockInstance;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    // Mock console methods
+    mockConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // Mock process.exit
+    mockProcessExit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+
+    // Mock process.chdir
+    vi.spyOn(process, 'chdir').mockImplementation(() => undefined);
+
+    // Mock fileURLToPath and path operations
+    vi.mocked(fileURLToPath).mockReturnValue('/mocked/path/to/script.js');
+    vi.mocked(path.dirname).mockReturnValue('/mocked/path/to');
+    vi.mocked(path.resolve).mockReturnValue('/mocked/package/root');
+    vi.mocked(path.join).mockReturnValue('/mocked/package/root/package.json');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should validate build successfully when all files are present', async () => {
+    // Mock spawnSync to return tarball contents
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: `
+npm notice 
+npm notice 📦  @coinbase/onchainkit@1.2.0
+npm notice Tarball Contents
+npm notice 1.2kB dist/index.js
+npm notice 2.3kB dist/index.d.ts
+npm notice 3.4kB dist/esm/index.js
+npm notice 1.1kB package.json
+npm notice Tarball Details
+npm notice name:          @coinbase/onchainkit
+npm notice version:       1.2.0
+npm notice filename:      coinbase-onchainkit-1.2.0.tgz
+npm notice package size:  5.0 kB
+npm notice unpacked size: 8.0 kB
+npm notice shasum:        1234567890abcdef1234567890abcdef12345678
+npm notice integrity:     sha512-[...]
+npm notice total files:   4
+npm notice
+      `,
+      stderr: '',
+      status: 0,
+      signal: null,
+      error: undefined,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    // Mock fs.readFileSync to return package.json content
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        name: '@coinbase/onchainkit',
+        version: '1.2.0',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        module: './dist/esm/index.js',
+        exports: {
+          '.': {
+            import: './dist/esm/index.js',
+            require: './dist/index.js',
+            types: './dist/index.d.ts',
+          },
+        },
+      }),
+    );
+
+    // Import the script
+    await import('./validate-build.js');
+
+    // Verify process.chdir was called with the mocked root
+    expect(process.chdir).toHaveBeenCalledWith('/mocked/package/root');
+
+    // Verify spawnSync was called with correct arguments
+    expect(spawnSync).toHaveBeenCalledWith(
+      'pnpm',
+      ['publish', '--dry-run', '--force', '--no-git-checks'],
+      {
+        cwd: '/mocked/package/root',
+        shell: true,
+        encoding: 'utf-8',
+        stdio: ['inherit', 'pipe', 'pipe'],
+      },
+    );
+
+    // Verify successful completion
+    expect(mockConsoleLog).toHaveBeenCalledWith('Build validation successful');
+    expect(mockProcessExit).toHaveBeenCalledWith(0);
+  });
+
+  it('should detect missing files in tarball and exit with error', async () => {
+    // Mock spawnSync to return tarball contents missing one file
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: `
+npm notice 
+npm notice 📦  @coinbase/onchainkit@1.2.0
+npm notice Tarball Contents
+npm notice 1.2kB dist/index.js
+npm notice 3.4kB dist/esm/index.js
+npm notice 1.1kB package.json
+npm notice Tarball Details
+npm notice name:          @coinbase/onchainkit
+npm notice version:       1.2.0
+npm notice filename:      coinbase-onchainkit-1.2.0.tgz
+npm notice package size:  4.0 kB
+npm notice unpacked size: 6.0 kB
+npm notice shasum:        1234567890abcdef1234567890abcdef12345678
+npm notice integrity:     sha512-[...]
+npm notice total files:   3
+npm notice
+      `,
+      stderr: '',
+      status: 0,
+      signal: null,
+      error: undefined,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    // Mock fs.readFileSync to return package.json content
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        name: '@coinbase/onchainkit',
+        version: '1.2.0',
+        main: './dist/index.js',
+        types: './dist/index.d.ts', // This file will be missing
+        module: './dist/esm/index.js',
+        exports: {
+          '.': {
+            import: './dist/esm/index.js',
+            require: './dist/index.js',
+            types: './dist/index.d.ts', // This file will be missing
+          },
+        },
+      }),
+    );
+
+    // Import the script
+    await import('./validate-build.js');
+
+    // Verify error handling
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Something went wrong during build validation:',
+    );
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+  });
+
+  it('should handle nested exports structure correctly', async () => {
+    // Mock spawnSync to return tarball contents
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: `
+npm notice 
+npm notice 📦  @coinbase/onchainkit@1.2.0
+npm notice Tarball Contents
+npm notice 1.2kB dist/index.js
+npm notice 2.3kB dist/index.d.ts
+npm notice 3.4kB dist/esm/index.js
+npm notice 4.5kB dist/components/Button.js
+npm notice 5.6kB dist/components/Button.d.ts
+npm notice 1.1kB package.json
+npm notice Tarball Details
+npm notice name:          @coinbase/onchainkit
+npm notice version:       1.2.0
+npm notice filename:      coinbase-onchainkit-1.2.0.tgz
+npm notice package size:  10.0 kB
+npm notice unpacked size: 18.0 kB
+npm notice shasum:        1234567890abcdef1234567890abcdef12345678
+npm notice integrity:     sha512-[...]
+npm notice total files:   6
+npm notice
+      `,
+      stderr: '',
+      status: 0,
+      signal: null,
+      error: undefined,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    // Mock fs.readFileSync to return package.json with nested exports
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        name: '@coinbase/onchainkit',
+        version: '1.2.0',
+        main: './dist/index.js',
+        types: './dist/index.d.ts',
+        module: './dist/esm/index.js',
+        exports: {
+          '.': {
+            import: './dist/esm/index.js',
+            require: './dist/index.js',
+            types: './dist/index.d.ts',
+          },
+          './components': {
+            import: './dist/components/Button.js',
+            types: './dist/components/Button.d.ts',
+          },
+        },
+      }),
+    );
+
+    // Import the script
+    await import('./validate-build.js');
+
+    // Verify successful completion
+    expect(mockConsoleLog).toHaveBeenCalledWith('Build validation successful');
+    expect(mockProcessExit).toHaveBeenCalledWith(0);
+  });
+
+  it('should handle spawnSync error', async () => {
+    // Mock spawnSync to throw an error
+    vi.mocked(spawnSync).mockImplementation(() => {
+      throw new Error('Command failed');
+    });
+
+    // Import the script
+    await import('./validate-build.js');
+
+    // Verify error handling
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Something went wrong during build validation:',
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Command failed',
+      }),
+    );
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+  });
+
+  it('should handle fs.readFileSync error', async () => {
+    // Mock spawnSync to return valid tarball contents
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: `
+npm notice 
+npm notice 📦  @coinbase/onchainkit@1.2.0
+npm notice Tarball Contents
+npm notice 1.2kB dist/index.js
+npm notice Tarball Details
+npm notice
+      `,
+      stderr: '',
+      status: 0,
+      signal: null,
+      error: undefined,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    // Mock fs.readFileSync to throw an error
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error('File not found');
+    });
+
+    // Import the script
+    await import('./validate-build.js');
+
+    // Verify error handling
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      'Something went wrong during build validation:',
+    );
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'File not found',
+      }),
+    );
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+  });
+
+  it('should handle missing tarball markers in spawn output', async () => {
+    // Mock spawnSync to return output without tarball contents markers
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: `
+npm notice 
+npm notice 📦  @coinbase/onchainkit@1.2.0
+npm notice Some other content
+      `,
+      stderr: '',
+      status: 0,
+      signal: null,
+      error: undefined,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    // Mock fs.readFileSync to return package.json content
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        name: '@coinbase/onchainkit',
+        version: '1.2.0',
+        main: './dist/index.js',
+      }),
+    );
+
+    // Import the script
+    await import('./validate-build.js');
+
+    // Because indexOf returns -1 for missing content, we should get an error
+    expect(mockConsoleError).toHaveBeenCalled();
+    expect(mockProcessExit).toHaveBeenCalledWith(1);
+  });
+
+  it('should handle non-string values in package.json fields correctly', async () => {
+    // Mock spawnSync to return tarball contents
+    vi.mocked(spawnSync).mockReturnValue({
+      stdout: `
+npm notice 
+npm notice 📦  @coinbase/onchainkit@1.2.0
+npm notice Tarball Contents
+npm notice 1.2kB dist/index.js
+npm notice Tarball Details
+npm notice
+      `,
+      stderr: '',
+      status: 0,
+      signal: null,
+      error: undefined,
+    } as unknown as ReturnType<typeof spawnSync>);
+
+    // Mock fs.readFileSync to return package.json with a mixture of string and object values
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        name: '@coinbase/onchainkit',
+        version: '1.2.0',
+        main: './dist/index.js',
+        otherField: true, // boolean value should be ignored
+        exports: {
+          numberedField: 123, // number value should be ignored
+          '.': './dist/index.js',
+        },
+      }),
+    );
+
+    // Import the script
+    await import('./validate-build.js');
+
+    // Only string values are checked, so this should still pass
+    expect(mockConsoleLog).toHaveBeenCalledWith('Build validation successful');
+    expect(mockProcessExit).toHaveBeenCalledWith(0);
+  });
+});


### PR DESCRIPTION
**What changed? Why?**

Recently we published a build that didn't include a file that was referenced in our package.json exports.

This script will mock publishing the package and ensure that all exported files make it to the packed package.

**Notes to reviewers**

I added this check to the current build workflow. Let me know if you think it belongs somewhere else.

**How has it been tested?**

- Manually
- Unit tests