### PR TITLE
chore: Add @farcaster/frame-sdk dependency to minikit templates

### DIFF
--- a/packages/create-onchain/templates/minikit-basic/package.json
+++ b/packages/create-onchain/templates/minikit-basic/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@coinbase/onchainkit": "latest",
+    "@farcaster/frame-sdk": "^0.0.35",
     "@upstash/redis": "^1.34.4",
     "next": "^14.2.15",
     "react": "^18",

--- a/packages/create-onchain/templates/minikit-snake/package.json
+++ b/packages/create-onchain/templates/minikit-snake/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@coinbase/onchainkit": "latest",
+    "@farcaster/frame-sdk": "^0.0.35",
     "@upstash/redis": "^1.34.4",
     "next": "^14.2.15",
     "react": "^18",


### PR DESCRIPTION
**What changed? Why?**

I just spun up a new minikit app locally, and one of the first things I noticed when I opened the codebase was the use of the @farcaster/frame-sdk package, but it was not actually installed (i.e not included in package.json). This PR adds that package to the package.json for both minikit app templates so people won't have to install it separately. 

**Notes to reviewers**

I just copy and pasted the line from my own package.json into the templates.

**How has it been tested?**

My linter is happy. 