### PR TITLE
chore: switch enums -> object consts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,4 +53,11 @@ export default [
       ],
     },
   },
+  {
+    settings: {
+      react: {
+        version: 'detect',
+      },
+    },
+  },
 ];

--- a/packages/onchainkit/src/api/buildMintTransaction.ts
+++ b/packages/onchainkit/src/api/buildMintTransaction.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { CDP_MINT_TOKEN } from '../core/network/definitions/nft';
 import { sendRequest } from '../core/network/request';
 import type {
@@ -11,7 +11,7 @@ import type {
  */
 export async function buildMintTransaction(
   params: BuildMintTransactionParams,
-  context: RequestContext = RequestContext.API,
+  context: RequestContextType = RequestContext.API,
 ): Promise<BuildMintTransactionResponse> {
   const { mintAddress, tokenId, network = '', quantity, takerAddress } = params;
 

--- a/packages/onchainkit/src/api/buildPayTransaction.ts
+++ b/packages/onchainkit/src/api/buildPayTransaction.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import {
   CDP_CREATE_PRODUCT_CHARGE,
   CDP_HYDRATE_CHARGE,
@@ -14,7 +14,7 @@ import { getPayErrorMessage } from './utils/getPayErrorMessage';
 
 export async function buildPayTransaction(
   params: BuildPayTransactionParams,
-  _context: RequestContext = RequestContext.API,
+  _context: RequestContextType = RequestContext.API,
 ): Promise<BuildPayTransactionResponse> {
   const { address, chargeId, productId } = params;
 

--- a/packages/onchainkit/src/api/buildSwapTransaction.ts
+++ b/packages/onchainkit/src/api/buildSwapTransaction.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_TRADE } from '../core/network/definitions/swap';
@@ -18,7 +18,7 @@ import { getSwapTransaction } from './utils/getSwapTransaction';
  */
 export async function buildSwapTransaction(
   params: BuildSwapTransactionParams,
-  _context: RequestContext = RequestContext.API,
+  _context: RequestContextType = RequestContext.API,
 ): Promise<BuildSwapTransactionResponse> {
   // Default parameters
   const defaultParams = {

--- a/packages/onchainkit/src/api/getMintDetails.ts
+++ b/packages/onchainkit/src/api/getMintDetails.ts
@@ -1,4 +1,4 @@
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { CDP_GET_MINT_DETAILS } from '../core/network/definitions/nft';
 import { sendRequest } from '../core/network/request';
 import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
@@ -8,7 +8,7 @@ import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
  */
 export async function getMintDetails(
   params: GetMintDetailsParams,
-  context: RequestContextType = 'api',
+  context: RequestContextType = RequestContext.API,
 ): Promise<GetMintDetailsResponse> {
   const { contractAddress, takerAddress, tokenId } = params;
 

--- a/packages/onchainkit/src/api/getMintDetails.ts
+++ b/packages/onchainkit/src/api/getMintDetails.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { CDP_GET_MINT_DETAILS } from '../core/network/definitions/nft';
 import { sendRequest } from '../core/network/request';
 import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
@@ -8,7 +8,7 @@ import type { GetMintDetailsParams, GetMintDetailsResponse } from './types';
  */
 export async function getMintDetails(
   params: GetMintDetailsParams,
-  context: RequestContext = RequestContext.API,
+  context: RequestContextType = 'api',
 ): Promise<GetMintDetailsResponse> {
   const { contractAddress, takerAddress, tokenId } = params;
 

--- a/packages/onchainkit/src/api/getPortfolios.ts
+++ b/packages/onchainkit/src/api/getPortfolios.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
 import { sendRequest } from '@/core/network/request';
 import type {
@@ -13,7 +13,7 @@ import type {
  */
 export async function getPortfolios(
   params: GetPortfoliosParams,
-  _context: RequestContext = RequestContext.API,
+  _context: RequestContextType = 'api',
 ): Promise<GetPortfoliosResponse | APIError> {
   const { addresses } = params;
 

--- a/packages/onchainkit/src/api/getPortfolios.ts
+++ b/packages/onchainkit/src/api/getPortfolios.ts
@@ -1,4 +1,4 @@
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { CDP_GET_PORTFOLIO_TOKEN_BALANCES } from '@/core/network/definitions/wallet';
 import { sendRequest } from '@/core/network/request';
 import type {
@@ -13,7 +13,7 @@ import type {
  */
 export async function getPortfolios(
   params: GetPortfoliosParams,
-  _context: RequestContextType = 'api',
+  _context: RequestContextType = RequestContext.API,
 ): Promise<GetPortfoliosResponse | APIError> {
   const { addresses } = params;
 

--- a/packages/onchainkit/src/api/getPriceQuote.ts
+++ b/packages/onchainkit/src/api/getPriceQuote.ts
@@ -1,4 +1,4 @@
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { CDP_GET_PRICE_QUOTE } from '@/core/network/definitions/wallet';
 import { sendRequest } from '@/core/network/request';
 
@@ -14,7 +14,7 @@ import type { GetPriceQuoteParams, GetPriceQuoteResponse } from './types';
  */
 export async function getPriceQuote(
   params: GetPriceQuoteParams,
-  _context: RequestContextType = 'api',
+  _context: RequestContextType = RequestContext.API,
 ): Promise<GetPriceQuoteResponse> {
   const apiParams = validateGetPriceQuoteParams(params);
   if ('error' in apiParams) {

--- a/packages/onchainkit/src/api/getPriceQuote.ts
+++ b/packages/onchainkit/src/api/getPriceQuote.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { CDP_GET_PRICE_QUOTE } from '@/core/network/definitions/wallet';
 import { sendRequest } from '@/core/network/request';
 
@@ -14,7 +14,7 @@ import type { GetPriceQuoteParams, GetPriceQuoteResponse } from './types';
  */
 export async function getPriceQuote(
   params: GetPriceQuoteParams,
-  _context: RequestContext = RequestContext.API,
+  _context: RequestContextType = 'api',
 ): Promise<GetPriceQuoteResponse> {
   const apiParams = validateGetPriceQuoteParams(params);
   if ('error' in apiParams) {

--- a/packages/onchainkit/src/api/getSwapQuote.ts
+++ b/packages/onchainkit/src/api/getSwapQuote.ts
@@ -1,4 +1,4 @@
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_QUOTE } from '../core/network/definitions/swap';
@@ -17,7 +17,7 @@ import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
  */
 export async function getSwapQuote(
   params: GetSwapQuoteParams,
-  _context: RequestContextType = 'api',
+  _context: RequestContextType = RequestContext.API,
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {

--- a/packages/onchainkit/src/api/getSwapQuote.ts
+++ b/packages/onchainkit/src/api/getSwapQuote.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { SwapMessage } from '@/swap/constants';
 import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
 import { CDP_GET_SWAP_QUOTE } from '../core/network/definitions/swap';
@@ -17,7 +17,7 @@ import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
  */
 export async function getSwapQuote(
   params: GetSwapQuoteParams,
-  _context: RequestContext = RequestContext.API,
+  _context: RequestContextType = 'api',
 ): Promise<GetSwapQuoteResponse> {
   // Default parameters
   const defaultParams = {

--- a/packages/onchainkit/src/api/getTokenDetails.ts
+++ b/packages/onchainkit/src/api/getTokenDetails.ts
@@ -1,4 +1,4 @@
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { CDP_GET_TOKEN_DETAILS } from '../core/network/definitions/nft';
 import { sendRequest } from '../core/network/request';
 import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
@@ -8,7 +8,7 @@ import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
  */
 export async function getTokenDetails(
   params: GetTokenDetailsParams,
-  _context: RequestContextType = 'api',
+  _context: RequestContextType = RequestContext.API,
 ): Promise<GetTokenDetailsResponse> {
   const { contractAddress, tokenId } = params;
 

--- a/packages/onchainkit/src/api/getTokenDetails.ts
+++ b/packages/onchainkit/src/api/getTokenDetails.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { CDP_GET_TOKEN_DETAILS } from '../core/network/definitions/nft';
 import { sendRequest } from '../core/network/request';
 import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
@@ -8,7 +8,7 @@ import type { GetTokenDetailsParams, GetTokenDetailsResponse } from './types';
  */
 export async function getTokenDetails(
   params: GetTokenDetailsParams,
-  _context: RequestContext = RequestContext.API,
+  _context: RequestContextType = 'api',
 ): Promise<GetTokenDetailsResponse> {
   const { contractAddress, tokenId } = params;
 

--- a/packages/onchainkit/src/api/getTokens.ts
+++ b/packages/onchainkit/src/api/getTokens.ts
@@ -1,4 +1,4 @@
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { CDP_LIST_SWAP_ASSETS } from '../core/network/definitions/swap';
 import { sendRequest } from '../core/network/request';
 import type { Token } from '../token/types';
@@ -9,7 +9,7 @@ import type { GetTokensOptions, GetTokensResponse } from './types';
  */
 export async function getTokens(
   options?: GetTokensOptions,
-  _context: RequestContextType = 'api',
+  _context: RequestContextType = RequestContext.API,
 ): Promise<GetTokensResponse> {
   // Default filter values
   const defaultFilter: GetTokensOptions = {

--- a/packages/onchainkit/src/api/getTokens.ts
+++ b/packages/onchainkit/src/api/getTokens.ts
@@ -1,4 +1,4 @@
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { CDP_LIST_SWAP_ASSETS } from '../core/network/definitions/swap';
 import { sendRequest } from '../core/network/request';
 import type { Token } from '../token/types';
@@ -9,7 +9,7 @@ import type { GetTokensOptions, GetTokensResponse } from './types';
  */
 export async function getTokens(
   options?: GetTokensOptions,
-  _context: RequestContext = RequestContext.API,
+  _context: RequestContextType = 'api',
 ): Promise<GetTokensResponse> {
   // Default filter values
   const defaultFilter: GetTokensOptions = {

--- a/packages/onchainkit/src/buy/components/BuyDropdown.tsx
+++ b/packages/onchainkit/src/buy/components/BuyDropdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useAnalytics } from '@/core/analytics/hooks/useAnalytics';
-import { BuyEvent, type BuyOption } from '@/core/analytics/types';
+import { BuyEvent, type BuyOptionType } from '@/core/analytics/types';
 import { openPopup } from '@/internal/utils/openPopup';
 import { useOnchainKit } from '@/useOnchainKit';
 import { useCallback, useEffect, useMemo } from 'react';
@@ -27,7 +27,7 @@ export function BuyDropdown() {
     (paymentMethodId: string) => {
       return () => {
         sendAnalytics(BuyEvent.BuyOptionSelected, {
-          option: paymentMethodId as BuyOption,
+          option: paymentMethodId as BuyOptionType,
         });
 
         const assetSymbol = to?.token?.symbol;

--- a/packages/onchainkit/src/checkout/components/CheckoutButton.test.tsx
+++ b/packages/onchainkit/src/checkout/components/CheckoutButton.test.tsx
@@ -11,7 +11,7 @@ import {
 import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
 import { CheckoutEvent } from '../../core/analytics/types';
 import { useIcon } from '../../internal/hooks/useIcon';
-import { CHECKOUT_LIFECYCLESTATUS } from '../constants';
+import { CHECKOUT_LIFECYCLE_STATUS } from '../constants';
 import { CheckoutButton } from './CheckoutButton';
 import { useCheckoutContext } from './CheckoutProvider';
 
@@ -74,7 +74,7 @@ describe('CheckoutButton', () => {
 
   it('disables button when lifecycle status is PENDING', () => {
     (useCheckoutContext as Mock).mockReturnValue({
-      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLESTATUS.PENDING },
+      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLE_STATUS.PENDING },
       onSubmit: mockOnSubmit,
     });
 
@@ -84,7 +84,7 @@ describe('CheckoutButton', () => {
 
   it('disables button when lifecycle status is FETCHING_DATA', () => {
     (useCheckoutContext as Mock).mockReturnValue({
-      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLESTATUS.FETCHING_DATA },
+      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLE_STATUS.FETCHING_DATA },
       onSubmit: mockOnSubmit,
     });
 
@@ -94,7 +94,7 @@ describe('CheckoutButton', () => {
 
   it('shows spinner when lifecycle status is PENDING', () => {
     (useCheckoutContext as Mock).mockReturnValue({
-      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLESTATUS.PENDING },
+      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLE_STATUS.PENDING },
       onSubmit: mockOnSubmit,
     });
 
@@ -106,7 +106,7 @@ describe('CheckoutButton', () => {
 
   it('changes button text to "View payment details" when transaction is successful', () => {
     (useCheckoutContext as Mock).mockReturnValue({
-      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLESTATUS.SUCCESS },
+      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLE_STATUS.SUCCESS },
       onSubmit: mockOnSubmit,
     });
 
@@ -126,7 +126,7 @@ describe('CheckoutButton', () => {
 
     (useCheckoutContext as Mock).mockReturnValue({
       lifecycleStatus: {
-        statusName: CHECKOUT_LIFECYCLESTATUS.SUCCESS,
+        statusName: CHECKOUT_LIFECYCLE_STATUS.SUCCESS,
         statusData: {
           transactionReceipts: [{ transactionHash }],
           chargeId,
@@ -151,7 +151,7 @@ describe('CheckoutButton', () => {
   it('does not track analytics when transaction hash or charge ID is missing', () => {
     (useCheckoutContext as Mock).mockReturnValue({
       lifecycleStatus: {
-        statusName: CHECKOUT_LIFECYCLESTATUS.SUCCESS,
+        statusName: CHECKOUT_LIFECYCLE_STATUS.SUCCESS,
         statusData: {
           transactionReceipts: [{ transactionHash: null }],
           chargeId: 'charge-123',
@@ -166,7 +166,7 @@ describe('CheckoutButton', () => {
 
   it('does not track analytics when status is not SUCCESS', () => {
     (useCheckoutContext as Mock).mockReturnValue({
-      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLESTATUS.READY },
+      lifecycleStatus: { statusName: CHECKOUT_LIFECYCLE_STATUS.READY },
       onSubmit: mockOnSubmit,
     });
 

--- a/packages/onchainkit/src/checkout/components/CheckoutButton.tsx
+++ b/packages/onchainkit/src/checkout/components/CheckoutButton.tsx
@@ -25,8 +25,10 @@ export function CheckoutButton({
   const iconSvg = useIcon({ icon });
   const { sendAnalytics } = useAnalytics();
 
-  const isLoading = lifecycleStatus?.statusName === 'pending';
-  const isFetchingData = lifecycleStatus?.statusName === 'fetchingData';
+  const isLoading =
+    lifecycleStatus?.statusName === CHECKOUT_LIFECYCLE_STATUS.PENDING;
+  const isFetchingData =
+    lifecycleStatus?.statusName === CHECKOUT_LIFECYCLE_STATUS.FETCHING_DATA;
   const isDisabled = disabled || isLoading || isFetchingData;
   const buttonText = useMemo(() => {
     if (lifecycleStatus?.statusName === CHECKOUT_LIFECYCLE_STATUS.SUCCESS) {

--- a/packages/onchainkit/src/checkout/components/CheckoutButton.tsx
+++ b/packages/onchainkit/src/checkout/components/CheckoutButton.tsx
@@ -8,6 +8,7 @@ import { useIcon } from '../../internal/hooks/useIcon';
 import { cn, pressable, text as styleText } from '../../styles/theme';
 import type { CheckoutButtonReact } from '../types';
 import { useCheckoutContext } from './CheckoutProvider';
+import { CHECKOUT_LIFECYCLE_STATUS } from '../constants';
 
 export function CheckoutButton({
   className,
@@ -28,7 +29,7 @@ export function CheckoutButton({
   const isFetchingData = lifecycleStatus?.statusName === 'fetchingData';
   const isDisabled = disabled || isLoading || isFetchingData;
   const buttonText = useMemo(() => {
-    if (lifecycleStatus?.statusName === 'success') {
+    if (lifecycleStatus?.statusName === CHECKOUT_LIFECYCLE_STATUS.SUCCESS) {
       return 'View payment details';
     }
     return text;
@@ -37,7 +38,7 @@ export function CheckoutButton({
 
   useEffect(() => {
     if (
-      lifecycleStatus?.statusName === 'success' &&
+      lifecycleStatus?.statusName === CHECKOUT_LIFECYCLE_STATUS.SUCCESS &&
       lifecycleStatus.statusData
     ) {
       const { transactionReceipts, chargeId } = lifecycleStatus.statusData;

--- a/packages/onchainkit/src/checkout/components/CheckoutButton.tsx
+++ b/packages/onchainkit/src/checkout/components/CheckoutButton.tsx
@@ -6,7 +6,6 @@ import { CheckoutEvent } from '../../core/analytics/types';
 import { Spinner } from '../../internal/components/Spinner';
 import { useIcon } from '../../internal/hooks/useIcon';
 import { cn, pressable, text as styleText } from '../../styles/theme';
-import { CHECKOUT_LIFECYCLESTATUS } from '../constants';
 import type { CheckoutButtonReact } from '../types';
 import { useCheckoutContext } from './CheckoutProvider';
 
@@ -25,13 +24,11 @@ export function CheckoutButton({
   const iconSvg = useIcon({ icon });
   const { sendAnalytics } = useAnalytics();
 
-  const isLoading =
-    lifecycleStatus?.statusName === CHECKOUT_LIFECYCLESTATUS.PENDING;
-  const isFetchingData =
-    lifecycleStatus?.statusName === CHECKOUT_LIFECYCLESTATUS.FETCHING_DATA;
+  const isLoading = lifecycleStatus?.statusName === 'pending';
+  const isFetchingData = lifecycleStatus?.statusName === 'fetchingData';
   const isDisabled = disabled || isLoading || isFetchingData;
   const buttonText = useMemo(() => {
-    if (lifecycleStatus?.statusName === CHECKOUT_LIFECYCLESTATUS.SUCCESS) {
+    if (lifecycleStatus?.statusName === 'success') {
       return 'View payment details';
     }
     return text;
@@ -40,7 +37,7 @@ export function CheckoutButton({
 
   useEffect(() => {
     if (
-      lifecycleStatus?.statusName === CHECKOUT_LIFECYCLESTATUS.SUCCESS &&
+      lifecycleStatus?.statusName === 'success' &&
       lifecycleStatus.statusData
     ) {
       const { transactionReceipts, chargeId } = lifecycleStatus.statusData;

--- a/packages/onchainkit/src/checkout/components/CheckoutProvider.tsx
+++ b/packages/onchainkit/src/checkout/components/CheckoutProvider.tsx
@@ -26,6 +26,7 @@ import { isUserRejectedRequestError } from '../../transaction/utils/isUserReject
 import { useOnchainKit } from '../../useOnchainKit';
 import { useIsWalletACoinbaseSmartWallet } from '../../wallet/hooks/useIsWalletACoinbaseSmartWallet';
 import {
+  CHECKOUT_LIFECYCLE_STATUS,
   GENERIC_ERROR_MESSAGE,
   NO_CONNECTED_ADDRESS_ERROR,
   NO_CONTRACTS_ERROR,
@@ -91,7 +92,7 @@ export function CheckoutProvider({
   // Component lifecycle
   const [lifecycleStatus, updateLifecycleStatus] =
     useLifecycleStatus<LifecycleStatus>({
-      statusName: 'init',
+      statusName: CHECKOUT_LIFECYCLE_STATUS.INIT,
       statusData: {},
     });
 
@@ -105,7 +106,7 @@ export function CheckoutProvider({
   const fetchData = useCallback(
     async (address: Address) => {
       updateLifecycleStatus({
-        statusName: 'fetchingData',
+        statusName: CHECKOUT_LIFECYCLE_STATUS.FETCHING_DATA,
         statusData: {},
       });
       const {
@@ -118,7 +119,7 @@ export function CheckoutProvider({
       if (error) {
         setErrorMessage(GENERIC_ERROR_MESSAGE);
         updateLifecycleStatus({
-          statusName: 'error',
+          statusName: CHECKOUT_LIFECYCLE_STATUS.ERROR,
           statusData: {
             code: CheckoutErrorCode.UNEXPECTED_ERROR,
             error: (error as Error).name,
@@ -132,7 +133,7 @@ export function CheckoutProvider({
       insufficientBalanceRef.current = insufficientBalance;
       priceInUSDCRef.current = priceInUSDC;
       updateLifecycleStatus({
-        statusName: 'ready',
+        statusName: CHECKOUT_LIFECYCLE_STATUS.READY,
         statusData: {
           chargeId,
           contracts: contractsRef.current || [],
@@ -156,7 +157,7 @@ export function CheckoutProvider({
     query: {
       /* v8 ignore next 5 */
       refetchInterval: (query) => {
-        return normalizeStatus(query.state.data?.status) === 'success'
+        return normalizeStatus(query.state.data?.status) === CHECKOUT_LIFECYCLE_STATUS.SUCCESS
           ? false
           : 1000;
       },
@@ -180,9 +181,9 @@ export function CheckoutProvider({
 
   // Set transaction pending status when writeContracts is pending
   useEffect(() => {
-    if (status === 'pending') {
+    if (status === CHECKOUT_LIFECYCLE_STATUS.PENDING) {
       updateLifecycleStatus({
-        statusName: 'pending',
+        statusName: CHECKOUT_LIFECYCLE_STATUS.PENDING,
         statusData: {},
       });
     }
@@ -194,7 +195,7 @@ export function CheckoutProvider({
       return;
     }
     updateLifecycleStatus({
-      statusName: 'success',
+      statusName: CHECKOUT_LIFECYCLE_STATUS.SUCCESS,
       statusData: {
         transactionReceipts: [receipt],
         chargeId: chargeId,
@@ -206,7 +207,7 @@ export function CheckoutProvider({
   // We need to pre-load transaction data in `useEffect` when the wallet is already connected due to a Smart Wallet popup blocking issue in Safari iOS
   useEffect(() => {
     if (
-      lifecycleStatus.statusName === 'init' &&
+      lifecycleStatus.statusName === CHECKOUT_LIFECYCLE_STATUS.INIT &&
       address &&
       !fetchedDataHandleSubmit.current
     ) {
@@ -232,7 +233,7 @@ export function CheckoutProvider({
       });
 
       // Open Coinbase Commerce receipt
-      if (lifecycleStatus.statusName === 'success') {
+      if (lifecycleStatus.statusName === CHECKOUT_LIFECYCLE_STATUS.SUCCESS) {
         window.open(
           `https://commerce.coinbase.com/pay/${chargeId}/receipt`,
           '_blank',
@@ -268,7 +269,7 @@ export function CheckoutProvider({
       if (!connectedAddress) {
         setErrorMessage(GENERIC_ERROR_MESSAGE);
         updateLifecycleStatus({
-          statusName: 'error',
+          statusName: CHECKOUT_LIFECYCLE_STATUS.ERROR,
           statusData: {
             code: CheckoutErrorCode.UNEXPECTED_ERROR,
             error: NO_CONNECTED_ADDRESS_ERROR,
@@ -310,7 +311,7 @@ export function CheckoutProvider({
       if (!contractsRef.current || contractsRef.current.length === 0) {
         setErrorMessage(GENERIC_ERROR_MESSAGE);
         updateLifecycleStatus({
-          statusName: 'error',
+          statusName: CHECKOUT_LIFECYCLE_STATUS.ERROR,
           statusData: {
             code: CheckoutErrorCode.UNEXPECTED_ERROR,
             error: NO_CONTRACTS_ERROR,
@@ -353,7 +354,7 @@ export function CheckoutProvider({
 
       setErrorMessage(errorMessage);
       updateLifecycleStatus({
-        statusName: 'error',
+        statusName: CHECKOUT_LIFECYCLE_STATUS.ERROR,
         statusData: {
           code: errorCode,
           error: JSON.stringify(error),

--- a/packages/onchainkit/src/checkout/components/CheckoutProvider.tsx
+++ b/packages/onchainkit/src/checkout/components/CheckoutProvider.tsx
@@ -157,7 +157,7 @@ export function CheckoutProvider({
     query: {
       /* v8 ignore next 5 */
       refetchInterval: (query) => {
-        return normalizeStatus(query.state.data?.status) === CHECKOUT_LIFECYCLE_STATUS.SUCCESS
+        return normalizeStatus(query.state.data?.status) === 'success'
           ? false
           : 1000;
       },
@@ -181,7 +181,7 @@ export function CheckoutProvider({
 
   // Set transaction pending status when writeContracts is pending
   useEffect(() => {
-    if (status === CHECKOUT_LIFECYCLE_STATUS.PENDING) {
+    if (status === 'pending') {
       updateLifecycleStatus({
         statusName: CHECKOUT_LIFECYCLE_STATUS.PENDING,
         statusData: {},

--- a/packages/onchainkit/src/checkout/constants.ts
+++ b/packages/onchainkit/src/checkout/constants.ts
@@ -15,39 +15,46 @@ export const CHECKOUT_INVALID_PARAMETER_ERROR_MESSAGE =
 export const UNCAUGHT_CHECKOUT_ERROR_MESSAGE = 'UNCAUGHT_CHECKOUT_ERROR';
 export const USER_REJECTED_ERROR = 'Request denied.';
 
-export enum CheckoutErrorCode {
-  INSUFFICIENT_BALANCE = 'insufficient_balance',
-  GENERIC_ERROR = 'generic_error',
-  UNEXPECTED_ERROR = 'unexpected_error',
-  USER_REJECTED_ERROR = 'user_rejected',
-}
+export const CheckoutErrorCode = {
+  INSUFFICIENT_BALANCE: 'insufficient_balance',
+  GENERIC_ERROR: 'generic_error',
+  UNEXPECTED_ERROR: 'unexpected_error',
+  USER_REJECTED_ERROR: 'user_rejected',
+} as const;
+
+export type CheckoutErrorCodeType = keyof typeof CheckoutErrorCode;
 
 export interface CheckoutErrorType {
-  code: CheckoutErrorCode;
+  code: CheckoutErrorCodeType;
   error: string;
   message: string;
 }
 
 export type CheckoutErrors = {
-  [K in CheckoutErrorCode]: CheckoutErrorType;
+  [K in CheckoutErrorCodeType]: CheckoutErrorType;
 };
 
-export enum CHECKOUT_LIFECYCLESTATUS {
-  FETCHING_DATA = 'fetchingData',
-  INIT = 'init',
-  PENDING = 'pending',
-  READY = 'ready',
-  SUCCESS = 'success',
-  ERROR = 'error',
-}
+export const CHECKOUT_LIFECYCLE_STATUS = {
+  FETCHING_DATA: 'fetchingData',
+  INIT: 'init',
+  PENDING: 'pending',
+  READY: 'ready',
+  SUCCESS: 'success',
+  ERROR: 'error',
+} as const;
+
+export type CheckoutLifecycleStatusType =
+  keyof typeof CHECKOUT_LIFECYCLE_STATUS;
 
 export const USDC_ADDRESS_BASE = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
 
-export enum CONTRACT_METHODS {
-  APPROVE = 'approve',
-  BALANCE_OF = 'balanceOf',
-  TRANSFER_TOKEN_PRE_APPROVED = 'transferTokenPreApproved',
-}
+export const CONTRACT_METHODS = {
+  APPROVE: 'approve',
+  BALANCE_OF: 'balanceOf',
+  TRANSFER_TOKEN_PRE_APPROVED: 'transferTokenPreApproved',
+} as const;
+
+export type ContractMethodsType = keyof typeof CONTRACT_METHODS;
 
 export const COMMERCE_ABI = [
   {

--- a/packages/onchainkit/src/checkout/hooks/useGetCheckoutStatus.test.tsx
+++ b/packages/onchainkit/src/checkout/hooks/useGetCheckoutStatus.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { useCheckoutContext } from '../components/CheckoutProvider';
-import { CHECKOUT_LIFECYCLESTATUS } from '../constants';
 import { useGetCheckoutStatus } from './useGetCheckoutStatus';
 
 vi.mock('../components/CheckoutProvider', () => ({
@@ -13,7 +12,7 @@ describe('useGetCheckoutStatus', () => {
     vi.mocked(useCheckoutContext).mockReturnValue({
       errorMessage: '',
       lifecycleStatus: {
-        statusName: CHECKOUT_LIFECYCLESTATUS.PENDING,
+        statusName: 'pending',
         statusData: {},
       },
       onSubmit: vi.fn(),
@@ -30,7 +29,7 @@ describe('useGetCheckoutStatus', () => {
     vi.mocked(useCheckoutContext).mockReturnValue({
       errorMessage: '',
       lifecycleStatus: {
-        statusName: CHECKOUT_LIFECYCLESTATUS.SUCCESS,
+        statusName: 'success',
         statusData: {
           transactionReceipts: [],
           chargeId: '',
@@ -51,7 +50,7 @@ describe('useGetCheckoutStatus', () => {
     vi.mocked(useCheckoutContext).mockReturnValue({
       errorMessage: 'Payment failed',
       lifecycleStatus: {
-        statusName: CHECKOUT_LIFECYCLESTATUS.ERROR,
+        statusName: 'error',
         statusData: {
           code: 'PmUWCSh01',
           error: 'Payment failed',

--- a/packages/onchainkit/src/checkout/hooks/useGetCheckoutStatus.test.tsx
+++ b/packages/onchainkit/src/checkout/hooks/useGetCheckoutStatus.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { useCheckoutContext } from '../components/CheckoutProvider';
 import { useGetCheckoutStatus } from './useGetCheckoutStatus';
+import { CHECKOUT_LIFECYCLE_STATUS } from '../constants';
 
 vi.mock('../components/CheckoutProvider', () => ({
   useCheckoutContext: vi.fn(),
@@ -12,7 +13,7 @@ describe('useGetCheckoutStatus', () => {
     vi.mocked(useCheckoutContext).mockReturnValue({
       errorMessage: '',
       lifecycleStatus: {
-        statusName: 'pending',
+        statusName: CHECKOUT_LIFECYCLE_STATUS.PENDING,
         statusData: {},
       },
       onSubmit: vi.fn(),
@@ -29,7 +30,7 @@ describe('useGetCheckoutStatus', () => {
     vi.mocked(useCheckoutContext).mockReturnValue({
       errorMessage: '',
       lifecycleStatus: {
-        statusName: 'success',
+        statusName: CHECKOUT_LIFECYCLE_STATUS.SUCCESS,
         statusData: {
           transactionReceipts: [],
           chargeId: '',
@@ -50,7 +51,7 @@ describe('useGetCheckoutStatus', () => {
     vi.mocked(useCheckoutContext).mockReturnValue({
       errorMessage: 'Payment failed',
       lifecycleStatus: {
-        statusName: 'error',
+        statusName: CHECKOUT_LIFECYCLE_STATUS.ERROR,
         statusData: {
           code: 'PmUWCSh01',
           error: 'Payment failed',

--- a/packages/onchainkit/src/checkout/hooks/useGetCheckoutStatus.tsx
+++ b/packages/onchainkit/src/checkout/hooks/useGetCheckoutStatus.tsx
@@ -1,10 +1,13 @@
 import { useMemo } from 'react';
 import { useCheckoutContext } from '../components/CheckoutProvider';
+import { CHECKOUT_LIFECYCLE_STATUS } from '../constants';
 
 export function useGetCheckoutStatus() {
   const { errorMessage, lifecycleStatus } = useCheckoutContext();
-  const isPending = lifecycleStatus?.statusName === 'pending';
-  const isSuccess = lifecycleStatus?.statusName === 'success';
+  const isPending =
+    lifecycleStatus?.statusName === CHECKOUT_LIFECYCLE_STATUS.PENDING;
+  const isSuccess =
+    lifecycleStatus?.statusName === CHECKOUT_LIFECYCLE_STATUS.SUCCESS;
 
   return useMemo(() => {
     let label = '';

--- a/packages/onchainkit/src/checkout/hooks/useGetCheckoutStatus.tsx
+++ b/packages/onchainkit/src/checkout/hooks/useGetCheckoutStatus.tsx
@@ -1,13 +1,10 @@
 import { useMemo } from 'react';
 import { useCheckoutContext } from '../components/CheckoutProvider';
-import { CHECKOUT_LIFECYCLESTATUS } from '../constants';
 
 export function useGetCheckoutStatus() {
   const { errorMessage, lifecycleStatus } = useCheckoutContext();
-  const isPending =
-    lifecycleStatus?.statusName === CHECKOUT_LIFECYCLESTATUS.PENDING;
-  const isSuccess =
-    lifecycleStatus?.statusName === CHECKOUT_LIFECYCLESTATUS.SUCCESS;
+  const isPending = lifecycleStatus?.statusName === 'pending';
+  const isSuccess = lifecycleStatus?.statusName === 'success';
 
   return useMemo(() => {
     let label = '';

--- a/packages/onchainkit/src/core/analytics/types.ts
+++ b/packages/onchainkit/src/core/analytics/types.ts
@@ -179,7 +179,7 @@ export type AnalyticsEvent =
   | TransactionEventType
   | FundEventType
   | EarnEventType
-  | ErrorEvent;
+  | ErrorEventType;
 
 /**
  * Common analytics data included in all events

--- a/packages/onchainkit/src/core/analytics/types.ts
+++ b/packages/onchainkit/src/core/analytics/types.ts
@@ -8,163 +8,177 @@ import type { Hex } from 'viem';
  * Wallet component events - Tracks all possible wallet interaction states
  * Used to monitor wallet connection flow and user interactions
  */
-export enum WalletEvent {
+export const WalletEvent = {
   /** Wallet connection fails */
-  ConnectError = 'walletConnectError',
+  ConnectError: 'walletConnectError',
   /** User clicks connect wallet button */
-  ConnectInitiated = 'walletConnectInitiated',
+  ConnectInitiated: 'walletConnectInitiated',
   /** Wallet successfully connected */
-  ConnectSuccess = 'walletConnectSuccess',
+  ConnectSuccess: 'walletConnectSuccess',
   /** User disconnects wallet */
-  Disconnect = 'walletDisconnect',
+  Disconnect: 'walletDisconnect',
   /** User selects a wallet option */
-  OptionSelected = 'walletOptionSelected',
+  OptionSelected: 'walletOptionSelected',
   /** User cancels wallet connection */
-  ConnectCanceled = 'walletConnectCanceled',
-}
+  ConnectCanceled: 'walletConnectCanceled',
+} as const;
+
+export type WalletEventType = (typeof WalletEvent)[keyof typeof WalletEvent];
 
 /**
  * Wallet option - Available actions in the wallet interface
  * Used to track which wallet features users interact with
  */
-export enum WalletOption {
-  Buy = 'buy',
-  Explorer = 'explorer',
-  QR = 'qr',
-  Refresh = 'refresh',
-  Send = 'send',
-  Swap = 'swap',
-}
+export const WalletOption = {
+  Buy: 'buy',
+  Explorer: 'explorer',
+  QR: 'qr',
+  Refresh: 'refresh',
+  Send: 'send',
+  Swap: 'swap',
+} as const;
+export type WalletOptionType = (typeof WalletOption)[keyof typeof WalletOption];
 
 /**
  * Swap component events
  */
-export enum SwapEvent {
-  SlippageChanged = 'swapSlippageChanged',
-  TokenSelected = 'swapTokenSelected',
-  SwapSuccess = 'swapSuccess',
-  SwapInitiated = 'swapInitiated',
-  SwapFailure = 'swapFailure',
-  SwapCanceled = 'swapCanceled',
-}
+export const SwapEvent = {
+  SlippageChanged: 'swapSlippageChanged',
+  TokenSelected: 'swapTokenSelected',
+  SwapSuccess: 'swapSuccess',
+  SwapInitiated: 'swapInitiated',
+  SwapFailure: 'swapFailure',
+  SwapCanceled: 'swapCanceled',
+} as const;
+export type SwapEventType = (typeof SwapEvent)[keyof typeof SwapEvent];
 
 /**
  * Buy option - Available payment methods for buying
  * Used to track which payment method users select
  */
-export enum BuyOption {
-  APPLE_PAY = 'apple_pay',
-  COINBASE = 'coinbase_account',
-  DEBIT_CARD = 'debit_card',
-  ETH = 'eth',
-  USDC = 'usdc',
-}
-
+export const BuyOption = {
+  APPLE_PAY: 'apple_pay',
+  COINBASE: 'coinbase_account',
+  DEBIT_CARD: 'debit_card',
+  ETH: 'eth',
+  USDC: 'usdc',
+} as const;
+export type BuyOptionType = (typeof BuyOption)[keyof typeof BuyOption];
 /**
  * Buy component events
  */
-export enum BuyEvent {
-  BuyFailure = 'buyFailure',
-  BuyInitiated = 'buyInitiated',
-  BuyOptionSelected = 'buyOptionSelected',
-  BuySuccess = 'buySuccess',
-  BuyCanceled = 'buyCanceled',
-}
-
+export const BuyEvent = {
+  BuyFailure: 'buyFailure',
+  BuyInitiated: 'buyInitiated',
+  BuyOptionSelected: 'buyOptionSelected',
+  BuySuccess: 'buySuccess',
+  BuyCanceled: 'buyCanceled',
+} as const;
+export type BuyEventType = (typeof BuyEvent)[keyof typeof BuyEvent];
 /**
  * Checkout component events
  */
-export enum CheckoutEvent {
-  CheckoutFailure = 'checkoutFailure',
-  CheckoutInitiated = 'checkoutInitiated',
-  CheckoutSuccess = 'checkoutSuccess',
-  CheckoutCanceled = 'checkoutCanceled',
-}
+export const CheckoutEvent = {
+  CheckoutFailure: 'checkoutFailure',
+  CheckoutInitiated: 'checkoutInitiated',
+  CheckoutSuccess: 'checkoutSuccess',
+  CheckoutCanceled: 'checkoutCanceled',
+} as const;
+export type CheckoutEventType =
+  (typeof CheckoutEvent)[keyof typeof CheckoutEvent];
 
 /**
  * Mint component events
  */
-export enum MintEvent {
-  MintFailure = 'mintFailure',
-  MintInitiated = 'mintInitiated',
-  MintQuantityChanged = 'mintQuantityChanged',
-  MintSuccess = 'mintSuccess',
-  MintCanceled = 'mintCanceled',
-}
+export const MintEvent = {
+  MintFailure: 'mintFailure',
+  MintInitiated: 'mintInitiated',
+  MintQuantityChanged: 'mintQuantityChanged',
+  MintSuccess: 'mintSuccess',
+  MintCanceled: 'mintCanceled',
+} as const;
+export type MintEventType = (typeof MintEvent)[keyof typeof MintEvent];
 
 /**
  * Transaction component events
  */
-export enum TransactionEvent {
-  TransactionFailure = 'transactionFailure',
-  TransactionInitiated = 'transactionInitiated',
-  TransactionSuccess = 'transactionSuccess',
-  TransactionCanceled = 'transactionCanceled',
-}
+export const TransactionEvent = {
+  TransactionFailure: 'transactionFailure',
+  TransactionInitiated: 'transactionInitiated',
+  TransactionSuccess: 'transactionSuccess',
+  TransactionCanceled: 'transactionCanceled',
+} as const;
+export type TransactionEventType =
+  (typeof TransactionEvent)[keyof typeof TransactionEvent];
 
 /**
  * Fund component events
  */
-export enum FundEvent {
-  FundAmountChanged = 'fundAmountChanged',
-  FundFailure = 'fundFailure',
-  FundInitiated = 'fundInitiated',
-  FundOptionSelected = 'fundOptionSelected',
-  FundSuccess = 'fundSuccess',
-  FundCanceled = 'fundCanceled',
-}
+export const FundEvent = {
+  FundAmountChanged: 'fundAmountChanged',
+  FundFailure: 'fundFailure',
+  FundInitiated: 'fundInitiated',
+  FundOptionSelected: 'fundOptionSelected',
+  FundSuccess: 'fundSuccess',
+  FundCanceled: 'fundCanceled',
+} as const;
+export type FundEventType = (typeof FundEvent)[keyof typeof FundEvent];
 
 /**
  * Earn component events
  */
-export enum EarnEvent {
-  EarnDepositInitiated = 'earnDepositInitiated',
-  EarnDepositSuccess = 'earnDepositSuccess',
-  EarnDepositFailure = 'earnDepositFailure',
-  EarnDepositCanceled = 'earnDepositCanceled',
-  EarnWithdrawInitiated = 'earnWithdrawInitiated',
-  EarnWithdrawSuccess = 'earnWithdrawSuccess',
-  EarnWithdrawFailure = 'earnWithdrawFailure',
-  EarnWithdrawCanceled = 'earnWithdrawCanceled',
-}
+export const EarnEvent = {
+  EarnDepositInitiated: 'earnDepositInitiated',
+  EarnDepositSuccess: 'earnDepositSuccess',
+  EarnDepositFailure: 'earnDepositFailure',
+  EarnDepositCanceled: 'earnDepositCanceled',
+  EarnWithdrawInitiated: 'earnWithdrawInitiated',
+  EarnWithdrawSuccess: 'earnWithdrawSuccess',
+  EarnWithdrawFailure: 'earnWithdrawFailure',
+  EarnWithdrawCanceled: 'earnWithdrawCanceled',
+} as const;
+export type EarnEventType = (typeof EarnEvent)[keyof typeof EarnEvent];
 
 /**
  * Appchain component events
  */
-export enum AppchainEvent {
-  AppchainBridgeDepositInitiated = 'appchainBridgeDepositInitiated',
-  AppchainBridgeDepositSuccess = 'appchainBridgeDepositSuccess',
-  AppchainBridgeDepositFailure = 'appchainBridgeDepositFailure',
-  AppchainBridgeWithdrawInitiated = 'appchainBridgeWithdrawInitiated',
-  AppchainBridgeWithdrawSuccess = 'appchainBridgeWithdrawSuccess',
-  AppchainBridgeWithdrawFailure = 'appchainBridgeWithdrawFailure',
-  AppchainBridgeWaitForClaimFailure = 'appchainBridgeWaitForClaimFailure',
-  AppchainBridgeClaimSuccess = 'appchainBridgeClaimSuccess',
-  AppchainBridgeClaimFailure = 'appchainBridgeClaimFailure',
-}
+export const AppchainEvent = {
+  AppchainBridgeDepositInitiated: 'appchainBridgeDepositInitiated',
+  AppchainBridgeDepositSuccess: 'appchainBridgeDepositSuccess',
+  AppchainBridgeDepositFailure: 'appchainBridgeDepositFailure',
+  AppchainBridgeWithdrawInitiated: 'appchainBridgeWithdrawInitiated',
+  AppchainBridgeWithdrawSuccess: 'appchainBridgeWithdrawSuccess',
+  AppchainBridgeWithdrawFailure: 'appchainBridgeWithdrawFailure',
+  AppchainBridgeWaitForClaimFailure: 'appchainBridgeWaitForClaimFailure',
+  AppchainBridgeClaimSuccess: 'appchainBridgeClaimSuccess',
+  AppchainBridgeClaimFailure: 'appchainBridgeClaimFailure',
+} as const;
+export type AppchainEventType =
+  (typeof AppchainEvent)[keyof typeof AppchainEvent];
 
 /**
  * Generic error events across components
  * Used for error tracking and monitoring
  */
-export enum ErrorEvent {
-  ComponentError = 'componentError',
-}
+export const ErrorEvent = {
+  ComponentError: 'componentError',
+} as const;
+export type ErrorEventType = (typeof ErrorEvent)[keyof typeof ErrorEvent];
 
 /**
  * Analytics event types
  * Combines all possible event types
  */
 export type AnalyticsEvent =
-  | AppchainEvent
-  | WalletEvent
-  | SwapEvent
-  | BuyEvent
-  | CheckoutEvent
-  | MintEvent
-  | TransactionEvent
-  | FundEvent
-  | EarnEvent
+  | AppchainEventType
+  | WalletEventType
+  | SwapEventType
+  | BuyEventType
+  | CheckoutEventType
+  | MintEventType
+  | TransactionEventType
+  | FundEventType
+  | EarnEventType
   | ErrorEvent;
 
 /**
@@ -235,7 +249,7 @@ export type WalletEventData = {
     walletProvider: string;
   };
   [WalletEvent.OptionSelected]: CommonAnalyticsData & {
-    option: WalletOption;
+    option: WalletOptionType;
   };
   [WalletEvent.ConnectCanceled]: CommonAnalyticsData;
 };
@@ -276,7 +290,7 @@ export type BuyEventData = {
     token: string | undefined;
   };
   [BuyEvent.BuyOptionSelected]: CommonAnalyticsData & {
-    option: BuyOption | undefined;
+    option: BuyOptionType | undefined;
   };
   [BuyEvent.BuySuccess]: CommonAnalyticsData & {
     address: string | undefined;
@@ -428,77 +442,75 @@ export type EarnEventData = {
 // Update main AnalyticsEventData type to include all component events
 export type AnalyticsEventData = {
   // Appchain events
-  [AppchainEvent.AppchainBridgeDepositInitiated]: AppchainEventData[AppchainEvent.AppchainBridgeDepositInitiated];
-  [AppchainEvent.AppchainBridgeDepositSuccess]: AppchainEventData[AppchainEvent.AppchainBridgeDepositSuccess];
-  [AppchainEvent.AppchainBridgeDepositFailure]: AppchainEventData[AppchainEvent.AppchainBridgeDepositFailure];
-  [AppchainEvent.AppchainBridgeWithdrawInitiated]: AppchainEventData[AppchainEvent.AppchainBridgeWithdrawInitiated];
-  [AppchainEvent.AppchainBridgeWithdrawSuccess]: AppchainEventData[AppchainEvent.AppchainBridgeWithdrawSuccess];
-  [AppchainEvent.AppchainBridgeWithdrawFailure]: AppchainEventData[AppchainEvent.AppchainBridgeWithdrawFailure];
-  [AppchainEvent.AppchainBridgeWaitForClaimFailure]: AppchainEventData[AppchainEvent.AppchainBridgeWaitForClaimFailure];
-  [AppchainEvent.AppchainBridgeClaimSuccess]: AppchainEventData[AppchainEvent.AppchainBridgeClaimSuccess];
-  [AppchainEvent.AppchainBridgeClaimFailure]: AppchainEventData[AppchainEvent.AppchainBridgeClaimFailure];
+  [AppchainEvent.AppchainBridgeDepositInitiated]: AppchainEventData[typeof AppchainEvent.AppchainBridgeDepositInitiated];
+  [AppchainEvent.AppchainBridgeDepositSuccess]: AppchainEventData[typeof AppchainEvent.AppchainBridgeDepositSuccess];
+  [AppchainEvent.AppchainBridgeDepositFailure]: AppchainEventData[typeof AppchainEvent.AppchainBridgeDepositFailure];
+  [AppchainEvent.AppchainBridgeWithdrawInitiated]: AppchainEventData[typeof AppchainEvent.AppchainBridgeWithdrawInitiated];
+  [AppchainEvent.AppchainBridgeWithdrawSuccess]: AppchainEventData[typeof AppchainEvent.AppchainBridgeWithdrawSuccess];
+  [AppchainEvent.AppchainBridgeWithdrawFailure]: AppchainEventData[typeof AppchainEvent.AppchainBridgeWithdrawFailure];
+  [AppchainEvent.AppchainBridgeWaitForClaimFailure]: AppchainEventData[typeof AppchainEvent.AppchainBridgeWaitForClaimFailure];
+  [AppchainEvent.AppchainBridgeClaimSuccess]: AppchainEventData[typeof AppchainEvent.AppchainBridgeClaimSuccess];
+  [AppchainEvent.AppchainBridgeClaimFailure]: AppchainEventData[typeof AppchainEvent.AppchainBridgeClaimFailure];
 
   // Wallet events
-  [WalletEvent.ConnectError]: WalletEventData[WalletEvent.ConnectError];
-  [WalletEvent.ConnectInitiated]: WalletEventData[WalletEvent.ConnectInitiated];
-  [WalletEvent.ConnectSuccess]: WalletEventData[WalletEvent.ConnectSuccess];
-  [WalletEvent.Disconnect]: WalletEventData[WalletEvent.Disconnect];
-  [WalletEvent.OptionSelected]: CommonAnalyticsData & {
-    option: WalletOption;
-  };
-  [WalletEvent.ConnectCanceled]: WalletEventData[WalletEvent.ConnectCanceled];
+  [WalletEvent.ConnectError]: WalletEventData[typeof WalletEvent.ConnectError];
+  [WalletEvent.ConnectInitiated]: WalletEventData[typeof WalletEvent.ConnectInitiated];
+  [WalletEvent.ConnectSuccess]: WalletEventData[typeof WalletEvent.ConnectSuccess];
+  [WalletEvent.Disconnect]: WalletEventData[typeof WalletEvent.Disconnect];
+  [WalletEvent.OptionSelected]: WalletEventData[typeof WalletEvent.OptionSelected];
+  [WalletEvent.ConnectCanceled]: WalletEventData[typeof WalletEvent.ConnectCanceled];
 
   // Swap events
-  [SwapEvent.SlippageChanged]: SwapEventData[SwapEvent.SlippageChanged];
-  [SwapEvent.TokenSelected]: SwapEventData[SwapEvent.TokenSelected];
-  [SwapEvent.SwapSuccess]: SwapEventData[SwapEvent.SwapSuccess];
-  [SwapEvent.SwapFailure]: SwapEventData[SwapEvent.SwapFailure];
-  [SwapEvent.SwapInitiated]: SwapEventData[SwapEvent.SwapInitiated];
-  [SwapEvent.SwapCanceled]: SwapEventData[SwapEvent.SwapCanceled];
+  [SwapEvent.SlippageChanged]: SwapEventData[typeof SwapEvent.SlippageChanged];
+  [SwapEvent.TokenSelected]: SwapEventData[typeof SwapEvent.TokenSelected];
+  [SwapEvent.SwapSuccess]: SwapEventData[typeof SwapEvent.SwapSuccess];
+  [SwapEvent.SwapFailure]: SwapEventData[typeof SwapEvent.SwapFailure];
+  [SwapEvent.SwapInitiated]: SwapEventData[typeof SwapEvent.SwapInitiated];
+  [SwapEvent.SwapCanceled]: SwapEventData[typeof SwapEvent.SwapCanceled];
 
   // Buy events
-  [BuyEvent.BuyFailure]: BuyEventData[BuyEvent.BuyFailure];
-  [BuyEvent.BuyInitiated]: BuyEventData[BuyEvent.BuyInitiated];
-  [BuyEvent.BuyOptionSelected]: BuyEventData[BuyEvent.BuyOptionSelected];
-  [BuyEvent.BuySuccess]: BuyEventData[BuyEvent.BuySuccess];
-  [BuyEvent.BuyCanceled]: BuyEventData[BuyEvent.BuyCanceled];
+  [BuyEvent.BuyFailure]: BuyEventData[typeof BuyEvent.BuyFailure];
+  [BuyEvent.BuyInitiated]: BuyEventData[typeof BuyEvent.BuyInitiated];
+  [BuyEvent.BuyOptionSelected]: BuyEventData[typeof BuyEvent.BuyOptionSelected];
+  [BuyEvent.BuySuccess]: BuyEventData[typeof BuyEvent.BuySuccess];
+  [BuyEvent.BuyCanceled]: BuyEventData[typeof BuyEvent.BuyCanceled];
 
   // Checkout events
-  [CheckoutEvent.CheckoutFailure]: CheckoutEventData[CheckoutEvent.CheckoutFailure];
-  [CheckoutEvent.CheckoutInitiated]: CheckoutEventData[CheckoutEvent.CheckoutInitiated];
-  [CheckoutEvent.CheckoutSuccess]: CheckoutEventData[CheckoutEvent.CheckoutSuccess];
-  [CheckoutEvent.CheckoutCanceled]: CheckoutEventData[CheckoutEvent.CheckoutCanceled];
+  [CheckoutEvent.CheckoutFailure]: CheckoutEventData[typeof CheckoutEvent.CheckoutFailure];
+  [CheckoutEvent.CheckoutInitiated]: CheckoutEventData[typeof CheckoutEvent.CheckoutInitiated];
+  [CheckoutEvent.CheckoutSuccess]: CheckoutEventData[typeof CheckoutEvent.CheckoutSuccess];
+  [CheckoutEvent.CheckoutCanceled]: CheckoutEventData[typeof CheckoutEvent.CheckoutCanceled];
 
   // Mint events
-  [MintEvent.MintFailure]: MintEventData[MintEvent.MintFailure];
-  [MintEvent.MintInitiated]: MintEventData[MintEvent.MintInitiated];
-  [MintEvent.MintQuantityChanged]: MintEventData[MintEvent.MintQuantityChanged];
-  [MintEvent.MintSuccess]: MintEventData[MintEvent.MintSuccess];
-  [MintEvent.MintCanceled]: MintEventData[MintEvent.MintCanceled];
+  [MintEvent.MintFailure]: MintEventData[typeof MintEvent.MintFailure];
+  [MintEvent.MintInitiated]: MintEventData[typeof MintEvent.MintInitiated];
+  [MintEvent.MintQuantityChanged]: MintEventData[typeof MintEvent.MintQuantityChanged];
+  [MintEvent.MintSuccess]: MintEventData[typeof MintEvent.MintSuccess];
+  [MintEvent.MintCanceled]: MintEventData[typeof MintEvent.MintCanceled];
 
   // Transaction events
-  [TransactionEvent.TransactionFailure]: TransactionEventData[TransactionEvent.TransactionFailure];
-  [TransactionEvent.TransactionInitiated]: TransactionEventData[TransactionEvent.TransactionInitiated];
-  [TransactionEvent.TransactionSuccess]: TransactionEventData[TransactionEvent.TransactionSuccess];
-  [TransactionEvent.TransactionCanceled]: TransactionEventData[TransactionEvent.TransactionCanceled];
+  [TransactionEvent.TransactionFailure]: TransactionEventData[typeof TransactionEvent.TransactionFailure];
+  [TransactionEvent.TransactionInitiated]: TransactionEventData[typeof TransactionEvent.TransactionInitiated];
+  [TransactionEvent.TransactionSuccess]: TransactionEventData[typeof TransactionEvent.TransactionSuccess];
+  [TransactionEvent.TransactionCanceled]: TransactionEventData[typeof TransactionEvent.TransactionCanceled];
 
   // Fund events
-  [FundEvent.FundAmountChanged]: FundEventData[FundEvent.FundAmountChanged];
-  [FundEvent.FundFailure]: FundEventData[FundEvent.FundFailure];
-  [FundEvent.FundInitiated]: FundEventData[FundEvent.FundInitiated];
-  [FundEvent.FundOptionSelected]: FundEventData[FundEvent.FundOptionSelected];
-  [FundEvent.FundSuccess]: FundEventData[FundEvent.FundSuccess];
-  [FundEvent.FundCanceled]: FundEventData[FundEvent.FundCanceled];
+  [FundEvent.FundAmountChanged]: FundEventData[typeof FundEvent.FundAmountChanged];
+  [FundEvent.FundFailure]: FundEventData[typeof FundEvent.FundFailure];
+  [FundEvent.FundInitiated]: FundEventData[typeof FundEvent.FundInitiated];
+  [FundEvent.FundOptionSelected]: FundEventData[typeof FundEvent.FundOptionSelected];
+  [FundEvent.FundSuccess]: FundEventData[typeof FundEvent.FundSuccess];
+  [FundEvent.FundCanceled]: FundEventData[typeof FundEvent.FundCanceled];
 
   // Earn events
-  [EarnEvent.EarnDepositInitiated]: EarnEventData[EarnEvent.EarnDepositInitiated];
-  [EarnEvent.EarnDepositSuccess]: EarnEventData[EarnEvent.EarnDepositSuccess];
-  [EarnEvent.EarnDepositFailure]: EarnEventData[EarnEvent.EarnDepositFailure];
-  [EarnEvent.EarnDepositCanceled]: EarnEventData[EarnEvent.EarnDepositCanceled];
-  [EarnEvent.EarnWithdrawInitiated]: EarnEventData[EarnEvent.EarnWithdrawInitiated];
-  [EarnEvent.EarnWithdrawSuccess]: EarnEventData[EarnEvent.EarnWithdrawSuccess];
-  [EarnEvent.EarnWithdrawFailure]: EarnEventData[EarnEvent.EarnWithdrawFailure];
-  [EarnEvent.EarnWithdrawCanceled]: EarnEventData[EarnEvent.EarnWithdrawCanceled];
+  [EarnEvent.EarnDepositInitiated]: EarnEventData[typeof EarnEvent.EarnDepositInitiated];
+  [EarnEvent.EarnDepositSuccess]: EarnEventData[typeof EarnEvent.EarnDepositSuccess];
+  [EarnEvent.EarnDepositFailure]: EarnEventData[typeof EarnEvent.EarnDepositFailure];
+  [EarnEvent.EarnDepositCanceled]: EarnEventData[typeof EarnEvent.EarnDepositCanceled];
+  [EarnEvent.EarnWithdrawInitiated]: EarnEventData[typeof EarnEvent.EarnWithdrawInitiated];
+  [EarnEvent.EarnWithdrawSuccess]: EarnEventData[typeof EarnEvent.EarnWithdrawSuccess];
+  [EarnEvent.EarnWithdrawFailure]: EarnEventData[typeof EarnEvent.EarnWithdrawFailure];
+  [EarnEvent.EarnWithdrawCanceled]: EarnEventData[typeof EarnEvent.EarnWithdrawCanceled];
 
   // Error events
   [ErrorEvent.ComponentError]: CommonAnalyticsData & {

--- a/packages/onchainkit/src/core/constants.ts
+++ b/packages/onchainkit/src/core/constants.ts
@@ -1,8 +1,11 @@
 // Capabilities
-export enum Capabilities {
-  AtomicBatch = 'atomicBatch',
-  AuxiliaryFunds = 'auxiliaryFunds',
-  PaymasterService = 'paymasterService',
-}
+export const Capabilities = {
+  AtomicBatch: 'atomicBatch',
+  AuxiliaryFunds: 'auxiliaryFunds',
+  PaymasterService: 'paymasterService',
+} as const;
+
+export type CapabilitiesType = (typeof Capabilities)[keyof typeof Capabilities];
+
 export const DEFAULT_PRIVACY_URL = 'https://base.org/privacy-policy';
 export const DEFAULT_TERMS_URL = 'https://base.org/terms-of-service';

--- a/packages/onchainkit/src/core/network/constants.ts
+++ b/packages/onchainkit/src/core/network/constants.ts
@@ -14,12 +14,15 @@ export const JSON_RPC_VERSION = '2.0';
  * @enum {string}
  * @readonly
  */
-export enum RequestContext {
-  API = 'api',
-  Buy = 'buy',
-  Checkout = 'checkout',
-  Hook = 'hook',
-  NFT = 'nft',
-  Swap = 'swap',
-  Wallet = 'wallet',
-}
+export const RequestContext = {
+  API: 'api',
+  Buy: 'buy',
+  Checkout: 'checkout',
+  Hook: 'hook',
+  NFT: 'nft',
+  Swap: 'swap',
+  Wallet: 'wallet',
+} as const;
+
+export type RequestContextType =
+  (typeof RequestContext)[keyof typeof RequestContext];

--- a/packages/onchainkit/src/core/network/request.ts
+++ b/packages/onchainkit/src/core/network/request.ts
@@ -4,6 +4,7 @@ import {
   JSON_RPC_VERSION,
   POST_METHOD,
   RequestContext,
+  RequestContextType,
 } from './constants';
 import { getRPCUrl } from './getRPCUrl';
 
@@ -53,7 +54,7 @@ export function buildRequestBody<T>(
  * @returns The headers for the JSON-RPC request.
  */
 export function buildRequestHeaders(
-  context?: RequestContext,
+  context?: RequestContextType,
 ): Record<string, string> {
   if (context) {
     // if an invalid context is provided, default to 'api'
@@ -84,7 +85,7 @@ export function buildRequestHeaders(
 export async function sendRequest<T, V>(
   method: string,
   params: T[],
-  _context?: RequestContext,
+  _context?: RequestContextType,
 ): Promise<JSONRPCResult<V>> {
   try {
     const body = buildRequestBody<T>(method, params);

--- a/packages/onchainkit/src/fund/utils/subscribeToWindowMessage.ts
+++ b/packages/onchainkit/src/fund/utils/subscribeToWindowMessage.ts
@@ -1,14 +1,15 @@
 import { DEFAULT_ONRAMP_URL } from '../constants';
 import type { JsonObject } from '../types';
 
-export enum MessageCodes {
-  AppParams = 'app_params',
-  PaymentLinkSuccess = 'payment_link_success',
-  PaymentLinkClosed = 'payment_link_closed',
-  GuestCheckoutRedirectSuccess = 'guest_checkout_redirect_success',
-  Success = 'success',
-  Event = 'event',
-}
+export const MessageCodes = {
+  AppParams: 'app_params',
+  PaymentLinkSuccess: 'payment_link_success',
+  PaymentLinkClosed: 'payment_link_closed',
+  GuestCheckoutRedirectSuccess: 'guest_checkout_redirect_success',
+  Success: 'success',
+  Event: 'event',
+} as const;
+export type MessageCodesType = (typeof MessageCodes)[keyof typeof MessageCodes];
 
 type MessageData = JsonObject;
 

--- a/packages/onchainkit/src/internal/hooks/usePriceQuote.ts
+++ b/packages/onchainkit/src/internal/hooks/usePriceQuote.ts
@@ -16,7 +16,7 @@ type UsePriceQuoteParams<T> = {
 
 export function usePriceQuote(
   params: UsePriceQuoteParams<GetPriceQuoteResponse>,
-  _context: RequestContextType = RequestContext.Hook, 
+  _context: RequestContextType = RequestContext.Hook,
 ): UseQueryResult<GetPriceQuoteResponse> {
   const { token, queryOptions } = params;
 

--- a/packages/onchainkit/src/internal/hooks/usePriceQuote.ts
+++ b/packages/onchainkit/src/internal/hooks/usePriceQuote.ts
@@ -1,6 +1,6 @@
 import { getPriceQuote } from '@/api';
 import type { GetPriceQuoteResponse, PriceQuoteToken } from '@/api/types';
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { DEFAULT_QUERY_OPTIONS } from '@/internal/constants';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import {
@@ -16,7 +16,7 @@ type UsePriceQuoteParams<T> = {
 
 export function usePriceQuote(
   params: UsePriceQuoteParams<GetPriceQuoteResponse>,
-  _context: RequestContextType = 'hook',
+  _context: RequestContextType = RequestContext.Hook, 
 ): UseQueryResult<GetPriceQuoteResponse> {
   const { token, queryOptions } = params;
 

--- a/packages/onchainkit/src/internal/hooks/usePriceQuote.ts
+++ b/packages/onchainkit/src/internal/hooks/usePriceQuote.ts
@@ -1,6 +1,6 @@
 import { getPriceQuote } from '@/api';
 import type { GetPriceQuoteResponse, PriceQuoteToken } from '@/api/types';
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { DEFAULT_QUERY_OPTIONS } from '@/internal/constants';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import {
@@ -16,7 +16,7 @@ type UsePriceQuoteParams<T> = {
 
 export function usePriceQuote(
   params: UsePriceQuoteParams<GetPriceQuoteResponse>,
-  _context: RequestContext = RequestContext.Hook,
+  _context: RequestContextType = 'hook',
 ): UseQueryResult<GetPriceQuoteResponse> {
   const { token, queryOptions } = params;
 

--- a/packages/onchainkit/src/nft/components/NFTCard.tsx
+++ b/packages/onchainkit/src/nft/components/NFTCard.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@/internal/hooks/useTheme';
 import { NFTLifecycleProvider } from '@/nft/components/NFTLifecycleProvider';
 import { NFTProvider } from '@/nft/components/NFTProvider';
 import { useNFTData as defaultUseNFTData } from '@/nft/hooks/useNFTData';
-import { LifecycleType, type NFTCardReact } from '@/nft/types';
+import { type NFTCardReact } from '@/nft/types';
 import { useCallback } from 'react';
 import { useAccount } from 'wagmi';
 import { cn, pressable } from '../../styles/theme';
@@ -60,7 +60,7 @@ export function NFTCard({
   return (
     <NFTErrorBoundary fallback={NFTErrorFallback}>
       <NFTLifecycleProvider
-        type={LifecycleType.VIEW}
+        type="view"
         onStatus={onStatus}
         onError={onError}
         onSuccess={onSuccess}

--- a/packages/onchainkit/src/nft/components/NFTCard.tsx
+++ b/packages/onchainkit/src/nft/components/NFTCard.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@/internal/hooks/useTheme';
 import { NFTLifecycleProvider } from '@/nft/components/NFTLifecycleProvider';
 import { NFTProvider } from '@/nft/components/NFTProvider';
 import { useNFTData as defaultUseNFTData } from '@/nft/hooks/useNFTData';
-import { type NFTCardReact } from '@/nft/types';
+import { Lifecycle, type NFTCardReact } from '@/nft/types';
 import { useCallback } from 'react';
 import { useAccount } from 'wagmi';
 import { cn, pressable } from '../../styles/theme';
@@ -60,7 +60,7 @@ export function NFTCard({
   return (
     <NFTErrorBoundary fallback={NFTErrorFallback}>
       <NFTLifecycleProvider
-        type="view"
+        type={Lifecycle.VIEW}
         onStatus={onStatus}
         onError={onError}
         onSuccess={onSuccess}

--- a/packages/onchainkit/src/nft/components/NFTLifecycleProvider.test.tsx
+++ b/packages/onchainkit/src/nft/components/NFTLifecycleProvider.test.tsx
@@ -3,7 +3,7 @@ import type { NFTError } from '@/api/types';
 import { fireEvent, render } from '@testing-library/react';
 import type { TransactionReceipt } from 'viem';
 import { describe, expect, it, vi } from 'vitest';
-import { type LifecycleStatus, LifecycleType, MediaType } from '../types';
+import { type LifecycleStatus, Lifecycle, MediaType } from '../types';
 import {
   NFTLifecycleProvider,
   useNFTLifecycleContext,
@@ -84,7 +84,7 @@ const renderWithProviders = ({
 }) => {
   return render(
     <NFTLifecycleProvider
-      type={LifecycleType.MINT}
+      type={Lifecycle.MINT}
       onError={onError}
       onStatus={onStatus}
       onSuccess={onSuccess}

--- a/packages/onchainkit/src/nft/components/NFTMintCard.tsx
+++ b/packages/onchainkit/src/nft/components/NFTMintCard.tsx
@@ -11,7 +11,7 @@ import {
   NFTQuantitySelector,
 } from '@/nft/components/mint';
 import { useMintData as defaultUseMintData } from '@/nft/hooks/useMintData';
-import { type NFTMintCardReact } from '@/nft/types';
+import { Lifecycle, type NFTMintCardReact } from '@/nft/types';
 import { buildMintTransactionData as defaultBuildMintTransaction } from '@/nft/utils/buildMintTransactionData';
 import { cn } from '../../styles/theme';
 import NFTErrorBoundary from './NFTErrorBoundary';
@@ -55,7 +55,7 @@ export function NFTMintCard({
   return (
     <NFTErrorBoundary fallback={NFTErrorFallback}>
       <NFTLifecycleProvider
-        type="mint"
+        type={Lifecycle.MINT}
         onStatus={onStatus}
         onError={onError}
         onSuccess={onSuccess}

--- a/packages/onchainkit/src/nft/components/NFTMintCard.tsx
+++ b/packages/onchainkit/src/nft/components/NFTMintCard.tsx
@@ -11,7 +11,7 @@ import {
   NFTQuantitySelector,
 } from '@/nft/components/mint';
 import { useMintData as defaultUseMintData } from '@/nft/hooks/useMintData';
-import { LifecycleType, type NFTMintCardReact } from '@/nft/types';
+import { type NFTMintCardReact } from '@/nft/types';
 import { buildMintTransactionData as defaultBuildMintTransaction } from '@/nft/utils/buildMintTransactionData';
 import { cn } from '../../styles/theme';
 import NFTErrorBoundary from './NFTErrorBoundary';
@@ -55,7 +55,7 @@ export function NFTMintCard({
   return (
     <NFTErrorBoundary fallback={NFTErrorFallback}>
       <NFTLifecycleProvider
-        type={LifecycleType.MINT}
+        type="mint"
         onStatus={onStatus}
         onError={onError}
         onSuccess={onSuccess}

--- a/packages/onchainkit/src/nft/components/view/NFTMedia.test.tsx
+++ b/packages/onchainkit/src/nft/components/view/NFTMedia.test.tsx
@@ -1,10 +1,10 @@
 import '@testing-library/jest-dom';
 import { useNFTLifecycleContext } from '@/nft/components/NFTLifecycleProvider';
 import { useNFTContext } from '@/nft/components/NFTProvider';
-import { LifecycleType } from '@/nft/types';
 import { fireEvent, render } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NFTMedia } from './NFTMedia';
+import { Lifecycle } from '@/nft/types';
 
 vi.mock('@/nft/components/NFTProvider', () => ({
   useNFTContext: vi.fn(),
@@ -54,7 +54,7 @@ describe('NFTMedia', () => {
     mockUpdateLifecycleStatus = vi.fn();
     (useNFTContext as Mock).mockReturnValue({ mimeType: 'image/png' });
     (useNFTLifecycleContext as Mock).mockReturnValue({
-      type: LifecycleType.VIEW,
+      type: Lifecycle.VIEW,
       updateLifecycleStatus: mockUpdateLifecycleStatus,
     });
   });
@@ -105,7 +105,7 @@ describe('NFTMedia', () => {
 
   it('should call updateLifecycleStatus with mediaLoaded when media is loaded for type Mint', () => {
     (useNFTLifecycleContext as Mock).mockReturnValue({
-      type: LifecycleType.MINT,
+      type: Lifecycle.MINT,
       updateLifecycleStatus: mockUpdateLifecycleStatus,
     });
 

--- a/packages/onchainkit/src/nft/components/view/NFTMedia.tsx
+++ b/packages/onchainkit/src/nft/components/view/NFTMedia.tsx
@@ -1,7 +1,7 @@
 import type { NFTError } from '@/api/types';
 import { useNFTLifecycleContext } from '@/nft/components/NFTLifecycleProvider';
 import { useNFTContext } from '@/nft/components/NFTProvider';
-import { LifecycleType, MediaType } from '@/nft/types';
+import { MediaType } from '@/nft/types';
 import { useCallback, useMemo } from 'react';
 import { cn } from '../../../styles/theme';
 import { NFTAudio } from './NFTAudio';
@@ -46,7 +46,7 @@ export function NFTMedia({ className, square }: NFTMediaReact) {
   const handleLoaded = useCallback(() => {
     // for Views, this is the success state
     updateLifecycleStatus({
-      statusName: type === LifecycleType.MINT ? 'mediaLoaded' : 'success',
+      statusName: type === 'mint' ? 'mediaLoaded' : 'success',
     });
   }, [type, updateLifecycleStatus]);
 

--- a/packages/onchainkit/src/nft/components/view/NFTMedia.tsx
+++ b/packages/onchainkit/src/nft/components/view/NFTMedia.tsx
@@ -1,7 +1,7 @@
 import type { NFTError } from '@/api/types';
 import { useNFTLifecycleContext } from '@/nft/components/NFTLifecycleProvider';
 import { useNFTContext } from '@/nft/components/NFTProvider';
-import { MediaType } from '@/nft/types';
+import { MediaType, Lifecycle } from '@/nft/types';
 import { useCallback, useMemo } from 'react';
 import { cn } from '../../../styles/theme';
 import { NFTAudio } from './NFTAudio';
@@ -46,7 +46,7 @@ export function NFTMedia({ className, square }: NFTMediaReact) {
   const handleLoaded = useCallback(() => {
     // for Views, this is the success state
     updateLifecycleStatus({
-      statusName: type === 'mint' ? 'mediaLoaded' : 'success',
+      statusName: type === Lifecycle.MINT ? 'mediaLoaded' : 'success',
     });
   }, [type, updateLifecycleStatus]);
 

--- a/packages/onchainkit/src/nft/hooks/useMintDetails.ts
+++ b/packages/onchainkit/src/nft/hooks/useMintDetails.ts
@@ -1,13 +1,13 @@
 import { getMintDetails } from '@/api/getMintDetails';
 import type { MintDetails } from '@/api/types';
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseMintDetailsParams } from '../types';
 
 export function useMintDetails(
   params: UseMintDetailsParams<MintDetails>,
-  _context: RequestContext = RequestContext.Hook,
+  _context: RequestContextType = 'hook',
 ): UseQueryResult<MintDetails> {
   const { contractAddress, takerAddress, tokenId, queryOptions } = params;
 

--- a/packages/onchainkit/src/nft/hooks/useMintDetails.ts
+++ b/packages/onchainkit/src/nft/hooks/useMintDetails.ts
@@ -1,13 +1,13 @@
 import { getMintDetails } from '@/api/getMintDetails';
 import type { MintDetails } from '@/api/types';
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseMintDetailsParams } from '../types';
 
 export function useMintDetails(
   params: UseMintDetailsParams<MintDetails>,
-  _context: RequestContextType = 'hook',
+  _context: RequestContextType = RequestContext.Hook,
 ): UseQueryResult<MintDetails> {
   const { contractAddress, takerAddress, tokenId, queryOptions } = params;
 

--- a/packages/onchainkit/src/nft/hooks/useTokenDetails.ts
+++ b/packages/onchainkit/src/nft/hooks/useTokenDetails.ts
@@ -1,13 +1,13 @@
 import { getTokenDetails } from '@/api/getTokenDetails';
 import type { TokenDetails } from '@/api/types';
-import { RequestContext } from '@/core/network/constants';
+import { RequestContextType } from '@/core/network/constants';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseTokenDetailsParams } from '../types';
 
 export function useTokenDetails(
   params: UseTokenDetailsParams<TokenDetails>,
-  _context: RequestContext = RequestContext.Hook,
+  _context: RequestContextType = 'hook',
 ): UseQueryResult<TokenDetails> {
   const { contractAddress, tokenId, queryOptions } = params;
 

--- a/packages/onchainkit/src/nft/hooks/useTokenDetails.ts
+++ b/packages/onchainkit/src/nft/hooks/useTokenDetails.ts
@@ -1,13 +1,13 @@
 import { getTokenDetails } from '@/api/getTokenDetails';
 import type { TokenDetails } from '@/api/types';
-import { RequestContextType } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { isNFTError } from '@/nft/utils/isNFTError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { UseTokenDetailsParams } from '../types';
 
 export function useTokenDetails(
   params: UseTokenDetailsParams<TokenDetails>,
-  _context: RequestContextType = 'hook',
+  _context: RequestContextType = RequestContext.Hook,
 ): UseQueryResult<TokenDetails> {
   const { contractAddress, tokenId, queryOptions } = params;
 

--- a/packages/onchainkit/src/nft/types.ts
+++ b/packages/onchainkit/src/nft/types.ts
@@ -11,20 +11,22 @@ import type {
 import type { LifecycleStatusUpdate } from '../internal/types';
 import type { Call } from '../transaction/types';
 
-export enum MediaType {
-  Image = 'image',
-  Video = 'video',
-  Audio = 'audio',
-  Unknown = 'unknown',
-}
+export const MediaType = {
+  Image: 'image',
+  Video: 'video',
+  Audio: 'audio',
+  Unknown: 'unknown',
+} as const;
+export type MediaType = (typeof MediaType)[keyof typeof MediaType];
 
 /**
  * Lifecycle Provider
  */
-export enum LifecycleType {
-  VIEW = 'view',
-  MINT = 'mint',
-}
+export const Lifecycle = {
+  VIEW: 'view',
+  MINT: 'mint',
+} as const;
+export type LifecycleType = (typeof Lifecycle)[keyof typeof Lifecycle];
 
 export type NFTLifecycleProviderReact = {
   type: LifecycleType;

--- a/packages/onchainkit/src/signature/components/SignatureIcon.test.tsx
+++ b/packages/onchainkit/src/signature/components/SignatureIcon.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { type Mock, describe, expect, it, vi } from 'vitest';
-import { MessageType } from '../types';
+import { Message } from '../types';
 import { SignatureIcon } from './SignatureIcon';
 import { useSignatureContext } from './SignatureProvider';
 
@@ -24,7 +24,7 @@ describe('SignatureIcon', () => {
         statusName: 'success',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });
@@ -39,7 +39,7 @@ describe('SignatureIcon', () => {
         statusName: 'error',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });
@@ -53,7 +53,7 @@ describe('SignatureIcon', () => {
         statusName: 'pending',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });
@@ -67,7 +67,7 @@ describe('SignatureIcon', () => {
         statusName: 'success',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });

--- a/packages/onchainkit/src/signature/components/SignatureLabel.test.tsx
+++ b/packages/onchainkit/src/signature/components/SignatureLabel.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { type Mock, describe, expect, it, vi } from 'vitest';
-import { MessageType } from '../types';
+import { Message } from '../types';
 import { SignatureLabel } from './SignatureLabel';
 import { useSignatureContext } from './SignatureProvider';
 
@@ -15,7 +15,7 @@ describe('SignatureLabel', () => {
         statusName: 'success',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });
@@ -31,7 +31,7 @@ describe('SignatureLabel', () => {
         statusData: {
           code: 'TEST01',
           message: 'Test error message',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });
@@ -44,7 +44,7 @@ describe('SignatureLabel', () => {
       lifecycleStatus: {
         statusName: 'pending',
         statusData: {
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });
@@ -58,7 +58,7 @@ describe('SignatureLabel', () => {
         statusName: 'success',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });

--- a/packages/onchainkit/src/signature/components/SignatureProvider.tsx
+++ b/packages/onchainkit/src/signature/components/SignatureProvider.tsx
@@ -9,11 +9,7 @@ import type {
   SignMessageParameters,
   SignTypedDataParameters,
 } from 'wagmi/actions';
-import {
-  type LifecycleStatus,
-  MessageType,
-  type SignatureProviderProps,
-} from '../types';
+import { type LifecycleStatus, type SignatureProviderProps } from '../types';
 import { validateMessage } from '../utils/validateMessage';
 
 type SignatureContextType = {
@@ -138,11 +134,11 @@ export function SignatureProvider({
         message,
         primaryType,
       });
-      if (validatedMessage.type === MessageType.TYPED_DATA) {
+      if (validatedMessage.type === 'typed_data') {
         await handleSignTypedData(validatedMessage.data);
-      } else if (validatedMessage.type === MessageType.SIGNABLE_MESSAGE) {
+      } else if (validatedMessage.type === 'signable_message') {
         await handleSignMessage(validatedMessage.data);
-      } else if (validatedMessage.type === MessageType.INVALID) {
+      } else if (validatedMessage.type === 'invalid') {
         throw new Error('Invalid message data');
       }
     } catch (err) {

--- a/packages/onchainkit/src/signature/components/SignatureProvider.tsx
+++ b/packages/onchainkit/src/signature/components/SignatureProvider.tsx
@@ -9,7 +9,11 @@ import type {
   SignMessageParameters,
   SignTypedDataParameters,
 } from 'wagmi/actions';
-import { type LifecycleStatus, type SignatureProviderProps } from '../types';
+import {
+  Message,
+  type LifecycleStatus,
+  type SignatureProviderProps,
+} from '../types';
 import { validateMessage } from '../utils/validateMessage';
 
 type SignatureContextType = {
@@ -134,11 +138,11 @@ export function SignatureProvider({
         message,
         primaryType,
       });
-      if (validatedMessage.type === 'typed_data') {
+      if (validatedMessage.type === Message.TYPED_DATA) {
         await handleSignTypedData(validatedMessage.data);
-      } else if (validatedMessage.type === 'signable_message') {
+      } else if (validatedMessage.type === Message.SIGNABLE_MESSAGE) {
         await handleSignMessage(validatedMessage.data);
-      } else if (validatedMessage.type === 'invalid') {
+      } else if (validatedMessage.type === Message.INVALID) {
         throw new Error('Invalid message data');
       }
     } catch (err) {

--- a/packages/onchainkit/src/signature/components/SignatureToast.test.tsx
+++ b/packages/onchainkit/src/signature/components/SignatureToast.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, describe, expect, it, vi } from 'vitest';
-import { MessageType } from '../types';
+import { Message } from '../types';
 import { useSignatureContext } from './SignatureProvider';
 import { SignatureToast } from './SignatureToast';
 
@@ -22,7 +22,7 @@ describe('SignatureToast', () => {
         statusName: 'success',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });
@@ -49,7 +49,7 @@ describe('SignatureToast', () => {
         statusName: 'success',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });
@@ -64,7 +64,7 @@ describe('SignatureToast', () => {
         statusName: 'success',
         statusData: {
           signature: '0x123',
-          type: MessageType.TYPED_DATA,
+          type: Message.TYPED_DATA,
         },
       },
     });

--- a/packages/onchainkit/src/signature/types.ts
+++ b/packages/onchainkit/src/signature/types.ts
@@ -4,16 +4,17 @@ import type {
 } from 'wagmi/actions';
 import type { APIError } from '../api/types';
 
-export enum MessageType {
-  SIGNABLE_MESSAGE = 'signable_message',
-  TYPED_DATA = 'typed_data',
-  INVALID = 'invalid',
-}
+export const Message = {
+  SIGNABLE_MESSAGE: 'signable_message',
+  TYPED_DATA: 'typed_data',
+  INVALID: 'invalid',
+} as const;
+export type MessageType = (typeof Message)[keyof typeof Message];
 
 export type ValidateMessageResult =
-  | { type: MessageType.TYPED_DATA; data: SignTypedDataParameters }
-  | { type: MessageType.SIGNABLE_MESSAGE; data: SignMessageParameters }
-  | { type: MessageType.INVALID; data: null };
+  | { type: typeof Message.TYPED_DATA; data: SignTypedDataParameters }
+  | { type: typeof Message.SIGNABLE_MESSAGE; data: SignMessageParameters }
+  | { type: typeof Message.INVALID; data: null };
 
 export type MessageData = {
   domain?: SignTypedDataParameters['domain'];

--- a/packages/onchainkit/src/signature/utils/validateMessage.test.ts
+++ b/packages/onchainkit/src/signature/utils/validateMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { MessageType } from '../types';
+import { Message } from '../types';
 import { validateMessage } from './validateMessage';
 
 describe('validateMessage', () => {
@@ -13,7 +13,7 @@ describe('validateMessage', () => {
 
     const result = validateMessage(typedData);
     expect(result).toEqual({
-      type: MessageType.TYPED_DATA,
+      type: Message.TYPED_DATA,
       data: typedData,
     });
   });
@@ -25,7 +25,7 @@ describe('validateMessage', () => {
 
     const result = validateMessage(messageData);
     expect(result).toEqual({
-      type: MessageType.SIGNABLE_MESSAGE,
+      type: Message.SIGNABLE_MESSAGE,
       data: messageData,
     });
   });
@@ -33,7 +33,7 @@ describe('validateMessage', () => {
   it('should validate string message', () => {
     const result = validateMessage({ message: 'Test message' });
     expect(result).toEqual({
-      type: MessageType.SIGNABLE_MESSAGE,
+      type: Message.SIGNABLE_MESSAGE,
       data: { message: 'Test message' },
     });
   });
@@ -43,7 +43,7 @@ describe('validateMessage', () => {
       message: { raw: '0x1234' },
     });
     expect(result).toEqual({
-      type: MessageType.SIGNABLE_MESSAGE,
+      type: Message.SIGNABLE_MESSAGE,
       data: { message: { raw: '0x1234' } },
     });
   });
@@ -53,7 +53,7 @@ describe('validateMessage', () => {
       message: { raw: new Uint8Array([1, 2, 3, 4]) },
     });
     expect(result).toEqual({
-      type: MessageType.SIGNABLE_MESSAGE,
+      type: Message.SIGNABLE_MESSAGE,
       data: { message: { raw: new Uint8Array([1, 2, 3, 4]) } },
     });
   });
@@ -68,7 +68,7 @@ describe('validateMessage', () => {
     // @ts-expect-error testing invalid input
     const result = validateMessage(invalidTypedData);
     expect(result).toEqual({
-      type: MessageType.INVALID,
+      type: Message.INVALID,
       data: null,
     });
   });
@@ -77,7 +77,7 @@ describe('validateMessage', () => {
     // @ts-expect-error testing invalid input
     const result = validateMessage({});
     expect(result).toEqual({
-      type: MessageType.INVALID,
+      type: Message.INVALID,
       data: null,
     });
   });
@@ -86,7 +86,7 @@ describe('validateMessage', () => {
     // @ts-expect-error testing invalid input
     const result = validateMessage(null);
     expect(result).toEqual({
-      type: MessageType.INVALID,
+      type: Message.INVALID,
       data: null,
     });
   });

--- a/packages/onchainkit/src/signature/utils/validateMessage.ts
+++ b/packages/onchainkit/src/signature/utils/validateMessage.ts
@@ -2,7 +2,11 @@ import type {
   SignMessageParameters,
   SignTypedDataParameters,
 } from 'wagmi/actions';
-import { type MessageData, type ValidateMessageResult } from '../types';
+import {
+  Message,
+  type MessageData,
+  type ValidateMessageResult,
+} from '../types';
 
 export function isTypedData(
   params: MessageData,
@@ -31,20 +35,20 @@ export function validateMessage(
 ): ValidateMessageResult {
   if (isTypedData(messageData)) {
     return {
-      type: 'typed_data',
+      type: Message.TYPED_DATA,
       data: messageData,
     };
   }
 
   if (isSignableMessage(messageData)) {
     return {
-      type: 'signable_message',
+      type: Message.SIGNABLE_MESSAGE,
       data: messageData,
     };
   }
 
   return {
-    type: 'invalid',
+    type: Message.INVALID,
     data: null,
   };
 }

--- a/packages/onchainkit/src/signature/utils/validateMessage.ts
+++ b/packages/onchainkit/src/signature/utils/validateMessage.ts
@@ -2,11 +2,7 @@ import type {
   SignMessageParameters,
   SignTypedDataParameters,
 } from 'wagmi/actions';
-import {
-  type MessageData,
-  MessageType,
-  type ValidateMessageResult,
-} from '../types';
+import { type MessageData, type ValidateMessageResult } from '../types';
 
 export function isTypedData(
   params: MessageData,
@@ -35,20 +31,20 @@ export function validateMessage(
 ): ValidateMessageResult {
   if (isTypedData(messageData)) {
     return {
-      type: MessageType.TYPED_DATA,
+      type: 'typed_data',
       data: messageData,
     };
   }
 
   if (isSignableMessage(messageData)) {
     return {
-      type: MessageType.SIGNABLE_MESSAGE,
+      type: 'signable_message',
       data: messageData,
     };
   }
 
   return {
-    type: MessageType.INVALID,
+    type: 'invalid',
     data: null,
   };
 }

--- a/packages/onchainkit/src/swap/constants.ts
+++ b/packages/onchainkit/src/swap/constants.ts
@@ -13,19 +13,21 @@ export const UNIVERSALROUTER_CONTRACT_ADDRESS =
 export const USER_REJECTED_ERROR_CODE = 'USER_REJECTED';
 export const UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE =
   'UNSUPPORTED_AMOUNT_REFERENCE_ERROR';
-export enum SwapMessage {
-  BALANCE_ERROR = 'Error fetching token balance',
-  CONFIRM_IN_WALLET = 'Confirm in wallet',
-  FETCHING_QUOTE = 'Fetching quote...',
-  FETCHING_BALANCE = 'Fetching balance...',
-  INCOMPLETE_FIELD = 'Complete the fields to continue',
-  INSUFFICIENT_BALANCE = 'Insufficient balance',
-  LOW_LIQUIDITY = 'Insufficient liquidity for this trade.',
-  SWAP_IN_PROGRESS = 'Swap in progress...',
-  TOO_MANY_REQUESTS = 'Too many requests. Please try again later.',
-  USER_REJECTED = 'User rejected the transaction',
-  UNSUPPORTED_AMOUNT_REFERENCE = 'useAggregator does not support amountReference: to, please use useAggregator: false',
-}
+export const SwapMessage = {
+  BALANCE_ERROR: 'Error fetching token balance',
+  CONFIRM_IN_WALLET: 'Confirm in wallet',
+  FETCHING_QUOTE: 'Fetching quote...',
+  FETCHING_BALANCE: 'Fetching balance...',
+  INCOMPLETE_FIELD: 'Complete the fields to continue',
+  INSUFFICIENT_BALANCE: 'Insufficient balance',
+  LOW_LIQUIDITY: 'Insufficient liquidity for this trade.',
+  SWAP_IN_PROGRESS: 'Swap in progress...',
+  TOO_MANY_REQUESTS: 'Too many requests. Please try again later.',
+  USER_REJECTED: 'User rejected the transaction',
+  UNSUPPORTED_AMOUNT_REFERENCE:
+    'useAggregator does not support amountReference: to, please use useAggregator: false',
+} as const;
+export type SwapMessageType = (typeof SwapMessage)[keyof typeof SwapMessage];
 
 export const ONRAMP_PAYMENT_METHODS = [
   {

--- a/packages/onchainkit/src/transaction/components/TransactionProvider.tsx
+++ b/packages/onchainkit/src/transaction/components/TransactionProvider.tsx
@@ -17,6 +17,7 @@ import { waitForTransactionReceipt } from 'wagmi/actions';
 import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
 import {
   TransactionEvent,
+  TransactionEventType,
   type TransactionEventData,
 } from '../../core/analytics/types';
 import { Capabilities } from '../../core/constants';
@@ -158,7 +159,10 @@ export function TransactionProvider({
   const { sendAnalytics } = useAnalytics();
 
   const handleAnalytics = useCallback(
-    (event: TransactionEvent, data: TransactionEventData[TransactionEvent]) => {
+    (
+      event: TransactionEventType,
+      data: TransactionEventData[TransactionEventType],
+    ) => {
       sendAnalytics(event, data);
     },
     [sendAnalytics],

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedTransactionActions.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedTransactionActions.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useAnalytics } from '@/core/analytics/hooks/useAnalytics';
-import { WalletEvent, WalletOption } from '@/core/analytics/types';
+import {
+  WalletEvent,
+  WalletOption,
+  WalletOptionType,
+} from '@/core/analytics/types';
 import { Skeleton } from '@/internal/components/Skeleton';
 import { addSvgForeground } from '@/internal/svg/addForegroundSvg';
 import { arrowUpRightSvg } from '@/internal/svg/arrowUpRightSvg';
@@ -46,7 +50,7 @@ export function WalletAdvancedTransactionActions({
   );
 
   const handleAnalyticsOptionSelected = useCallback(
-    (option: WalletOption) => {
+    (option: WalletOptionType) => {
       sendAnalytics(WalletEvent.OptionSelected, {
         option,
       });

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAnalytics } from '@/core/analytics/hooks/useAnalytics';
-import { WalletEvent, WalletOption } from '@/core/analytics/types';
+import { WalletEvent, WalletOptionType } from '@/core/analytics/types';
 import { PressableIcon } from '@/internal/components/PressableIcon';
 import { baseScanSvg } from '@/internal/svg/baseScanSvg';
 import { disconnectSvg } from '@/internal/svg/disconnectSvg';
@@ -12,7 +12,6 @@ import { useCallback } from 'react';
 import { useAccount, useDisconnect } from 'wagmi';
 import { useWalletContext } from './WalletProvider';
 import { usePortfolio } from '../hooks/usePortfolio';
-import { RequestContext } from '@/core/network/constants';
 
 type WalletAdvancedWalletActionsProps = {
   classNames?: {
@@ -32,13 +31,10 @@ export function WalletAdvancedWalletActions({
   const { disconnect, connectors } = useDisconnect();
   const { sendAnalytics } = useAnalytics();
 
-  const { refetch: refetchPortfolioData } = usePortfolio(
-    { address },
-    RequestContext.Wallet,
-  );
+  const { refetch: refetchPortfolioData } = usePortfolio({ address }, 'wallet');
 
   const handleAnalyticsOptionSelected = useCallback(
-    (option: WalletOption) => {
+    (option: WalletOptionType) => {
       sendAnalytics(WalletEvent.OptionSelected, {
         option,
       });
@@ -57,7 +53,7 @@ export function WalletAdvancedWalletActions({
   );
 
   const handleTransactions = useCallback(() => {
-    handleAnalyticsOptionSelected(WalletOption.Explorer);
+    handleAnalyticsOptionSelected('explorer');
     window.open(`https://basescan.org/address/${address}`, '_blank');
   }, [address, handleAnalyticsOptionSelected]);
 
@@ -72,12 +68,12 @@ export function WalletAdvancedWalletActions({
   }, [disconnect, connectors, handleClose, handleAnalyticsDisconnect]);
 
   const handleQr = useCallback(() => {
-    handleAnalyticsOptionSelected(WalletOption.QR);
+    handleAnalyticsOptionSelected('qr');
     setActiveFeature('qr');
   }, [setActiveFeature, handleAnalyticsOptionSelected]);
 
   const handleRefreshPortfolioData = useCallback(async () => {
-    handleAnalyticsOptionSelected(WalletOption.Refresh);
+    handleAnalyticsOptionSelected('refresh');
     await refetchPortfolioData();
   }, [refetchPortfolioData, handleAnalyticsOptionSelected]);
 

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useAnalytics } from '@/core/analytics/hooks/useAnalytics';
-import { WalletEvent, WalletOptionType } from '@/core/analytics/types';
+import {
+  WalletEvent,
+  WalletOption,
+  WalletOptionType,
+} from '@/core/analytics/types';
 import { PressableIcon } from '@/internal/components/PressableIcon';
 import { baseScanSvg } from '@/internal/svg/baseScanSvg';
 import { disconnectSvg } from '@/internal/svg/disconnectSvg';
@@ -53,7 +57,7 @@ export function WalletAdvancedWalletActions({
   );
 
   const handleTransactions = useCallback(() => {
-    handleAnalyticsOptionSelected('explorer');
+    handleAnalyticsOptionSelected(WalletOption.Explorer);
     window.open(`https://basescan.org/address/${address}`, '_blank');
   }, [address, handleAnalyticsOptionSelected]);
 
@@ -68,12 +72,12 @@ export function WalletAdvancedWalletActions({
   }, [disconnect, connectors, handleClose, handleAnalyticsDisconnect]);
 
   const handleQr = useCallback(() => {
-    handleAnalyticsOptionSelected('qr');
+    handleAnalyticsOptionSelected(WalletOption.QR);
     setActiveFeature('qr');
   }, [setActiveFeature, handleAnalyticsOptionSelected]);
 
   const handleRefreshPortfolioData = useCallback(async () => {
-    handleAnalyticsOptionSelected('refresh');
+    handleAnalyticsOptionSelected(WalletOption.Refresh);
     await refetchPortfolioData();
   }, [refetchPortfolioData, handleAnalyticsOptionSelected]);
 

--- a/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletAdvancedWalletActions.tsx
@@ -16,6 +16,7 @@ import { useCallback } from 'react';
 import { useAccount, useDisconnect } from 'wagmi';
 import { useWalletContext } from './WalletProvider';
 import { usePortfolio } from '../hooks/usePortfolio';
+import { RequestContext } from '@/core/network/constants';
 
 type WalletAdvancedWalletActionsProps = {
   classNames?: {
@@ -35,7 +36,10 @@ export function WalletAdvancedWalletActions({
   const { disconnect, connectors } = useDisconnect();
   const { sendAnalytics } = useAnalytics();
 
-  const { refetch: refetchPortfolioData } = usePortfolio({ address }, 'wallet');
+  const { refetch: refetchPortfolioData } = usePortfolio(
+    { address },
+    RequestContext.Wallet,
+  );
 
   const handleAnalyticsOptionSelected = useCallback(
     (option: WalletOptionType) => {

--- a/packages/onchainkit/src/wallet/hooks/usePortfolio.ts
+++ b/packages/onchainkit/src/wallet/hooks/usePortfolio.ts
@@ -1,6 +1,6 @@
 import { getPortfolios } from '@/api/getPortfolios';
 import type { Portfolio } from '@/api/types';
-import { RequestContext } from '@/core/network/constants';
+import { RequestContext, RequestContextType } from '@/core/network/constants';
 import { isApiError } from '@/internal/utils/isApiResponseError';
 import { type UseQueryResult, useQuery } from '@tanstack/react-query';
 import type { Address } from 'viem';
@@ -16,7 +16,7 @@ type UsePortfolioProps = {
  */
 export function usePortfolio(
   { address, enabled = true }: UsePortfolioProps,
-  _context: RequestContext = RequestContext.Hook,
+  _context: RequestContextType = RequestContext.Hook,
 ): UseQueryResult<Portfolio> {
   return useQuery({
     queryKey: ['usePortfolio', address],

--- a/packages/playground/components/form/wallet-type.tsx
+++ b/packages/playground/components/form/wallet-type.tsx
@@ -6,13 +6,15 @@ import { useEffect, useState } from 'react';
 import { useAccount, useConnect, useConnectors, useDisconnect } from 'wagmi';
 import type { GetConnectorsReturnType } from 'wagmi/actions';
 
-export enum WalletPreference {
-  SMART_WALLET = 'smartWalletOnly',
-  EOA = 'eoaOnly',
-}
+export const WalletPreference = {
+  SMART_WALLET: 'smartWalletOnly',
+  EOA: 'eoaOnly',
+} as const;
+export type WalletPreferenceType =
+  (typeof WalletPreference)[keyof typeof WalletPreference];
 
 const getConnector = (
-  walletType: WalletPreference,
+  walletType: WalletPreferenceType,
   connectors: GetConnectorsReturnType,
 ) => {
   if (walletType === WalletPreference.SMART_WALLET) {
@@ -27,20 +29,20 @@ export function WalletType() {
   const account = useAccount();
   const { connect } = useConnect();
 
-  const [walletType, setWalletType] = useState<WalletPreference>();
+  const [walletType, setWalletType] = useState<WalletPreferenceType>();
 
   useEffect(() => {
     const storedWalletType = localStorage.getItem(getStorageKey('walletType'));
     if (storedWalletType) {
-      setWalletType(storedWalletType as WalletPreference);
+      setWalletType(storedWalletType as WalletPreferenceType);
     }
   }, []);
 
-  async function handleConnect(value: WalletPreference) {
+  async function handleConnect(value: WalletPreferenceType) {
     setWalletType(value);
     connect(
       {
-        connector: getConnector(value as WalletPreference, connectors),
+        connector: getConnector(value, connectors),
       },
       {
         // Set localStorage ONLY when user has connected

--- a/packages/playground/types/onchainkit.ts
+++ b/packages/playground/types/onchainkit.ts
@@ -1,37 +1,39 @@
-export enum OnchainKitComponent {
-  FundButton = 'fund-button',
-  FundButtonWithRenderProp = 'fund-button-with-render-prop',
-  FundCard = 'fund-card',
-  Buy = 'buy',
-  Identity = 'identity',
-  IdentityCard = 'identity-card',
-  Checkout = 'checkout',
-  Swap = 'swap',
-  SwapDefault = 'swap-default',
-  Transaction = 'transaction',
-  TransactionWithRenderProp = 'transaction-with-render-prop',
-  TransactionDefault = 'transaction-default',
-  Wallet = 'wallet',
-  WalletDefault = 'wallet-default',
-  WalletIsland = 'wallet-island',
-  WalletAdvancedDefault = 'wallet-advanced-default',
-  NFTCard = 'nft-card',
-  NFTCardDefault = 'nft-card-default',
-  NFTMintCard = 'nft-mint-card',
-  NFTMintCardDefault = 'nft-mint-card-default',
-  Earn = 'earn',
-  Signature = 'signature',
-}
+export const OnchainKitComponent = {
+  FundButton: 'fund-button',
+  FundButtonWithRenderProp: 'fund-button-with-render-prop',
+  FundCard: 'fund-card',
+  Buy: 'buy',
+  Identity: 'identity',
+  IdentityCard: 'identity-card',
+  Checkout: 'checkout',
+  Swap: 'swap',
+  SwapDefault: 'swap-default',
+  Transaction: 'transaction',
+  TransactionWithRenderProp: 'transaction-with-render-prop',
+  TransactionDefault: 'transaction-default',
+  Wallet: 'wallet',
+  WalletDefault: 'wallet-default',
+  WalletIsland: 'wallet-island',
+  WalletAdvancedDefault: 'wallet-advanced-default',
+  NFTCard: 'nft-card',
+  NFTCardDefault: 'nft-card-default',
+  NFTMintCard: 'nft-mint-card',
+  NFTMintCardDefault: 'nft-mint-card-default',
+  Earn: 'earn',
+  Signature: 'signature',
+} as const;
 
-export enum TransactionTypes {
-  Calls = 'calls',
-  Contracts = 'contracts',
-  CallsPromise = 'callsPromise',
-  ContractsPromise = 'contractsPromise',
-  CallsCallback = 'callsCallback',
-  ContractsCallback = 'contractsCallback',
-  ContractsAndCalls = 'contractsAndCalls',
-}
+export const TransactionTypes = {
+  Calls: 'calls',
+  Contracts: 'contracts',
+  CallsPromise: 'callsPromise',
+  ContractsPromise: 'contractsPromise',
+  CallsCallback: 'callsCallback',
+  ContractsCallback: 'contractsCallback',
+  ContractsAndCalls: 'contractsAndCalls',
+} as const;
+export type TransactionTypesType =
+  (typeof TransactionTypes)[keyof typeof TransactionTypes];
 
 export type Paymaster = {
   url: string;
@@ -43,10 +45,13 @@ export type CheckoutOptions = {
   productId?: string;
 };
 
-export enum CheckoutTypes {
-  ChargeID = 'chargeId',
-  ProductID = 'productId',
-}
+export const CheckoutTypes = {
+  ChargeID: 'chargeId',
+  ProductID: 'productId',
+} as const;
+
+export type CheckoutTypesType =
+  (typeof CheckoutTypes)[keyof typeof CheckoutTypes];
 
 export type ComponentTheme =
   | 'base'


### PR DESCRIPTION
**What changed? Why?**

- Switch off of enums in favor of object consts ( can use string literals as a drop in replacement for referencing enum specifically )

**Notes to reviewers**

**How has it been tested?**
