### PR TITLE
chore: refactor fund components

### DIFF
--- a/packages/onchainkit/src/fund/components/FundButton.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.test.tsx
@@ -125,14 +125,18 @@ describe('FundButton', () => {
   });
 
   it('renders calls window.open when the openIn prop is set to tab', () => {
+    const onClickMock = vi.fn();
     const fundingUrl = 'https://props.funding.url';
     const { height, width } = { height: 200, width: 100 };
     (getFundingPopupSize as Mock).mockReturnValue({ height, width });
 
-    render(<FundButton fundingUrl={fundingUrl} openIn="tab" />);
+    render(
+      <FundButton fundingUrl={fundingUrl} openIn="tab" onClick={onClickMock} />,
+    );
     const button = screen.getByTestId('ockFundButton');
     fireEvent.click(button);
 
+    expect(onClickMock).toHaveBeenCalled();
     expect(openSpy).toHaveBeenCalledWith(fundingUrl, '_blank');
   });
 

--- a/packages/onchainkit/src/fund/components/FundButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.tsx
@@ -17,7 +17,7 @@ import { SuccessSvg } from '../../internal/svg/successSvg';
 import { background } from '../../styles/theme';
 import { ConnectWallet } from '../../wallet/components/ConnectWallet';
 import { useGetFundingUrl } from '../hooks/useGetFundingUrl';
-import type { FundButtonReact } from '../types';
+import type { FundButtonProps } from '../types';
 import { getFundingPopupSize } from '../utils/getFundingPopupSize';
 
 export function FundButton({
@@ -33,7 +33,7 @@ export function FundButton({
   onPopupClose,
   onClick,
   render,
-}: FundButtonReact) {
+}: FundButtonProps) {
   const componentTheme = useTheme();
   // If the fundingUrl prop is undefined, fallback to our recommended funding URL based on the wallet type
   const fallbackFundingUrl = useGetFundingUrl({

--- a/packages/onchainkit/src/fund/components/FundButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.tsx
@@ -140,6 +140,7 @@ export function FundButton({
         return <AddSvg />;
     }
   }, [buttonState]);
+
   const buttonTextContent = useMemo(() => {
     switch (buttonState) {
       case 'loading':

--- a/packages/onchainkit/src/fund/components/FundButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.tsx
@@ -22,21 +22,17 @@ import { getFundingPopupSize } from '../utils/getFundingPopupSize';
 
 export function FundButton({
   className,
+  children,
   disabled = false,
   fundingUrl,
-  hideIcon = false,
-  hideText = false,
   openIn = 'popup',
   popupSize = 'md',
-  rel,
   target,
-  text: buttonText = 'Fund',
-  successText: buttonSuccessText = 'Success',
-  errorText: buttonErrorText = 'Something went wrong',
   state: buttonState = 'default',
   fiatCurrency = 'USD',
   onPopupClose,
   onClick,
+  render,
 }: FundButtonReact) {
   const componentTheme = useTheme();
   // If the fundingUrl prop is undefined, fallback to our recommended funding URL based on the wallet type
@@ -72,6 +68,13 @@ export function FundButton({
     (e: React.MouseEvent) => {
       e.preventDefault();
 
+      if (fundingUrlToRender && openIn === 'tab') {
+        handleAnalyticsInitiated();
+        onClick?.();
+        window.open(fundingUrlToRender, '_blank');
+        return;
+      }
+
       if (fundingUrlToRender) {
         handleAnalyticsInitiated();
         onClick?.();
@@ -95,11 +98,12 @@ export function FundButton({
     },
     [
       fundingUrlToRender,
+      openIn,
+      handleAnalyticsInitiated,
+      onClick,
       popupSize,
       target,
-      onClick,
       startPopupMonitor,
-      handleAnalyticsInitiated,
       handleAnalyticsFailure,
     ],
   );
@@ -125,9 +129,6 @@ export function FundButton({
   );
 
   const buttonIcon = useMemo(() => {
-    if (hideIcon) {
-      return null;
-    }
     switch (buttonState) {
       case 'loading':
         return '';
@@ -138,20 +139,19 @@ export function FundButton({
       default:
         return <AddSvg />;
     }
-  }, [buttonState, hideIcon]);
-
+  }, [buttonState]);
   const buttonTextContent = useMemo(() => {
     switch (buttonState) {
       case 'loading':
         return '';
       case 'success':
-        return buttonSuccessText;
+        return 'Success';
       case 'error':
-        return buttonErrorText;
+        return 'Something went wrong';
       default:
-        return buttonText;
+        return 'Fund';
     }
-  }, [buttonState, buttonSuccessText, buttonErrorText, buttonText]);
+  }, [buttonState]);
 
   const buttonContent = useMemo(() => {
     if (buttonState === 'loading') {
@@ -168,31 +168,21 @@ export function FundButton({
             {buttonIcon}
           </span>
         )}
-        {hideText || (
-          <span data-testid="ockFundButtonTextContent">
-            {buttonTextContent}
-          </span>
-        )}
+        <span data-testid="ockFundButtonTextContent">{buttonTextContent}</span>
       </>
     );
-  }, [buttonState, buttonIcon, buttonTextContent, hideText]);
-
-  if (openIn === 'tab') {
-    return (
-      <a
-        className={classNames}
-        href={fundingUrlToRender}
-        // If openIn is 'tab', default target to _blank so we don't accidentally navigate in the current tab
-        target={target ?? '_blank'}
-        rel={rel}
-      >
-        {buttonContent}
-      </a>
-    );
-  }
+  }, [buttonState, buttonIcon, buttonTextContent]);
 
   if (shouldShowConnectWallet) {
     return <ConnectWallet className={cn('w-full', className)} />;
+  }
+
+  if (render) {
+    return render({
+      state: buttonState,
+      onClick: handleClick,
+      isDisabled,
+    });
   }
 
   return (
@@ -203,7 +193,7 @@ export function FundButton({
       disabled={isDisabled}
       data-testid="ockFundButton"
     >
-      {buttonContent}
+      {children ?? buttonContent}
     </button>
   );
 }

--- a/packages/onchainkit/src/fund/components/FundButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.tsx
@@ -180,7 +180,7 @@ export function FundButton({
 
   if (render) {
     return render({
-      state: buttonState,
+      status: buttonState,
       onClick: handleClick,
       isDisabled,
     });

--- a/packages/onchainkit/src/fund/components/FundCard.tsx
+++ b/packages/onchainkit/src/fund/components/FundCard.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import { useTheme } from '../../internal/hooks/useTheme';
 import { background, border, cn, color, text } from '../../styles/theme';
 import { useFundCardSetupOnrampEventListeners } from '../hooks/useFundCardSetupOnrampEventListeners';
-import type { FundCardPropsReact } from '../types';
+import type { FundCardProps } from '../types';
 import FundCardAmountInput from './FundCardAmountInput';
 import FundCardAmountInputTypeSwitch from './FundCardAmountInputTypeSwitch';
 import { FundCardHeader } from './FundCardHeader';
@@ -26,7 +26,7 @@ export function FundCard({
   onError,
   onStatus,
   onSuccess,
-}: FundCardPropsReact) {
+}: FundCardProps) {
   const componentTheme = useTheme();
 
   return (

--- a/packages/onchainkit/src/fund/components/FundCardAmountInput.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardAmountInput.test.tsx
@@ -5,7 +5,7 @@ import { act } from 'react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
 import { quoteResponseDataMock } from '../mocks';
-import type { FundCardProviderReact } from '../types';
+import type { FundCardProviderProps } from '../types';
 import { FundCardAmountInput } from './FundCardAmountInput';
 import { FundCardProvider, useFundContext } from './FundCardProvider';
 
@@ -55,7 +55,7 @@ describe('FundCardAmountInput', () => {
   };
 
   const renderWithProvider = (
-    initialProps: Partial<FundCardProviderReact> = {},
+    initialProps: Partial<FundCardProviderProps> = {},
   ) => {
     return render(
       <FundCardProvider asset="ETH" country="US" {...initialProps}>

--- a/packages/onchainkit/src/fund/components/FundCardAmountInput.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardAmountInput.tsx
@@ -5,14 +5,14 @@ import { useCallback } from 'react';
 import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
 import { FundEvent } from '../../core/analytics/types';
 import { useOnrampExchangeRate } from '../hooks/useOnrampExchangeRate';
-import type { FundCardAmountInputPropsReact } from '../types';
+import type { FundCardAmountInputProps } from '../types';
 import { useFundContext } from './FundCardProvider';
 
 const THROTTLE_DELAY_MS = 5000;
 
 export const FundCardAmountInput = ({
   className,
-}: FundCardAmountInputPropsReact) => {
+}: FundCardAmountInputProps) => {
   const {
     fundAmountFiat,
     fundAmountCrypto,

--- a/packages/onchainkit/src/fund/components/FundCardAmountInputTypeSwitch.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardAmountInputTypeSwitch.test.tsx
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { quoteResponseDataMock } from '../mocks';
-import type { FundCardProviderReact } from '../types';
+import type { FundCardProviderProps } from '../types';
 import { FundCardAmountInputTypeSwitch } from './FundCardAmountInputTypeSwitch';
 import { FundCardProvider, useFundContext } from './FundCardProvider';
 
@@ -13,7 +13,7 @@ global.fetch = vi.fn(() =>
   }),
 ) as Mock;
 
-const mockContext: FundCardProviderReact = {
+const mockContext: FundCardProviderProps = {
   asset: 'ETH',
   country: 'US',
   inputType: 'fiat',

--- a/packages/onchainkit/src/fund/components/FundCardAmountInputTypeSwitch.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardAmountInputTypeSwitch.tsx
@@ -1,11 +1,11 @@
 'use client';
 import { AmountInputTypeSwitch } from '@/internal/components/amount-input/AmountInputTypeSwitch';
-import type { FundCardAmountInputTypeSwitchPropsReact } from '../types';
+import type { FundCardAmountInputTypeSwitchProps } from '../types';
 import { useFundContext } from './FundCardProvider';
 
 export const FundCardAmountInputTypeSwitch = ({
   className,
-}: FundCardAmountInputTypeSwitchPropsReact) => {
+}: FundCardAmountInputTypeSwitchProps) => {
   const {
     selectedInputType,
     setSelectedInputType,

--- a/packages/onchainkit/src/fund/components/FundCardHeader.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardHeader.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { cn, text } from '@/styles/theme';
-import type { FundCardHeaderPropsReact } from '../types';
+import type { FundCardHeaderProps } from '../types';
 import { useFundContext } from './FundCardProvider';
 
-export function FundCardHeader({ className }: FundCardHeaderPropsReact) {
+export function FundCardHeader({ className }: FundCardHeaderProps) {
   const { headerText } = useFundContext();
 
   return (

--- a/packages/onchainkit/src/fund/components/FundCardPaymentMethodDropdown.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardPaymentMethodDropdown.tsx
@@ -8,7 +8,7 @@ import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
 import { FundEvent } from '../../core/analytics/types';
 import { background, border, cn } from '../../styles/theme';
 import type {
-  FundCardPaymentMethodDropdownPropsReact,
+  FundCardPaymentMethodDropdownProps,
   PaymentMethod,
 } from '../types';
 import { FundCardPaymentMethodSelectRow } from './FundCardPaymentMethodSelectRow';
@@ -17,7 +17,7 @@ import { useFundContext } from './FundCardProvider';
 
 export function FundCardPaymentMethodDropdown({
   className,
-}: FundCardPaymentMethodDropdownPropsReact) {
+}: FundCardPaymentMethodDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const {

--- a/packages/onchainkit/src/fund/components/FundCardPaymentMethodImage.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardPaymentMethodImage.tsx
@@ -1,11 +1,11 @@
 import { useIcon } from '../../internal/hooks/useIcon';
 import { cn } from '../../styles/theme';
-import type { FundCardPaymentMethodImagePropsReact } from '../types';
+import type { FundCardPaymentMethodImageProps } from '../types';
 
 export function FundCardPaymentMethodImage({
   className,
   paymentMethod,
-}: FundCardPaymentMethodImagePropsReact) {
+}: FundCardPaymentMethodImageProps) {
   const { icon } = paymentMethod;
 
   const iconSvg = useIcon({ icon });

--- a/packages/onchainkit/src/fund/components/FundCardPaymentMethodSelectRow.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardPaymentMethodSelectRow.tsx
@@ -9,7 +9,7 @@ import {
   pressable,
   text,
 } from '../../styles/theme';
-import type { FundCardPaymentMethodSelectRowPropsReact } from '../types';
+import type { FundCardPaymentMethodSelectRowProps } from '../types';
 import { FundCardPaymentMethodImage } from './FundCardPaymentMethodImage';
 
 export const FundCardPaymentMethodSelectRow = memo(
@@ -21,7 +21,7 @@ export const FundCardPaymentMethodSelectRow = memo(
     disabled,
     disabledReason,
     testId,
-  }: FundCardPaymentMethodSelectRowPropsReact) => {
+  }: FundCardPaymentMethodSelectRowProps) => {
     const { sendAnalytics } = useAnalytics();
 
     const handleOnClick = useCallback(() => {

--- a/packages/onchainkit/src/fund/components/FundCardPaymentMethodSelectorToggle.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardPaymentMethodSelectorToggle.tsx
@@ -1,7 +1,7 @@
 import { type ForwardedRef, forwardRef } from 'react';
 import { caretUpSvg } from '../../internal/svg/caretUpSvg';
 import { border, cn, color, pressable, text } from '../../styles/theme';
-import type { FundCardPaymentMethodSelectorTogglePropsReact } from '../types';
+import type { FundCardPaymentMethodSelectorToggleProps } from '../types';
 import { FundCardPaymentMethodImage } from './FundCardPaymentMethodImage';
 
 export const FundCardPaymentMethodSelectorToggle = forwardRef(
@@ -11,7 +11,7 @@ export const FundCardPaymentMethodSelectorToggle = forwardRef(
       paymentMethod,
       isOpen,
       className,
-    }: FundCardPaymentMethodSelectorTogglePropsReact,
+    }: FundCardPaymentMethodSelectorToggleProps,
     ref: ForwardedRef<HTMLButtonElement>,
   ) => {
     return (

--- a/packages/onchainkit/src/fund/components/FundCardPresetAmountInputItem.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardPresetAmountInputItem.tsx
@@ -3,13 +3,13 @@ import { border, cn, color, text } from '@/styles/theme';
 import { useCallback, useMemo } from 'react';
 import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
 import { FundEvent } from '../../core/analytics/types';
-import type { PresetAmountInputItemPropsReact } from '../types';
+import type { PresetAmountInputItemProps } from '../types';
 
 export function FundCardPresetAmountInputItem({
   presetAmountInput,
   currency,
   onClick,
-}: PresetAmountInputItemPropsReact) {
+}: PresetAmountInputItemProps) {
   const { sendAnalytics } = useAnalytics();
 
   const presetAmountInputText = useMemo(() => {

--- a/packages/onchainkit/src/fund/components/FundCardProvider.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardProvider.tsx
@@ -15,8 +15,8 @@ import { useOnrampExchangeRate } from '../hooks/useOnrampExchangeRate';
 import { usePaymentMethods } from '../hooks/usePaymentMethods';
 import type {
   AmountInputType,
-  FundButtonStateReact,
-  FundCardProviderReact,
+  FundButtonState,
+  FundCardProviderProps,
   LifecycleStatus,
   OnrampError,
   PaymentMethod,
@@ -38,8 +38,8 @@ type FundCardContextType = {
   setExchangeRate: (exchangeRate: number) => void;
   exchangeRateLoading: boolean;
   setExchangeRateLoading: (loading: boolean) => void;
-  submitButtonState: FundButtonStateReact;
-  setSubmitButtonState: (state: FundButtonStateReact) => void;
+  submitButtonState: FundButtonState;
+  setSubmitButtonState: (state: FundButtonState) => void;
   paymentMethods: PaymentMethod[];
   setPaymentMethods: (paymentMethods: PaymentMethod[]) => void;
   isPaymentMethodsLoading: boolean;
@@ -73,7 +73,7 @@ export function FundCardProvider({
   onStatus,
   onSuccess,
   presetAmountInputs,
-}: FundCardProviderReact) {
+}: FundCardProviderProps) {
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
     PaymentMethod | undefined
   >();
@@ -86,7 +86,7 @@ export function FundCardProvider({
   const [exchangeRateLoading, setExchangeRateLoading] = useState<boolean>(true);
 
   const [submitButtonState, setSubmitButtonState] =
-    useState<FundButtonStateReact>('default');
+    useState<FundButtonState>('default');
 
   const [paymentMethods, setPaymentMethods] = useState<PaymentMethod[]>([]);
   const [isPaymentMethodsLoading, setIsPaymentMethodsLoading] =

--- a/packages/onchainkit/src/fund/components/FundCardSubmitButton.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardSubmitButton.test.tsx
@@ -144,13 +144,13 @@ describe('FundCardSubmitButton', () => {
     render(
       <FundCardProvider asset="ETH" country="US">
         <FundCardSubmitButton
-          render={({ onClick, isDisabled, state }) => (
+          render={({ onClick, isDisabled, status }) => (
             <button
               data-testid="custom-render-button"
               onClick={onClick}
               disabled={isDisabled}
             >
-              Custom Render - {state}
+              Custom Render - {status}
             </button>
           )}
         />

--- a/packages/onchainkit/src/fund/components/FundCardSubmitButton.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardSubmitButton.test.tsx
@@ -8,6 +8,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
+import React from 'react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { useFundCardFundingUrl } from '../hooks/useFundCardFundingUrl';
@@ -139,9 +140,87 @@ describe('FundCardSubmitButton', () => {
     );
   };
 
+  it('renders custom content when `render` prop is provided', () => {
+    render(
+      <FundCardProvider asset="ETH" country="US">
+        <FundCardSubmitButton
+          render={({ onClick, isDisabled, state }) => (
+            <button
+              data-testid="custom-render-button"
+              onClick={onClick}
+              disabled={isDisabled}
+            >
+              Custom Render - {state}
+            </button>
+          )}
+        />
+      </FundCardProvider>,
+    );
+
+    const customButton = screen.getByTestId('custom-render-button');
+    expect(customButton).toBeInTheDocument();
+    expect(customButton).toHaveTextContent('Custom Render - default');
+  });
+
   it('renders disabled by default when no amount is set', () => {
     renderComponent();
     expect(screen.getByTestId('ockFundButton')).toBeDisabled();
+  });
+
+  it('displays "Success" text when in success state', async () => {
+    const SuccessStateWrapper = () => {
+      const { setSubmitButtonState } = useFundContext();
+
+      React.useEffect(() => {
+        setSubmitButtonState('success');
+      }, [setSubmitButtonState]);
+
+      return <FundCardSubmitButton />;
+    };
+
+    render(
+      <FundCardProvider asset="ETH" country="US">
+        <TestHelperComponent />
+        <SuccessStateWrapper />
+      </FundCardProvider>,
+    );
+
+    const setFiatAmountButton = screen.getByTestId('set-fiat-amount');
+    fireEvent.click(setFiatAmountButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ockFundButtonTextContent')).toHaveTextContent(
+        'Success',
+      );
+    });
+  });
+
+  it('displays "Something went wrong" text when in error state', async () => {
+    const ErrorStateWrapper = () => {
+      const { setSubmitButtonState } = useFundContext();
+
+      React.useEffect(() => {
+        setSubmitButtonState('error');
+      }, [setSubmitButtonState]);
+
+      return <FundCardSubmitButton />;
+    };
+
+    render(
+      <FundCardProvider asset="ETH" country="US">
+        <TestHelperComponent />
+        <ErrorStateWrapper />
+      </FundCardProvider>,
+    );
+
+    const setFiatAmountButton = screen.getByTestId('set-fiat-amount');
+    fireEvent.click(setFiatAmountButton);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ockFundButtonTextContent')).toHaveTextContent(
+        'Something went wrong',
+      );
+    });
   });
 
   it('enables when fiat amount is set', async () => {

--- a/packages/onchainkit/src/fund/components/FundCardSubmitButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardSubmitButton.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { Spinner } from '@/internal/components/Spinner';
 import { useCallback, useMemo } from 'react';
 import { useFundCardFundingUrl } from '../hooks/useFundCardFundingUrl';
 import { FundButton } from './FundButton';
@@ -10,7 +11,6 @@ export function FundCardSubmitButton() {
     fundAmountCrypto,
     submitButtonState,
     setSubmitButtonState,
-    buttonText,
     currency,
     updateLifecycleStatus,
   } = useFundContext();
@@ -34,17 +34,40 @@ export function FundCardSubmitButton() {
     [fundAmountCrypto, fundAmountFiat],
   );
 
+  const buttonTextContent = useMemo(() => {
+    switch (submitButtonState) {
+      case 'loading':
+        return '';
+      case 'success':
+        return 'Success';
+      case 'error':
+        return 'Something went wrong';
+      default:
+        return 'Buy';
+    }
+  }, [submitButtonState]);
+
+  const buttonContent = useMemo(() => {
+    if (submitButtonState === 'loading') {
+      return <Spinner />;
+    }
+
+    return (
+      <span data-testid="ockFundButtonTextContent">{buttonTextContent}</span>
+    );
+  }, [submitButtonState, buttonTextContent]);
+
   return (
     <FundButton
       disabled={isButtonDisabled}
-      hideIcon={submitButtonState === 'default'}
-      text={buttonText}
       className="w-full"
       fundingUrl={fundingUrl}
       state={submitButtonState}
       onClick={handleOnClick}
       onPopupClose={handleOnPopupClose}
       fiatCurrency={currency}
-    />
+    >
+      {buttonContent}
+    </FundButton>
   );
 }

--- a/packages/onchainkit/src/fund/components/FundCardSubmitButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardSubmitButton.tsx
@@ -1,5 +1,7 @@
 'use client';
 import { Spinner } from '@/internal/components/Spinner';
+import { ErrorSvg } from '@/internal/svg/errorSvg';
+import { SuccessSvg } from '@/internal/svg/successSvg';
 import { useCallback, useMemo } from 'react';
 import { useFundCardFundingUrl } from '../hooks/useFundCardFundingUrl';
 import { FundCardSubmitButtonProps } from '../types';
@@ -38,6 +40,19 @@ export function FundCardSubmitButton({
     [fundAmountCrypto, fundAmountFiat],
   );
 
+  const buttonIcon = useMemo(() => {
+    switch (submitButtonState) {
+      case 'loading':
+        return '';
+      case 'success':
+        return <SuccessSvg fill="#F9FAFB" />;
+      case 'error':
+        return <ErrorSvg fill="#F9FAFB" />;
+      default:
+        return null;
+    }
+  }, [submitButtonState]);
+
   const buttonTextContent = useMemo(() => {
     switch (submitButtonState) {
       case 'loading':
@@ -57,9 +72,19 @@ export function FundCardSubmitButton({
     }
 
     return (
-      <span data-testid="ockFundButtonTextContent">{buttonTextContent}</span>
+      <>
+        {buttonIcon && (
+          <span
+            data-testid="ockFundButtonIcon"
+            className="flex h-6 items-center"
+          >
+            {buttonIcon}
+          </span>
+        )}
+        <span data-testid="ockFundButtonTextContent">{buttonTextContent}</span>
+      </>
     );
-  }, [submitButtonState, buttonTextContent]);
+  }, [submitButtonState, buttonIcon, buttonTextContent]);
 
   // FundButton accepts render prop or children but not both
   if (render) {

--- a/packages/onchainkit/src/fund/components/FundCardSubmitButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardSubmitButton.tsx
@@ -2,10 +2,14 @@
 import { Spinner } from '@/internal/components/Spinner';
 import { useCallback, useMemo } from 'react';
 import { useFundCardFundingUrl } from '../hooks/useFundCardFundingUrl';
+import { FundCardSubmitButtonProps } from '../types';
 import { FundButton } from './FundButton';
 import { useFundContext } from './FundCardProvider';
 
-export function FundCardSubmitButton() {
+export function FundCardSubmitButton({
+  children,
+  render,
+}: FundCardSubmitButtonProps) {
   const {
     fundAmountFiat,
     fundAmountCrypto,
@@ -57,6 +61,22 @@ export function FundCardSubmitButton() {
     );
   }, [submitButtonState, buttonTextContent]);
 
+  // FundButton accepts render prop or children but not both
+  if (render) {
+    return (
+      <FundButton
+        disabled={isButtonDisabled}
+        className="w-full"
+        fundingUrl={fundingUrl}
+        state={submitButtonState}
+        onClick={handleOnClick}
+        onPopupClose={handleOnPopupClose}
+        fiatCurrency={currency}
+        render={render}
+      />
+    );
+  }
+
   return (
     <FundButton
       disabled={isButtonDisabled}
@@ -67,7 +87,7 @@ export function FundCardSubmitButton() {
       onPopupClose={handleOnPopupClose}
       fiatCurrency={currency}
     >
-      {buttonContent}
+      {children || buttonContent}
     </FundButton>
   );
 }

--- a/packages/onchainkit/src/fund/components/FundCardSubmitButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardSubmitButton.tsx
@@ -91,7 +91,6 @@ export function FundCardSubmitButton({
     return (
       <FundButton
         disabled={isButtonDisabled}
-        className="w-full"
         fundingUrl={fundingUrl}
         state={submitButtonState}
         onClick={handleOnClick}

--- a/packages/onchainkit/src/fund/index.ts
+++ b/packages/onchainkit/src/fund/index.ts
@@ -25,7 +25,7 @@ export { useFundContext } from './components/FundCardProvider';
 // Types
 export type {
   EventMetadata,
-  FundCardPropsReact,
+  FundCardProps,
   GetOnrampUrlWithProjectIdParams,
   GetOnrampUrlWithSessionTokenParams,
   OnrampAmount,

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -126,14 +126,19 @@ type FundButtonBaseProps = {
   /* Whether to open the funding flow in a tab or a popup window */
   openIn?: 'popup' | 'tab';
   /**
+   * Size of the popup window if `openIn` is set to `popup`
    * Note: popupSize will be ignored when using a Coinbase Onramp URL (i.e. https://pay.coinbase.com/*) as it requires
    * a fixed popup size.
    */
-  popupSize?: 'sm' | 'md' | 'lg'; // Size of the popup window if `openIn` is set to `popup`
-  target?: string; // Where to open the target if `openIn` is set to tab
-  fiatCurrency?: string; // The currency code of the fiat amount provided in the presetFiatAmount param e.g. USD, CAD, EUR.
-  onPopupClose?: () => void; // A callback function that will be called when the popup window is closed
-  onClick?: () => void; // A callback function that will be called when the button is clicked
+  popupSize?: 'sm' | 'md' | 'lg';
+  /* Where to open the target if `openIn` is set to tab */
+  target?: string;
+  /* The currency code of the fiat amount provided in the presetFiatAmount param e.g. USD, CAD, EUR. */
+  fiatCurrency?: string;
+  /* A callback function that will be called when the popup window is closed */
+  onPopupClose?: () => void;
+  /* A callback function that will be called when the button is clicked */
+  onClick?: () => void;
 };
 
 export type FundButtonRenderParams = {

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -120,7 +120,7 @@ type FundButtonBaseProps = {
   /* A optional prop to disable the fund button */
   disabled?: boolean;
   /* The state of the button component */
-  state?: FundButtonStateReact;
+  state?: FundButtonState;
   /* An optional prop to provide a custom funding URL */
   fundingUrl?: string;
   /* Whether to open the funding flow in a tab or a popup window */
@@ -143,7 +143,7 @@ type FundButtonBaseProps = {
 
 export type FundButtonRenderParams = {
   /* The state of the button component, only relevant when using FundCardSubmitButton */
-  status: FundButtonStateReact;
+  status: FundButtonState;
   /* A callback function that will be called when the button is clicked */
   onClick: (e: React.MouseEvent) => void;
   /* Whether the button is disabled */
@@ -153,7 +153,7 @@ export type FundButtonRenderParams = {
 /**
  * Note: exported as public Type
  */
-export type FundButtonReact =
+export type FundButtonProps =
   | (FundButtonBaseProps & {
       render?: (props: FundButtonRenderParams) => React.ReactNode;
       /* An optional React node to be displayed in the button component */
@@ -180,7 +180,7 @@ export type FundCardSubmitButtonProps =
       children?: ReactNode;
     };
 
-export type FundButtonStateReact = 'default' | 'success' | 'error' | 'loading';
+export type FundButtonState = 'default' | 'success' | 'error' | 'loading';
 
 /**
  * Matches a JSON object.
@@ -363,19 +363,19 @@ export type OnrampPaymentCurrency = {
   iconUrl: string;
 };
 
-export type FundCardAmountInputPropsReact = {
+export type FundCardAmountInputProps = {
   className?: string;
 };
 
-export type FundCardAmountInputTypeSwitchPropsReact = {
+export type FundCardAmountInputTypeSwitchProps = {
   className?: string;
 };
 
-export type FundCardHeaderPropsReact = {
+export type FundCardHeaderProps = {
   className?: string;
 };
 
-export type FundCardPaymentMethodImagePropsReact = {
+export type FundCardPaymentMethodImageProps = {
   className?: string;
   size?: number;
   paymentMethod: PaymentMethod;
@@ -390,18 +390,14 @@ export type PaymentMethod = {
   maxAmount?: number;
 };
 
-export type FundCardPaymentMethodDropdownPropsReact = {
+export type FundCardPaymentMethodDropdownProps = {
   className?: string;
-};
-
-export type FundCardCurrencyLabelPropsReact = {
-  label: string;
 };
 
 /**
  * Note: exported as public Type
  */
-export type FundCardPropsReact = {
+export type FundCardProps = {
   children?: ReactNode;
   assetSymbol: string;
   placeholder?: string | React.ReactNode;
@@ -414,18 +410,18 @@ export type FundCardPropsReact = {
   presetAmountInputs?: PresetAmountInputs;
 } & LifecycleEvents;
 
-export type FundCardContentPropsReact = {
+export type FundCardContentProps = {
   children?: ReactNode;
 };
 
-export type FundCardPaymentMethodSelectorTogglePropsReact = {
+export type FundCardPaymentMethodSelectorToggleProps = {
   className?: string;
   isOpen: boolean; // Determines carot icon direction
   onClick: () => void; // Button on click handler
   paymentMethod: PaymentMethod;
 };
 
-export type FundCardPaymentMethodSelectRowPropsReact = {
+export type FundCardPaymentMethodSelectRowProps = {
   paymentMethod: PaymentMethod;
   onClick?: (paymentMethod: PaymentMethod) => void;
   hideImage?: boolean;
@@ -435,7 +431,7 @@ export type FundCardPaymentMethodSelectRowPropsReact = {
   testId?: string;
 };
 
-export type FundCardProviderReact = {
+export type FundCardProviderProps = {
   children: ReactNode;
   asset: string;
   /**
@@ -481,7 +477,7 @@ export type LifecycleStatus =
       statusData: null;
     };
 
-export type PresetAmountInputItemPropsReact = {
+export type PresetAmountInputItemProps = {
   presetAmountInput: string;
   currency: string;
   onClick: (presetAmountInput: string) => void;

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -136,21 +136,28 @@ type FundButtonBaseProps = {
   onClick?: () => void; // A callback function that will be called when the button is clicked
 };
 
+export type FundButtonRenderParams = {
+  /* The state of the button component, only relevant when using FundCardSubmitButton */
+  state: FundButtonStateReact;
+  /* A callback function that will be called when the button is clicked */
+  onClick: (e: React.MouseEvent) => void;
+  /* Whether the button is disabled */
+  isDisabled: boolean;
+};
+
 /**
  * Note: exported as public Type
  */
 export type FundButtonReact =
   | (FundButtonBaseProps & {
-      render?: (props: {
-        state: FundButtonStateReact;
-        onClick: (e: React.MouseEvent) => void;
-        isDisabled: boolean;
-      }) => React.ReactNode;
-      children?: never; // An optional React node to be displayed in the button component
+      render?: (props: FundButtonRenderParams) => React.ReactNode;
+      /* An optional React node to be displayed in the button component */
+      children?: never;
     })
   | (FundButtonBaseProps & {
       render?: never;
-      children?: ReactNode; // An optional React node to be displayed in the button component
+      /* An optional React node to be displayed in the button component */
+      children?: ReactNode;
     });
 
 /**
@@ -158,16 +165,14 @@ export type FundButtonReact =
  */
 export type FundCardSubmitButtonProps =
   | {
-      render?: (props: {
-        state: FundButtonStateReact;
-        onClick: (e: React.MouseEvent) => void;
-        isDisabled: boolean;
-      }) => React.ReactNode;
-      children?: never; // An optional React node to be displayed in the button component
+      render?: (props: FundButtonRenderParams) => React.ReactNode;
+      /* An optional React node to be displayed in the button component */
+      children?: never;
     }
   | {
       render?: never;
-      children?: ReactNode; // An optional React node to be displayed in the button component
+      /* An optional React node to be displayed in the button component */
+      children?: ReactNode;
     };
 
 export type FundButtonStateReact = 'default' | 'success' | 'error' | 'loading';

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import React from 'react';
 
 /**
  * Props used to get an Onramp buy URL by directly providing a CDP project ID.
@@ -116,13 +117,9 @@ type GetOnrampBuyUrlOptionalProps = {
  */
 export type FundButtonReact = {
   className?: string; // An optional CSS class name for styling the button component
+  children?: ReactNode; // An optional React node to be displayed in the button component
   disabled?: boolean; // A optional prop to disable the fund button
-  text?: string; // An optional text to be displayed in the button component
-  successText?: string; // An optional text to be displayed in the button component when the transaction is successful
-  errorText?: string; // An optional text to be displayed in the button component when the transaction fails
   state?: FundButtonStateReact; // The state of the button component
-  hideText?: boolean; // An optional prop to hide the text in the button component
-  hideIcon?: boolean; // An optional prop to hide the icon in the button component
   fundingUrl?: string; // An optional prop to provide a custom funding URL
   openIn?: 'popup' | 'tab'; // Whether to open the funding flow in a tab or a popup window
   /**
@@ -130,11 +127,15 @@ export type FundButtonReact = {
    * a fixed popup size.
    */
   popupSize?: 'sm' | 'md' | 'lg'; // Size of the popup window if `openIn` is set to `popup`
-  rel?: string; // Specifies the relationship between the current document and the linked document
   target?: string; // Where to open the target if `openIn` is set to tab
   fiatCurrency?: string; // The currency code of the fiat amount provided in the presetFiatAmount param e.g. USD, CAD, EUR.
   onPopupClose?: () => void; // A callback function that will be called when the popup window is closed
   onClick?: () => void; // A callback function that will be called when the button is clicked
+  render?: (props: {
+    state: FundButtonStateReact;
+    onClick: (e: React.MouseEvent) => void;
+    isDisabled: boolean;
+  }) => React.ReactNode;
 };
 
 export type FundButtonStateReact = 'default' | 'success' | 'error' | 'loading';

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -112,16 +112,19 @@ type GetOnrampBuyUrlOptionalProps = {
   originComponentName?: string;
 };
 
-/**
- * Note: exported as public Type
- */
-export type FundButtonReact = {
-  className?: string; // An optional CSS class name for styling the button component
-  children?: ReactNode; // An optional React node to be displayed in the button component
-  disabled?: boolean; // A optional prop to disable the fund button
-  state?: FundButtonStateReact; // The state of the button component
-  fundingUrl?: string; // An optional prop to provide a custom funding URL
-  openIn?: 'popup' | 'tab'; // Whether to open the funding flow in a tab or a popup window
+type FundButtonBaseProps = {
+  /* An optional CSS class name for styling the button component */
+  className?: string;
+  /* An optional React node to be displayed in the button component */
+  children?: ReactNode;
+  /* A optional prop to disable the fund button */
+  disabled?: boolean;
+  /* The state of the button component */
+  state?: FundButtonStateReact;
+  /* An optional prop to provide a custom funding URL */
+  fundingUrl?: string;
+  /* Whether to open the funding flow in a tab or a popup window */
+  openIn?: 'popup' | 'tab';
   /**
    * Note: popupSize will be ignored when using a Coinbase Onramp URL (i.e. https://pay.coinbase.com/*) as it requires
    * a fixed popup size.
@@ -131,12 +134,41 @@ export type FundButtonReact = {
   fiatCurrency?: string; // The currency code of the fiat amount provided in the presetFiatAmount param e.g. USD, CAD, EUR.
   onPopupClose?: () => void; // A callback function that will be called when the popup window is closed
   onClick?: () => void; // A callback function that will be called when the button is clicked
-  render?: (props: {
-    state: FundButtonStateReact;
-    onClick: (e: React.MouseEvent) => void;
-    isDisabled: boolean;
-  }) => React.ReactNode;
 };
+
+/**
+ * Note: exported as public Type
+ */
+export type FundButtonReact =
+  | (FundButtonBaseProps & {
+      render?: (props: {
+        state: FundButtonStateReact;
+        onClick: (e: React.MouseEvent) => void;
+        isDisabled: boolean;
+      }) => React.ReactNode;
+      children?: never; // An optional React node to be displayed in the button component
+    })
+  | (FundButtonBaseProps & {
+      render?: never;
+      children?: ReactNode; // An optional React node to be displayed in the button component
+    });
+
+/**
+ * Note: exported as public Type
+ */
+export type FundCardSubmitButtonProps =
+  | {
+      render?: (props: {
+        state: FundButtonStateReact;
+        onClick: (e: React.MouseEvent) => void;
+        isDisabled: boolean;
+      }) => React.ReactNode;
+      children?: never; // An optional React node to be displayed in the button component
+    }
+  | {
+      render?: never;
+      children?: ReactNode; // An optional React node to be displayed in the button component
+    };
 
 export type FundButtonStateReact = 'default' | 'success' | 'error' | 'loading';
 

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -143,7 +143,7 @@ type FundButtonBaseProps = {
 
 export type FundButtonRenderParams = {
   /* The state of the button component, only relevant when using FundCardSubmitButton */
-  state: FundButtonStateReact;
+  status: FundButtonStateReact;
   /* A callback function that will be called when the button is clicked */
   onClick: (e: React.MouseEvent) => void;
   /* Whether the button is disabled */

--- a/packages/playground/components/Demo.tsx
+++ b/packages/playground/components/Demo.tsx
@@ -9,6 +9,7 @@ import DemoOptions from './DemoOptions';
 import BuyDemo from './demo/Buy';
 import CheckoutDemo from './demo/Checkout';
 import FundButtonDemo from './demo/FundButton';
+import FundButtonWithRenderPropDemo from './demo/FundButtonWithRenderProp';
 import FundCardDemo from './demo/FundCard';
 import IdentityDemo from './demo/Identity';
 import { IdentityCardDemo } from './demo/IdentityCard';
@@ -28,6 +29,7 @@ import WalletIslandDemo from './demo/WalletIsland';
 
 const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
   [OnchainKitComponent.FundButton]: FundButtonDemo,
+  [OnchainKitComponent.FundButtonWithRenderProp]: FundButtonWithRenderPropDemo,
   [OnchainKitComponent.FundCard]: FundCardDemo,
   [OnchainKitComponent.Buy]: BuyDemo,
   [OnchainKitComponent.Identity]: IdentityDemo,

--- a/packages/playground/components/demo/FundButtonWithRenderProp.tsx
+++ b/packages/playground/components/demo/FundButtonWithRenderProp.tsx
@@ -1,0 +1,104 @@
+import { cn } from '@/lib/utils';
+import {
+  FundCard,
+  FundCardAmountInput,
+  FundCardAmountInputTypeSwitch,
+  FundCardHeader,
+  FundCardPaymentMethodDropdown,
+  FundCardPresetAmountInputList,
+  FundCardSubmitButton,
+} from '@coinbase/onchainkit/fund';
+import { border, color, pressable, text } from '@coinbase/onchainkit/theme';
+import {
+  FundButtonStateReact,
+  PresetAmountInputs,
+} from '../../../onchainkit/dist/fund/types';
+
+function Spinner() {
+  return (
+    <div
+      className="flex h-full items-center justify-center"
+      data-testid="ockSpinner"
+    >
+      <div
+        className={cn(
+          'animate-spin border-2 border-gray-200 border-t-3',
+          'rounded-full border-t-gray-400 px-2.5 py-2.5',
+        )}
+      />
+    </div>
+  );
+}
+
+function customRender({
+  state,
+  onClick,
+  isDisabled,
+}: {
+  state: FundButtonStateReact;
+  onClick: (e: React.MouseEvent) => void;
+  isDisabled: boolean;
+}) {
+  const classNames = cn(
+    'w-full',
+    'bg-purple-500',
+    'px-4 py-3 inline-flex items-center justify-center space-x-2',
+    {
+      [pressable.disabled]: isDisabled,
+    },
+    text.headline,
+    border.radius,
+    color.inverse,
+  );
+
+  let buttonContent = <span>Click to fund</span>;
+
+  if (state === 'loading') {
+    buttonContent = <Spinner />;
+  }
+
+  if (state === 'success') {
+    buttonContent = <span>Success</span>;
+  }
+
+  if (state === 'error') {
+    buttonContent = <span>Something went wrong</span>;
+  }
+
+  return (
+    <button className={classNames} onClick={onClick} disabled={isDisabled}>
+      {buttonContent}
+    </button>
+  );
+}
+
+const presetAmountInputs: PresetAmountInputs = ['10', '20', '100'];
+
+export default function FundButtonWithRenderPropDemo() {
+  return (
+    <div className="mx-auto grid w-1/2 gap-8">
+      <FundCard
+        assetSymbol="ETH"
+        country="US"
+        currency="USD"
+        presetAmountInputs={presetAmountInputs}
+        onError={(error) => {
+          console.log('FundCard onError', error);
+        }}
+        onStatus={(status) => {
+          console.log('FundCard onStatus', status);
+        }}
+        onSuccess={() => {
+          console.log('FundCard onSuccess');
+        }}
+      >
+        <FundCardHeader />
+        <FundCardAmountInput />
+        <FundCardAmountInputTypeSwitch />
+        <FundCardPresetAmountInputList />
+        <FundCardPaymentMethodDropdown />
+        <FundCardSubmitButton render={customRender} />
+      </FundCard>
+    </div>
+  );
+}

--- a/packages/playground/components/demo/FundButtonWithRenderProp.tsx
+++ b/packages/playground/components/demo/FundButtonWithRenderProp.tsx
@@ -10,7 +10,7 @@ import {
 } from '@coinbase/onchainkit/fund';
 import { border, color, pressable, text } from '@coinbase/onchainkit/theme';
 import {
-  FundButtonStateReact,
+  FundButtonState,
   PresetAmountInputs,
 } from '../../../onchainkit/dist/fund/types';
 
@@ -31,11 +31,11 @@ function Spinner() {
 }
 
 function customRender({
-  state,
+  status,
   onClick,
   isDisabled,
 }: {
-  state: FundButtonStateReact;
+  status: FundButtonState;
   onClick: (e: React.MouseEvent) => void;
   isDisabled: boolean;
 }) {
@@ -53,15 +53,15 @@ function customRender({
 
   let buttonContent = <span>Click to fund</span>;
 
-  if (state === 'loading') {
+  if (status === 'loading') {
     buttonContent = <Spinner />;
   }
 
-  if (state === 'success') {
+  if (status === 'success') {
     buttonContent = <span>Success</span>;
   }
 
-  if (state === 'error') {
+  if (status === 'error') {
     buttonContent = <span>Something went wrong</span>;
   }
 

--- a/packages/playground/components/form/active-component.tsx
+++ b/packages/playground/components/form/active-component.tsx
@@ -27,11 +27,12 @@ export function ActiveComponent() {
         </SelectTrigger>
         <SelectContent>
           <SelectItem value={OnchainKitComponent.FundButton}>
-            Fund Button
+            FundButton
           </SelectItem>
-          <SelectItem value={OnchainKitComponent.FundCard}>
-            Fund Card
+          <SelectItem value={OnchainKitComponent.FundButtonWithRenderProp}>
+            FundButtonWithRenderProp
           </SelectItem>
+          <SelectItem value={OnchainKitComponent.FundCard}>FundCard</SelectItem>
           <SelectItem value={OnchainKitComponent.Buy}>Buy</SelectItem>
           <SelectItem value={OnchainKitComponent.Identity}>Identity</SelectItem>
           <SelectItem value={OnchainKitComponent.IdentityCard}>

--- a/packages/playground/types/onchainkit.ts
+++ b/packages/playground/types/onchainkit.ts
@@ -1,5 +1,6 @@
 export enum OnchainKitComponent {
   FundButton = 'fund-button',
+  FundButtonWithRenderProp = 'fund-button-with-render-prop',
   FundCard = 'fund-card',
   Buy = 'buy',
   Identity = 'identity',


### PR DESCRIPTION
**What changed? Why?**
- add render prop to FundButton and remove display props 
- add children prop to FundButton (mutually exclusive with render prop)
- remove `text`, `successText`, `errorText`, `hideIcon`, `hideText` props

```js

<FundCardSubmitButton render={customRender} />

<FundButton render={customRender} />


```

**Notes to reviewers**

**How has it been tested?**
