### PR TITLE
fix: Basenames bidirectional validation

### DIFF
--- a/.changeset/twenty-news-hide.md
+++ b/.changeset/twenty-news-hide.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+fix: Basename resolution

--- a/packages/onchainkit/src/identity/hooks/useAddress.test.tsx
+++ b/packages/onchainkit/src/identity/hooks/useAddress.test.tsx
@@ -1,7 +1,6 @@
 import { publicClient } from '@/core/network/client';
-import { getChainPublicClient } from '@/core/network/getChainPublicClient';
 import { renderHook, waitFor } from '@testing-library/react';
-import { base, baseSepolia, mainnet } from 'viem/chains';
+import { base, baseSepolia } from 'viem/chains';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getNewReactQueryTestProvider } from './getNewReactQueryTestProvider';
 import { useAddress } from './useAddress';

--- a/packages/onchainkit/src/identity/hooks/useAddress.test.tsx
+++ b/packages/onchainkit/src/identity/hooks/useAddress.test.tsx
@@ -55,7 +55,6 @@ describe('useAddress', () => {
       expect(result.current.data).toBe(testEnsAddress);
       expect(result.current.isLoading).toBe(false);
     });
-    expect(getChainPublicClient).toHaveBeenCalledWith(mainnet);
   });
 
   it('should return the loading state true while still fetching ENS address', async () => {
@@ -83,7 +82,6 @@ describe('useAddress', () => {
       expect(result.current.data).toBe(testEnsAddress);
       expect(result.current.isLoading).toBe(false);
     });
-    expect(getChainPublicClient).toHaveBeenCalledWith(base);
   });
 
   it('should return correct base sepolia address', async () => {
@@ -100,7 +98,6 @@ describe('useAddress', () => {
       expect(result.current.data).toBe(testEnsAddress);
       expect(result.current.isLoading).toBe(false);
     });
-    expect(getChainPublicClient).toHaveBeenCalledWith(baseSepolia);
   });
 
   it('correctly maps cacheTime to gcTime for backwards compatibility', async () => {

--- a/packages/onchainkit/src/identity/hooks/useAddresses.test.tsx
+++ b/packages/onchainkit/src/identity/hooks/useAddresses.test.tsx
@@ -1,7 +1,6 @@
 import { publicClient } from '@/core/network/client';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { Address } from 'viem';
-import { base, baseSepolia, mainnet, optimism } from 'viem/chains';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAddresses } from '../utils/getAddresses';
 import { getNewReactQueryTestProvider } from './getNewReactQueryTestProvider';
@@ -70,18 +69,16 @@ describe('useAddresses', () => {
 
     expect(getAddresses).toHaveBeenCalledWith({
       names: testNames,
-      chain: mainnet,
     });
   });
 
-  it('returns the correct addresses for custom chain', async () => {
+  it('returns the correct addresses for different name inputs', async () => {
     vi.mocked(getAddresses).mockResolvedValue(testAddresses);
 
     const { result } = renderHook(
       () =>
         useAddresses({
           names: testNames,
-          chain: base,
         }),
       {
         wrapper: getNewReactQueryTestProvider(),
@@ -95,20 +92,17 @@ describe('useAddresses', () => {
 
     expect(getAddresses).toHaveBeenCalledWith({
       names: testNames,
-      chain: base,
     });
   });
 
-  it('returns error for unsupported chain', async () => {
-    const errorMessage =
-      'ChainId not supported, name resolution is only supported on Ethereum and Base.';
+  it('returns error when name resolution fails', async () => {
+    const errorMessage = 'Error resolving names';
     vi.mocked(getAddresses).mockRejectedValue(errorMessage);
 
     const { result } = renderHook(
       () =>
         useAddresses({
           names: testNames,
-          chain: optimism,
         }),
       {
         wrapper: getNewReactQueryTestProvider(),
@@ -151,11 +145,7 @@ describe('useAddresses', () => {
 
     const options = mockUseQuery.mock.calls[0][0];
     expect(options).toHaveProperty('queryKey');
-    expect(options.queryKey).toEqual([
-      'useAddresses',
-      testNames.join(','),
-      mainnet.id,
-    ]);
+    expect(options.queryKey).toEqual(['useAddresses', testNames.join(',')]);
   });
 
   it('merges custom queryOptions with default options', async () => {
@@ -213,7 +203,7 @@ describe('useAddresses', () => {
     expect(optionsWithBoth).toHaveProperty('gcTime', mockGcTime);
   });
 
-  it('creates a stable query key based on names and chain', async () => {
+  it('creates a stable query key based on names', async () => {
     vi.mocked(getAddresses).mockResolvedValue(testAddresses);
 
     const { result, rerender } = renderHook(
@@ -251,7 +241,6 @@ describe('useAddresses', () => {
 
     expect(getAddresses).toHaveBeenCalledWith({
       names: testNames,
-      chain: mainnet,
     });
   });
 
@@ -291,32 +280,6 @@ describe('useAddresses', () => {
 
     expect(getAddresses).toHaveBeenCalledWith({
       names: testNames,
-      chain: mainnet,
-    });
-  });
-
-  it('supports Base Sepolia chain', async () => {
-    vi.mocked(getAddresses).mockResolvedValue(testAddresses);
-
-    const { result } = renderHook(
-      () =>
-        useAddresses({
-          names: testNames,
-          chain: baseSepolia,
-        }),
-      {
-        wrapper: getNewReactQueryTestProvider(),
-      },
-    );
-
-    await waitFor(() => {
-      expect(result.current.data).toEqual(testAddresses);
-      expect(result.current.isPending).toBe(false);
-    });
-
-    expect(getAddresses).toHaveBeenCalledWith({
-      names: testNames,
-      chain: baseSepolia,
     });
   });
 

--- a/packages/onchainkit/src/identity/hooks/useAddresses.ts
+++ b/packages/onchainkit/src/identity/hooks/useAddresses.ts
@@ -1,7 +1,6 @@
 import { getAddresses } from '@/identity/utils/getAddresses';
 import { DEFAULT_QUERY_OPTIONS } from '@/internal/constants';
 import { useQuery } from '@tanstack/react-query';
-import { mainnet } from 'viem/chains';
 import type {
   GetAddressReturnType,
   UseAddressesOptions,
@@ -13,11 +12,11 @@ import type {
  * multiple Ethereum addresses from ENS names or Basenames in a single batch request.
  */
 export const useAddresses = (
-  { names, chain = mainnet }: UseAddressesOptions,
+  { names }: UseAddressesOptions,
   queryOptions?: UseQueryOptions<GetAddressReturnType[]>,
 ) => {
   const namesKey = names.join(',');
-  const queryKey = ['useAddresses', namesKey, chain.id];
+  const queryKey = ['useAddresses', namesKey];
 
   return useQuery<GetAddressReturnType[]>({
     queryKey,

--- a/packages/onchainkit/src/identity/hooks/useAddresses.ts
+++ b/packages/onchainkit/src/identity/hooks/useAddresses.ts
@@ -21,7 +21,7 @@ export const useAddresses = (
 
   return useQuery<GetAddressReturnType[]>({
     queryKey,
-    queryFn: () => getAddresses({ names, chain }),
+    queryFn: () => getAddresses({ names }),
     enabled: !!names.length,
     ...DEFAULT_QUERY_OPTIONS,
     // Use cacheTime as gcTime for backward compatibility

--- a/packages/onchainkit/src/identity/types.ts
+++ b/packages/onchainkit/src/identity/types.ts
@@ -146,8 +146,6 @@ export type GetAddress = {
 export type GetAddresses = {
   /** Array of names to resolve addresses for */
   names: Array<string | Basename>;
-  /** Optional chain for domain resolution */
-  chain?: Chain;
 };
 
 /**

--- a/packages/onchainkit/src/identity/types.ts
+++ b/packages/onchainkit/src/identity/types.ts
@@ -299,8 +299,6 @@ export type UseAddressOptions = {
 export type UseAddressesOptions = {
   /** Array of ENS or Basenames to resolve addresses for */
   names: Array<string | Basename>;
-  /** Optional chain for domain resolution */
-  chain?: Chain;
 };
 
 /**

--- a/packages/onchainkit/src/identity/utils/getAddress.test.ts
+++ b/packages/onchainkit/src/identity/utils/getAddress.test.ts
@@ -1,6 +1,4 @@
 import { publicClient } from '@/core/network/client';
-import { getChainPublicClient } from '@/core/network/getChainPublicClient';
-import { mainnet } from 'viem/chains';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAddress } from './getAddress';
 

--- a/packages/onchainkit/src/identity/utils/getAddress.test.ts
+++ b/packages/onchainkit/src/identity/utils/getAddress.test.ts
@@ -1,6 +1,6 @@
 import { publicClient } from '@/core/network/client';
 import { getChainPublicClient } from '@/core/network/getChainPublicClient';
-import { base, baseSepolia, mainnet, optimism } from 'viem/chains';
+import { mainnet } from 'viem/chains';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAddress } from './getAddress';
 
@@ -24,27 +24,6 @@ describe('getAddress', () => {
     const address = await getAddress({ name });
     expect(address).toBe(expectedAddress);
     expect(mockGetEnsAddress).toHaveBeenCalledWith({ name });
-    expect(getChainPublicClient).toHaveBeenCalledWith(mainnet);
-  });
-
-  it('should resolve to base mainnet address', async () => {
-    const name = 'shrek.base.eth';
-    const expectedAddress = '0x1234';
-    mockGetEnsAddress.mockResolvedValue(expectedAddress);
-    const address = await getAddress({ name, chain: base });
-    expect(address).toBe(expectedAddress);
-    expect(getChainPublicClient).toHaveBeenCalledWith(base);
-    expect(getChainPublicClient).not.toHaveBeenCalledWith(mainnet);
-  });
-
-  it('should resolve to baseSepolia address', async () => {
-    const name = 'shrek.base.eth';
-    const expectedAddress = '0x1234';
-    mockGetEnsAddress.mockResolvedValue(expectedAddress);
-    const address = await getAddress({ name, chain: baseSepolia });
-    expect(address).toBe(expectedAddress);
-    expect(getChainPublicClient).toHaveBeenCalledWith(baseSepolia);
-    expect(getChainPublicClient).not.toHaveBeenCalledWith(mainnet);
   });
 
   it('should return null if address is not found', async () => {
@@ -53,14 +32,14 @@ describe('getAddress', () => {
     const address = await getAddress({ name });
     expect(address).toBeNull();
     expect(mockGetEnsAddress).toHaveBeenCalledWith({ name });
-    expect(getChainPublicClient).toHaveBeenCalledWith(mainnet);
   });
 
-  it('should throw an error on unsupported chain', async () => {
-    await expect(
-      getAddress({ name: 'test.ens', chain: optimism }),
-    ).rejects.toBe(
-      'ChainId not supported, name resolution is only supported on Ethereum and Base.',
-    );
+  it('should resolve basename correctly', async () => {
+    const name = 'shrek.base.eth';
+    const expectedAddress = '0x1234';
+    mockGetEnsAddress.mockResolvedValue(expectedAddress);
+    const address = await getAddress({ name });
+    expect(address).toBe(expectedAddress);
+    expect(mockGetEnsAddress).toHaveBeenCalledWith({ name });
   });
 });

--- a/packages/onchainkit/src/identity/utils/getAddress.ts
+++ b/packages/onchainkit/src/identity/utils/getAddress.ts
@@ -1,35 +1,19 @@
 import { getChainPublicClient } from '@/core/network/getChainPublicClient';
-import { isBase } from '@/core/utils/isBase';
-import { isEthereum } from '@/core/utils/isEthereum';
-import { RESOLVER_ADDRESSES_BY_CHAIN_ID } from '@/identity/constants';
 import type { GetAddress, GetAddressReturnType } from '@/identity/types';
-import { isBasename } from '@/identity/utils/isBasename';
 import { mainnet } from 'viem/chains';
+
+const mainnetClient = getChainPublicClient(mainnet);
 
 /**
  * Get address from ENS name or Basename.
  */
 export const getAddress = async ({
   name,
-  chain = mainnet,
 }: GetAddress): Promise<GetAddressReturnType> => {
-  const chainIsBase = isBase({ chainId: chain.id });
-  const chainIsEthereum = isEthereum({ chainId: chain.id });
-  const chainSupportsUniversalResolver = chainIsEthereum || chainIsBase;
-
-  if (!chainSupportsUniversalResolver) {
-    return Promise.reject(
-      'ChainId not supported, name resolution is only supported on Ethereum and Base.',
-    );
-  }
-
-  const client = getChainPublicClient(chain);
   // Gets address for ENS name.
-  const address = await client.getEnsAddress({
+  const address = await mainnetClient.getEnsAddress({
     name,
-    universalResolverAddress: isBasename(name)
-      ? RESOLVER_ADDRESSES_BY_CHAIN_ID[chain.id]
-      : undefined,
   });
+
   return address ?? null;
 };

--- a/packages/onchainkit/src/identity/utils/getName.test.ts
+++ b/packages/onchainkit/src/identity/utils/getName.test.ts
@@ -43,7 +43,6 @@ describe('getName', () => {
     expect(mockGetEnsName).toHaveBeenCalledWith({ address: walletAddress });
     expect(mockGetAddress).toHaveBeenCalledWith({
       name: expectedEnsName,
-      chain: mainnet,
     });
   });
 
@@ -60,7 +59,6 @@ describe('getName', () => {
     expect(mockGetEnsName).toHaveBeenCalledWith({ address: walletAddress });
     expect(mockGetAddress).toHaveBeenCalledWith({
       name: ensName,
-      chain: mainnet,
     });
   });
 
@@ -75,7 +73,6 @@ describe('getName', () => {
     expect(name).toBeNull();
     expect(mockGetAddress).toHaveBeenCalledWith({
       name: ensName,
-      chain: mainnet,
     });
   });
 
@@ -91,7 +88,6 @@ describe('getName', () => {
     expect(mockGetEnsName).toHaveBeenCalledWith({ address: walletAddress });
     expect(mockGetAddress).toHaveBeenCalledWith({
       name: ensName,
-      chain: mainnet,
     });
   });
 
@@ -107,7 +103,6 @@ describe('getName', () => {
     expect(mockReadContract).toHaveBeenCalled();
     expect(mockGetAddress).toHaveBeenCalledWith({
       name: expectedBaseName,
-      chain: base,
     });
 
     expect(mockGetEnsName).not.toHaveBeenCalled();

--- a/packages/onchainkit/src/identity/utils/getName.ts
+++ b/packages/onchainkit/src/identity/utils/getName.ts
@@ -44,7 +44,6 @@ export const getName = async ({
         try {
           const resolvedAddress = await getAddress({
             name: basename,
-            chain: base,
           });
 
           if (

--- a/packages/onchainkit/src/identity/utils/getName.ts
+++ b/packages/onchainkit/src/identity/utils/getName.ts
@@ -79,7 +79,6 @@ export const getName = async ({
       try {
         const resolvedAddress = await getAddress({
           name: ensName,
-          chain: mainnet,
         });
 
         if (

--- a/packages/onchainkit/src/identity/utils/getNames.ts
+++ b/packages/onchainkit/src/identity/utils/getNames.ts
@@ -70,7 +70,6 @@ export const getNames = async ({
           );
           const resolvedAddresses = await getAddresses({
             names: basenames,
-            chain: base,
           });
 
           // Update results with validated basenames
@@ -150,7 +149,6 @@ export const getNames = async ({
           const ensNames = ensNamesWithIndices.map(({ ensName }) => ensName);
           const resolvedAddresses = await getAddresses({
             names: ensNames,
-            chain: mainnet,
           });
 
           // Update results with validated ENS names

--- a/packages/onchainkit/src/identity/utils/getNames.ts
+++ b/packages/onchainkit/src/identity/utils/getNames.ts
@@ -1,5 +1,5 @@
 import type { Basename, GetNameReturnType, GetNames } from '@/identity/types';
-import { base, mainnet } from 'viem/chains';
+import { mainnet } from 'viem/chains';
 import { getChainPublicClient } from '../../core/network/getChainPublicClient';
 import { isBase } from '../../core/utils/isBase';
 import { isEthereum } from '../../core/utils/isEthereum';


### PR DESCRIPTION
**What changed? Why?**

Updates calls to `viem.client.getEnsAddress` to use the mainnet client exclusively.

This is the intended way to do ENS resolution. This was only working until recently because the function signature expected by Viem matched our Basenames resolver, but this changed in a recent update to Viem.

**Notes to reviewers**

**How has it been tested?**
