### PR TITLE
chore: add 'use client' directive to core provider modules for Next.j…

### DIFF
--- a/packages/onchainkit/src/DefaultOnchainKitProviders.tsx
+++ b/packages/onchainkit/src/DefaultOnchainKitProviders.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { type PropsWithChildren, useContext, useMemo } from 'react';
 import { Config, WagmiProvider } from 'wagmi';

--- a/packages/onchainkit/src/useOnchainKit.tsx
+++ b/packages/onchainkit/src/useOnchainKit.tsx
@@ -1,3 +1,4 @@
+'use client';
 import { createContext, useContext } from 'react';
 import { ONCHAIN_KIT_CONFIG } from '@/core/OnchainKitConfig';
 import { OnchainKitContextType } from './core/types';


### PR DESCRIPTION
TLDR; Improves DX when using onchainkit with Nextjs App Router by moving `use client` to core modules and avoids confusion like #2364 

**What changed? Why?**

The `'use client';` directive has been added to the top of the following files:

- `packages/onchainkit/src/useOnchainKit.tsx`
- `packages/onchainkit/src/DefaultOnchainKitProviders.tsx`

These files contain client-side React hooks (`createContext`, `useState`, etc.)

This improves the developer experience and robustness of onchainkit when used with the Next.js by adding `'use client'` directive to core provider modules.

Current install docs for nextjs [correctly instructs users](https://docs.base.org/onchainkit/installation/nextjs) to create a `providers.tsx` file with `'use client'`, but this places extra burden on devs and can lead to confusion, as evidenced by issue #2364 

**Notes to reviewers**

By moving the `'use client'` directive *into* the library itself, we can:
- **Improve Developer Experience:** Offer a more "plug-and-play" setup, reducing friction and removing a potential point of error.
- **Enhance Robustness:** Ensure the provider works correctly out-of-the-box, regardless of how it's imported within a Next.js App Router project.
- **Better Encapsulation:** The library now correctly declares its own client-side requirements instead of relying on the end-user to do so

The `use client` directive is completely ignored by bundlers and environments that don't support React Server Components so it doesn't affect anything else

**How has it been tested?**

1.  **Manual Verification (within this monorepo):**
    - The `examples/minikit-example` application can be used for testing.
    - In `examples/minikit-example/app/layout.tsx`, you can remove the import for `./providers` and use the `<OnchainKitProvider>` directly.
    - Run `pnpm dev` from the `examples/minikit-example` directory.
    - The application will render correctly, showing the library works without requiring the user to create a separate client boundary file.

2.  **Automated Tests:**
    - The existing test suite for the `onchainkit` package was run via `pnpm --filter onchainkit test`.
    - All 2611 tests passed, confirming that this change does not introduce any regressions.
<img width="736" alt="Screenshot 2025-07-02 at 7 42 48 PM" src="https://github.com/user-attachments/assets/560d7b00-0e9b-4797-bde0-ea4bd6fd0165" />

### Checklist

- [x] I have read **CONTRIBUTING** 
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. *(Note: The installation docs should be updated to reflect that `use client` and `providers.tsx` wrapper is no longer necessary for setup).*
- [x] I have verified that all new and existing tests pass.
