### PR TITLE
Fix typo in README.md

### DIFF
--- a/packages/onchainkit/README.md
+++ b/packages/onchainkit/README.md
@@ -51,7 +51,7 @@
 
 ## 🚀 Quickstart
 
-Run `npm create onchain` to boostrap an example onchain app with all the batteries included.
+Run `npm create onchain` to bootstrap an example onchain app with all the batteries included.
 
 ## ✨ Documentation
 


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the Quickstart section of packages/onchainkit/README.md, changing "boostrap" to the correct spelling "bootstrap". This improves the clarity and professionalism of the documentation. No other changes were made.

