### PR TITLE
chore: Add bidirectional resolution validation when batching Basenames and ENS names

### DIFF
--- a/.changeset/pretty-tools-own.md
+++ b/.changeset/pretty-tools-own.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **chore**: Add bidirectional resolution validation when batching `Basenames` and `ENS` names. By @cpcramer #000

--- a/packages/onchainkit/src/identity/utils/getNames.ts
+++ b/packages/onchainkit/src/identity/utils/getNames.ts
@@ -1,17 +1,19 @@
 import type { Basename, GetNameReturnType, GetNames } from '@/identity/types';
-import { mainnet } from 'viem/chains';
+import { base, mainnet } from 'viem/chains';
 import { getChainPublicClient } from '../../core/network/getChainPublicClient';
 import { isBase } from '../../core/utils/isBase';
 import { isEthereum } from '../../core/utils/isEthereum';
 import L2ResolverAbi from '../abis/L2ResolverAbi';
 import { RESOLVER_ADDRESSES_BY_CHAIN_ID } from '../constants';
 import { convertReverseNodeToBytes } from './convertReverseNodeToBytes';
+import { getAddress } from './getAddress';
 
 /**
  * An asynchronous function to fetch multiple Basenames or Ethereum Name Service (ENS)
  * names for a given array of Ethereum addresses in a single batch request.
  * It returns an array of ENS names in the same order as the input addresses.
  */
+// eslint-disable-next-line complexity
 export const getNames = async ({
   addresses,
   chain = mainnet,
@@ -48,11 +50,32 @@ export const getNames = async ({
         allowFailure: true,
       });
 
-      batchResults.forEach((result, index) => {
+      // Process Basename results and verify with forward resolution
+      for (let index = 0; index < batchResults.length; index++) {
+        const result = batchResults[index];
         if (result.status === 'success' && result.result) {
-          results[index] = result.result as Basename;
+          const basename = result.result as Basename;
+          try {
+            // Verify basename with forward resolution
+            const resolvedAddress = await getAddress({
+              name: basename,
+              chain: base,
+            });
+
+            if (
+              resolvedAddress &&
+              resolvedAddress.toLowerCase() === addresses[index].toLowerCase()
+            ) {
+              results[index] = basename;
+            }
+          } catch (error) {
+            console.error(
+              `Error during basename forward resolution verification for ${addresses[index]}:`,
+              error,
+            );
+          }
         }
-      });
+      }
 
       // If we have all results, return them
       if (results.every((result) => result !== null)) {
@@ -90,11 +113,34 @@ export const getNames = async ({
 
       const ensResults = await Promise.all(ensPromises);
 
-      // Update results with ENS names
-      ensResults.forEach((ensName, i) => {
+      // Update results with ENS names after verifying with forward resolution
+      for (let i = 0; i < ensResults.length; i++) {
+        const ensName = ensResults[i];
         const originalIndex = unresolvedIndices[i];
-        results[originalIndex] = ensName;
-      });
+
+        if (ensName) {
+          try {
+            // Verify ENS name with forward resolution
+            const resolvedAddress = await getAddress({
+              name: ensName,
+              chain: mainnet,
+            });
+
+            if (
+              resolvedAddress &&
+              resolvedAddress.toLowerCase() ===
+                addresses[originalIndex].toLowerCase()
+            ) {
+              results[originalIndex] = ensName;
+            }
+          } catch (error) {
+            console.error(
+              `Error during ENS forward resolution verification for ${addresses[originalIndex]}:`,
+              error,
+            );
+          }
+        }
+      }
     } catch (error) {
       console.error('Error resolving ENS names in batch:', error);
     }


### PR DESCRIPTION
**What changed? Why?**
This PR fixes a vulnerability in the identity resolution system that allowed users to spoof their displayed names.

The current implementation of reverse resolution (address → name) didn't verify name ownership:

- It's possible to spoof the address by setting a name on the reverse registry without actually owning the name
- We would display that name without verification

The Solution: Bidirectional Validation

- Reverse Resolution: Get name from address (getName)
- Forward Resolution: Resolve name back to address (getAddress)
- Validation: Only display the name if addresses match

This prevents malicious actors from falsely displaying names they don't control, ensuring all displayed names are properly verified and legitimate.

**Notes to reviewers**
This is a follow up PR from [chore: Add bidirectional resolution validation to Basenames and ENS names](https://github.com/coinbase/onchainkit/pull/2255#top)

**How has it been tested?**
Unit tests.