### PR TITLE
fix: support an insecure fallback for session id to allow for testing on http contexts

### DIFF
--- a/packages/onchainkit/src/OnchainKitProvider.tsx
+++ b/packages/onchainkit/src/OnchainKitProvider.tsx
@@ -12,6 +12,7 @@ import type { OnchainKitContextType } from './core/types';
 import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from './identity/constants';
 import { checkHashLength } from './internal/utils/checkHashLength';
 import type { OnchainKitProviderReact } from './types';
+import { generateUUIDWithInsecureFallback } from './utils/crypto';
 
 export const OnchainKitContext =
   createContext<OnchainKitContextType>(ONCHAIN_KIT_CONFIG);
@@ -34,7 +35,7 @@ export function OnchainKitProvider({
     throw Error('EAS schemaId must be 64 characters prefixed with "0x"');
   }
 
-  const sessionId = useMemo(() => crypto.randomUUID(), []);
+  const sessionId = useMemo(() => generateUUIDWithInsecureFallback(), []);
 
   // eslint-disable-next-line complexity
   const value = useMemo(() => {

--- a/packages/onchainkit/src/utils/crypto.test.ts
+++ b/packages/onchainkit/src/utils/crypto.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+import { generateUUIDWithInsecureFallback } from './crypto';
+
+describe('generateUUIDWithInsecureFallback', () => {
+  it('should generate a UUID when crypto is defined', () => {
+    vi.mock('crypto', () => ({
+      randomUUID: vi.fn(() => '123e4567-e89b-12d3-a456-426614174000'),
+    }));
+
+    const uuid = generateUUIDWithInsecureFallback();
+    expect(uuid).toBeDefined();
+    expect(uuid.length).toBe(36);
+  });
+
+  it('should generate a UUID when crypto is not defined', () => {
+    vi.mock('crypto', () => ({
+      randomUUID: undefined,
+    }));
+
+    const uuid = generateUUIDWithInsecureFallback();
+    expect(uuid).toBeDefined();
+    expect(uuid.length).toBe(36);
+  });
+});

--- a/packages/onchainkit/src/utils/crypto.test.ts
+++ b/packages/onchainkit/src/utils/crypto.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import { generateUUIDWithInsecureFallback } from './crypto';
+import { beforeEach } from 'node:test';
 
 describe('generateUUIDWithInsecureFallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should generate a UUID when crypto is defined', () => {
     vi.mock('crypto', () => ({
       randomUUID: vi.fn(() => '123e4567-e89b-12d3-a456-426614174000'),
@@ -13,9 +18,10 @@ describe('generateUUIDWithInsecureFallback', () => {
   });
 
   it('should generate a UUID when crypto is not defined', () => {
-    vi.mock('crypto', () => ({
+    vi.stubGlobal('crypto', {
       randomUUID: undefined,
-    }));
+      getRandomValues: () => new Uint8Array(16),
+    });
 
     const uuid = generateUUIDWithInsecureFallback();
     expect(uuid).toBeDefined();

--- a/packages/onchainkit/src/utils/crypto.ts
+++ b/packages/onchainkit/src/utils/crypto.ts
@@ -1,0 +1,20 @@
+/**
+ * Generates a UUID using the crypto API if available, otherwise falls back to a
+ * more insecure method. Only use this for non-critical purposes.
+ *
+ * @returns string - A UUID string that may not be cryptographically secure
+ */
+export const generateUUIDWithInsecureFallback = () => {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+};

--- a/packages/onchainkit/src/utils/crypto.ts
+++ b/packages/onchainkit/src/utils/crypto.ts
@@ -12,9 +12,35 @@ export const generateUUIDWithInsecureFallback = () => {
     return crypto.randomUUID();
   }
 
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+  // Secure fallback using crypto.getRandomValues
+  const getRandomValues = (size: number) => {
+    const array = new Uint8Array(size);
+    crypto.getRandomValues(array);
+    return array;
+  };
+
+  const bytes = getRandomValues(16);
+  // Format the random bytes into a UUID string
+  return (
+    bytes[0].toString(16).padStart(2, '0') +
+    bytes[1].toString(16).padStart(2, '0') +
+    bytes[2].toString(16).padStart(2, '0') +
+    bytes[3].toString(16).padStart(2, '0') +
+    '-' +
+    bytes[4].toString(16).padStart(2, '0') +
+    bytes[5].toString(16).padStart(2, '0') +
+    '-' +
+    ((bytes[6] & 0x0f) | 0x40).toString(16).padStart(2, '0') + // UUID version 4
+    bytes[7].toString(16).padStart(2, '0') +
+    '-' +
+    ((bytes[8] & 0x3f) | 0x80).toString(16).padStart(2, '0') + // UUID variant
+    bytes[9].toString(16).padStart(2, '0') +
+    '-' +
+    bytes[10].toString(16).padStart(2, '0') +
+    bytes[11].toString(16).padStart(2, '0') +
+    bytes[12].toString(16).padStart(2, '0') +
+    bytes[13].toString(16).padStart(2, '0') +
+    bytes[14].toString(16).padStart(2, '0') +
+    bytes[15].toString(16).padStart(2, '0')
+  );
 };

--- a/packages/onchainkit/src/utils/crypto.ts
+++ b/packages/onchainkit/src/utils/crypto.ts
@@ -1,3 +1,10 @@
+// Secure fallback using crypto.getRandomValues
+const getRandomValues = (size: number) => {
+  const array = new Uint8Array(size);
+  crypto.getRandomValues(array);
+  return array;
+};
+
 /**
  * Generates a UUID using the crypto API if available, otherwise falls back to a
  * more insecure method. Only use this for non-critical purposes.
@@ -11,13 +18,6 @@ export const generateUUIDWithInsecureFallback = () => {
   ) {
     return crypto.randomUUID();
   }
-
-  // Secure fallback using crypto.getRandomValues
-  const getRandomValues = (size: number) => {
-    const array = new Uint8Array(size);
-    crypto.getRandomValues(array);
-    return array;
-  };
 
   const bytes = getRandomValues(16);
   // Format the random bytes into a UUID string

--- a/packages/onchainkit/src/utils/crypto.ts
+++ b/packages/onchainkit/src/utils/crypto.ts
@@ -2,7 +2,7 @@
  * Generates a UUID using the crypto API if available, otherwise falls back to a
  * more insecure method. Only use this for non-critical purposes.
  *
- * @returns string - A UUID string that may not be cryptographically secure
+ * @returns A UUID string that may not be cryptographically secure
  */
 export const generateUUIDWithInsecureFallback = () => {
   if (


### PR DESCRIPTION
**What changed? Why?**

- Added a fallback for non-critical uuid usages to allow for testing in http environments

See issue https://github.com/coinbase/onchainkit/issues/2309

**Notes to reviewers**

Did not introduce `uuid` dependency to avoid bloating package/security concerns (though extremely unlikely), but it's a consideration we can make

**How has it been tested?**
