### PR TITLE
feat: use crypto api for nonce generation

### DIFF
--- a/packages/onchainkit/src/minikit/hooks/useAuthenticate.ts
+++ b/packages/onchainkit/src/minikit/hooks/useAuthenticate.ts
@@ -103,6 +103,21 @@ function validateSignInMessage({
   }
 }
 
+/**
+ * Generates a cryptographically secure random nonce string.
+ * Uses the Web Crypto API to create random values that are then converted to a base-36 string.
+ *
+ * @param length - The length of the nonce to generate in bytes. Defaults to 8 bytes.
+ * @returns A random string of base-36 characters (0-9, a-z) derived from the random bytes.
+ */
+function generateSecureNonce(length = 8): string {
+  const array = new Uint8Array(length);
+  crypto.getRandomValues(array);
+  return Array.from(array)
+    .map((val) => (val % 36).toString(36))
+    .join('');
+}
+
 type UseAuthenticateProps = Omit<SignInCore.SignInOptions, 'nonce'> & {
   nonce?: string;
 };
@@ -120,9 +135,7 @@ export const useAuthenticate = (domain?: string) => {
     async (signInOptions: UseAuthenticateProps = {}) => {
       try {
         if (!signInOptions?.nonce) {
-          signInOptions.nonce = [...Array(8)]
-            .map(() => Math.floor(Math.random() * 36).toString(36))
-            .join('');
+          signInOptions.nonce = generateSecureNonce();
         }
         const result = await sdk.actions.signIn(
           signInOptions as SignInCore.SignInOptions,


### PR DESCRIPTION
**What changed? Why?**
Replaced the usage of Math.random with crypto.getRandomValues for generating nonces in the signIn flow. Math.random is not cryptographically secure and could lead to predictable or replayable nonces, introducing potential security vulnerabilities. This change ensures that nonces are generated using a secure random number generator, aligning with best practices for authentication.

**Notes to reviewers**

**How has it been tested?**
