### PR TITLE
docs: update TransactionToastReact link to new official documentation

### DIFF
--- a/packages/onchainkit/CHANGELOG.md
+++ b/packages/onchainkit/CHANGELOG.md
@@ -851,7 +851,7 @@ type TransactionResponse = {
 Breaking Changes
 The `delayMs` prop for the `<TransactionToast>` component has been renamed to `durationMs`. Thischange clarifies that `delay` refers to when something starts, while `duration` specifies how longit lasts.
 
-Learn more about this component type at https://onchainkit.xyz/transactiontypes#transactiontoastreact
+Learn more about this component type at https://docs.base.org/builderkits/onchainkit/transaction/types#transactiontoastreact
 
 ## 0.26.16
 


### PR DESCRIPTION
**What changed? Why?**

Replaced the outdated link to TransactionToastReact type in the changelog with the new official documentation URL at docs.base.org. This ensures users are directed to the most current and accurate resource.
