### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 ## 🚀 Quickstart
 
-Run `npm create onchain` to boostrap an example onchain app with all the batteries included.
+Run `npm create onchain` to bootstrap an example onchain app with all the batteries included.
 
 ## ✨ Documentation
 

--- a/packages/create-onchain/templates/minikit-basic/README.md
+++ b/packages/create-onchain/templates/minikit-basic/README.md
@@ -22,12 +22,12 @@ bun install
 
 2. Verify environment variables, these will be set up by the `npx create-onchain --mini` command:
 
-You can regenerate the FARCASTER Account Assocation environment variables by running `npx create-onchain --manifest` in your project directory.
+You can regenerate the FARCASTER Account Association environment variables by running `npx create-onchain --manifest` in your project directory.
 
 The environment variables enable the following features:
 
 - Frame metadata - Sets up the Frame Embed that will be shown when you cast your frame
-- Account assocation - Allows users to add your frame to their account, enables notifications
+- Account association - Allows users to add your frame to their account, enables notifications
 - Redis API keys - Enable Webhooks and background notifications for your application by storing users notification details
 
 ```bash

--- a/packages/create-onchain/templates/minikit-snake/README.md
+++ b/packages/create-onchain/templates/minikit-snake/README.md
@@ -22,12 +22,12 @@ bun install
 
 2. Verify environment variables, these will be set up by the `npx create-onchain --template=minikit-snake` command:
 
-You can regenerate the FARCASTER Account Assocation environment variables by running `npx create-onchain --manifest` in your project directory.
+You can regenerate the FARCASTER Account Association environment variables by running `npx create-onchain --manifest` in your project directory.
 
 The environment variables enable the following features:
 
 - Frame metadata - Sets up the Frame Embed that will be shown when you cast your frame
-- Account assocation - Allows users to add your frame to their account, enables notifications
+- Account association - Allows users to add your frame to their account, enables notifications
 - Redis API keys - Enable Webhooks and background notifications for your application by storing users notification details
 
 ```bash


### PR DESCRIPTION
**What changed? Why?**

This PR fixes several typos in the documentation:

1. Corrects the misspelling of "Association" (was "Assocation") in multiple README files
2. Fixes the typo "boostrap" to "bootstrap" in the main README.md

These changes improve the readability and professionalism of the documentation without changing any functionality.
