### PR TITLE
fix: MiniKitProvider respects wallet.preference option

### DIFF
--- a/packages/onchainkit/src/minikit/MiniKitProvider.tsx
+++ b/packages/onchainkit/src/minikit/MiniKitProvider.tsx
@@ -110,10 +110,10 @@ export function MiniKitProvider({
         : coinbaseWallet({
             appName: process.env.NEXT_PUBLIC_ONCHAINKIT_PROJECT_NAME,
             appLogoUrl: process.env.NEXT_PUBLIC_ICON_URL,
-            preference: 'all',
+            preference: onchainKitProps.config?.wallet?.preference,
           }),
     ];
-  }, [context]);
+  }, [context, onchainKitProps.config?.wallet?.preference]);
 
   const value = useMemo(() => {
     return {


### PR DESCRIPTION
**What changed? Why?**

Updates MiniKitProvider so that it respects the wallet.preference option if it's running outside the context of a mini app

**Notes to reviewers**

**How has it been tested?**

- Manually
- Unit tests