### PR TITLE
add batch swap txn method

### DIFF
--- a/.changeset/angry-results-care.md
+++ b/.changeset/angry-results-care.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+Introduce buildBatchSwapTransactions api method

--- a/packages/onchainkit/src/api/buildBatchSwapTransactions.test.ts
+++ b/packages/onchainkit/src/api/buildBatchSwapTransactions.test.ts
@@ -1,0 +1,247 @@
+import { RequestContext } from '@/core/network/constants';
+import { CDP_GET_SWAP_TRADE } from '@/core/network/definitions/swap';
+import { sendRequest } from '@/core/network/request';
+import { SwapMessage } from '@/swap/constants';
+import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
+import { DEGEN_TOKEN, ETH_TOKEN } from '@/swap/mocks';
+import type { Address } from 'viem';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildBatchSwapTransactions } from './buildBatchSwapTransactions';
+import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
+
+vi.mock('@/core/network/request');
+
+const testFromAddress: Address = '0x6Cd01c0F55ce9E0Bf78f5E90f72b4345b16d515d';
+const testAmount = '3305894409732200';
+const testAmountReference = 'from' as const;
+
+describe('buildBatchSwapTransactions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return multiple swaps in a batch', async () => {
+    const mockParams = [
+      {
+        useAggregator: true,
+        fromAddress: testFromAddress,
+        amountReference: testAmountReference,
+        from: ETH_TOKEN,
+        to: DEGEN_TOKEN,
+        amount: testAmount,
+      },
+      {
+        useAggregator: true,
+        fromAddress: testFromAddress,
+        amountReference: testAmountReference,
+        from: DEGEN_TOKEN,
+        to: ETH_TOKEN,
+        amount: testAmount,
+      },
+    ];
+
+    const mockApiParams = mockParams.map((params) =>
+      getAPIParamsForToken(params),
+    );
+
+    const mockResponse = [
+      {
+        id: 1,
+        jsonrpc: '2.0',
+        result: {
+          tx: {
+            data: '0x0000000000000',
+            gas: '463613',
+            gasPrice: '2106527',
+            from: '0xaeE5834a78a30F6762407F6F8c3A2090054b0086',
+            to: '0xdef1c0ded9bec7f1a1670819833240f027b25eff',
+            value: '100000000000000',
+          },
+          quote: {
+            from: ETH_TOKEN,
+            to: DEGEN_TOKEN,
+            fromAmount: '100000000000000',
+            toAmount: '19395353519910973703',
+            amountReference: 'from',
+            priceImpact: '0.94',
+            chainId: 8453,
+            highPriceImpact: false,
+            slippage: '3',
+            warning: undefined,
+          },
+          fee: {
+            baseAsset: {
+              name: 'DEGEN',
+              address: '0x4ed4e862860bed51a9570b96d89af5e1b0efefed',
+              currencyCode: 'DEGEN',
+              decimals: 18,
+              imageURL:
+                'https://d3r81g40ycuhqg.cloudfront.net/wallet/wais/3b/bf/3bbf118b5e6dc2f9e7fc607a6e7526647b4ba8f0bea87125f971446d57b296d2-MDNmNjY0MmEtNGFiZi00N2I0LWIwMTItMDUyMzg2ZDZhMWNm',
+              blockchain: 'eth',
+              aggregators: [Array],
+              swappable: true,
+              unverified: false,
+              chainId: 8453,
+            },
+            percentage: '1',
+            amount: '195912661817282562',
+          },
+          approveTx: undefined,
+          chainId: '8453',
+        },
+      },
+      {
+        id: 2,
+        jsonrpc: '2.0',
+        result: {
+          tx: {
+            data: '0x0000000000000',
+            gas: '463613',
+            gasPrice: '2106527',
+            from: '0xaeE5834a78a30F6762407F6F8c3A2090054b0086',
+            to: '0xdef1c0ded9bec7f1a1670819833240f027b25eff',
+            value: '100000000000000',
+          },
+          quote: {
+            from: DEGEN_TOKEN,
+            to: ETH_TOKEN,
+            fromAmount: '100000000000000',
+            toAmount: '19395353519910973703',
+            amountReference: 'from',
+            priceImpact: '0.94',
+            chainId: 8453,
+            highPriceImpact: false,
+            slippage: '3',
+            warning: undefined,
+          },
+          fee: {
+            baseAsset: {
+              name: 'ETH',
+              address: '0x0000000000000000000000000000000000000000',
+              currencyCode: 'ETH',
+              decimals: 18,
+              imageURL:
+                'https://wallet-api-production.s3.amazonaws.com/uploads/tokens/eth_288.png',
+              blockchain: 'eth',
+              aggregators: [Array],
+              swappable: true,
+              unverified: false,
+              chainId: 8453,
+            },
+            percentage: '1',
+            amount: '195912661817282562',
+          },
+          approveTx: undefined,
+          chainId: '8453',
+        },
+      },
+    ];
+
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
+
+    const expectedBatchRequests = mockApiParams.map((apiParams, index) => ({
+      jsonrpc: '2.0',
+      id: index + 1,
+      method: CDP_GET_SWAP_TRADE,
+      params: [apiParams],
+    }));
+
+    const results = await buildBatchSwapTransactions(mockParams);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toHaveProperty('transaction');
+    expect(results[1]).toHaveProperty('transaction');
+    expect(sendRequest).toHaveBeenCalledTimes(1);
+    expect(sendRequest).toHaveBeenCalledWith(
+      'batch',
+      expectedBatchRequests,
+      RequestContext.API,
+    );
+  });
+
+  it('should handle errors in batch requests', async () => {
+    const mockParams = [
+      {
+        useAggregator: true,
+        fromAddress: testFromAddress,
+        amountReference: 'to' as const,
+        from: ETH_TOKEN,
+        to: DEGEN_TOKEN,
+        amount: testAmount,
+      },
+      {
+        useAggregator: true,
+        fromAddress: testFromAddress,
+        amountReference: testAmountReference,
+        from: ETH_TOKEN,
+        to: DEGEN_TOKEN,
+        amount: testAmount,
+      },
+    ];
+
+    const results = await buildBatchSwapTransactions(mockParams);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual({
+      code: UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE,
+      error: SwapMessage.UNSUPPORTED_AMOUNT_REFERENCE,
+      message: '',
+    });
+    expect(sendRequest).not.toHaveBeenCalled();
+  });
+
+  it('should handle API errors in batch responses', async () => {
+    const mockParams = [
+      {
+        useAggregator: true,
+        fromAddress: testFromAddress,
+        amountReference: testAmountReference,
+        from: ETH_TOKEN,
+        to: DEGEN_TOKEN,
+        amount: testAmount,
+      },
+    ];
+
+    const mockResponse = [
+      {
+        id: 1,
+        jsonrpc: '2.0',
+        error: {
+          code: 'SWAP_ERROR',
+          message: 'Invalid response',
+        },
+      },
+    ];
+
+    (sendRequest as Mock).mockResolvedValue(mockResponse);
+
+    const results = await buildBatchSwapTransactions(mockParams);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      code: 'SWAP_ERROR',
+      error: 'Invalid response',
+      message: '',
+    });
+  });
+
+  it('should handle network errors', async () => {
+    const mockParams = [
+      {
+        useAggregator: true,
+        fromAddress: testFromAddress,
+        amountReference: testAmountReference,
+        from: ETH_TOKEN,
+        to: DEGEN_TOKEN,
+        amount: testAmount,
+      },
+    ];
+
+    (sendRequest as Mock).mockRejectedValue(new Error('Network error'));
+
+    const results = await buildBatchSwapTransactions(mockParams);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      code: 'UNCAUGHT_SWAP_ERROR',
+      error: 'Something went wrong',
+      message: '',
+    });
+  });
+});

--- a/packages/onchainkit/src/api/buildBatchSwapTransactions.ts
+++ b/packages/onchainkit/src/api/buildBatchSwapTransactions.ts
@@ -1,0 +1,144 @@
+import { RequestContext } from '@/core/network/constants';
+import { SwapMessage } from '@/swap/constants';
+import { UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE } from '@/swap/constants';
+import { CDP_GET_SWAP_TRADE } from '../core/network/definitions/swap';
+import { sendBatchRequest } from '../core/network/request';
+import { getSwapErrorCode } from '../swap/utils/getSwapErrorCode';
+import type {
+  BatchRequest,
+  BatchResponse,
+  BuildSwapTransactionParams,
+  BuildSwapTransactionResponse,
+  SwapAPIParams,
+} from './types';
+import { getAPIParamsForToken } from './utils/getAPIParamsForToken';
+import { getSwapTransaction } from './utils/getSwapTransaction';
+
+/**
+ * Retrieves unsigned transactions for multiple swaps in a single batch request.
+ * @param params Array of swap parameters for each transaction
+ * @param context Request context
+ * @returns Array of swap transaction responses
+ */
+export async function buildBatchSwapTransactions(
+  params: BuildSwapTransactionParams[],
+  _context: RequestContext = RequestContext.API,
+): Promise<BuildSwapTransactionResponse[]> {
+  // Default parameters
+  const defaultParams = {
+    amountReference: 'from' as const,
+    isAmountInDecimals: false,
+  };
+
+  // Process each parameter set
+  const apiParamsArray = params.map((param) => {
+    // Check for unsupported amount reference
+    if (param.useAggregator && param.amountReference === 'to') {
+      return {
+        code: UNSUPPORTED_AMOUNT_REFERENCE_ERROR_CODE,
+        error: SwapMessage.UNSUPPORTED_AMOUNT_REFERENCE,
+        message: '',
+      };
+    }
+
+    let apiParams = getAPIParamsForToken({
+      ...defaultParams,
+      ...param,
+    });
+
+    if ('error' in apiParams) {
+      return apiParams;
+    }
+
+    if (!param.useAggregator) {
+      apiParams = {
+        v2Enabled: true,
+        ...apiParams,
+      };
+    }
+
+    if (param.maxSlippage) {
+      let slippagePercentage = param.maxSlippage;
+      // Adjust slippage for V1 API (aggregator)
+      if (param.useAggregator) {
+        slippagePercentage = (Number(param.maxSlippage) * 10).toString();
+      }
+      apiParams = {
+        slippagePercentage,
+        ...apiParams,
+      };
+    }
+
+    return apiParams;
+  });
+
+  // Check if any parameters had errors
+  const errors = apiParamsArray.filter((params) => 'error' in params);
+  if (errors.length > 0) {
+    // Return error responses for all parameters
+    return params.map((_, index) => {
+      const error = errors[index];
+      if (error && 'error' in error) {
+        return error as BuildSwapTransactionResponse;
+      }
+      return {
+        code: getSwapErrorCode('uncaught-swap'),
+        error: 'Something went wrong',
+        message: '',
+      };
+    });
+  }
+
+  try {
+    // Create batch request
+    const batchRequests: BatchRequest[] = apiParamsArray.map(
+      (apiParams, index) => ({
+        jsonrpc: '2.0',
+        id: index + 1,
+        method: CDP_GET_SWAP_TRADE,
+        params: [apiParams as SwapAPIParams],
+      }),
+    );
+
+    const responses = (await sendBatchRequest<BatchRequest>(
+      batchRequests,
+      _context,
+    )) as unknown as BatchResponse[];
+
+    // Process responses
+    return responses.map((res: BatchResponse) => {
+      if (res.error) {
+        return {
+          code: getSwapErrorCode('swap', res.error.code),
+          error: res.error.message,
+          message: '',
+        };
+      }
+
+      if (!res.result) {
+        return {
+          code: getSwapErrorCode('uncaught-swap'),
+          error: 'Invalid response format',
+          message: '',
+        };
+      }
+
+      const trade = res.result;
+      return {
+        approveTransaction: trade.approveTx
+          ? getSwapTransaction(trade.approveTx, trade.chainId)
+          : undefined,
+        fee: trade.fee,
+        quote: trade.quote,
+        transaction: getSwapTransaction(trade.tx, trade.chainId),
+        warning: trade.quote.warning,
+      };
+    });
+  } catch {
+    return params.map(() => ({
+      code: getSwapErrorCode('uncaught-swap'),
+      error: 'Something went wrong',
+      message: '',
+    }));
+  }
+}

--- a/packages/onchainkit/src/api/index.ts
+++ b/packages/onchainkit/src/api/index.ts
@@ -1,6 +1,7 @@
 // 🌲☀️🌲
 export { buildMintTransaction } from './buildMintTransaction';
 export { buildSwapTransaction } from './buildSwapTransaction';
+export { buildBatchSwapTransactions } from './buildBatchSwapTransactions';
 export { buildPayTransaction } from './buildPayTransaction';
 export { getMintDetails } from './getMintDetails';
 export { getSwapQuote } from './getSwapQuote';
@@ -10,6 +11,10 @@ export { getPortfolios } from './getPortfolios';
 export { getPriceQuote } from './getPriceQuote';
 export type {
   APIError,
+  BatchRequest,
+  BatchResponse,
+  BuildBatchSwapTransactionParams,
+  BuildBatchSwapTransactionResponse,
   BuildMintTransactionParams,
   BuildMintTransactionResponse,
   BuildPayTransactionParams,

--- a/packages/onchainkit/src/api/types.ts
+++ b/packages/onchainkit/src/api/types.ts
@@ -2,6 +2,7 @@ import type { Address } from 'viem';
 import type { Fee, QuoteWarning, SwapQuote, Transaction } from '../swap/types';
 import type { Token } from '../token/types';
 import type { Call } from '../transaction/types';
+import type { SwapAPIResponse } from '../swap/types';
 
 export type AddressOrETH = Address | 'ETH';
 
@@ -417,3 +418,44 @@ export type GetPriceQuoteResponse =
       priceQuotes: PriceQuote[];
     }
   | APIError;
+
+/**
+ * Note: exported as public Type
+ */
+export type BatchRequest = {
+  /** JSON-RPC version */
+  jsonrpc: '2.0';
+  /** The ID of the request */
+  id: number;
+  /** The JSON-RPC method */
+  method: string;
+  /** The parameters for the JSON-RPC method */
+  params: SwapAPIParams[];
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type BatchResponse = {
+  /** JSON-RPC version */
+  jsonrpc: '2.0';
+  /** The ID corresponding to the request */
+  id: number;
+  /** The result of the request if successful */
+  result?: SwapAPIResponse;
+  /** The error returned by the request (if any) */
+  error?: {
+    code: number;
+    message: string;
+  };
+};
+
+/**
+ * Note: exported as public Type
+ */
+export type BuildBatchSwapTransactionParams = BuildSwapTransactionParams[];
+
+/**
+ * Note: exported as public Type
+ */
+export type BuildBatchSwapTransactionResponse = BuildSwapTransactionResponse[];

--- a/packages/onchainkit/src/core/network/request.ts
+++ b/packages/onchainkit/src/core/network/request.ts
@@ -103,3 +103,32 @@ export async function sendRequest<T, V>(
     throw error;
   }
 }
+
+/**
+ * Sends a JSON-RPC batch request to the configured RPC URL.
+ * Each entry in the array must follow the standard JSON-RPC 2.0 request shape.
+ *
+ * @param requests - The array of JSON-RPC requests to execute in a single HTTP call.
+ * @param _context - Tracks the context where the request originated.
+ * @returns A promise that resolves to an array of JSON-RPC responses.
+ */
+export async function sendBatchRequest<T>(
+  requests: T[],
+  _context?: RequestContext,
+): Promise<unknown[]> {
+  try {
+    const url = getRPCUrl();
+    const response = await fetch(url, {
+      body: JSON.stringify(requests),
+      headers: buildRequestHeaders(_context),
+      method: POST_METHOD,
+    });
+    const data = await response.json();
+    return data as unknown[];
+  } catch (error) {
+    console.log(
+      `sendBatchRequest: error sending request: ${(error as Error).message}`,
+    );
+    throw error;
+  }
+}


### PR DESCRIPTION
**What changed? Why?**
### What changed
This just adds a batch swap txn method by following the convention outlined here: https://docs.cdp.coinbase.com/api/docs/node/json-rpc#batch-requests 

for the already existing method found here:
https://docs.base.org/builderkits/onchainkit/api/build-swap-transaction

### Why?
Thanks to [the pectra update](https://www.eip5792.xyz/reference/sendCalls) we can now batch txns but the current onchainkit api only exposes a method to build swap transactions sequentially. This is meant to help with that as I'm currently building a dashboard to execute many swaps at once. 

**Notes to reviewers**
If we batch call more than 3, the rpc returns a 429. Is it possible to increase this at all? 

**How has it been tested?**
Test included and have used this method locally in a separate repo 