### PR TITLE
Replace broken Reference in CHANGELOG.md

### DIFF
--- a/packages/onchainkit/CHANGELOG.md
+++ b/packages/onchainkit/CHANGELOG.md
@@ -851,7 +851,7 @@ type TransactionResponse = {
 Breaking Changes
 The `delayMs` prop for the `<TransactionToast>` component has been renamed to `durationMs`. Thischange clarifies that `delay` refers to when something starts, while `duration` specifies how longit lasts.
 
-Learn more about this component type at https://onchainkit.xyz/transactiontypes#transactiontoastreact
+Learn more about this component type at https://docs.base.org/builderkits/onchainkit/transaction/types#transactiontoastreact
 
 ## 0.26.16
 


### PR DESCRIPTION
**What changed? Why?**
Hey! Found and fix `broken` reference in `packages/onchainkit/CHANGELOG.md`

https://onchainkit.xyz/transactiontypes#transactiontoastreact - broken
https://docs.base.org/builderkits/onchainkit/transaction/types#transactiontoastreact - new