### PR TITLE
Feat: TextInput updates

### DIFF
--- a/packages/onchainkit/src/internal/components/TextInput.test.tsx
+++ b/packages/onchainkit/src/internal/components/TextInput.test.tsx
@@ -15,6 +15,7 @@ type RenderTestProps = {
   value?: string;
   disabled?: boolean;
   inputMode?: React.InputHTMLAttributes<HTMLInputElement>['inputMode'];
+  errorMessage?: string;
 };
 
 const RenderTest = ({
@@ -24,6 +25,7 @@ const RenderTest = ({
   placeholder = 'Enter text',
   setValue = vi.fn(),
   value = 'test',
+  errorMessage = '',
   ...props
 }: RenderTestProps) => (
   <TextInput
@@ -33,6 +35,7 @@ const RenderTest = ({
     placeholder={placeholder}
     setValue={setValue}
     value={value}
+    errorMessage={errorMessage}
     {...props}
   />
 );
@@ -87,6 +90,13 @@ describe('TextInput', () => {
     expect(getByTestId('ockTextInput_Input')).toHaveAttribute(
       'inputMode',
       'decimal',
+    );
+  });
+
+  it('handles errorMessage', () => {
+    render(<RenderTest errorMessage="Error message" />);
+    expect(screen.getByTestId('ockTextInput_Input')).toHaveClass(
+      'text-ock-text-error',
     );
   });
 });

--- a/packages/onchainkit/src/internal/components/TextInput.tsx
+++ b/packages/onchainkit/src/internal/components/TextInput.tsx
@@ -4,10 +4,15 @@ import {
   type ForwardedRef,
   useCallback,
   forwardRef,
+  HTMLProps,
 } from 'react';
 import { useDebounce } from '../hooks/useDebounce';
+import { cn } from '@/styles/theme';
 
-type TextInputReact = {
+type TextInputProps = Omit<
+  HTMLProps<HTMLInputElement>,
+  'aria-label' | 'className' | 'onChange' | 'onBlur' | 'onFocus'
+> & {
   'aria-label'?: string;
   className: string;
   delayMs?: number;
@@ -21,6 +26,8 @@ type TextInputReact = {
   setValue?: (s: string) => void;
   value: string;
   inputValidator?: (s: string) => boolean;
+  /** specify 'message' to show error state (change in color), message is used for a11y purposes, not actually rendered currently */
+  errorMessage?: string;
 };
 
 export const TextInput = forwardRef(
@@ -38,7 +45,9 @@ export const TextInput = forwardRef(
       inputMode,
       value,
       inputValidator = () => true,
-    }: TextInputReact,
+      errorMessage,
+      ...rest
+    }: TextInputProps,
     ref: ForwardedRef<HTMLInputElement>,
   ) => {
     const handleDebounce = useDebounce((value) => {
@@ -63,11 +72,14 @@ export const TextInput = forwardRef(
 
     return (
       <input
+        aria-disabled={disabled}
+        aria-errormessage={errorMessage}
+        aria-invalid={!!errorMessage}
         aria-label={ariaLabel}
         data-testid="ockTextInput_Input"
         ref={ref}
         type="text"
-        className={className}
+        className={cn(className, !!errorMessage && 'text-ock-text-error')}
         inputMode={inputMode}
         placeholder={placeholder}
         value={value}
@@ -77,6 +89,7 @@ export const TextInput = forwardRef(
         disabled={disabled}
         autoComplete="off" // autocomplete attribute handles browser autocomplete
         data-1p-ignore={true} // data-1p-ignore attribute handles password manager autocomplete
+        {...rest}
       />
     );
   },


### PR DESCRIPTION
**What changed? Why?**

- a11y updates
- support error state
- support existing input props being able to be passed in 

**Notes to reviewers**

**How has it been tested?**
