### PR TITLE
fix: only call useportfolio when subcomponents need it

### DIFF
--- a/.changeset/tame-pugs-create.md
+++ b/.changeset/tame-pugs-create.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+Fix: Wallet unnecessarily fetching tokenBalances

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedAddressDetails.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedAddressDetails.tsx
@@ -6,6 +6,9 @@ import { zIndex } from '@/styles/constants';
 import { border, cn, color, pressable, text } from '@/styles/theme';
 import { useCallback, useState } from 'react';
 import { useWalletContext } from './WalletProvider';
+import { usePortfolio } from '../hooks/usePortfolio';
+import { RequestContext } from '@/core/network/constants';
+import { useAccount } from 'wagmi';
 
 type WalletAdvancedAddressDetailsProps = {
   classNames?: {
@@ -93,7 +96,12 @@ export function WalletAdvancedAddressDetails({
 }
 
 function AddressBalanceInFiat({ className }: { className?: string }) {
-  const { portfolioFiatValue, isFetchingPortfolioData } = useWalletContext();
+  const { address } = useAccount();
+
+  const { data: portfolioData, isFetching: isFetchingPortfolioData } =
+    usePortfolio({ address }, RequestContext.Wallet);
+
+  const portfolioFiatValue = portfolioData?.portfolioBalanceInUsd;
 
   const formattedValueInFiat = new Intl.NumberFormat('en-US', {
     style: 'currency',

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedTokenHoldings.test.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedTokenHoldings.test.tsx
@@ -1,7 +1,18 @@
 import { render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { WalletAdvancedTokenHoldings } from './WalletAdvancedTokenHoldings';
 import { useWalletContext } from './WalletProvider';
+import { usePortfolio } from '../hooks/usePortfolio';
+
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn().mockReturnValue({
+    address: '0x123',
+  }),
+}));
+
+vi.mock('../hooks/usePortfolio', () => ({
+  usePortfolio: vi.fn(),
+}));
 
 vi.mock('./WalletProvider', () => ({
   useWalletContext: vi.fn(),
@@ -31,6 +42,12 @@ describe('WalletAdvancedTokenHoldings', () => {
     mockUseWalletAdvancedContext.mockReturnValue(
       defaultMockUseWalletAdvancedContext,
     );
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [],
+      },
+      isFetching: false,
+    });
   });
 
   it('does not render token lists with zero tokens', () => {
@@ -40,9 +57,11 @@ describe('WalletAdvancedTokenHoldings', () => {
   });
 
   it('renders a placeholder when fetcher is loading', () => {
-    mockUseWalletAdvancedContext.mockReturnValue({
-      ...defaultMockUseWalletAdvancedContext,
-      isFetchingPortfolioData: true,
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [],
+      },
+      isFetching: true,
     });
 
     render(<WalletAdvancedTokenHoldings />);
@@ -96,9 +115,11 @@ describe('WalletAdvancedTokenHoldings', () => {
       },
     ];
 
-    mockUseWalletAdvancedContext.mockReturnValue({
-      ...defaultMockUseWalletAdvancedContext,
-      tokenBalances: tokens,
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: tokens,
+      },
+      isFetching: false,
     });
 
     render(<WalletAdvancedTokenHoldings />);
@@ -120,9 +141,11 @@ describe('WalletAdvancedTokenHoldings', () => {
       },
     ];
 
-    mockUseWalletAdvancedContext.mockReturnValue({
-      ...defaultMockUseWalletAdvancedContext,
-      tokenBalances: tokens,
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: tokens,
+      },
+      isFetching: false,
     });
 
     render(<WalletAdvancedTokenHoldings />);
@@ -155,9 +178,11 @@ describe('WalletAdvancedTokenHoldings', () => {
       },
     };
 
-    mockUseWalletAdvancedContext.mockReturnValue({
-      ...defaultMockUseWalletAdvancedContext,
-      tokenBalances: tokens,
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: tokens,
+      },
+      isFetching: false,
     });
 
     render(<WalletAdvancedTokenHoldings classNames={customClassNames} />);

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedTokenHoldings.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedTokenHoldings.tsx
@@ -4,6 +4,9 @@ import { cn, color, text } from '@/styles/theme';
 import { type Token, TokenImage } from '@/token';
 import { formatUnits } from 'viem';
 import { useWalletContext } from './WalletProvider';
+import { usePortfolio } from '../hooks/usePortfolio';
+import { RequestContext } from '@/core/network/constants';
+import { useAccount } from 'wagmi';
 
 type WalletAdvancedTokenDetailsProps = {
   token: Token;
@@ -29,8 +32,13 @@ type WalletAdvancedTokenHoldingsProps = {
 export function WalletAdvancedTokenHoldings({
   classNames,
 }: WalletAdvancedTokenHoldingsProps) {
-  const { tokenBalances, isFetchingPortfolioData, animations } =
-    useWalletContext();
+  const { address } = useAccount();
+  const { animations } = useWalletContext();
+
+  const { data: portfolioData, isFetching: isFetchingPortfolioData } =
+    usePortfolio({ address }, RequestContext.Wallet);
+
+  const tokenBalances = portfolioData?.tokenBalances;
 
   if (isFetchingPortfolioData || !tokenBalances || tokenBalances.length === 0) {
     return (

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedTransactionActions.test.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedTransactionActions.test.tsx
@@ -2,9 +2,10 @@ import { useAnalytics } from '@/core/analytics/hooks/useAnalytics';
 import { WalletEvent, WalletOption } from '@/core/analytics/types';
 import { useOnchainKit } from '@/useOnchainKit';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { WalletAdvancedTransactionActions } from './WalletAdvancedTransactionActions';
 import { useWalletContext } from './WalletProvider';
+import { usePortfolio } from '../hooks/usePortfolio';
 
 vi.mock('@/useOnchainKit', () => ({
   useOnchainKit: vi.fn(),
@@ -12,6 +13,10 @@ vi.mock('@/useOnchainKit', () => ({
 
 vi.mock('./WalletProvider', () => ({
   useWalletContext: vi.fn(),
+}));
+
+vi.mock('../hooks/usePortfolio', () => ({
+  usePortfolio: vi.fn(),
 }));
 
 vi.mock('@/core/analytics/hooks/useAnalytics', () => ({
@@ -53,6 +58,13 @@ describe('WalletAdvancedTransactionActons', () => {
 
     (useAnalytics as ReturnType<typeof vi.fn>).mockReturnValue({
       sendAnalytics: mockSendAnalytics,
+    });
+
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [],
+      },
+      isFetching: false,
     });
   });
 
@@ -163,7 +175,13 @@ describe('WalletAdvancedTransactionActons', () => {
       address: mockAddress,
       chain: mockChain,
       ...defaultMockUseWalletAdvancedContext,
-      isFetchingPortfolioData: true,
+    });
+
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [],
+      },
+      isFetching: true,
     });
 
     render(<WalletAdvancedTransactionActions />);

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedTransactionActions.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedTransactionActions.tsx
@@ -10,6 +10,8 @@ import { border, cn, color, pressable, text } from '@/styles/theme';
 import { useOnchainKit } from '@/useOnchainKit';
 import { useCallback } from 'react';
 import { useWalletContext } from './WalletProvider';
+import { RequestContext } from '@/core/network/constants';
+import { usePortfolio } from '../hooks/usePortfolio';
 
 type WalletAdvancedTransactionActionProps = {
   icon: React.ReactNode;
@@ -34,15 +36,14 @@ type WalletAdvancedTransactionActionsProps = {
 export function WalletAdvancedTransactionActions({
   classNames,
 }: WalletAdvancedTransactionActionsProps) {
-  const {
-    address,
-    chain,
-    isFetchingPortfolioData,
-    setActiveFeature,
-    animations,
-  } = useWalletContext();
+  const { address, chain, setActiveFeature, animations } = useWalletContext();
   const { projectId } = useOnchainKit();
   const { sendAnalytics } = useAnalytics();
+
+  const { isFetching: isFetchingPortfolioData } = usePortfolio(
+    { address },
+    RequestContext.Wallet,
+  );
 
   const handleAnalyticsOptionSelected = useCallback(
     (option: WalletOption) => {

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.test.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.test.tsx
@@ -5,9 +5,17 @@ import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useDisconnect } from 'wagmi';
 import { WalletAdvancedWalletActions } from './WalletAdvancedWalletActions';
 import { useWalletContext } from './WalletProvider';
+import { usePortfolio } from '../hooks/usePortfolio';
 
 vi.mock('wagmi', () => ({
   useDisconnect: vi.fn(),
+  useAccount: vi.fn().mockReturnValue({
+    address: '0x123',
+  }),
+}));
+
+vi.mock('../hooks/usePortfolio', () => ({
+  usePortfolio: vi.fn(),
 }));
 
 vi.mock('wagmi/actions', () => ({
@@ -30,10 +38,10 @@ vi.mock('@/core/analytics/hooks/useAnalytics', () => ({
 describe('WalletAdvancedWalletActions', () => {
   const mockUseWalletContext = useWalletContext as ReturnType<typeof vi.fn>;
   const mockSendAnalytics = vi.fn();
+  const refetchPortfolioDataMock = vi.fn();
 
   const defaultMockUseWalletAdvancedContext = {
     setActiveFeature: vi.fn(),
-    refetchPortfolioData: vi.fn(),
     animations: {
       content: '',
     },
@@ -45,6 +53,10 @@ describe('WalletAdvancedWalletActions', () => {
 
     (useAnalytics as Mock).mockReturnValue({
       sendAnalytics: mockSendAnalytics,
+    });
+
+    (usePortfolio as Mock).mockReturnValue({
+      refetch: refetchPortfolioDataMock,
     });
   });
 
@@ -121,9 +133,7 @@ describe('WalletAdvancedWalletActions', () => {
     const refreshButton = screen.getByTestId('ockWalletAdvanced_RefreshButton');
     fireEvent.click(refreshButton);
 
-    expect(
-      defaultMockUseWalletAdvancedContext.refetchPortfolioData,
-    ).toHaveBeenCalled();
+    expect(refetchPortfolioDataMock).toHaveBeenCalled();
   });
 
   it('opens transaction history when transactions button is clicked', () => {

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.tsx
@@ -9,8 +9,10 @@ import { qrIconSvg } from '@/internal/svg/qrIconSvg';
 import { refreshSvg } from '@/internal/svg/refreshSvg';
 import { cn } from '@/styles/theme';
 import { useCallback } from 'react';
-import { useDisconnect } from 'wagmi';
+import { useAccount, useDisconnect } from 'wagmi';
 import { useWalletContext } from './WalletProvider';
+import { usePortfolio } from '../hooks/usePortfolio';
+import { RequestContext } from '@/core/network/constants';
 
 type WalletAdvancedWalletActionsProps = {
   classNames?: {
@@ -25,15 +27,15 @@ type WalletAdvancedWalletActionsProps = {
 export function WalletAdvancedWalletActions({
   classNames,
 }: WalletAdvancedWalletActionsProps) {
-  const {
-    address,
-    handleClose,
-    setActiveFeature,
-    refetchPortfolioData,
-    animations,
-  } = useWalletContext();
+  const { address } = useAccount();
+  const { handleClose, setActiveFeature, animations } = useWalletContext();
   const { disconnect, connectors } = useDisconnect();
   const { sendAnalytics } = useAnalytics();
+
+  const { refetch: refetchPortfolioData } = usePortfolio(
+    { address },
+    RequestContext.Wallet,
+  );
 
   const handleAnalyticsOptionSelected = useCallback(
     (option: WalletOption) => {

--- a/packages/onchainkit/src/wallet/components/WalletDropdownContent.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletDropdownContent.tsx
@@ -8,6 +8,9 @@ import { WalletAdvancedQrReceive } from './WalletAdvancedQrReceive';
 import { WalletAdvancedSwap } from './WalletAdvancedSwap';
 import { useWalletContext } from './WalletProvider';
 import { Send } from './wallet-advanced-send/components/Send';
+import { RequestContext } from '@/core/network/constants';
+import { usePortfolio } from '@/wallet/hooks/usePortfolio';
+import { useAccount } from 'wagmi';
 
 export function WalletDropdownContent({
   children,
@@ -22,9 +25,15 @@ export function WalletDropdownContent({
     connectRef,
     breakpoint,
     activeFeature,
-    tokenBalances,
     animations,
   } = useWalletContext();
+
+  const { address } = useAccount();
+  const { data: portfolioData } = usePortfolio(
+    { address, enabled: Boolean(activeFeature) },
+    RequestContext.Wallet,
+  );
+  const tokenBalances = portfolioData?.tokenBalances;
 
   const handleBottomSheetClose = useCallback(() => {
     setIsSubComponentOpen(false);

--- a/packages/onchainkit/src/wallet/components/WalletProvider.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletProvider.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { RequestContext } from '@/core/network/constants';
 import { useBreakpoints } from '@/internal/hooks/useBreakpoints';
 import { useOnchainKit } from '@/useOnchainKit';
 import {
@@ -14,7 +13,6 @@ import {
 } from 'react';
 import type { ReactNode } from 'react';
 import { useAccount } from 'wagmi';
-import { usePortfolio } from '../hooks/usePortfolio';
 import type { WalletAdvancedFeature, WalletContextType } from '../types';
 import { getAnimations } from '../utils/getAnimations';
 import { calculateSubComponentPosition } from '../utils/getWalletSubComponentPosition';
@@ -42,15 +40,6 @@ export function WalletProvider({ children }: WalletProviderReact) {
   const [activeFeature, setActiveFeature] =
     useState<WalletAdvancedFeature | null>(null);
   const [isActiveFeatureClosing, setIsActiveFeatureClosing] = useState(false);
-  const {
-    data: portfolioData,
-    refetch: refetchPortfolioData,
-    isFetching: isFetchingPortfolioData,
-    dataUpdatedAt: portfolioDataUpdatedAt,
-  } = usePortfolio({ address }, RequestContext.Wallet);
-
-  const portfolioFiatValue = portfolioData?.portfolioBalanceInUsd;
-  const tokenBalances = portfolioData?.tokenBalances;
 
   const animations = useMemo(() => {
     return getAnimations(isSubComponentClosing, showSubComponentAbove);
@@ -91,11 +80,6 @@ export function WalletProvider({ children }: WalletProviderReact) {
       setActiveFeature,
       isActiveFeatureClosing,
       setIsActiveFeatureClosing,
-      tokenBalances,
-      portfolioFiatValue,
-      isFetchingPortfolioData,
-      portfolioDataUpdatedAt,
-      refetchPortfolioData,
       animations,
     };
   }, [
@@ -110,11 +94,6 @@ export function WalletProvider({ children }: WalletProviderReact) {
     alignSubComponentRight,
     activeFeature,
     isActiveFeatureClosing,
-    tokenBalances,
-    portfolioFiatValue,
-    isFetchingPortfolioData,
-    portfolioDataUpdatedAt,
-    refetchPortfolioData,
     animations,
   ]);
 

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendProvider.test.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendProvider.test.tsx
@@ -2,9 +2,18 @@ import { RequestContext } from '@/core/network/constants';
 import { usePriceQuote } from '@/internal/hooks/usePriceQuote';
 import { act, render, renderHook } from '@testing-library/react';
 import { formatUnits } from 'viem';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useWalletContext } from '../../WalletProvider';
+import { beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 import { SendProvider, useSendContext } from './SendProvider';
+import { usePortfolio } from '@/wallet/hooks/usePortfolio';
+import { useAccount } from 'wagmi';
+
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+}));
+
+vi.mock('@/wallet/hooks/usePortfolio', () => ({
+  usePortfolio: vi.fn(),
+}));
 
 vi.mock('../../WalletProvider', () => ({
   useWalletContext: vi.fn(),
@@ -30,22 +39,26 @@ vi.mock('viem', async () => {
 });
 
 describe('useSendContext', () => {
-  const mockUseWalletAdvancedContext = useWalletContext as ReturnType<
-    typeof vi.fn
-  >;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseWalletAdvancedContext.mockReturnValue({
-      tokenBalances: [
-        {
-          address: '',
-          symbol: 'ETH',
-          decimals: 18,
-          cryptoBalance: '2000000000000000000',
-          fiatBalance: 4000,
-        },
-      ],
+
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [
+          {
+            address: '',
+            symbol: 'ETH',
+            decimals: 18,
+            cryptoBalance: '2000000000000000000',
+            fiatBalance: 4000,
+          },
+        ],
+      },
+      isFetching: false,
+    });
+
+    (useAccount as Mock).mockReturnValue({
+      address: '0x123',
     });
 
     vi.mocked(formatUnits).mockReturnValue('2');
@@ -104,17 +117,20 @@ describe('useSendContext', () => {
   });
 
   it('should initialize and set lifecycle status when the user does not have an ETH balance', () => {
-    mockUseWalletAdvancedContext.mockReturnValue({
-      tokenBalances: [
-        {
-          address: '0x0000000000000000000000000000000000000000',
-          symbol: 'USDC',
-          decimals: 6,
-          cryptoBalance: '2000000000000000000',
-          fiatBalance: 4000,
-        },
-      ],
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [
+          {
+            address: '0x0000000000000000000000000000000000000000',
+            symbol: 'USDC',
+            decimals: 6,
+            cryptoBalance: '2000000000000000000',
+            fiatBalance: 4000,
+          },
+        ],
+      },
     });
+
     const { result } = renderHook(() => useSendContext(), {
       wrapper: SendProvider,
     });
@@ -378,18 +394,18 @@ describe('useSendContext', () => {
   });
 
   it('should return the correct exchange rate when the price quote is loaded', () => {
-    vi.resetAllMocks();
-
-    mockUseWalletAdvancedContext.mockReturnValue({
-      tokenBalances: [
-        {
-          address: '0x0000000000000000000000000000000000000000',
-          symbol: 'USDC',
-          decimals: 6,
-          cryptoBalance: '2000000000000000000',
-          fiatBalance: 4000,
-        },
-      ],
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [
+          {
+            address: '0x0000000000000000000000000000000000000000',
+            symbol: 'USDC',
+            decimals: 6,
+            cryptoBalance: '2000000000000000000',
+            fiatBalance: 4000,
+          },
+        ],
+      },
     });
 
     const mockUsePriceQuote = usePriceQuote as ReturnType<typeof vi.fn>;
@@ -431,18 +447,18 @@ describe('useSendContext', () => {
   });
 
   it('should return 0 for exchange rate when the price quote response is empty', () => {
-    vi.resetAllMocks();
-
-    mockUseWalletAdvancedContext.mockReturnValue({
-      tokenBalances: [
-        {
-          address: '0x0000000000000000000000000000000000000000',
-          symbol: 'USDC',
-          decimals: 6,
-          cryptoBalance: '2000000000000000000',
-          fiatBalance: 4000,
-        },
-      ],
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [
+          {
+            address: '0x0000000000000000000000000000000000000000',
+            symbol: 'USDC',
+            decimals: 6,
+            cryptoBalance: '2000000000000000000',
+            fiatBalance: 4000,
+          },
+        ],
+      },
     });
 
     const mockUsePriceQuote = usePriceQuote as ReturnType<typeof vi.fn>;
@@ -476,18 +492,18 @@ describe('useSendContext', () => {
   });
 
   it('should return 0 for exchange rate when the price quote response is an error', () => {
-    vi.resetAllMocks();
-
-    mockUseWalletAdvancedContext.mockReturnValue({
-      tokenBalances: [
-        {
-          address: '0x0000000000000000000000000000000000000000',
-          symbol: 'USDC',
-          decimals: 6,
-          cryptoBalance: '2000000000000000000',
-          fiatBalance: 4000,
-        },
-      ],
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [
+          {
+            address: '0x0000000000000000000000000000000000000000',
+            symbol: 'USDC',
+            decimals: 6,
+            cryptoBalance: '2000000000000000000',
+            fiatBalance: 4000,
+          },
+        ],
+      },
     });
 
     const mockUsePriceQuote = usePriceQuote as ReturnType<typeof vi.fn>;

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendProvider.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendProvider.tsx
@@ -14,13 +14,14 @@ import {
   useState,
 } from 'react';
 import { formatUnits } from 'viem';
-import { useWalletContext } from '../../WalletProvider';
 import type {
   Recipient,
   SendContextType,
   SendLifecycleStatus,
   SendProviderReact,
 } from '../types';
+import { usePortfolio } from '@/wallet/hooks/usePortfolio';
+import { useAccount } from 'wagmi';
 
 const emptyContext = {} as SendContextType;
 
@@ -80,8 +81,14 @@ export function SendProvider({ children }: SendProviderReact) {
   }, [selectedInputType, selectedToken, cryptoAmount, fiatAmount]);
 
   // fetch & set ETH balance
-  const { tokenBalances } = useWalletContext();
-  const ethHolding = tokenBalances?.find((token) => token.address === '');
+  const { address } = useAccount();
+  const { data: portfolioData } = usePortfolio(
+    { address },
+    RequestContext.Wallet,
+  );
+  const ethHolding = portfolioData?.tokenBalances?.find(
+    (token) => token.address === '',
+  );
   const ethBalance = ethHolding
     ? Number(formatUnits(BigInt(ethHolding.cryptoBalance), ethHolding.decimals))
     : 0;

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendTokenSelector.test.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendTokenSelector.test.tsx
@@ -1,9 +1,10 @@
 import type { PortfolioTokenWithFiatValue } from '@/api/types';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useWalletContext } from '../../WalletProvider';
 import { useSendContext } from './SendProvider';
 import { SendTokenSelector } from './SendTokenSelector';
+import { usePortfolio } from '@/wallet/hooks/usePortfolio';
+import { useAccount } from 'wagmi';
 
 // Mock the context hook
 vi.mock('../../WalletProvider', () => ({
@@ -12,6 +13,14 @@ vi.mock('../../WalletProvider', () => ({
 
 vi.mock('./SendProvider', () => ({
   useSendContext: vi.fn(),
+}));
+
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+}));
+
+vi.mock('@/wallet/hooks/usePortfolio', () => ({
+  usePortfolio: vi.fn(),
 }));
 
 const mockTokenBalances: PortfolioTokenWithFiatValue[] = [
@@ -49,8 +58,13 @@ const defaultContext = {
 describe('SendTokenSelector', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (useWalletContext as Mock).mockReturnValue({
-      tokenBalances: mockTokenBalances,
+    (useAccount as Mock).mockReturnValue({
+      address: '0x123',
+    });
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: mockTokenBalances,
+      },
     });
     (useSendContext as Mock).mockReturnValue(defaultContext);
   });
@@ -116,8 +130,10 @@ describe('SendTokenSelector', () => {
   });
 
   it('handles empty tokenBalances gracefully', () => {
-    (useWalletContext as Mock).mockReturnValue({
-      tokenBalances: [],
+    (usePortfolio as Mock).mockReturnValue({
+      data: {
+        tokenBalances: [],
+      },
     });
 
     render(<SendTokenSelector />);

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendTokenSelector.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendTokenSelector.tsx
@@ -3,8 +3,10 @@
 import { border, cn, color, pressable, text } from '@/styles/theme';
 import { TokenBalance } from '@/token';
 import { formatUnits } from 'viem';
-import { useWalletContext } from '../../WalletProvider';
 import { useSendContext } from './SendProvider';
+import { RequestContext } from '@/core/network/constants';
+import { useAccount } from 'wagmi';
+import { usePortfolio } from '@/wallet/hooks/usePortfolio';
 
 type SendTokenSelectorProps = {
   classNames?: {
@@ -17,7 +19,13 @@ type SendTokenSelectorProps = {
 };
 
 export function SendTokenSelector({ classNames }: SendTokenSelectorProps) {
-  const { tokenBalances } = useWalletContext();
+  const { address } = useAccount();
+  const { data: portfolioData } = usePortfolio(
+    { address },
+    RequestContext.Wallet,
+  );
+  const tokenBalances = portfolioData?.tokenBalances;
+
   const {
     selectedToken,
     handleTokenSelection,

--- a/packages/onchainkit/src/wallet/hooks/usePortfolio.test.tsx
+++ b/packages/onchainkit/src/wallet/hooks/usePortfolio.test.tsx
@@ -97,6 +97,14 @@ describe('usePortfolio', () => {
     expect(getPortfolios).not.toHaveBeenCalled();
   });
 
+  it('should not fetch when enabled is false', () => {
+    renderHook(() => usePortfolio({ address: mockAddress, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(getPortfolios).not.toHaveBeenCalled();
+  });
+
   it('should not fetch when address is undefined', () => {
     renderHook(() => usePortfolio({ address: undefined }), {
       wrapper: createWrapper(),

--- a/packages/onchainkit/src/wallet/hooks/usePortfolio.ts
+++ b/packages/onchainkit/src/wallet/hooks/usePortfolio.ts
@@ -5,12 +5,17 @@ import { isApiError } from '@/internal/utils/isApiResponseError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { Address } from 'viem';
 
+type UsePortfolioProps = {
+  address: Address | undefined | null;
+  enabled?: boolean;
+};
+
 /**
  * Retrieves the portfolio for the provided address
  * portfolio includes the address, the balance of the address in USD, and the tokens in the address
  */
 export function usePortfolio(
-  { address }: { address: Address | undefined | null },
+  { address, enabled = true }: UsePortfolioProps,
   _context: RequestContext = RequestContext.Hook,
 ): UseQueryResult<Portfolio> {
   return useQuery({
@@ -38,7 +43,7 @@ export function usePortfolio(
       return response.portfolios[0];
     },
     retry: false,
-    enabled: !!address,
+    enabled: !!address && enabled,
     refetchOnWindowFocus: true, // refresh on window focus
     staleTime: 1000 * 60 * 5, // refresh on mount every 5 minutes
     refetchOnMount: true,

--- a/packages/onchainkit/src/wallet/types.ts
+++ b/packages/onchainkit/src/wallet/types.ts
@@ -109,11 +109,6 @@ export type WalletContextType = {
   setActiveFeature: Dispatch<SetStateAction<WalletAdvancedFeature | null>>;
   isActiveFeatureClosing: boolean;
   setIsActiveFeatureClosing: Dispatch<SetStateAction<boolean>>;
-  tokenBalances: PortfolioTokenWithFiatValue[] | undefined;
-  portfolioFiatValue: number | undefined;
-  isFetchingPortfolioData: boolean;
-  portfolioDataUpdatedAt: number | undefined;
-  refetchPortfolioData: () => Promise<QueryObserverResult<Portfolio, Error>>;
   animations: {
     container: string;
     content: string;


### PR DESCRIPTION
**What changed? Why?**
Move usePortfolio out of wallet context so its only called when its actually used

**Notes to reviewers**

**How has it been tested?**
