### PR TITLE
fix: copy text cleanup

### DIFF
--- a/packages/onchainkit/src/identity/components/Address.tsx
+++ b/packages/onchainkit/src/identity/components/Address.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { copyToClipboard } from '@/internal/utils/copyToClipboard';
+import { useCopyToClipboard } from '@/internal/hooks/useCopyToClipboard';
 import { useState } from 'react';
 import { border, cn, color, pressable, text } from '../../styles/theme';
 import type { AddressReact } from '../types';
@@ -14,6 +14,18 @@ export function Address({
   hasCopyAddressOnClick = true,
 }: AddressReact) {
   const [copyText, setCopyText] = useState('Copy');
+  const copyToClipboard = useCopyToClipboard({
+    onSuccess: () => {
+      setCopyText('Copied');
+    },
+    onError: (err: unknown) => {
+      console.error('Failed to copy address:', err);
+      setCopyText('Failed to copy');
+    },
+    onReset: () => {
+      setCopyText('Copy');
+    },
+  });
   const { address: contextAddress } = useIdentityContext();
   const accountAddress = address ?? contextAddress;
 
@@ -42,18 +54,7 @@ export function Address({
 
   // Interactive version with copy functionality
   const handleClick = async () => {
-    await copyToClipboard({
-      copyValue: accountAddress,
-      onSuccess: () => {
-        setCopyText('Copied');
-        setTimeout(() => setCopyText('Copy'), 2000);
-      },
-      onError: (err: unknown) => {
-        console.error('Failed to copy address:', err);
-        setCopyText('Failed to copy');
-        setTimeout(() => setCopyText('Copy'), 2000);
-      },
-    });
+    await copyToClipboard(accountAddress);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/packages/onchainkit/src/internal/components/CopyButton.tsx
+++ b/packages/onchainkit/src/internal/components/CopyButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { copyToClipboard } from '@/internal/utils/copyToClipboard';
+import { useCopyToClipboard } from '@/internal/hooks/useCopyToClipboard';
 import { type ReactNode, useCallback } from 'react';
 
 type CopyButtonProps = {
@@ -8,6 +8,7 @@ type CopyButtonProps = {
   copyValue: string;
   onSuccess?: () => void;
   onError?: (error: unknown) => void;
+  onReset?: () => void;
   className?: string;
   'aria-label'?: string;
 };
@@ -17,12 +18,19 @@ export function CopyButton({
   copyValue,
   onSuccess,
   onError,
+  onReset,
   className,
   'aria-label': ariaLabel,
 }: CopyButtonProps) {
+  const copyToClipboard = useCopyToClipboard({
+    onSuccess,
+    onError,
+    onReset,
+  });
+
   const handleCopy = useCallback(
-    () => copyToClipboard({ copyValue, onSuccess, onError }),
-    [copyValue, onSuccess, onError],
+    () => copyToClipboard(copyValue),
+    [copyToClipboard, copyValue],
   );
 
   return (

--- a/packages/onchainkit/src/internal/hooks/useCopyToClipboard.test.ts
+++ b/packages/onchainkit/src/internal/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,143 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { useCopyToClipboard } from './useCopyToClipboard';
+
+const mockClipboard = {
+  writeText: vi.fn(),
+};
+
+describe('useCopyToClipboard', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: mockClipboard,
+      configurable: true,
+    });
+    mockClipboard.writeText.mockReset();
+    mockClipboard.writeText.mockResolvedValue(undefined);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('should call navigator.clipboard.writeText with the provided text', async () => {
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current('test text');
+    });
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('test text');
+  });
+
+  it('should call onSuccess callback when copy is successful', async () => {
+    const onSuccess = vi.fn();
+    mockClipboard.writeText.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useCopyToClipboard({ onSuccess }));
+
+    await act(async () => {
+      await result.current('test text');
+    });
+
+    expect(onSuccess).toHaveBeenCalled();
+  });
+
+  it('should call onError callback when copy fails', async () => {
+    const onError = vi.fn();
+    const testError = new Error('Clipboard error');
+    mockClipboard.writeText.mockRejectedValueOnce(testError);
+
+    const { result } = renderHook(() => useCopyToClipboard({ onError }));
+
+    await act(async () => {
+      await result.current('test text');
+    });
+
+    expect(onError).toHaveBeenCalledWith(testError);
+  });
+
+  it('should call onReset after resetDelay time', async () => {
+    const onReset = vi.fn();
+    const resetDelay = 2000;
+    mockClipboard.writeText.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() =>
+      useCopyToClipboard({ onReset, resetDelay }),
+    );
+
+    await act(async () => {
+      await result.current('test text');
+    });
+
+    expect(onReset).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(resetDelay);
+    });
+
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it('should clear any existing timeout when called again', async () => {
+    const onReset = vi.fn();
+    const resetDelay = 2000;
+    mockClipboard.writeText.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() =>
+      useCopyToClipboard({ onReset, resetDelay }),
+    );
+
+    await act(async () => {
+      await result.current('first text');
+    });
+
+    // Advance time but not enough to trigger reset
+    await act(async () => {
+      vi.advanceTimersByTime(resetDelay / 2);
+    });
+
+    await act(async () => {
+      await result.current('second text');
+    });
+
+    // Advance time to what would trigger the first reset if it wasn't cleared
+    await act(async () => {
+      vi.advanceTimersByTime(resetDelay / 2);
+    });
+
+    expect(onReset).not.toHaveBeenCalled();
+
+    // Now advance enough to trigger the second reset
+    await act(async () => {
+      vi.advanceTimersByTime(resetDelay / 2);
+    });
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clean up timeout on unmount', async () => {
+    const onReset = vi.fn();
+    const resetDelay = 2000;
+    mockClipboard.writeText.mockResolvedValueOnce(undefined);
+
+    const { result, unmount } = renderHook(() =>
+      useCopyToClipboard({ onReset, resetDelay }),
+    );
+
+    await act(async () => {
+      await result.current('test text');
+    });
+
+    unmount();
+
+    // Advance time past when the reset would happen
+    await act(async () => {
+      vi.advanceTimersByTime(resetDelay + 100);
+    });
+
+    expect(onReset).not.toHaveBeenCalled();
+  });
+});

--- a/packages/onchainkit/src/internal/hooks/useCopyToClipboard.ts
+++ b/packages/onchainkit/src/internal/hooks/useCopyToClipboard.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { copyToClipboard } from '../utils/copyToClipboard';
+
+type UseCopyToClipboardParams = {
+  resetDelay?: number;
+  onSuccess?: () => void;
+  onReset?: () => void;
+  onError?: (error: unknown) => void;
+};
+
+export function useCopyToClipboard({
+  resetDelay = 2000,
+  onSuccess,
+  onError,
+  onReset,
+}: UseCopyToClipboardParams = {}) {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    onReset?.();
+  }, [onReset]);
+
+  const copy = useCallback(
+    async (text: string) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      await copyToClipboard({
+        copyValue: text,
+        onSuccess: () => {
+          onSuccess?.();
+          timeoutRef.current = setTimeout(reset, resetDelay);
+        },
+        onError: (error) => {
+          onError?.(error);
+          timeoutRef.current = setTimeout(reset, resetDelay);
+        },
+      });
+    },
+    [onSuccess, reset, resetDelay, onError],
+  );
+
+  return copy;
+}

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedAddressDetails.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedAddressDetails.tsx
@@ -2,6 +2,7 @@
 
 import { Avatar, Name } from '@/identity';
 import { Spinner } from '@/internal/components/Spinner';
+import { useCopyToClipboard } from '@/internal/hooks/useCopyToClipboard';
 import { zIndex } from '@/styles/constants';
 import { border, cn, color, pressable, text } from '@/styles/theme';
 import { useCallback, useState } from 'react';
@@ -24,18 +25,21 @@ export function WalletAdvancedAddressDetails({
 }: WalletAdvancedAddressDetailsProps) {
   const { address, chain, animations } = useWalletContext();
   const [copyText, setCopyText] = useState('Copy');
-
-  const handleCopyAddress = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(String(address));
+  const copyToClipboard = useCopyToClipboard({
+    onSuccess: () => {
       setCopyText('Copied');
-      setTimeout(() => setCopyText('Copy'), 2000);
-    } catch (err) {
+    },
+    onError: (err: unknown) => {
       console.error('Failed to copy address:', err);
       setCopyText('Failed to copy');
-      setTimeout(() => setCopyText('Copy'), 2000);
-    }
-  }, [address]);
+    },
+    onReset: () => {
+      setCopyText('Copy');
+    },
+  });
+  const handleCopyAddress = useCallback(async () => {
+    await copyToClipboard(String(address));
+  }, [address, copyToClipboard]);
 
   if (!address || !chain) {
     return <div className="mt-1 h-28 w-10 px-4 py-3" />; // Prevent layout shift

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedQrReceive.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedQrReceive.tsx
@@ -36,31 +36,25 @@ export function WalletAdvancedQrReceive({
   }, [isActiveFeatureClosing, setActiveFeature, setIsActiveFeatureClosing]);
 
   const resetAffordanceText = useCallback(() => {
-    setTimeout(() => {
-      setCopyText('Copy');
-      setCopyButtonText('Copy address');
-    }, 2000);
+    setCopyText('Copy');
+    setCopyButtonText('Copy address');
   }, []);
 
   const handleCopyButtonSuccess = useCallback(() => {
     setCopyButtonText('Address copied');
-    resetAffordanceText();
-  }, [resetAffordanceText]);
+  }, []);
 
   const handleCopyButtonError = useCallback(() => {
     setCopyButtonText('Failed to copy address');
-    resetAffordanceText();
-  }, [resetAffordanceText]);
+  }, []);
 
   const handleCopyIconSuccess = useCallback(() => {
     setCopyText('Copied');
-    resetAffordanceText();
-  }, [resetAffordanceText]);
+  }, []);
 
   const handleCopyIconError = useCallback(() => {
     setCopyText('Failed to copy');
-    resetAffordanceText();
-  }, [resetAffordanceText]);
+  }, []);
 
   return (
     <div
@@ -94,6 +88,7 @@ export function WalletAdvancedQrReceive({
             copyValue={address ?? ''}
             onSuccess={handleCopyIconSuccess}
             onError={handleCopyIconError}
+            onReset={resetAffordanceText}
             className={cn(
               pressable.default,
               border.radiusInner,
@@ -107,6 +102,7 @@ export function WalletAdvancedQrReceive({
             copyValue={address ?? ''}
             onSuccess={handleCopyIconSuccess}
             onError={handleCopyIconError}
+            onReset={resetAffordanceText}
             className={cn(
               pressable.alternate,
               text.legal,
@@ -132,6 +128,7 @@ export function WalletAdvancedQrReceive({
         )}
         onSuccess={handleCopyButtonSuccess}
         onError={handleCopyButtonError}
+        onReset={resetAffordanceText}
         aria-label="Copy your address by clicking the button"
       />
     </div>


### PR DESCRIPTION
**What changed? Why?**
Refactored copy-to-clipboard functionality by creating a dedicated useCopyToClipboard hook to improve code reusability and consistency. This eliminates duplicate code across components and centralizes the clipboard operation logic with proper timeout management.

**Notes to reviewers**
- The new hook manages its own timeout cleanup to prevent memory leaks
- Updated all components using clipboard functionality to leverage the new hook

**How has it been tested?**
