### PR TITLE
chore: cleanup types and export utils

### DIFF
--- a/packages/onchainkit/src/buy/components/BuyOnrampItem.tsx
+++ b/packages/onchainkit/src/buy/components/BuyOnrampItem.tsx
@@ -8,7 +8,7 @@ import { coinbaseLogoSvg } from '../../internal/svg/coinbaseLogoSvg';
 import { cn, pressable, text } from '../../styles/theme';
 import { useBuyContext } from './BuyProvider';
 
-type OnrampItemReact = {
+type OnrampItemProps = {
   name: string;
   description: string;
   onClick: () => void;
@@ -29,7 +29,7 @@ export function BuyOnrampItem({
   onClick,
   icon,
   to,
-}: OnrampItemReact) {
+}: OnrampItemProps) {
   const { setIsDropdownOpen } = useBuyContext();
 
   const handleClick = useCallback(() => {

--- a/packages/onchainkit/src/identity/components/IdentityCard.tsx
+++ b/packages/onchainkit/src/identity/components/IdentityCard.tsx
@@ -9,7 +9,7 @@ import { Socials } from './Socials';
 
 import { border, cn } from '../../styles/theme';
 
-type IdentityCardReact = {
+type IdentityCardProps = {
   address?: Address;
   chain?: Chain;
   className?: string;
@@ -24,7 +24,7 @@ export function IdentityCard({
   className = '',
   schemaId,
   badgeTooltip,
-}: IdentityCardReact) {
+}: IdentityCardProps) {
   return (
     <Identity
       address={address}

--- a/packages/onchainkit/src/identity/components/IdentityLayout.tsx
+++ b/packages/onchainkit/src/identity/components/IdentityLayout.tsx
@@ -9,7 +9,7 @@ import { EthBalance } from './EthBalance';
 import { Name } from './Name';
 import { Socials } from './Socials';
 
-type IdentityLayoutReact = {
+type IdentityLayoutProps = {
   children: ReactNode;
   className?: string;
   hasCopyAddressOnClick?: boolean;
@@ -19,7 +19,7 @@ export function IdentityLayout({
   children,
   className,
   hasCopyAddressOnClick,
-}: IdentityLayoutReact) {
+}: IdentityLayoutProps) {
   const componentTheme = useTheme();
 
   const {

--- a/packages/onchainkit/src/wallet/hooks/useGetETHBalance.ts
+++ b/packages/onchainkit/src/wallet/hooks/useGetETHBalance.ts
@@ -11,6 +11,23 @@ import type { UseGetETHBalanceResponse } from '../types';
 
 const ETH_DECIMALS = 18;
 
+/**
+ * A custom hook that retrieves and formats the ETH balance for a given wallet address.
+ *
+ * This hook uses `wagmi`'s `useBalance` internally and formats the raw balance value
+ * into a human-readable string with 18 decimals (ETH standard), along with a rounded
+ * version limited to 8 decimal places.
+ *
+ * It also handles potential balance-fetching errors and returns them in a structured format.
+ *
+ * @param address - The wallet address for which to fetch the ETH balance.
+ * @returns An object containing:
+ * - `convertedBalance`: The balance in ETH as a string.
+ * - `roundedBalance`: The balance rounded to 8 decimal places.
+ * - `error`: An optional `SwapError` object if an error occurred while fetching the balance.
+ * - `response`: The original `useBalance` response from `wagmi`.
+ */
+
 export function useGetETHBalance(address?: Address): UseGetETHBalanceResponse {
   const ethBalanceResponse: UseBalanceReturnType = useBalance({
     address,

--- a/packages/onchainkit/src/wallet/hooks/useGetTokenBalance.ts
+++ b/packages/onchainkit/src/wallet/hooks/useGetTokenBalance.ts
@@ -9,6 +9,24 @@ import { getSwapErrorCode } from '../../swap/utils/getSwapErrorCode';
 import type { Token } from '../../token';
 import type { UseGetTokenBalanceResponse } from '../types';
 
+/**
+ * A custom hook that retrieves and formats the balance of an ERC-20 token for a given address.
+ *
+ * This hook uses `wagmi`'s `useReadContract` to call the `balanceOf` function on the token contract,
+ * and returns both the raw and rounded token balance. It also handles loading, error, and refetch states.
+ *
+ * @param address - The wallet address whose token balance is being fetched.
+ * @param token - The ERC-20 token object containing the token's address and decimals.
+ *
+ * @returns An object containing:
+ * - `convertedBalance`: The full precision balance formatted using the token's decimals.
+ * - `roundedBalance`: The balance rounded to 8 decimal places for display purposes.
+ * - `status`: The status of the balance fetch operation (`idle`, `loading`, `success`, or `error`).
+ * - `error`: A `SwapError` object if an error occurred while fetching the balance.
+ * - `response`: The original `useReadContract` response from `wagmi`.
+ * - `refetch`: A function to manually re-trigger the balance fetch.
+ */
+
 export function useGetTokenBalance(
   address?: Address,
   token?: Token,

--- a/packages/onchainkit/src/wallet/index.ts
+++ b/packages/onchainkit/src/wallet/index.ts
@@ -25,6 +25,9 @@ export { isWalletACoinbaseSmartWallet } from './utils/isWalletACoinbaseSmartWall
 // Hooks
 export { useWalletContext } from './components/WalletProvider';
 export { usePortfolio } from './hooks/usePortfolio';
+export { useGetTokenBalance } from './hooks/useGetTokenBalance';
+export { useGetETHBalance } from './hooks/useGetETHBalance';
+export { useIsWalletACoinbaseSmartWallet } from './hooks/useIsWalletACoinbaseSmartWallet';
 
 // Types
 export type {


### PR DESCRIPTION
**What changed? Why?**
- rename types
- export utils

**Notes to reviewers**

**How has it been tested?**
