### PR TITLE
feat: Add LLM documentation setup for MiniKit projects

### DIFF
--- a/packages/create-onchain/src/minikit.ts
+++ b/packages/create-onchain/src/minikit.ts
@@ -284,7 +284,7 @@ async function setupAgentDocs(root: string, selectedDocs: string[], customUrls?:
       await fs.promises.writeFile(filepath, placeholder);
     }
   } else {
-    const spinner = ora('Downloading LLM documentation...').start();
+    const spinner = ora().start();
     const results: Array<{ name: string; success: boolean; error?: string; size?: number }> = [];
 
     try {
@@ -615,7 +615,7 @@ export async function createMiniKitTemplate(
 
   const defaultProjectName = 'my-minikit-app';
 
-  let result: prompts.Answers<'projectName' | 'packageName' | 'clientKey' | 'llmDocs' | 'customUrls'>;
+  let result: prompts.Answers<'projectName' | 'packageName' | 'clientKey' | 'llmDocs'>;
 
   try {
     result = await prompts(
@@ -672,12 +672,6 @@ export async function createMiniKitTemplate(
           hint: '↑↓ navigate, space to select, enter to confirm',
           instructions: false,
         },
-        {
-          type: (prev) => prev && prev.length > 0 ? 'confirm' : null,
-          name: 'customUrls',
-          message: pc.reset('Customize documentation URLs? (Default URLs will be used if declined)'),
-          initial: false,
-        },
       ],
       {
         onCancel: () => {
@@ -691,13 +685,7 @@ export async function createMiniKitTemplate(
     process.exit(1);
   }
 
-  const { projectName, packageName, clientKey, llmDocs, customUrls } = result;
-  
-  // Handle custom URLs if requested
-  let customUrlsConfig: Record<string, string> | undefined;
-  if (customUrls && llmDocs && llmDocs.length > 0) {
-    console.log(pc.gray('\\nNote: You can customize URLs later by editing agent-docs/agent-config.json'));
-  }
+  const { projectName, packageName, clientKey, llmDocs } = result;
   const root = path.join(process.cwd(), projectName);
 
   await analyticsPrompt(template);
@@ -726,7 +714,7 @@ export async function createMiniKitTemplate(
 
   // Create agent-docs folder and download LLM text files
   if (llmDocs && llmDocs.length > 0) {
-    await setupAgentDocs(root, llmDocs, customUrlsConfig);
+    await setupAgentDocs(root, llmDocs);
   }
 
   // Create .env file


### PR DESCRIPTION
https://github.com/user-attachments/assets/f9f6c351-09ab-4b1b-a23f-de3fcb11c39a

 What changed? Why?

  Added LLM documentation integration to MiniKit projects to enable AI
  agents and "vibe coders" to build Mini Apps more easily.

  When creating a MiniKit project with create-onchain --mini, developers can
   now select and download LLM-optimized documentation for:
  - Base - selected by default
  - Farcaster (Mini App APIs) - selected by default
  - Neynar (Farcaster API service)
  - Privy (Auth & wallets)

  Key features:
  - Downloads comprehensive LLM-friendly documentation during project setup
  - Creates agent-docs/ folder with structured documentation files and preferences 
  - Includes npm run update-llm-docs script to refresh documentation
  - Saves preferences in agent-config.json for easy sharing of LLM setups

  Why: This dramatically improves the developer experience for those using
  AI coding assistants (Cursor, GitHub Copilot, etc.) by providing rich,
  contextual documentation that AI agents can consume to generate better
  Mini App code.

  Notes to reviewers

  - Feature is completely opt-in during project creation
  - Uses native fetch API (Node 18+) instead of external dependencies
  - Downloads happen silently during the "Creating [app-name]..." phase
  - The agent-config.json enables teams to share their preferred
  documentation setup
  - Documentation URLs are configurable via the config file
  - All security best practices followed: HTTPS validation, timeouts, proper
   error handling

  How has it been tested?

  - Built and tested locally with pnpm run build
  - Created multiple test projects with various documentation selections
  - Verified offline mode creates placeholder files correctly
  - Tested npm run update-llm-docs script functionality
  - Confirmed backward compatibility when no docs are selected
  - Validated file downloads with progress tracking
  - Tested retry logic with network interruptions

  Test command:
  cd test-area && node ../packages/create-onchain/dist/esm/cli.js --mini