### PR TITLE
rename error in isBasename.test.ts

### DIFF
--- a/packages/onchainkit/src/identity/utils/isBasename.test.ts
+++ b/packages/onchainkit/src/identity/utils/isBasename.test.ts
@@ -15,7 +15,7 @@ describe('isBasename', () => {
   });
 
   it('Returns false for any other name', async () => {
-    expect(isBasename('shrek.optimisim.eth')).toBe(false);
+    expect(isBasename('shrek.optimism.eth')).toBe(false);
     expect(isBasename('shrek.eth')).toBe(false);
     expect(isBasename('shrek.baaaaaes.eth')).toBe(false);
   });


### PR DESCRIPTION
**What changed? Why?**
onchainkit/packages/onchainkit/src/identity/utils/isBasename.test.ts: 

`optimisim` -- `optimism`