### PR TITLE
refactor: useIsInMiniApp now uses context to determine if in mini app

### DIFF
--- a/packages/onchainkit/src/minikit/MiniKitProvider.test.tsx
+++ b/packages/onchainkit/src/minikit/MiniKitProvider.test.tsx
@@ -26,7 +26,6 @@ vi.mock('@farcaster/frame-sdk', () => {
         listeners = {};
       }),
       context: vi.fn(),
-      isInMiniApp: vi.fn(),
     },
   };
 });
@@ -56,7 +55,6 @@ describe('MiniKitProvider', () => {
         safeAreaInsets: { top: 0, bottom: 0, left: 0, right: 0 },
       },
     }) as unknown as Promise<Context.FrameContext>;
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(false);
   });
 
   afterEach(() => {

--- a/packages/onchainkit/src/minikit/MiniKitProvider.tsx
+++ b/packages/onchainkit/src/minikit/MiniKitProvider.tsx
@@ -1,5 +1,4 @@
 'use client';
-
 import { DefaultOnchainKitProviders } from '@/DefaultOnchainKitProviders';
 import { OnchainKitProvider } from '@/OnchainKitProvider';
 import type { OnchainKitProviderReact } from '@/types';
@@ -70,7 +69,7 @@ export function MiniKitProvider({
 
     async function fetchContext() {
       try {
-        // if not running in a frame, context resolves as undefined
+        // if not running in a mini app, context resolves as undefined
         const context = await sdk.context;
         setContext(context);
       } catch (error) {

--- a/packages/onchainkit/src/minikit/components/AutoConnect.test.tsx
+++ b/packages/onchainkit/src/minikit/components/AutoConnect.test.tsx
@@ -9,7 +9,7 @@ import { AutoConnect } from './AutoConnect';
 
 vi.mock('@farcaster/frame-sdk', () => ({
   default: {
-    isInMiniApp: vi.fn(),
+    context: undefined,
   },
 }));
 
@@ -70,7 +70,11 @@ describe('AutoConnect', () => {
   });
 
   it('should not attempt connection if not in Mini App', async () => {
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(false);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve(null),
+      writable: true,
+      configurable: true,
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -88,7 +92,11 @@ describe('AutoConnect', () => {
   });
 
   it('should not attempt connection if already connected', async () => {
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     // Mock account to be already connected
     mockUseAccount.mockReturnValue({
@@ -112,7 +120,11 @@ describe('AutoConnect', () => {
   });
 
   it('should not attempt connection if connector is not Farcaster Frame', async () => {
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     // Mock connectors to have a different type of connector
     mockUseConnect.mockReturnValue({
@@ -136,7 +148,11 @@ describe('AutoConnect', () => {
   });
 
   it('should not attempt connection when disabled', async () => {
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -154,7 +170,11 @@ describe('AutoConnect', () => {
   });
 
   it('should attempt connection when in Mini App, not connected, and enabled', async () => {
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -172,7 +192,11 @@ describe('AutoConnect', () => {
   });
 
   it('should only attempt connection once', async () => {
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     const { rerender } = render(
       <QueryClientProvider client={queryClient}>
@@ -205,8 +229,11 @@ describe('AutoConnect', () => {
   });
 
   it('should call connect with connector when in Mini App and all conditions are met', async () => {
-    // Mock isInMiniApp to return true
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     // Render the component
     render(
@@ -227,7 +254,11 @@ describe('AutoConnect', () => {
   });
 
   it('should not attempt connection if currently connecting', async () => {
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     // Mock account to be currently connecting
     mockUseAccount.mockReturnValue({
@@ -251,7 +282,11 @@ describe('AutoConnect', () => {
   });
 
   it('should not attempt connection if no connectors available', async () => {
-    vi.mocked(sdk.isInMiniApp).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     // Mock empty connectors array
     mockUseConnect.mockReturnValue({

--- a/packages/onchainkit/src/minikit/hooks/useIsInMiniApp.test.tsx
+++ b/packages/onchainkit/src/minikit/hooks/useIsInMiniApp.test.tsx
@@ -1,12 +1,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import sdk from '@farcaster/frame-sdk';
 import { renderHook, waitFor } from '@testing-library/react';
-import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useIsInMiniApp } from './useIsInMiniApp';
 
 vi.mock('@farcaster/frame-sdk', () => ({
   default: {
-    isInMiniApp: vi.fn(),
+    context: undefined,
   },
 }));
 
@@ -30,7 +30,11 @@ describe('useIsInMiniApp', () => {
   });
 
   it('should return isInMiniApp as true when in mini app context', async () => {
-    (sdk.isInMiniApp as Mock).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     const { result } = renderHook(() => useIsInMiniApp(), {
       wrapper: createWrapper(),
@@ -38,12 +42,15 @@ describe('useIsInMiniApp', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(sdk.isInMiniApp).toHaveBeenCalled();
     expect(result.current.isInMiniApp).toBe(true);
   });
 
   it('should return isInMiniApp as false when not in mini app context', async () => {
-    (sdk.isInMiniApp as Mock).mockResolvedValue(false);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve(null),
+      writable: true,
+      configurable: true,
+    });
 
     const { result } = renderHook(() => useIsInMiniApp(), {
       wrapper: createWrapper(),
@@ -51,13 +58,16 @@ describe('useIsInMiniApp', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(sdk.isInMiniApp).toHaveBeenCalled();
     expect(result.current.isInMiniApp).toBe(false);
   });
 
-  it('should handle errors when sdk.isInMiniApp fails', async () => {
+  it('should handle errors when sdk.context fails', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(vi.fn());
-    (sdk.isInMiniApp as Mock).mockRejectedValue(new Error('SDK error'));
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.reject(new Error('SDK error')),
+      writable: true,
+      configurable: true,
+    });
 
     const { result } = renderHook(() => useIsInMiniApp(), {
       wrapper: createWrapper(),
@@ -65,14 +75,17 @@ describe('useIsInMiniApp', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
-    expect(sdk.isInMiniApp).toHaveBeenCalled();
     expect(result.current.isInMiniApp).toBeUndefined();
 
     consoleSpy.mockRestore();
   });
 
   it('should handle mutation states correctly', async () => {
-    (sdk.isInMiniApp as Mock).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     const { result } = renderHook(() => useIsInMiniApp(), {
       wrapper: createWrapper(),
@@ -89,7 +102,11 @@ describe('useIsInMiniApp', () => {
   });
 
   it('should return all useQuery properties', async () => {
-    (sdk.isInMiniApp as Mock).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     const { result } = renderHook(() => useIsInMiniApp(), {
       wrapper: createWrapper(),
@@ -107,7 +124,11 @@ describe('useIsInMiniApp', () => {
   });
 
   it('should use correct query key', async () => {
-    (sdk.isInMiniApp as Mock).mockResolvedValue(true);
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
 
     const { result } = renderHook(() => useIsInMiniApp(), {
       wrapper: createWrapper(),
@@ -115,18 +136,18 @@ describe('useIsInMiniApp', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(sdk.isInMiniApp).toHaveBeenCalledWith(
-      expect.objectContaining({
-        queryKey: ['useIsInMiniApp'],
-        signal: expect.any(AbortSignal),
-      }),
-    );
+    // Since we're no longer calling a function, we just verify the query worked
+    expect(result.current.isInMiniApp).toBe(true);
   });
 
   it('should handle initial loading state', () => {
-    (sdk.isInMiniApp as Mock).mockImplementation(
-      () => new Promise((resolve) => setTimeout(() => resolve(true), 100)),
-    );
+    Object.defineProperty(sdk, 'context', {
+      value: new Promise((resolve) =>
+        setTimeout(() => resolve({ user: { fid: 123 } }), 100),
+      ),
+      writable: true,
+      configurable: true,
+    });
 
     const { result } = renderHook(() => useIsInMiniApp(), {
       wrapper: createWrapper(),

--- a/packages/onchainkit/src/minikit/hooks/useIsInMiniApp.tsx
+++ b/packages/onchainkit/src/minikit/hooks/useIsInMiniApp.tsx
@@ -7,7 +7,7 @@ import { useQuery } from '@tanstack/react-query';
 export function useIsInMiniApp() {
   const { data, ...rest } = useQuery({
     queryKey: ['useIsInMiniApp'],
-    queryFn: sdk.isInMiniApp,
+    queryFn: async () => !!(await sdk.context),
   });
 
   return {


### PR DESCRIPTION
**What changed? Why?**

Updates isInMiniApp to use the existance of `sdk.context` because TBA doesn't currently support isInMiniApp

**Notes to reviewers**

**How has it been tested?**
