### PR TITLE
docs: fix a path to license.md

### DIFF
--- a/packages/create-onchain/README.md
+++ b/packages/create-onchain/README.md
@@ -125,4 +125,4 @@ When using `--manifest`, the tool will:
 
 ## 🌊 License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License - see the [LICENSE.md](./LICENSE.md) file for details


### PR DESCRIPTION
**What changed? Why?**

There was an issue with a path to license