### PR TITLE
chore: improve TypeScript typing for Providers Component

### DIFF
--- a/packages/create-onchain/templates/minikit-snake/app/providers.tsx
+++ b/packages/create-onchain/templates/minikit-snake/app/providers.tsx
@@ -4,7 +4,7 @@ import { type ReactNode } from "react";
 import { base } from "wagmi/chains";
 import { MiniKitProvider } from "@coinbase/onchainkit/minikit";
 
-export function Providers(props: { children: ReactNode }) {
+export function Providers(props: React.PropsWithChildren<{}>) {
   return (
     <MiniKitProvider
       apiKey={process.env.NEXT_PUBLIC_ONCHAINKIT_API_KEY}


### PR DESCRIPTION
**What changed? Why?**

I refactored the typing for the `Providers` component. Instead of specifying `{ children: ReactNode }` directly, I used `React.PropsWithChildren<{}>`. This improves compatibility with React and provides better type inference, making it easier to extend the component with additional props in the future.

**Notes to reviewers**

This change should ensure the component is more flexible without introducing any breaking changes. Please check if the updated type works well with the rest of the codebase and doesn’t cause any issues with children handling.

**How has it been tested?**

I ran the component in the existing environment and confirmed that no type errors were introduced and that it works seamlessly with the current usage of the `Providers` component.
