### PR TITLE
fix: OnchainKit package.json publishConfig.access = public

### DIFF
--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -4,7 +4,6 @@
   "type": "module",
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",
-  "access": "public",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -5,6 +5,9 @@
   "repository": "https://github.com/coinbase/onchainkit.git",
   "license": "MIT",
   "access": "public",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "pnpm clean && pnpm bundle:prod && pnpm tailwind:prod",
     "dev": "concurrently \"pnpm tailwind:dev\" \"pnpm bundle:dev\"",


### PR DESCRIPTION
**What changed? Why?**

- Fixes syntax for publishConfig.access

**Notes to reviewers**

**How has it been tested?**

- Manually