### PR TITLE
chore: show connect button when disconnected in Identity demo

### DIFF
--- a/packages/playground/components/AppProvider.tsx
+++ b/packages/playground/components/AppProvider.tsx
@@ -173,7 +173,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
       }}
     >
       <OnchainKitProvider
-        apiKey="4eV4DKscAFcCCwn06w1FLX13bZD4yze2"
+        apiKey={ENVIRONMENT_VARIABLES[ENVIRONMENT.API_KEY]}
         chain={base}
         config={{
           appearance: {
@@ -194,7 +194,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
             },
           },
         }}
-        projectId="10fcf655-bfe0-421e-9ebc-36c72044b0cc"
+        projectId={ENVIRONMENT_VARIABLES[ENVIRONMENT.PROJECT_ID]}
         schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
       >
         {children}

--- a/packages/playground/components/AppProvider.tsx
+++ b/packages/playground/components/AppProvider.tsx
@@ -173,7 +173,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
       }}
     >
       <OnchainKitProvider
-        apiKey={ENVIRONMENT_VARIABLES[ENVIRONMENT.API_KEY]}
+        apiKey="4eV4DKscAFcCCwn06w1FLX13bZD4yze2"
         chain={base}
         config={{
           appearance: {
@@ -194,7 +194,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
             },
           },
         }}
-        projectId={ENVIRONMENT_VARIABLES[ENVIRONMENT.PROJECT_ID]}
+        projectId="10fcf655-bfe0-421e-9ebc-36c72044b0cc"
         schemaId="0xf8b05c79f090979bf4a80270aba232dff11a10d9ca55c4f88de95317970f0de9"
       >
         {children}

--- a/packages/playground/components/demo/Identity.tsx
+++ b/packages/playground/components/demo/Identity.tsx
@@ -6,6 +6,7 @@ import {
   Name,
   Socials,
 } from '@coinbase/onchainkit/identity';
+import { ConnectWallet } from '@coinbase/onchainkit/wallet';
 import { base, mainnet } from 'viem/chains';
 import { useAccount } from 'wagmi';
 
@@ -15,7 +16,7 @@ export default function IdentityDemo() {
   return (
     <div className="mx-auto max-w-2xl p-4">
       <div className="relative">
-        {address && (
+        {address ? (
           <div className="flex flex-col gap-6">
             <div className="space-y-2">
               <h2 className="font-medium text-gray-500 text-sm">
@@ -46,6 +47,8 @@ export default function IdentityDemo() {
               </div>
             </div>
           </div>
+        ) : (
+          <ConnectWallet />
         )}
       </div>
     </div>

--- a/packages/playground/components/demo/IdentityCard.tsx
+++ b/packages/playground/components/demo/IdentityCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { IdentityCard } from '@coinbase/onchainkit/identity';
+import { ConnectWallet } from '@coinbase/onchainkit/wallet';
 import { base, mainnet } from 'viem/chains';
 import { useAccount } from 'wagmi';
 
@@ -18,11 +19,20 @@ export function IdentityCardDemo() {
           <h2 className="font-medium text-gray-500 text-sm">
             Mainnet Identity
           </h2>
-          <IdentityCard address={address} chain={mainnet} />
+
+          {address ? (g
+            <IdentityCard address={address} chain={mainnet} />
+          ) : (
+            <ConnectWallet />
+          )}
         </div>
         <div className="space-y-2">
           <h2 className="font-medium text-gray-500 text-sm">Base Identity</h2>
-          <IdentityCard address={address} chain={base} />
+          {address ? (
+            <IdentityCard address={address} chain={base} />
+          ) : (
+            <ConnectWallet />
+          )}
         </div>
       </div>
     </div>

--- a/packages/playground/components/demo/IdentityCard.tsx
+++ b/packages/playground/components/demo/IdentityCard.tsx
@@ -20,7 +20,7 @@ export function IdentityCardDemo() {
             Mainnet Identity
           </h2>
 
-          {address ? (g
+          {address ? (
             <IdentityCard address={address} chain={mainnet} />
           ) : (
             <ConnectWallet />

--- a/packages/playground/components/demo/IdentityCard.tsx
+++ b/packages/playground/components/demo/IdentityCard.tsx
@@ -8,10 +8,6 @@ import { useAccount } from 'wagmi';
 export function IdentityCardDemo() {
   const { address } = useAccount();
 
-  if (!address) {
-    return null;
-  }
-
   return (
     <div className="mx-auto max-w-2xl p-4">
       <div className="flex flex-col gap-6">

--- a/packages/playground/components/demo/IdentityCard.tsx
+++ b/packages/playground/components/demo/IdentityCard.tsx
@@ -10,27 +10,28 @@ export function IdentityCardDemo() {
 
   return (
     <div className="mx-auto max-w-2xl p-4">
-      <div className="flex flex-col gap-6">
-        <div className="space-y-2">
-          <h2 className="font-medium text-gray-500 text-sm">
-            Mainnet Identity
-          </h2>
+      {address ? (
+        <div className="flex flex-col gap-6">
+          <div className="space-y-2">
+            <h2 className="font-medium text-gray-500 text-sm">
+              Mainnet Identity
+            </h2>
 
-          {address ? (
             <IdentityCard address={address} chain={mainnet} />
-          ) : (
-            <ConnectWallet />
-          )}
-        </div>
-        <div className="space-y-2">
-          <h2 className="font-medium text-gray-500 text-sm">Base Identity</h2>
-          {address ? (
+          </div>
+          <div className="space-y-2">
+            <h2 className="font-medium text-gray-500 text-sm">Base Identity</h2>
             <IdentityCard address={address} chain={base} />
-          ) : (
-            <ConnectWallet />
-          )}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="space-y-2 items-center flex flex-col">
+          <div className="mb-5 italic">
+            Connect wallet to view identity cards
+          </div>
+          <ConnectWallet />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
**What changed? Why?**
currently, if disconnected in the identity demo, the page is blank. we can either show the `<ConnectWallet />` or a message indicating user needs to connect

<img width="364" alt="Screenshot 2025-04-16 at 8 36 37 AM" src="https://github.com/user-attachments/assets/cabe4824-a063-4647-a611-d4d22c6a671a" />




**Notes to reviewers**

**How has it been tested?**
