### PR TITLE
chore: Make create-onchain library public

### DIFF
--- a/packages/create-onchain/package.json
+++ b/packages/create-onchain/package.json
@@ -3,6 +3,9 @@
   "description": "Instantly create onchain applications with OnchainKit.",
   "version": "0.0.18",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "pnpm run clean && pnpm run build:esm+types && pnpm run build:manifest",
     "build:manifest": "pnpm --filter miniapp-manifest-generator build:copy --out $(pwd)/dist/manifest",


### PR DESCRIPTION
**What changed? Why?**

Marks `create-onchain` library as public

**Notes to reviewers**

**How has it been tested?**
