### PR TITLE
feat: Add batch ENS / Basename resolution with useAddresses hook and getAddresses utility

### DIFF
--- a/.changeset/early-schools-lie.md
+++ b/.changeset/early-schools-lie.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+- **feat**: Add batch ENS / Basename resolution with useAddresses hook and getAddresses utility. By @cpcramer #2277

--- a/packages/onchainkit/src/identity/hooks/useAddresses.test.tsx
+++ b/packages/onchainkit/src/identity/hooks/useAddresses.test.tsx
@@ -1,0 +1,358 @@
+import { publicClient } from '@/core/network/client';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { Address } from 'viem';
+import { base, baseSepolia, mainnet, optimism } from 'viem/chains';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAddresses } from '../utils/getAddresses';
+import { getNewReactQueryTestProvider } from './getNewReactQueryTestProvider';
+import { useAddresses } from './useAddresses';
+
+vi.mock('@/core/network/client');
+
+vi.mock('@/core/network/getChainPublicClient', () => ({
+  ...vi.importActual('@/core/network/getChainPublicClient'),
+  getChainPublicClient: vi.fn(() => publicClient),
+}));
+
+vi.mock('../utils/getAddresses');
+
+const mockUseQuery = vi.fn();
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  type UseQueryType = <TData, _TError = Error>(options: {
+    queryKey: unknown[];
+    queryFn: () => Promise<TData>;
+    [key: string]: unknown;
+  }) => unknown;
+
+  return {
+    ...actual,
+    useQuery: <TData, TError = Error>(options: {
+      queryKey: unknown[];
+      queryFn: () => Promise<TData>;
+      [key: string]: unknown;
+    }) => {
+      mockUseQuery(options);
+      return (actual.useQuery as UseQueryType)<TData, TError>(options);
+    },
+  };
+});
+
+describe('useAddresses', () => {
+  const testNames = ['test.eth', 'test2.eth', 'shrek.base.eth'];
+  const testAddresses = [
+    '0x1234567890123456789012345678901234567890',
+    '0x2345678901234567890123456789012345678901',
+    '0x3456789012345678901234567890123456789012',
+  ] as Address[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetAllMocks();
+    mockUseQuery.mockClear();
+  });
+
+  it('returns the correct addresses and loading state', async () => {
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    const { result } = renderHook(() => useAddresses({ names: testNames }), {
+      wrapper: getNewReactQueryTestProvider(),
+    });
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.data).toBe(undefined);
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(testAddresses);
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(getAddresses).toHaveBeenCalledWith({
+      names: testNames,
+      chain: mainnet,
+    });
+  });
+
+  it('returns the correct addresses for custom chain', async () => {
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    const { result } = renderHook(
+      () =>
+        useAddresses({
+          names: testNames,
+          chain: base,
+        }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(testAddresses);
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(getAddresses).toHaveBeenCalledWith({
+      names: testNames,
+      chain: base,
+    });
+  });
+
+  it('returns error for unsupported chain', async () => {
+    const errorMessage =
+      'ChainId not supported, name resolution is only supported on Ethereum and Base.';
+    vi.mocked(getAddresses).mockRejectedValue(errorMessage);
+
+    const { result } = renderHook(
+      () =>
+        useAddresses({
+          names: testNames,
+          chain: optimism,
+        }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toBe(undefined);
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isError).toBe(true);
+      expect(result.current.error).toBe(errorMessage);
+    });
+  });
+
+  it('is disabled when names array is empty', async () => {
+    vi.mocked(getAddresses).mockImplementation(() => {
+      throw new Error('This should not be called');
+    });
+
+    const { result } = renderHook(() => useAddresses({ names: [] }), {
+      wrapper: getNewReactQueryTestProvider(),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(getAddresses).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('uses the default query options when no queryOptions are provided', async () => {
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    renderHook(() => useAddresses({ names: testNames }), {
+      wrapper: getNewReactQueryTestProvider(),
+    });
+
+    await waitFor(() => {
+      expect(getAddresses).toHaveBeenCalled();
+    });
+
+    const options = mockUseQuery.mock.calls[0][0];
+    expect(options).toHaveProperty('queryKey');
+    expect(options.queryKey).toEqual([
+      'useAddresses',
+      testNames.join(','),
+      mainnet.id,
+    ]);
+  });
+
+  it('merges custom queryOptions with default options', async () => {
+    const customCacheTime = 120000;
+
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    renderHook(
+      () => useAddresses({ names: testNames }, { cacheTime: customCacheTime }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    expect(mockUseQuery).toHaveBeenCalled();
+    const options = mockUseQuery.mock.calls[0][0];
+    expect(options).toHaveProperty('gcTime', customCacheTime);
+  });
+
+  it('correctly maps cacheTime to gcTime for backwards compatibility', async () => {
+    const mockCacheTime = 60000;
+    const mockGcTime = 120000;
+
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    renderHook(
+      () => useAddresses({ names: testNames }, { cacheTime: mockCacheTime }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    expect(mockUseQuery).toHaveBeenCalled();
+    const optionsWithCacheTime = mockUseQuery.mock.calls[0][0];
+    expect(optionsWithCacheTime).toHaveProperty('gcTime', mockCacheTime);
+
+    mockUseQuery.mockClear();
+
+    renderHook(
+      () =>
+        useAddresses(
+          { names: testNames },
+          {
+            cacheTime: mockCacheTime,
+            gcTime: mockGcTime,
+          },
+        ),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    expect(mockUseQuery).toHaveBeenCalled();
+    const optionsWithBoth = mockUseQuery.mock.calls[0][0];
+    expect(optionsWithBoth).toHaveProperty('gcTime', mockGcTime);
+  });
+
+  it('creates a stable query key based on names and chain', async () => {
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    const { result, rerender } = renderHook(
+      (props: { names: string[] }) => useAddresses({ names: props.names }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+        initialProps: { names: testNames },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(testAddresses);
+    });
+
+    vi.clearAllMocks();
+
+    rerender({ names: [...testNames] });
+
+    expect(getAddresses).not.toHaveBeenCalled();
+  });
+
+  it('handles partial failures in address resolution', async () => {
+    const partialResults = [testAddresses[0], null, testAddresses[2]];
+    vi.mocked(getAddresses).mockResolvedValue(partialResults);
+
+    const { result } = renderHook(() => useAddresses({ names: testNames }), {
+      wrapper: getNewReactQueryTestProvider(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(partialResults);
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isError).toBe(false);
+    });
+
+    expect(getAddresses).toHaveBeenCalledWith({
+      names: testNames,
+      chain: mainnet,
+    });
+  });
+
+  it('respects enabled=false in queryOptions even with valid names', async () => {
+    vi.mocked(getAddresses).mockImplementation(() => {
+      throw new Error('This should not be called');
+    });
+
+    const { result } = renderHook(
+      () => useAddresses({ names: testNames }, { enabled: false }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(getAddresses).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('enables the query when enabled=true and names are valid', async () => {
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    const { result } = renderHook(
+      () => useAddresses({ names: testNames }, { enabled: true }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(testAddresses);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(getAddresses).toHaveBeenCalledWith({
+      names: testNames,
+      chain: mainnet,
+    });
+  });
+
+  it('supports Base Sepolia chain', async () => {
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    const { result } = renderHook(
+      () =>
+        useAddresses({
+          names: testNames,
+          chain: baseSepolia,
+        }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(testAddresses);
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(getAddresses).toHaveBeenCalledWith({
+      names: testNames,
+      chain: baseSepolia,
+    });
+  });
+
+  it('handles empty results from getAddresses', async () => {
+    vi.mocked(getAddresses).mockResolvedValue([]);
+
+    const { result } = renderHook(() => useAddresses({ names: testNames }), {
+      wrapper: getNewReactQueryTestProvider(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+      expect(result.current.isPending).toBe(false);
+      expect(result.current.isError).toBe(false);
+    });
+  });
+
+  it('does not run query when names prop changes to empty array', async () => {
+    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
+
+    const { result, rerender } = renderHook(
+      (props: { names: string[] }) => useAddresses({ names: props.names }),
+      {
+        wrapper: getNewReactQueryTestProvider(),
+        initialProps: { names: testNames },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(testAddresses);
+    });
+
+    vi.clearAllMocks();
+    rerender({ names: [] });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(getAddresses).not.toHaveBeenCalled();
+  });
+});

--- a/packages/onchainkit/src/identity/hooks/useAddresses.ts
+++ b/packages/onchainkit/src/identity/hooks/useAddresses.ts
@@ -1,0 +1,31 @@
+import { getAddresses } from '@/identity/utils/getAddresses';
+import { DEFAULT_QUERY_OPTIONS } from '@/internal/constants';
+import { useQuery } from '@tanstack/react-query';
+import { mainnet } from 'viem/chains';
+import type {
+  GetAddressReturnType,
+  UseAddressesOptions,
+  UseQueryOptions,
+} from '../types';
+
+/**
+ * A React hook that leverages the `@tanstack/react-query` for fetching and optionally caching
+ * multiple Ethereum addresses from ENS names or Basenames in a single batch request.
+ */
+export const useAddresses = (
+  { names, chain = mainnet }: UseAddressesOptions,
+  queryOptions?: UseQueryOptions<GetAddressReturnType[]>,
+) => {
+  const namesKey = names.join(',');
+  const queryKey = ['useAddresses', namesKey, chain.id];
+
+  return useQuery<GetAddressReturnType[]>({
+    queryKey,
+    queryFn: () => getAddresses({ names, chain }),
+    enabled: !!names.length,
+    ...DEFAULT_QUERY_OPTIONS,
+    // Use cacheTime as gcTime for backward compatibility
+    gcTime: queryOptions?.cacheTime,
+    ...queryOptions,
+  });
+};

--- a/packages/onchainkit/src/identity/index.ts
+++ b/packages/onchainkit/src/identity/index.ts
@@ -9,12 +9,14 @@ export { Socials } from './components/Socials';
 export { isBasename } from './utils/isBasename';
 export { IdentityCard } from './components/IdentityCard';
 export { getAddress } from './utils/getAddress';
+export { getAddresses } from './utils/getAddresses';
 export { getAttestations } from './utils/getAttestations';
 export { getAvatar } from './utils/getAvatar';
 export { getAvatars } from './utils/getAvatars';
 export { getName } from './utils/getName';
 export { getNames } from './utils/getNames';
 export { useAddress } from './hooks/useAddress';
+export { useAddresses } from './hooks/useAddresses';
 export { useAttestations } from './hooks/useAttestations';
 export { useAvatar } from './hooks/useAvatar';
 export { useAvatars } from './hooks/useAvatars';
@@ -32,6 +34,7 @@ export type {
   EASSchemaUid,
   EthBalanceReact,
   GetAddress,
+  GetAddresses,
   GetAddressReturnType,
   GetAttestationsOptions,
   GetAvatar,
@@ -44,6 +47,7 @@ export type {
   IdentityReact,
   NameReact,
   UseAddressOptions,
+  UseAddressesOptions,
   UseAvatarOptions,
   UseNamesOptions,
   UseQueryOptions,

--- a/packages/onchainkit/src/identity/types.ts
+++ b/packages/onchainkit/src/identity/types.ts
@@ -143,6 +143,16 @@ export type GetAddress = {
 /**
  * Note: exported as public Type
  */
+export type GetAddresses = {
+  /** Array of names to resolve addresses for */
+  names: Array<string | Basename>;
+  /** Optional chain for domain resolution */
+  chain?: Chain;
+};
+
+/**
+ * Note: exported as public Type
+ */
 export type GetAddressReturnType = Address | null;
 
 /**
@@ -281,6 +291,16 @@ export type UseAttestations = {
 export type UseAddressOptions = {
   /** The ENS or Basename for which the Ethereum address is to be fetched */
   name: string | Basename;
+  /** Optional chain for domain resolution */
+  chain?: Chain;
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type UseAddressesOptions = {
+  /** Array of ENS or Basenames to resolve addresses for */
+  names: Array<string | Basename>;
   /** Optional chain for domain resolution */
   chain?: Chain;
 };

--- a/packages/onchainkit/src/identity/utils/getAddresses.test.ts
+++ b/packages/onchainkit/src/identity/utils/getAddresses.test.ts
@@ -1,0 +1,184 @@
+import { publicClient } from '@/core/network/client';
+import { isBase } from '@/core/utils/isBase';
+import { isEthereum } from '@/core/utils/isEthereum';
+import { isBasename } from '@/identity/utils/isBasename';
+import type { Address } from 'viem';
+import { base, mainnet, optimism } from 'viem/chains';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { RESOLVER_ADDRESSES_BY_CHAIN_ID } from '../constants';
+import { getAddresses } from './getAddresses';
+
+vi.mock('@/core/network/client');
+
+vi.mock('@/core/utils/isBase', () => ({
+  isBase: vi.fn(),
+}));
+
+vi.mock('@/core/utils/isEthereum', () => ({
+  isEthereum: vi.fn(),
+}));
+
+vi.mock('@/identity/utils/isBasename', () => ({
+  isBasename: vi.fn(),
+}));
+
+vi.mock('@/core/network/getChainPublicClient', () => ({
+  ...vi.importActual('@/core/network/getChainPublicClient'),
+  getChainPublicClient: vi.fn(() => publicClient),
+}));
+
+describe('getAddresses', () => {
+  const mockGetEnsAddress = publicClient.getEnsAddress as Mock;
+  const testNames = ['user1.eth', 'user2.eth', 'user3.base.eth'];
+  const testAddresses = [
+    '0x1234567890123456789012345678901234567890',
+    '0x2345678901234567890123456789012345678901',
+    '0x3456789012345678901234567890123456789012',
+  ] as Address[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isBase).mockImplementation(({ chainId }) => chainId === base.id);
+    vi.mocked(isEthereum).mockImplementation(
+      ({ chainId }) => chainId === mainnet.id,
+    );
+    vi.mocked(isBasename).mockImplementation(
+      (name) => name.includes('.base.eth') || name.includes('.basetest.eth'),
+    );
+  });
+
+  it('returns empty array when no names are provided', async () => {
+    const addresses = await getAddresses({ names: [] });
+    expect(addresses).toEqual([]);
+  });
+
+  it('fetches addresses for multiple ENS names on mainnet', async () => {
+    mockGetEnsAddress.mockImplementation((params) => {
+      if (params.name === testNames[0])
+        return Promise.resolve(testAddresses[0]);
+      if (params.name === testNames[1])
+        return Promise.resolve(testAddresses[1]);
+      if (params.name === testNames[2])
+        return Promise.resolve(testAddresses[2]);
+      return Promise.resolve(null);
+    });
+
+    const addresses = await getAddresses({ names: testNames });
+
+    expect(addresses).toEqual(testAddresses);
+    expect(mockGetEnsAddress).toHaveBeenCalledTimes(3);
+    testNames.forEach((name, index) => {
+      const isBasenameName = isBasename(name);
+      expect(mockGetEnsAddress).toHaveBeenNthCalledWith(index + 1, {
+        name,
+        universalResolverAddress: isBasenameName
+          ? RESOLVER_ADDRESSES_BY_CHAIN_ID[mainnet.id]
+          : undefined,
+      });
+    });
+  });
+
+  it('fetches addresses for multiple names on Base chain', async () => {
+    mockGetEnsAddress.mockImplementation((params) => {
+      if (params.name === testNames[0])
+        return Promise.resolve(testAddresses[0]);
+      if (params.name === testNames[1])
+        return Promise.resolve(testAddresses[1]);
+      if (params.name === testNames[2])
+        return Promise.resolve(testAddresses[2]);
+      return Promise.resolve(null);
+    });
+
+    const addresses = await getAddresses({ names: testNames, chain: base });
+
+    expect(addresses).toEqual(testAddresses);
+    expect(mockGetEnsAddress).toHaveBeenCalledTimes(3);
+    testNames.forEach((name, index) => {
+      const isBasenameName = isBasename(name);
+      expect(mockGetEnsAddress).toHaveBeenNthCalledWith(index + 1, {
+        name,
+        universalResolverAddress: isBasenameName
+          ? RESOLVER_ADDRESSES_BY_CHAIN_ID[base.id]
+          : undefined,
+      });
+    });
+  });
+
+  it('rejects for unsupported chains', async () => {
+    await expect(
+      getAddresses({
+        names: testNames,
+        chain: optimism,
+      }),
+    ).rejects.toBe(
+      'ChainId not supported, name resolution is only supported on Ethereum and Base.',
+    );
+
+    expect(mockGetEnsAddress).not.toHaveBeenCalled();
+  });
+
+  it('handles partial failures in address resolution', async () => {
+    mockGetEnsAddress.mockImplementation((params) => {
+      if (params.name === testNames[0])
+        return Promise.resolve(testAddresses[0]);
+      if (params.name === testNames[1])
+        return Promise.reject(new Error('Resolution failed'));
+      if (params.name === testNames[2])
+        return Promise.resolve(testAddresses[2]);
+      return Promise.resolve(null);
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const addresses = await getAddresses({ names: testNames });
+
+    expect(addresses).toEqual([testAddresses[0], null, testAddresses[2]]);
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(mockGetEnsAddress).toHaveBeenCalledTimes(3);
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles errors in batch resolution process', async () => {
+    mockGetEnsAddress.mockImplementation(() => {
+      throw new Error('Batch resolution failed');
+    });
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const addresses = await getAddresses({ names: testNames });
+
+    expect(addresses).toEqual([null, null, null]);
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Error resolving addresses in batch:',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles null result in names array', async () => {
+    const namesWithNull = ['user1.eth', null, 'user3.eth'];
+
+    mockGetEnsAddress.mockImplementation((params) => {
+      if (params.name === 'user1.eth') return Promise.resolve(testAddresses[0]);
+      if (params.name === 'user3.eth') return Promise.resolve(testAddresses[2]);
+      return Promise.resolve(null);
+    });
+
+    const addresses = await getAddresses({ names: namesWithNull as string[] });
+
+    expect(addresses).toEqual([testAddresses[0], null, testAddresses[2]]);
+    expect(mockGetEnsAddress).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns array of nulls when all names are null or undefined', async () => {
+    const allNullNames = [null, undefined, null] as unknown as string[];
+
+    const addresses = await getAddresses({ names: allNullNames });
+
+    expect(addresses).toEqual([null, null, null]);
+    expect(mockGetEnsAddress).not.toHaveBeenCalled();
+  });
+});

--- a/packages/onchainkit/src/identity/utils/getAddresses.ts
+++ b/packages/onchainkit/src/identity/utils/getAddresses.ts
@@ -1,0 +1,74 @@
+import { getChainPublicClient } from '@/core/network/getChainPublicClient';
+import { isBase } from '@/core/utils/isBase';
+import { isEthereum } from '@/core/utils/isEthereum';
+import { RESOLVER_ADDRESSES_BY_CHAIN_ID } from '@/identity/constants';
+import type { GetAddressReturnType, GetAddresses } from '@/identity/types';
+import { isBasename } from '@/identity/utils/isBasename';
+import { mainnet } from 'viem/chains';
+
+/**
+ * An asynchronous function to fetch multiple Ethereum addresses from ENS names or Basenames
+ * in a single batch request.
+ */
+export const getAddresses = async ({
+  names,
+  chain = mainnet,
+}: GetAddresses): Promise<GetAddressReturnType[]> => {
+  if (!names || names.length === 0) {
+    return [];
+  }
+
+  const chainIsBase = isBase({ chainId: chain.id });
+  const chainIsEthereum = isEthereum({ chainId: chain.id });
+  const chainSupportsUniversalResolver = chainIsEthereum || chainIsBase;
+
+  if (!chainSupportsUniversalResolver) {
+    return Promise.reject(
+      'ChainId not supported, name resolution is only supported on Ethereum and Base.',
+    );
+  }
+
+  const client = getChainPublicClient(chain);
+  const results: GetAddressReturnType[] = Array(names.length).fill(null);
+
+  try {
+    // Filter out null or undefined names
+    const validItems = names
+      .map((name, index) => (name ? { name, index } : null))
+      .filter((item): item is { name: string; index: number } => item !== null);
+
+    if (validItems.length === 0) {
+      return results;
+    }
+
+    const addressPromises = validItems.map(({ name, index }) =>
+      client
+        .getEnsAddress({
+          name,
+          universalResolverAddress: isBasename(name)
+            ? RESOLVER_ADDRESSES_BY_CHAIN_ID[chain.id]
+            : undefined,
+        })
+        .then((address) => {
+          return { index, address };
+        })
+        .catch((error) => {
+          console.error(`Error resolving address for ${name}:`, error);
+          // Return null for the address if resolution fails
+          return { index, address: null };
+        }),
+    );
+
+    const resolvedAddresses = await Promise.all(addressPromises);
+
+    // Update results array with resolved addresses
+    resolvedAddresses.forEach(({ index, address }) => {
+      results[index] = address;
+    });
+  } catch (error) {
+    console.error('Error resolving addresses in batch:', error);
+    return Array(names.length).fill(null);
+  }
+
+  return results;
+};


### PR DESCRIPTION
**What changed? Why?**
Added new multicall ENS resolution utilities with `useAddresses` hook and `getAddresses` utility function to efficiently resolve multiple ENS or Basenames to Ethereum addresses, reducing network requests and improving performance for batch resolution scenarios.

**Notes to reviewers**

Follow up from [chore: Add bidirectional resolution validation when batching Basenames and ENS names](https://github.com/coinbase/onchainkit/pull/2264#top). As an additional fast follow, I will be implementing this function into `getNames`.

**How has it been tested?**
Unit tests.
