### PR TITLE
docs: fix broken link

### DIFF
--- a/packages/onchainkit/CHANGELOG.md
+++ b/packages/onchainkit/CHANGELOG.md
@@ -198,7 +198,7 @@
 
   To fully disable telemetry collection, set the `analytics` flag to `false` in your OnchainKit Provider:
 
-  Learn more at https://onchainkit.xyz/guides/telemetry
+  Learn more at https://docs.base.org/builderkits/onchainkit/guides/telemetry
 
 ## 0.36.11
 


### PR DESCRIPTION
**What changed? Why?**
changed link, previous one was 404

