### PR TITLE
chore: enable paymaster for wallet advanced Send

### DIFF
--- a/packages/onchainkit/src/wallet/components/Wallet.tsx
+++ b/packages/onchainkit/src/wallet/components/Wallet.tsx
@@ -32,6 +32,7 @@ export function Wallet({
   className,
   draggable,
   draggableStartingPosition,
+  isSponsored,
 }: WalletReact) {
   const componentTheme = useTheme();
   const isMounted = useIsMounted();
@@ -42,7 +43,7 @@ export function Wallet({
   }
 
   return (
-    <WalletProvider>
+    <WalletProvider isSponsored={isSponsored}>
       <WalletContent
         className={cn(componentTheme, className)}
         {...getWalletDraggableProps({ draggable, draggableStartingPosition })}

--- a/packages/onchainkit/src/wallet/components/WalletIsland.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletIsland.tsx
@@ -13,11 +13,17 @@ import { WalletDropdown } from './WalletDropdown';
 
 export function WalletIsland({
   startingPosition = getDefaultDraggableStartingPosition(),
+  isSponsored,
 }: {
   startingPosition?: { x: number; y: number };
+  isSponsored?: boolean;
 }) {
   return (
-    <Wallet draggable={true} draggableStartingPosition={startingPosition}>
+    <Wallet
+      draggable={true}
+      draggableStartingPosition={startingPosition}
+      isSponsored={isSponsored}
+    >
       <ConnectWallet
         className="!rounded-full m-0 flex h-14 w-14 min-w-14 flex-col items-center justify-center p-0"
         disconnectedLabel={<div className="h-5 w-5">{portfolioSvg}</div>}

--- a/packages/onchainkit/src/wallet/components/WalletProvider.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletProvider.tsx
@@ -23,9 +23,11 @@ const WalletContext = createContext<WalletContextType>(emptyContext);
 
 export type WalletProviderReact = {
   children: ReactNode;
+  /** Whether to sponsor transactions for Send feature of advanced wallet implementation */
+  isSponsored?: boolean;
 };
 
-export function WalletProvider({ children }: WalletProviderReact) {
+export function WalletProvider({ children, isSponsored }: WalletProviderReact) {
   const { chain } = useOnchainKit();
   const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
   const [isSubComponentOpen, setIsSubComponentOpen] = useState(false);
@@ -81,6 +83,7 @@ export function WalletProvider({ children }: WalletProviderReact) {
       isActiveFeatureClosing,
       setIsActiveFeatureClosing,
       animations,
+      isSponsored,
     };
   }, [
     address,
@@ -95,6 +98,7 @@ export function WalletProvider({ children }: WalletProviderReact) {
     activeFeature,
     isActiveFeatureClosing,
     animations,
+    isSponsored,
   ]);
 
   return (

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendButton.test.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendButton.test.tsx
@@ -164,34 +164,12 @@ describe('SendButton', () => {
     ).toBeInTheDocument();
   });
 
-  it('passes custom label to TransactionButton', () => {
-    render(<SendButton label="Custom Send" />);
-
-    expect(TransactionButton).toHaveBeenCalledWith(
-      expect.objectContaining({
-        text: 'Custom Send',
-      }),
-      {},
-    );
-  });
-
   it('passes isSponsored prop to Transaction', () => {
     render(<SendButton isSponsored={true} />);
 
     expect(Transaction).toHaveBeenCalledWith(
       expect.objectContaining({
         isSponsored: true,
-      }),
-      {},
-    );
-  });
-
-  it('passes className to TransactionButton', () => {
-    render(<SendButton className="custom-button-class" />);
-
-    expect(TransactionButton).toHaveBeenCalledWith(
-      expect.objectContaining({
-        className: 'custom-button-class',
       }),
       {},
     );
@@ -204,17 +182,6 @@ describe('SendButton', () => {
     });
 
     render(<SendButton />);
-
-    expect(TransactionButton).toHaveBeenCalledWith(
-      expect.objectContaining({
-        disabled: true,
-      }),
-      {},
-    );
-  });
-
-  it('disables button when disabled prop is true', () => {
-    render(<SendButton disabled={true} />);
 
     expect(TransactionButton).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -347,29 +314,6 @@ describe('SendButton', () => {
     expect(mockSendContext.updateLifecycleStatus).not.toHaveBeenCalled();
   });
 
-  it('passes custom overrides to TransactionButton', () => {
-    const pendingOverride = { text: 'Sending...' };
-    const successOverride = { text: 'Sent!' };
-    const errorOverride = { text: 'Failed!' };
-
-    render(
-      <SendButton
-        pendingOverride={pendingOverride}
-        successOverride={successOverride}
-        errorOverride={errorOverride}
-      />,
-    );
-
-    expect(TransactionButton).toHaveBeenCalledWith(
-      expect.objectContaining({
-        pendingOverride,
-        successOverride,
-        errorOverride,
-      }),
-      {},
-    );
-  });
-
   it('handles null wallet address correctly', () => {
     mockUseWalletContext.mockReturnValue({
       ...mockWalletContext,
@@ -404,7 +348,7 @@ describe('SendButton', () => {
       setActiveFeature,
     });
 
-    render(<SendButton label="Send" />);
+    render(<SendButton />);
 
     const { onComplete } = mockDefaultSendTxSuccessHandler.mock.calls[0][0];
 

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendButton.test.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendButton.test.tsx
@@ -135,6 +135,7 @@ describe('SendButton', () => {
     mockUseWalletContext.mockReturnValue({
       ...mockWalletContext,
       ...mockWalletAdvancedContext,
+      isSponsored: false,
     });
     mockUseSendContext.mockReturnValue(mockSendContext);
     mockUseTransactionContext.mockReturnValue(mockTransactionContext);
@@ -162,17 +163,6 @@ describe('SendButton', () => {
     expect(
       screen.getByTestId('mock-transaction-status-action'),
     ).toBeInTheDocument();
-  });
-
-  it('passes isSponsored prop to Transaction', () => {
-    render(<SendButton isSponsored={true} />);
-
-    expect(Transaction).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isSponsored: true,
-      }),
-      {},
-    );
   });
 
   it('disables button when input amount is invalid', () => {

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendButton.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendButton.tsx
@@ -8,10 +8,7 @@ import { useTransactionContext } from '@/transaction/components/TransactionProvi
 import { TransactionStatus } from '@/transaction/components/TransactionStatus';
 import { TransactionStatusAction } from '@/transaction/components/TransactionStatusAction';
 import { TransactionStatusLabel } from '@/transaction/components/TransactionStatusLabel';
-import type {
-  LifecycleStatus,
-  TransactionButtonReact,
-} from '@/transaction/types';
+import type { LifecycleStatus } from '@/transaction/types';
 import { useCallback } from 'react';
 import { parseUnits } from 'viem';
 import { type Chain, base } from 'viem/chains';
@@ -22,23 +19,10 @@ import { getSendCalldata } from '../utils/getSendCalldata';
 import { useSendContext } from './SendProvider';
 
 type SendButtonProps = {
-  label?: string;
   isSponsored?: boolean;
-  className?: string;
-} & Pick<
-  TransactionButtonReact,
-  'disabled' | 'pendingOverride' | 'successOverride' | 'errorOverride'
->;
+};
 
-export function SendButton({
-  label,
-  isSponsored = false,
-  className,
-  disabled,
-  pendingOverride,
-  successOverride,
-  errorOverride,
-}: SendButtonProps) {
+export function SendButton({ isSponsored = false }: SendButtonProps) {
   const { chain: senderChain } = useWalletContext();
   const {
     recipientState,
@@ -54,7 +38,6 @@ export function SendButton({
   });
 
   const disableSendButton =
-    disabled ||
     Boolean(error) ||
     !validateAmountInput({
       inputAmount: inputAmount ?? '',
@@ -62,8 +45,7 @@ export function SendButton({
       selectedToken: selectedToken ?? undefined,
     });
 
-  const buttonLabel =
-    label ?? getDefaultSendButtonLabel(inputAmount, selectedToken);
+  const buttonLabel = getDefaultSendButtonLabel(inputAmount, selectedToken);
 
   const handleStatus = useCallback(
     (status: LifecycleStatus) => {
@@ -96,11 +78,7 @@ export function SendButton({
       <SendTransactionButton
         label={buttonLabel}
         senderChain={senderChain}
-        pendingOverride={pendingOverride}
-        errorOverride={errorOverride}
-        successOverride={successOverride}
         disabled={disableSendButton}
-        className={className}
       />
       <TransactionStatus>
         <TransactionStatusLabel />
@@ -119,18 +97,10 @@ function SendTransactionButton({
   label,
   senderChain,
   disabled,
-  pendingOverride,
-  successOverride,
-  errorOverride,
-  className,
 }: {
   label: string;
   senderChain?: Chain | null;
   disabled?: boolean;
-  pendingOverride?: TransactionButtonReact['pendingOverride'];
-  successOverride?: TransactionButtonReact['successOverride'];
-  errorOverride?: TransactionButtonReact['errorOverride'];
-  className?: string;
 }) {
   const { address, setActiveFeature } = useWalletContext();
   const { transactionHash, transactionId } = useTransactionContext();
@@ -151,11 +121,8 @@ function SendTransactionButton({
 
   return (
     <TransactionButton
-      className={className}
       text={label}
-      pendingOverride={pendingOverride}
-      successOverride={successOverride ?? defaultSuccessOverride}
-      errorOverride={errorOverride}
+      successOverride={defaultSuccessOverride}
       disabled={disabled}
     />
   );

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendButton.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/SendButton.tsx
@@ -18,12 +18,8 @@ import { defaultSendTxSuccessHandler } from '../utils/defaultSendTxSuccessHandle
 import { getSendCalldata } from '../utils/getSendCalldata';
 import { useSendContext } from './SendProvider';
 
-type SendButtonProps = {
-  isSponsored?: boolean;
-};
-
-export function SendButton({ isSponsored = false }: SendButtonProps) {
-  const { chain: senderChain } = useWalletContext();
+export function SendButton() {
+  const { chain: senderChain, isSponsored } = useWalletContext();
   const {
     recipientState,
     cryptoAmount: inputAmount,

--- a/packages/onchainkit/src/wallet/types.ts
+++ b/packages/onchainkit/src/wallet/types.ts
@@ -112,6 +112,8 @@ export type WalletContextType = {
     container: string;
     content: string;
   };
+  /** Whether to sponsor transactions for Send feature of advanced wallet implementation */
+  isSponsored?: boolean;
 };
 
 /**
@@ -119,6 +121,8 @@ export type WalletContextType = {
  */
 export type WalletReact = {
   children?: React.ReactNode;
+  /** Whether to sponsor transactions for Send feature of advanced wallet implementation */
+  isSponsored?: boolean;
   className?: string;
 } & (
   | { draggable?: true; draggableStartingPosition?: { x: number; y: number } }

--- a/packages/playground/components/DemoOptions.tsx
+++ b/packages/playground/components/DemoOptions.tsx
@@ -23,6 +23,7 @@ const COMPONENT_CONFIG: Partial<
   Record<OnchainKitComponent, (() => React.JSX.Element)[]>
 > = {
   [OnchainKitComponent.Buy]: [Chain, PaymasterUrl, IsSponsored, SwapConfig],
+  [OnchainKitComponent.WalletIsland]: [PaymasterUrl, IsSponsored],
   [OnchainKitComponent.Checkout]: [
     Chain,
     PaymasterUrl,

--- a/packages/playground/components/demo/WalletIsland.tsx
+++ b/packages/playground/components/demo/WalletIsland.tsx
@@ -1,5 +1,8 @@
 import { WalletIsland } from '@coinbase/onchainkit/wallet';
+import { AppContext } from '../AppProvider';
+import { useContext } from 'react';
 
 export default function WalletIslandDemo() {
-  return <WalletIsland />;
+  const { isSponsored } = useContext(AppContext);
+  return <WalletIsland isSponsored={isSponsored} />;
 }


### PR DESCRIPTION
**What changed? Why?**

Send component is an internal component only used within Wallet when configured with Advanced components. we were exposing multiple props through `SendButton` that would never be used, given that it is an internal component. This PR removes those props to simplify logic. 

This PR also adds an optional `isSponsored` prop to Wallet so devs can enable sponsored transaction with send

**Notes to reviewers**

**How has it been tested?**
