### PR TITLE
fix: Updates playground to remove outdated imports

### DIFF
--- a/packages/playground/app/mint/hooks/useEarningsData.ts
+++ b/packages/playground/app/mint/hooks/useEarningsData.ts
@@ -1,8 +1,10 @@
 import { useCollection } from '@/lib/nft/useCollection';
 import { useToken } from '@/lib/nft/useToken';
-import type { ContractType } from '@/onchainkit/esm/nft/types';
 import { useMemo } from 'react';
 
+type ContractType = 'ERC721' | 'ERC1155';
+
+// eslint-disable-next-line complexity
 export function useEarningsData(contractAddress: string, tokenId?: string) {
   const { data: collection } = useCollection(contractAddress);
 

--- a/packages/playground/components/demo/FundCard.tsx
+++ b/packages/playground/components/demo/FundCard.tsx
@@ -1,6 +1,6 @@
 import { FundCard } from '@coinbase/onchainkit/fund';
 
-export type PresetAmountInputs = readonly [string, string, string];
+type PresetAmountInputs = readonly [string, string, string];
 
 export default function FundCardDemo() {
   const presetAmountInputs: PresetAmountInputs = ['10', '20', '100'];

--- a/packages/playground/components/demo/FundCard.tsx
+++ b/packages/playground/components/demo/FundCard.tsx
@@ -1,5 +1,6 @@
 import { FundCard } from '@coinbase/onchainkit/fund';
-import type { PresetAmountInputs } from '../../onchainkit/esm/fund/types';
+
+export type PresetAmountInputs = readonly [string, string, string];
 
 export default function FundCardDemo() {
   const presetAmountInputs: PresetAmountInputs = ['10', '20', '100'];

--- a/packages/playground/components/demo/Transaction.tsx
+++ b/packages/playground/components/demo/Transaction.tsx
@@ -21,7 +21,7 @@ import { useCallback, useContext, useEffect, useMemo } from 'react';
 import type { ContractFunctionParameters, Hex } from 'viem';
 import { AppContext } from '../AppProvider';
 
-export type Call = { to: Hex; data?: Hex; value?: bigint };
+type Call = { to: Hex; data?: Hex; value?: bigint };
 
 function TransactionDemo() {
   const { chainId, transactionType, isSponsored } = useContext(AppContext);

--- a/packages/playground/components/demo/Transaction.tsx
+++ b/packages/playground/components/demo/Transaction.tsx
@@ -3,7 +3,6 @@ import {
   clickContracts,
   heterogeneousClickCalls,
 } from '@/lib/transactions';
-import type { LifecycleStatus } from '@coinbase/onchainkit/checkout';
 import { TransactionTypes } from '@/types/onchainkit';
 import {
   Transaction,
@@ -16,6 +15,7 @@ import {
   TransactionToastAction,
   TransactionToastIcon,
   TransactionToastLabel,
+  LifecycleStatus,
 } from '@coinbase/onchainkit/transaction';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
 import type { ContractFunctionParameters, Hex } from 'viem';

--- a/packages/playground/components/demo/Transaction.tsx
+++ b/packages/playground/components/demo/Transaction.tsx
@@ -3,8 +3,7 @@ import {
   clickContracts,
   heterogeneousClickCalls,
 } from '@/lib/transactions';
-import type { Call } from '@/onchainkit/esm/transaction/types';
-import type { LifecycleStatus } from '@/onchainkit/src/transaction';
+import type { LifecycleStatus } from '@coinbase/onchainkit/checkout';
 import { TransactionTypes } from '@/types/onchainkit';
 import {
   Transaction,
@@ -19,8 +18,10 @@ import {
   TransactionToastLabel,
 } from '@coinbase/onchainkit/transaction';
 import { useCallback, useContext, useEffect, useMemo } from 'react';
-import type { ContractFunctionParameters } from 'viem';
+import type { ContractFunctionParameters, Hex } from 'viem';
 import { AppContext } from '../AppProvider';
+
+export type Call = { to: Hex; data?: Hex; value?: bigint };
 
 function TransactionDemo() {
   const { chainId, transactionType, isSponsored } = useContext(AppContext);

--- a/packages/playground/lib/nft/buildMintTransaction.ts
+++ b/packages/playground/lib/nft/buildMintTransaction.ts
@@ -1,7 +1,10 @@
-import type { BuildMintTransactionDataProps } from '@/onchainkit/esm/nft/types';
-import type { Call } from '@/onchainkit/esm/transaction/types';
+import type { BuildMintTransaction } from '@coinbase/onchainkit/nft';
 import type { definitions } from '@reservoir0x/reservoir-sdk';
 import { ENVIRONMENT_VARIABLES } from '../constants';
+import { Hex } from 'viem';
+
+type BuildMintTransactionDataProps = Parameters<BuildMintTransaction>[0];
+export type Call = { to: Hex; data?: Hex; value?: bigint };
 
 const ERROR_MAP = {
   'Unable to mint requested quantity (max mints per wallet possibly exceeded)':

--- a/packages/playground/lib/nft/buildMintTransaction.ts
+++ b/packages/playground/lib/nft/buildMintTransaction.ts
@@ -4,7 +4,8 @@ import { ENVIRONMENT_VARIABLES } from '../constants';
 import { Hex } from 'viem';
 
 type BuildMintTransactionDataProps = Parameters<BuildMintTransaction>[0];
-export type Call = { to: Hex; data?: Hex; value?: bigint };
+
+type Call = { to: Hex; data?: Hex; value?: bigint };
 
 const ERROR_MAP = {
   'Unable to mint requested quantity (max mints per wallet possibly exceeded)':

--- a/packages/playground/lib/nft/useReservoirMintData.ts
+++ b/packages/playground/lib/nft/useReservoirMintData.ts
@@ -1,9 +1,11 @@
-import type { ContractType } from '@/onchainkit/esm/nft/types';
 import { useMemo } from 'react';
 import { useCollection } from './useCollection';
 import { useOwners } from './useOwners';
 import { useToken } from './useToken';
 
+type ContractType = 'ERC721' | 'ERC1155';
+
+// eslint-disable-next-line complexity
 export function useReservoirMintData(
   contractAddress: string,
   tokenId?: string,

--- a/packages/playground/lib/nft/useReservoirNFTData.ts
+++ b/packages/playground/lib/nft/useReservoirNFTData.ts
@@ -1,7 +1,9 @@
-import type { ContractType } from '@/onchainkit/esm/nft/types';
 import { useMemo } from 'react';
 import { useToken } from './useToken';
 
+type ContractType = 'ERC721' | 'ERC1155';
+
+// eslint-disable-next-line complexity
 export function useReservoirNFTData(contractAddress: string, tokenId = '0') {
   const { data: token } = useToken(contractAddress, tokenId);
 


### PR DESCRIPTION
**What changed? Why?**

We had some type imports that were still using imports from before the monorepo migration. This removes those imports.

**Notes to reviewers**

I went with quick and dirty since we're starting to land on what v1 looks like. IMO, this is a good example of more types that should be exported. Personally, I'd err on the side of exporting all internal types.

**How has it been tested?**

Manually