### PR TITLE
chore: Add bidirectional resolution validation to Basenames and ENS names

### DIFF
--- a/.changeset/mighty-rockets-teach.md
+++ b/.changeset/mighty-rockets-teach.md
@@ -2,4 +2,4 @@
 "@coinbase/onchainkit": patch
 ---
 
--**chore**: Add forward resolution to Basenames and ENS names. By @cpcramer #2255
+- **chore**: Add bidirectional resolution validation to `Basenames` and `ENS` names. By @cpcramer #2255

--- a/.changeset/mighty-rockets-teach.md
+++ b/.changeset/mighty-rockets-teach.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+-**chore**: Add forward resolution to Basenames and ENS names. By @cpcramer #2255


### PR DESCRIPTION
**What changed? Why?**
This PR fixes a vulnerability in the identity resolution system that allowed users to spoof their displayed names.

The current implementation of reverse resolution (address → name) didn't verify name ownership:

- It's possible to spoof the address by setting a name on the reverse registry without actually owning the name
- We would display that name without verification

The Solution: Bidirectional Validation

- Reverse Resolution: Get name from address (getName)
- Forward Resolution: Resolve name back to address (getAddress)
- Validation: Only display the name if addresses match

This prevents malicious actors from falsely displaying names they don't control, ensuring all displayed names are properly verified and legitimate.

**Notes to reviewers**

Following with getNames validation. 

**How has it been tested?**
Playground:
<img width="336" alt="Screenshot 2025-04-09 at 2 38 52 PM" src="https://github.com/user-attachments/assets/8277ae35-1318-4b9a-8a19-754309314173" />


No ENS or Basename:
<img width="340" alt="Screenshot 2025-04-09 at 2 38 29 PM" src="https://github.com/user-attachments/assets/bb686e69-b3aa-470e-8bcc-960e3498efe3" />
