### PR TITLE
fix: use same amount as `mint` for `value`

### DIFF
--- a/packages/onchainkit/src/appchain/bridge/hooks/useDeposit.ts
+++ b/packages/onchainkit/src/appchain/bridge/hooks/useDeposit.ts
@@ -98,7 +98,7 @@ export function useDeposit() {
             args: [
               bridgeParams.recipient,
               formattedAmount,
-              BigInt(0),
+              formattedAmount,
               BigInt(MIN_GAS_LIMIT),
               false,
               EXTRA_DATA,


### PR DESCRIPTION
**What changed? Why?**
- appchain

**Notes to reviewers**

**How has it been tested?**
