### PR TITLE
feat: Subscribe component

### DIFF
--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -176,6 +176,12 @@
       "import": "./dist/signature/index.js",
       "default": "./dist/signature/index.js"
     },
+    "./subscribe": {
+      "types": "./dist/subscribe/index.d.ts",
+      "module": "./dist/subscribe/index.js",
+      "import": "./dist/subscribe/index.js",
+      "default": "./dist/subscribe/index.js"
+    },
     "./swap": {
       "types": "./dist/swap/index.d.ts",
       "module": "./dist/swap/index.js",

--- a/packages/onchainkit/src/subscribe/README.md
+++ b/packages/onchainkit/src/subscribe/README.md
@@ -1,0 +1,397 @@
+# Subscribe Component
+
+The Subscribe component enables apps to accept subscriptions using spend permissions. Users can approve recurring payments that apps can collect within the specified limits and intervals.
+
+## Features
+
+- **Simple API**: Similar to Stripe payment links - just specify amount, token, interval, and spender
+- **ERC-712 Signatures**: Secure spend permission signatures using existing wallet infrastructure
+- **Multi-chain Support**: Works on all chains where SpendPermissionManager is deployed
+- **Flexible Intervals**: Support for arbitrary duration combinations (days, weeks, months, etc.)
+- **Automatic Allowance Calculation**: Calculates total allowance based on subscription length
+- **Component Composition**: Individual components for maximum flexibility
+
+## Basic Usage
+
+```tsx
+import { Subscribe } from '@coinbase/onchainkit/subscribe';
+import { usdcToken } from '@coinbase/onchainkit/token';
+
+function MyApp() {
+  return (
+    <Subscribe
+      amount="10"
+      token={usdcToken}
+      interval={{ days: 30 }}
+      spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+      onSuccess={(result) => {
+        console.log('Subscription approved!', result.signature);
+        // Send signature to your backend for processing
+      }}
+      onError={(error) => {
+        console.error('Subscription failed:', error);
+      }}
+    />
+  );
+}
+```
+
+**Note:** Without `subscriptionLength`, this creates an unlimited subscription where the spender can collect $10 every 30 days until the user revokes the permission.
+
+## Advanced Usage
+
+### Limited Subscription Length
+
+```tsx
+<Subscribe
+  amount="15"
+  token={usdcToken}
+  interval={{ months: 1 }}
+  subscriptionLength={{ years: 1 }}  // 12 payments total
+  spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+  buttonText="Subscribe for 1 Year"
+  onSuccess={(result) => {
+    // result.metadata contains all subscription details
+    console.log('Total allowance:', result.spendPermission.allowance);
+  }}
+/>
+```
+
+### Complex Intervals
+
+```tsx
+<Subscribe
+  amount="5"
+  token={usdcToken}
+  interval={{ weeks: 2, days: 3 }}  // Every 17 days
+  spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+/>
+```
+
+### With Extra Data
+
+```tsx
+// Include order number or user ID for tracking
+const orderData = `0x${Buffer.from(JSON.stringify({
+  orderId: 'order-12345',
+  userId: 'user-67890'
+})).toString('hex')}`;
+
+<Subscribe
+  amount="20"
+  token={usdcToken}
+  interval={{ days: 30 }}
+  spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+  extraData={orderData}
+  salt="auto" // Explicitly use timestamp-based salt for uniqueness
+  onSuccess={(result) => {
+    // Access the extraData in the spend permission
+    console.log('Extra data:', result.spendPermission.extraData);
+    console.log('Metadata:', result.metadata.extraData);
+    console.log('Generated salt:', result.spendPermission.salt);
+  }}
+/>
+```
+
+### Custom Components
+
+```tsx
+import {
+  SubscribeProvider,
+  SubscribeButton,
+  SubscribeStatus
+} from '@coinbase/onchainkit/subscribe';
+
+function CustomSubscribe() {
+  return (
+    <SubscribeProvider
+      amount="25"
+      token={usdcToken}
+      interval={{ days: 7 }}
+      spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+      onSuccess={(result) => handleSuccess(result)}
+    >
+      <div className="my-custom-layout">
+        <h2>Premium Subscription</h2>
+        <p>$25 weekly for premium features</p>
+        <SubscribeButton text="Start Premium" />
+        <SubscribeStatus />
+      </div>
+    </SubscribeProvider>
+  );
+}
+```
+
+### Subscription Status Management
+
+```tsx
+import { useSubscriptionStatus } from '@coinbase/onchainkit/subscribe';
+
+function SubscriptionManager({ spendPermission }) {
+  const { status, isLoading, refetch } = useSubscriptionStatus({
+    spendPermission,
+    refreshInterval: 30000, // Check every 30 seconds
+  });
+
+  if (isLoading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h3>Subscription Status</h3>
+      <p>Active: {status?.isActive ? 'Yes' : 'No'}</p>
+      <p>Current Period Spent: {status?.currentPeriodSpent ? 'Yes' : 'No'}</p>
+      <p>Total Spent: {status?.totalSpent.toString()}</p>
+      {status?.nextPeriodStart && (
+        <p>Next Period: {new Date(status.nextPeriodStart * 1000).toLocaleDateString()}</p>
+      )}
+      <button onClick={refetch}>Refresh Status</button>
+    </div>
+  );
+}
+```
+
+## Props
+
+### Subscribe
+
+| Prop                 | Type                                         | Required | Description                                                                          |
+|----------------------|----------------------------------------------|----------|--------------------------------------------------------------------------------------|
+| `amount`             | `string`                                     | Yes      | Amount to charge per period                                                          |
+| `token`              | `Token`                                      | Yes      | Token object (use constants from `@coinbase/onchainkit/token`)                       |
+| `interval`           | `Duration`                                   | Yes      | Subscription interval duration                                                       |
+| `spender`            | `Address`                                    | Yes      | Address authorized to spend user's tokens                                            |
+| `subscriptionLength` | `Duration`                                   | No       | Total subscription duration (defaults to unlimited recurring payments)               |
+| `buttonText`         | `string`                                     | No       | Custom button text (defaults to "Subscribe")                                         |
+| `className`          | `string`                                     | No       | Custom CSS classes                                                                   |
+| `disabled`           | `boolean`                                    | No       | Disable the subscribe button                                                         |
+| `extraData`          | `Hex`                                        | No       | Additional data to include in spend permission (e.g., order ID, user ID)             |
+| `salt`               | `bigint \| 'auto'`                           | No       | Salt for spend permission uniqueness (defaults to 0, use 'auto' for timestamp-based) |
+| `onSuccess`          | `(result: SubscribeSuccessResult) => void`   | No       | Success callback                                                                     |
+| `onError`            | `(error: APIError) => void`                  | No       | Error callback                                                                       |
+| `onStatus`           | `(status: SubscribeLifecycleStatus) => void` | No       | Status change callback                                                               |
+
+### Duration
+
+```tsx
+type Duration = {
+  seconds?: number;
+  minutes?: number;
+  hours?: number;
+  days?: number;
+  weeks?: number;
+  months?: number;
+  years?: number;
+};
+```
+
+Examples:
+
+- `{ days: 30 }` - Monthly
+- `{ months: 1 }` - Monthly (equivalent to 30 days)
+- `{ weeks: 1 }` - Weekly
+- `{ days: 7 }` - Weekly (alternative)
+- `{ weeks: 2, days: 3 }` - Every 17 days
+- `{ years: 1 }` - Annually (equivalent to 365 days)
+
+**Note:** Coinbase Wallet requires intervals to be divisible by whole days (86400 seconds). Time units are rounded:
+
+- ✅ **Days**: Exact values
+- ✅ **Weeks**: 7 days each
+- ✅ **Months**: Rounded to 30 days each
+- ✅ **Years**: Rounded to 365 days each
+
+## Performance Considerations
+
+### Stabilizing Props
+
+To prevent unnecessary permission refetches, ensure that object props like `interval` are stable across renders:
+
+```tsx
+import { useMemo } from 'react';
+
+function MyComponent() {
+  // ✅ Good: Stable interval object
+  const interval = useMemo(() => ({ days: 30 }), []);
+
+  // ❌ Bad: New object on every render causes refetch
+  // const interval = { days: 30 };
+
+  return (
+    <Subscribe
+      amount="10"
+      token={usdcToken}
+      interval={interval}
+      spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+    />
+  );
+}
+```
+
+### Dynamic Intervals
+
+For dynamic intervals, use proper dependencies:
+
+```tsx
+function DynamicSubscription({ planType }) {
+  const interval = useMemo(() => {
+    switch (planType) {
+      case 'weekly': return { days: 7 };
+      case 'monthly': return { days: 30 };
+      case 'yearly': return { years: 1 };
+      default: return { days: 30 };
+    }
+  }, [planType]);
+
+  return (
+    <Subscribe
+      amount="10"
+      token={usdcToken}
+      interval={interval}
+      spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+    />
+  );
+}
+```
+
+## Working with Extra Data
+
+The `extraData` parameter allows you to attach custom information to spend permissions. This is useful for tracking orders, user IDs, subscription plans, or any other metadata your application needs.
+
+### Encoding Custom Data
+
+**Note:** The examples below use Node.js `Buffer`. For browser environments, you'll need to use a polyfill or `TextEncoder`:
+
+```tsx
+// Browser-compatible encoding function
+function encodeToHex(data: string): `0x${string}` {
+  return `0x${Array.from(new TextEncoder().encode(data))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')}`;
+}
+
+// Simple string data
+const simpleData = `0x${Buffer.from('order-12345').toString('hex')}`;
+
+// JSON data for complex objects
+const complexData = `0x${Buffer.from(JSON.stringify({
+  orderId: 'sub-12345',
+  userId: 'user-67890',
+  planType: 'premium',
+  createdAt: Date.now()
+})).toString('hex')}`;
+
+// Use in Subscribe component
+    <Subscribe
+      amount="25"
+      token={usdcToken}
+      interval={{ months: 1 }}
+      spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+      extraData={complexData}
+      onSuccess={(result) => {
+        // The extraData is available in both places:
+        console.log('In spend permission:', result.spendPermission.extraData);
+        console.log('In metadata:', result.metadata.extraData);
+
+        // Decode the data for your backend
+        const decoded = JSON.parse(
+          Buffer.from(result.metadata.extraData.slice(2), 'hex').toString()
+        );
+        console.log('Decoded:', decoded);
+      }}
+    />
+```
+
+### Dynamic Extra Data
+
+```tsx
+function SubscriptionFlow({ orderId, userId }) {
+  // Generate dynamic extraData based on current context
+  const extraData = useMemo(() => {
+    const data = {
+      orderId,
+      userId,
+      timestamp: Date.now(),
+      version: '1.0'
+    };
+    return `0x${Buffer.from(JSON.stringify(data)).toString('hex')}`;
+  }, [orderId, userId]);
+
+  return (
+    <Subscribe
+      amount="10"
+      token={usdcToken}
+      interval={{ days: 30 }}
+      spender="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+      extraData={extraData}
+      onSuccess={(result) => {
+        // Send to backend with all context
+        processSubscription({
+          signature: result.signature,
+          spendPermission: result.spendPermission,
+          orderContext: JSON.parse(
+            Buffer.from(result.metadata.extraData.slice(2), 'hex').toString()
+          )
+        });
+      }}
+    />
+  );
+}
+```
+
+## Backend Integration
+
+After receiving the signature from `onSuccess`, your backend should:
+
+1. **Approve the spend permission** by calling `SpendPermissionManager.approveWithSignature()`
+2. **Collect payments** periodically by calling `SpendPermissionManager.spend()`
+
+```solidity
+// Example backend contract interaction
+ISpendPermissionManager manager = ISpendPermissionManager(0xf85210B21cC50302F477BA56686d2019dC9b67Ad);
+
+// 1. Approve the permission
+manager.approveWithSignature(spendPermission, signature);
+
+// 2. Later, collect payment
+manager.spend(spendPermission, spender, amount);
+```
+
+## Supported Chains
+
+The Subscribe component works on all chains where SpendPermissionManager is deployed:
+
+**Mainnets:**
+
+- Base
+- Ethereum
+- Optimism
+- Arbitrum
+- Polygon
+- Zora
+- Binance Smart Chain
+- Avalanche
+- LORDCHAIN
+- Metacade
+
+**Testnets:**
+
+- Base Sepolia
+- Optimism Sepolia
+- Ethereum Sepolia
+
+## Error Handling
+
+Common errors and their meanings:
+
+- `"Request denied."` - User rejected the signature request
+- `"Wallet not connected"` - User needs to connect their wallet
+- `"Subscription interval must be at least 1 minute"` - Interval too short
+- `"Amount must be greater than 0"` - Invalid amount specified
+- `"Subscription length results in too many periods"` - Total periods exceed 1000
+
+## Security Considerations
+
+- Users retain full control and can revoke permissions at any time
+- Spend permissions are limited to the exact token, amount, and time constraints specified
+- Apps cannot make arbitrary contract calls from user accounts
+- All signatures use ERC-712 for secure, readable authorization

--- a/packages/onchainkit/src/subscribe/components/Subscribe.test.tsx
+++ b/packages/onchainkit/src/subscribe/components/Subscribe.test.tsx
@@ -1,0 +1,318 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { usdcToken } from '@/token/constants';
+import { Subscribe } from './Subscribe';
+
+// Mock Wagmi hooks
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: '0x123' }),
+  useChainId: () => 8453,
+  useSignTypedData: () => ({ signTypedDataAsync: vi.fn() }),
+  useSwitchChain: () => ({ switchChainAsync: vi.fn() }),
+}));
+
+// Mock theme hook
+vi.mock('@/internal/hooks/useTheme', () => ({
+  useTheme: () => 'ock-theme',
+}));
+
+// Mock the subscription permissions hook
+vi.mock('../hooks/useSubscriptionPermissions', () => ({
+  useSubscriptionPermissions: vi.fn(() => ({
+    existingPermission: null,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}));
+
+// Mock the getCurrentPeriod utility
+vi.mock('../utils/getCurrentPeriod', () => ({
+  getPermissionStatus: vi.fn().mockResolvedValue({ currentPeriod: undefined }),
+}));
+
+// Mock the calculatePermissionHash utility
+vi.mock('../utils/calculatePermissionHash', () => ({
+  calculatePermissionHash: vi.fn().mockReturnValue('0x123456789abcdef'),
+}));
+
+describe('Subscribe', () => {
+  it('should render with default props', () => {
+    render(
+      <Subscribe
+        amount="10"
+        token={usdcToken}
+        interval={{ days: 30 }}
+        spender="0x123456789abcdef123456789abcdef123456789a"
+      />,
+    );
+
+    expect(screen.getByTestId('ockSubscribe')).toBeInTheDocument();
+    expect(screen.getByTestId('ockSubscribeButton')).toBeInTheDocument();
+    expect(screen.getByText('Subscribe $10/month')).toBeInTheDocument();
+  });
+
+  it('should render with custom button text', () => {
+    render(
+      <Subscribe
+        amount="5"
+        token={usdcToken}
+        interval={{ weeks: 1 }}
+        spender="0x123456789abcdef123456789abcdef123456789a"
+        buttonText="Subscribe Now"
+      />,
+    );
+
+    expect(screen.getByText('Subscribe Now')).toBeInTheDocument();
+  });
+
+  it('should render disabled state', () => {
+    render(
+      <Subscribe
+        amount="20"
+        token={usdcToken}
+        interval={{ months: 1 }}
+        spender="0x123456789abcdef123456789abcdef123456789a"
+        disabled={true}
+      />,
+    );
+
+    const button = screen.getByTestId('ockSubscribeButton');
+    expect(button).toBeDisabled();
+  });
+
+  it('should accept extraData parameter', () => {
+    const extraData = '0x1234567890abcdef' as const;
+
+    render(
+      <Subscribe
+        amount="15"
+        token={usdcToken}
+        interval={{ weeks: 2 }}
+        spender="0x123456789abcdef123456789abcdef123456789a"
+        extraData={extraData}
+      />,
+    );
+
+    expect(screen.getByTestId('ockSubscribe')).toBeInTheDocument();
+    expect(screen.getByTestId('ockSubscribeButton')).toBeInTheDocument();
+  });
+
+  it('should throw error for invalid amount', () => {
+    // Mock console.error to prevent error logs during test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Mock NODE_ENV to ensure development behavior
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    try {
+      expect(() => {
+        render(
+          <Subscribe
+            amount="0"
+            token={usdcToken}
+            interval={{ days: 30 }}
+            spender="0x123456789abcdef123456789abcdef123456789a"
+          />,
+        );
+      }).toThrow('Subscribe: amount must be greater than 0');
+
+      expect(() => {
+        render(
+          <Subscribe
+            amount="0.00"
+            token={usdcToken}
+            interval={{ days: 30 }}
+            spender="0x123456789abcdef123456789abcdef123456789a"
+          />,
+        );
+      }).toThrow('Subscribe: amount must be greater than 0');
+
+      expect(() => {
+        render(
+          <Subscribe
+            amount="abc"
+            token={usdcToken}
+            interval={{ days: 30 }}
+            spender="0x123456789abcdef123456789abcdef123456789a"
+          />,
+        );
+      }).toThrow('Subscribe: amount must be a valid number');
+
+      expect(() => {
+        render(
+          <Subscribe
+            amount=""
+            token={usdcToken}
+            interval={{ days: 30 }}
+            spender="0x123456789abcdef123456789abcdef123456789a"
+          />,
+        );
+      }).toThrow('Subscribe: amount is required');
+    } finally {
+      consoleSpy.mockRestore();
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it('should throw error for invalid spender', () => {
+    // Mock console.error to prevent error logs during test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Mock NODE_ENV to ensure development behavior
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    try {
+      expect(() => {
+        render(
+          <Subscribe
+            amount="10"
+            token={usdcToken}
+            interval={{ days: 30 }}
+            spender="0x0"
+          />,
+        );
+      }).toThrow('Subscribe: spender address is required');
+    } finally {
+      consoleSpy.mockRestore();
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+
+  it('should accept onStatus callback', () => {
+    const onStatus = vi.fn();
+
+    render(
+      <Subscribe
+        amount="10"
+        token={usdcToken}
+        interval={{ days: 30 }}
+        spender="0x123456789abcdef123456789abcdef123456789a"
+        onStatus={onStatus}
+      />,
+    );
+
+    expect(screen.getByTestId('ockSubscribe')).toBeInTheDocument();
+  });
+
+  it('should trigger onSuccess immediately when existing permission is found', async () => {
+    const mockExistingPermission = {
+      spendPermission: {
+        account: '0x123',
+        spender: '0x123456789abcdef123456789abcdef123456789a',
+        token: usdcToken.address,
+        allowance: '10000000', // 10 USDC
+        period: 2592000, // 30 days
+        start: 1640995200,
+        end: 1672531200,
+        salt: '0',
+        extraData: '0x',
+      },
+      signature: '0xsignature123',
+      permissionHash: '0xhash123',
+      createdAt: 1640995200,
+    };
+
+    const onSuccess = vi.fn();
+    const onStatus = vi.fn();
+
+    // Override the existing mock to return an existing permission
+    const { useSubscriptionPermissions } = await import(
+      '../hooks/useSubscriptionPermissions'
+    );
+    vi.mocked(useSubscriptionPermissions).mockReturnValue({
+      existingPermission: mockExistingPermission,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(
+      <Subscribe
+        amount="10"
+        token={usdcToken}
+        interval={{ days: 30 }}
+        spender="0x123456789abcdef123456789abcdef123456789a"
+        onSuccess={onSuccess}
+        onStatus={onStatus}
+      />,
+    );
+
+    // Wait for the component to process the existing permission
+    await vi.waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          signature: '0xsignature123',
+          permissionHash: '0xhash123',
+          isExistingPermission: true,
+          spendPermission: expect.objectContaining({
+            account: '0x123',
+            spender: '0x123456789abcdef123456789abcdef123456789a',
+            token: usdcToken.address,
+            allowance: BigInt('10000000'),
+            period: 2592000,
+            start: 1640995200,
+            end: 1672531200,
+            salt: BigInt('0'),
+            extraData: '0x',
+          }),
+        }),
+      );
+    });
+
+    expect(
+      screen.getByTestId('ockSubscribeStatus-subscribed'),
+    ).toBeInTheDocument();
+
+    // Reset the mock back to default
+    vi.mocked(useSubscriptionPermissions).mockReturnValue({
+      existingPermission: null,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+  });
+
+  it('should return null for invalid props in production', () => {
+    // Mock console.error to prevent error logs during test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Mock NODE_ENV to ensure production behavior
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      const { container } = render(
+        <Subscribe
+          amount="0"
+          token={usdcToken}
+          interval={{ days: 30 }}
+          spender="0x123456789abcdef123456789abcdef123456789a"
+        />,
+      );
+
+      // Should render nothing (null) in production
+      expect(container.firstChild).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Subscribe: amount must be greater than 0',
+      );
+
+      // Test other invalid amounts
+      consoleSpy.mockClear();
+      const { container: container2 } = render(
+        <Subscribe
+          amount="invalid"
+          token={usdcToken}
+          interval={{ days: 30 }}
+          spender="0x123456789abcdef123456789abcdef123456789a"
+        />,
+      );
+      expect(container2.firstChild).toBeNull();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Subscribe: amount must be a valid number',
+      );
+    } finally {
+      consoleSpy.mockRestore();
+      process.env.NODE_ENV = originalEnv;
+    }
+  });
+});

--- a/packages/onchainkit/src/subscribe/components/Subscribe.tsx
+++ b/packages/onchainkit/src/subscribe/components/Subscribe.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useTheme } from '@/internal/hooks/useTheme';
+import { background, border, cn, color, text } from '@/styles/theme';
+import type { ReactNode } from 'react';
+import type { SubscribeReact } from '../types';
+import { SubscribeButton } from './SubscribeButton';
+import { SubscribeProvider } from './SubscribeProvider';
+import { SubscribeStatus } from './SubscribeStatus';
+
+function SubscribeContent({
+  children,
+  buttonText,
+  disabled,
+  className,
+}: {
+  children?: ReactNode;
+  buttonText?: string;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const componentTheme = useTheme();
+
+  return (
+    <div
+      className={cn(
+        componentTheme,
+        background.default,
+        color.foreground,
+        'flex w-full flex-col gap-4 p-4',
+        text.body,
+        border.radius,
+        border.lineDefault,
+        className,
+      )}
+      data-testid="ockSubscribe"
+    >
+      {children || (
+        <>
+          <SubscribeButton text={buttonText} disabled={disabled} />
+          <SubscribeStatus />
+        </>
+      )}
+    </div>
+  );
+}
+
+export function Subscribe({
+  amount,
+  token,
+  interval,
+  spender,
+  subscriptionLength,
+  buttonText,
+  className,
+  disabled = false,
+  extraData,
+  salt,
+  onSuccess,
+  onError,
+  onStatus,
+  children,
+}: SubscribeReact & { children?: ReactNode }) {
+  const validateAmount = (amount: string): string | null => {
+    if (!amount || amount.trim() === '') {
+      return 'Subscribe: amount is required';
+    }
+
+    const numericValue = parseFloat(amount);
+    if (isNaN(numericValue) || !isFinite(numericValue)) {
+      return 'Subscribe: amount must be a valid number';
+    }
+
+    if (numericValue <= 0) {
+      return 'Subscribe: amount must be greater than 0';
+    }
+
+    return null;
+  };
+
+  if (process.env.NODE_ENV !== 'production') {
+    const amountError = validateAmount(amount);
+    if (amountError) {
+      throw new Error(amountError);
+    }
+
+    if (!token) {
+      throw new Error('Subscribe: token is required');
+    }
+
+    if (!interval) {
+      throw new Error('Subscribe: interval is required');
+    }
+
+    if (!spender || spender === '0x0') {
+      throw new Error('Subscribe: spender address is required');
+    }
+  } else {
+    const amountError = validateAmount(amount);
+    if (amountError) {
+      console.error(amountError);
+      return null;
+    }
+
+    if (!token) {
+      console.error('Subscribe: token is required');
+      return null;
+    }
+
+    if (!interval) {
+      console.error('Subscribe: interval is required');
+      return null;
+    }
+
+    if (!spender || spender === '0x0') {
+      console.error('Subscribe: spender address is required');
+      return null;
+    }
+  }
+
+  return (
+    <SubscribeProvider
+      amount={amount}
+      token={token}
+      interval={interval}
+      spender={spender}
+      subscriptionLength={subscriptionLength}
+      extraData={extraData}
+      salt={salt}
+      onSuccess={onSuccess}
+      onError={onError}
+      onStatus={onStatus}
+    >
+      <SubscribeContent
+        buttonText={buttonText}
+        disabled={disabled}
+        className={className}
+      >
+        {children}
+      </SubscribeContent>
+    </SubscribeProvider>
+  );
+}

--- a/packages/onchainkit/src/subscribe/components/SubscribeButton.tsx
+++ b/packages/onchainkit/src/subscribe/components/SubscribeButton.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useTheme } from '@/internal/hooks/useTheme';
+import { Spinner } from '@/internal/components/Spinner';
+import { background, cn, color, pressable, text } from '@/styles/theme';
+import { useCallback, useMemo } from 'react';
+import type {
+  SubscribeButtonReact,
+  FetchPermissionsResultItem,
+  Duration,
+} from '../types';
+import type { Token } from '@/token';
+import { useSubscribeContext } from './SubscribeProvider';
+import { SUBSCRIBE_LIFECYCLE_STATUS } from '../constants';
+import { formatSubscriptionText } from '../utils/formatAmount';
+
+function getButtonText(
+  buttonText: string | undefined,
+  amount: string,
+  token: Token,
+  interval: Duration,
+  isSigning: boolean,
+  isSuccess: boolean,
+  isSubscribed: boolean,
+  showSpinner: boolean,
+) {
+  const defaultText =
+    buttonText || formatSubscriptionText(amount, token, interval);
+
+  if (isSigning) {
+    return 'Signing';
+  }
+
+  if (!showSpinner && (isSuccess || isSubscribed)) {
+    return 'Subscribed';
+  }
+
+  return defaultText;
+}
+
+function shouldShowSpinner(
+  isCheckingPermissions: boolean | undefined,
+  isLoading: boolean,
+  isSigning: boolean,
+  existingPermission: FetchPermissionsResultItem | null | undefined,
+  isInit: boolean,
+) {
+  if (isCheckingPermissions) {
+    return true;
+  }
+
+  if (isLoading) {
+    return true;
+  }
+
+  if (isSigning) {
+    return true;
+  }
+
+  if (existingPermission && isInit) {
+    return true;
+  }
+
+  return false;
+}
+
+function getButtonClasses(
+  componentTheme: string,
+  isDisabled: boolean,
+  isSuccess: boolean,
+  isSubscribed: boolean,
+  className?: string,
+) {
+  const successClasses =
+    isSuccess || isSubscribed
+      ? [
+          background.success,
+          'hover:bg-[var(--ock-bg-success)]',
+          'active:bg-[var(--ock-bg-success)]',
+        ]
+      : [];
+
+  return cn(
+    componentTheme,
+    pressable.primary,
+    'relative w-full rounded-xl min-w-0',
+    'px-4 py-3 font-medium text-base leading-6',
+    text.headline,
+    color.inverse,
+    isDisabled && pressable.disabled,
+    successClasses,
+    className,
+  );
+}
+
+export function SubscribeButton({
+  text: buttonText,
+  className,
+  disabled = false,
+}: SubscribeButtonReact) {
+  const componentTheme = useTheme();
+  const {
+    lifecycleStatus,
+    handleSubscribe,
+    isCheckingPermissions,
+    existingPermission,
+    amount,
+    token,
+    interval,
+  } = useSubscribeContext();
+
+  const isInit = lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.INIT;
+  const isLoading =
+    lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.LOADING;
+  const isSigning =
+    lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.SIGNING;
+  const isSuccess =
+    lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.SUCCESS;
+  const isSubscribed =
+    lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.SUBSCRIBED;
+  const isDisabled =
+    disabled || isLoading || isSigning || isSuccess || isSubscribed;
+
+  const handleClick = useCallback(async () => {
+    if (!isDisabled && !isSubscribed && !isSuccess) {
+      await handleSubscribe();
+    }
+  }, [handleSubscribe, isDisabled, isSubscribed, isSuccess]);
+
+  const showSpinner = shouldShowSpinner(
+    isCheckingPermissions,
+    isLoading,
+    isSigning,
+    existingPermission,
+    isInit,
+  );
+
+  const displayText = useMemo(
+    () =>
+      getButtonText(
+        buttonText,
+        amount,
+        token,
+        interval,
+        isSigning,
+        isSuccess,
+        isSubscribed,
+        showSpinner,
+      ),
+    [
+      buttonText,
+      amount,
+      token,
+      interval,
+      isSigning,
+      isSuccess,
+      isSubscribed,
+      showSpinner,
+    ],
+  );
+
+  const buttonClasses = getButtonClasses(
+    componentTheme,
+    isDisabled,
+    isSuccess,
+    isSubscribed,
+    className,
+  );
+
+  const shouldShowText = (showSpinner && isSigning) || !showSpinner;
+
+  return (
+    <button
+      className={buttonClasses}
+      onClick={handleClick}
+      disabled={isDisabled}
+      type="button"
+      data-testid="ockSubscribeButton"
+    >
+      <div className="flex items-center justify-center gap-2 min-h-[1.5rem]">
+        {showSpinner && <Spinner />}
+        {shouldShowText && (
+          <span
+            className={cn(
+              text.headline,
+              color.inverse,
+              'flex justify-center whitespace-nowrap',
+            )}
+          >
+            {displayText}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/packages/onchainkit/src/subscribe/components/SubscribeProvider.tsx
+++ b/packages/onchainkit/src/subscribe/components/SubscribeProvider.tsx
@@ -1,0 +1,460 @@
+'use client';
+
+import type { APIError } from '@/api/types';
+import { useLifecycleStatus } from '@/internal/hooks/useLifecycleStatus';
+import { useValue } from '@/internal/hooks/useValue';
+import { GENERIC_ERROR_MESSAGE } from '@/transaction/constants';
+import { isUserRejectedRequestError } from '@/transaction/utils/isUserRejectedRequestError';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
+import { useAccount, useSignTypedData, useSwitchChain } from 'wagmi';
+import { base, baseSepolia } from 'viem/chains';
+import type { Chain } from 'viem';
+import {
+  SPEND_PERMISSION_ERC712_DOMAIN,
+  SPEND_PERMISSION_ERC712_TYPES,
+  SPEND_PERMISSION_MANAGER_ADDRESS,
+  SUBSCRIBE_LIFECYCLE_STATUS,
+} from '../constants';
+import type {
+  SubscribeContextType,
+  SubscribeLifecycleStatus,
+  SubscribeProviderReact,
+  SubscribeSuccessResult,
+} from '../types';
+import {
+  buildSpendPermission,
+  validateSpendPermission,
+} from '../utils/buildSpendPermission';
+import { useSubscriptionPermissions } from '../hooks/useSubscriptionPermissions';
+import { getPermissionStatus } from '../utils/getCurrentPeriod';
+import { calculatePermissionHash } from '../utils/calculatePermissionHash';
+
+const EMPTY_CONTEXT = {} as SubscribeContextType;
+
+const SubscribeContext = createContext<SubscribeContextType>(EMPTY_CONTEXT);
+
+// Helper to convert chainId to Chain object
+function getChainFromId(chainId: number): Chain {
+  switch (chainId) {
+    case base.id:
+      return base;
+    case baseSepolia.id:
+      return baseSepolia;
+    default:
+      return base; // Default to base mainnet
+  }
+}
+
+export function useSubscribeContext() {
+  const context = useContext(SubscribeContext);
+  if (context === EMPTY_CONTEXT) {
+    throw new Error(
+      'useSubscribeContext must be used within a SubscribeProvider',
+    );
+  }
+  return context;
+}
+
+export function SubscribeProvider({
+  children,
+  amount,
+  token,
+  interval,
+  spender,
+  subscriptionLength,
+  extraData,
+  salt,
+  onSuccess,
+  onError,
+  onStatus,
+}: SubscribeProviderReact) {
+  const { address, chainId } = useAccount();
+  const { signTypedDataAsync } = useSignTypedData();
+  const { switchChainAsync } = useSwitchChain();
+
+  const [lifecycleStatus, updateLifecycleStatusInternal] =
+    useLifecycleStatus<SubscribeLifecycleStatus>({
+      statusName: SUBSCRIBE_LIFECYCLE_STATUS.INIT,
+      statusData: null,
+    });
+
+  const updateLifecycleStatus = useCallback(
+    (status: SubscribeLifecycleStatus) => {
+      updateLifecycleStatusInternal(status);
+      onStatusRef.current?.(status);
+    },
+    [updateLifecycleStatusInternal],
+  );
+
+  const processedPermissionHashRef = useRef<string | null>(null);
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+  const onStatusRef = useRef(onStatus);
+  onSuccessRef.current = onSuccess;
+  onErrorRef.current = onError;
+  onStatusRef.current = onStatus;
+
+  // Reset processed permission hash when key parameters change
+  useEffect(() => {
+    processedPermissionHashRef.current = null;
+  }, [address, spender, token.address, amount, interval]);
+  const {
+    existingPermission,
+    isLoading: isCheckingPermissions,
+    error: permissionsError,
+    refetch: refetchPermissions,
+  } = useSubscriptionPermissions({
+    account: address,
+    chainId: token.chainId || chainId,
+    spender,
+    token,
+    amount,
+    interval,
+  });
+  useEffect(() => {
+    if (
+      existingPermission &&
+      lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.INIT
+    ) {
+      const permissionHash = existingPermission.permissionHash;
+
+      // Check if we've already processed this permission hash
+      if (processedPermissionHashRef.current === permissionHash) {
+        return;
+      }
+      processedPermissionHashRef.current = permissionHash;
+      const spendPermission = {
+        account: existingPermission.spendPermission.account as `0x${string}`,
+        spender: existingPermission.spendPermission.spender as `0x${string}`,
+        token: existingPermission.spendPermission.token as `0x${string}`,
+        allowance: BigInt(existingPermission.spendPermission.allowance),
+        period: existingPermission.spendPermission.period,
+        start: existingPermission.spendPermission.start,
+        end: existingPermission.spendPermission.end,
+        salt: BigInt(existingPermission.spendPermission.salt),
+        extraData: existingPermission.spendPermission
+          .extraData as `0x${string}`,
+      };
+      updateLifecycleStatus({
+        statusName: SUBSCRIBE_LIFECYCLE_STATUS.SUBSCRIBED,
+        statusData: {
+          existingPermission,
+          subscriptionData: {
+            amount,
+            token,
+            interval,
+            spender,
+            subscriptionLength,
+            extraData,
+            salt,
+          },
+        },
+      });
+      const result: SubscribeSuccessResult = {
+        signature: existingPermission.signature as `0x${string}`,
+        spendPermission,
+        permissionHash: existingPermission.permissionHash,
+        currentPeriod: undefined, // Will be updated if fetched successfully
+        isExistingPermission: true,
+        metadata: {
+          amount,
+          token,
+          interval,
+          spender,
+          subscriptionLength,
+          extraData,
+        },
+      };
+      onSuccessRef.current?.(result);
+      const fetchCurrentPeriodInBackground = async () => {
+        try {
+          await getPermissionStatus(
+            spendPermission,
+            getChainFromId(token.chainId || chainId || 1),
+          );
+        } catch (error) {
+          // Log error in development for debugging
+          if (process.env.NODE_ENV !== 'production') {
+            console.debug(
+              'Failed to fetch current period data (non-critical):',
+              error,
+            );
+          }
+        }
+      };
+
+      // Run background fetch without awaiting
+      fetchCurrentPeriodInBackground();
+    }
+  }, [
+    existingPermission,
+    lifecycleStatus.statusName,
+    amount,
+    token,
+    interval,
+    spender,
+    subscriptionLength,
+    extraData,
+    salt,
+    chainId,
+    updateLifecycleStatus,
+    // Note: onSuccess removed from dependencies to prevent duplicate execution
+    // The processedPermissionHashRef guard ensures we only process each permission once
+  ]);
+
+  function handleError(err: unknown) {
+    const errorMessage = isUserRejectedRequestError(err)
+      ? 'Request denied.'
+      : GENERIC_ERROR_MESSAGE;
+
+    const errorData: APIError = {
+      code: 'SuPr03', // Subscribe Provider 03 error
+      error: JSON.stringify(err),
+      message: errorMessage,
+    };
+
+    updateLifecycleStatus({
+      statusName: SUBSCRIBE_LIFECYCLE_STATUS.ERROR,
+      statusData: errorData,
+    });
+
+    onErrorRef.current?.(errorData);
+  }
+
+  async function refresh(): Promise<void> {
+    // Reset the processed permission hash to allow reprocessing
+    processedPermissionHashRef.current = null;
+    // Refetch permissions data
+    await refetchPermissions();
+  }
+
+  async function handleSubscribe(): Promise<void> {
+    if (!address) {
+      handleError(new Error('Wallet not connected'));
+      return;
+    }
+
+    // If there's already an existing permission, don't create a new one
+    if (existingPermission) {
+      updateLifecycleStatus({
+        statusName: SUBSCRIBE_LIFECYCLE_STATUS.SUBSCRIBED,
+        statusData: {
+          existingPermission,
+          subscriptionData: {
+            amount,
+            token,
+            interval,
+            spender,
+            subscriptionLength,
+            extraData,
+            salt,
+          },
+        },
+      });
+      return;
+    }
+
+    updateLifecycleStatus({
+      statusName: SUBSCRIBE_LIFECYCLE_STATUS.LOADING,
+      statusData: {},
+    });
+
+    try {
+      // Check if we need to switch chains based on token
+      if (token.chainId && chainId !== token.chainId) {
+        try {
+          await switchChainAsync({ chainId: token.chainId });
+        } catch {
+          const switchError = new Error(
+            `Please switch to the correct network for ${token.symbol}`,
+          );
+          handleError(switchError);
+          return;
+        }
+      }
+
+      // Build the spend permission
+      const spendPermission = buildSpendPermission({
+        account: address,
+        spender,
+        amount,
+        token,
+        interval,
+        subscriptionLength,
+        extraData,
+        salt,
+      });
+
+      // Validate the spend permission
+      validateSpendPermission(spendPermission);
+
+      updateLifecycleStatus({
+        statusName: SUBSCRIBE_LIFECYCLE_STATUS.SIGNING,
+        statusData: {},
+      });
+
+      // Sign the spend permission
+      const signature = await signTypedDataAsync({
+        domain: {
+          ...SPEND_PERMISSION_ERC712_DOMAIN,
+          chainId: token.chainId || chainId,
+          verifyingContract: SPEND_PERMISSION_MANAGER_ADDRESS,
+        },
+        types: SPEND_PERMISSION_ERC712_TYPES,
+        primaryType: 'SpendPermission',
+        message: spendPermission,
+      });
+
+      // Calculate permission hash for new subscription
+      const permissionHash = calculatePermissionHash(
+        spendPermission,
+        token.chainId || chainId || 1,
+      );
+
+      // Create success result (current period data not needed for UI)
+      const result: SubscribeSuccessResult = {
+        signature,
+        spendPermission,
+        permissionHash,
+        currentPeriod: undefined, // Not needed for component display
+        isExistingPermission: false,
+        metadata: {
+          amount,
+          token,
+          interval,
+          spender,
+          subscriptionLength,
+          extraData,
+        },
+      };
+
+      // Create a mock existingPermission structure for new subscriptions
+      const mockExistingPermission = {
+        spendPermission: {
+          account: spendPermission.account,
+          spender: spendPermission.spender,
+          token: spendPermission.token,
+          allowance: spendPermission.allowance.toString(),
+          period: spendPermission.period,
+          start: spendPermission.start,
+          end: spendPermission.end,
+          salt: spendPermission.salt.toString(),
+          extraData: spendPermission.extraData,
+        },
+        signature,
+        permissionHash,
+        createdAt: Math.floor(Date.now() / 1000), // Current timestamp
+      };
+
+      updateLifecycleStatus({
+        statusName: SUBSCRIBE_LIFECYCLE_STATUS.SUBSCRIBED,
+        statusData: {
+          existingPermission: mockExistingPermission,
+          subscriptionData: {
+            amount,
+            token,
+            interval,
+            spender,
+            subscriptionLength,
+            extraData,
+            salt,
+          },
+        },
+      });
+
+      onSuccessRef.current?.(result);
+
+      // Optionally fetch current period data in the background (not blocking)
+      const fetchCurrentPeriodInBackground = async () => {
+        try {
+          await getPermissionStatus(
+            spendPermission,
+            getChainFromId(token.chainId || chainId || 1),
+          );
+          // Current period data fetched but not used by components
+        } catch (error) {
+          // Log error in development for debugging
+          if (process.env.NODE_ENV !== 'production') {
+            console.debug(
+              'Failed to fetch current period data (non-critical):',
+              error,
+            );
+          }
+        }
+      };
+
+      // Run background fetch without awaiting
+      fetchCurrentPeriodInBackground();
+    } catch (err) {
+      handleError(err);
+    }
+  }
+
+  const spendPermission = useMemo(() => {
+    if (lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.SUBSCRIBED) {
+      return {
+        account: lifecycleStatus.statusData.existingPermission.spendPermission
+          .account as `0x${string}`,
+        spender: lifecycleStatus.statusData.existingPermission.spendPermission
+          .spender as `0x${string}`,
+        token: lifecycleStatus.statusData.existingPermission.spendPermission
+          .token as `0x${string}`,
+        allowance: BigInt(
+          lifecycleStatus.statusData.existingPermission.spendPermission
+            .allowance,
+        ),
+        period:
+          lifecycleStatus.statusData.existingPermission.spendPermission.period,
+        start:
+          lifecycleStatus.statusData.existingPermission.spendPermission.start,
+        end: lifecycleStatus.statusData.existingPermission.spendPermission.end,
+        salt: BigInt(
+          lifecycleStatus.statusData.existingPermission.spendPermission.salt,
+        ),
+        extraData: lifecycleStatus.statusData.existingPermission.spendPermission
+          .extraData as `0x${string}`,
+      };
+    }
+    return undefined;
+  }, [lifecycleStatus]);
+
+  const signature = useMemo(() => {
+    if (lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.SUBSCRIBED) {
+      return lifecycleStatus.statusData.existingPermission
+        .signature as `0x${string}`;
+    }
+    return undefined;
+  }, [lifecycleStatus]);
+
+  const value = useValue<SubscribeContextType>({
+    amount,
+    token,
+    interval,
+    spender,
+    subscriptionLength,
+    extraData,
+    salt,
+    lifecycleStatus,
+    spendPermission,
+    signature,
+    existingPermission,
+    isCheckingPermissions,
+    permissionsError,
+    handleSubscribe,
+    updateLifecycleStatus,
+    refresh,
+  });
+
+  return (
+    <SubscribeContext.Provider value={value}>
+      {children}
+    </SubscribeContext.Provider>
+  );
+}

--- a/packages/onchainkit/src/subscribe/components/SubscribeStatus.tsx
+++ b/packages/onchainkit/src/subscribe/components/SubscribeStatus.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useTheme } from '@/internal/hooks/useTheme';
+import { Spinner } from '@/internal/components/Spinner';
+import { background, cn, color, text } from '@/styles/theme';
+import type { SubscribeStatusReact } from '../types';
+import { useSubscribeContext } from './SubscribeProvider';
+import {
+  formatSubscriptionAmount,
+  formatPeriodShort,
+} from '../utils/formatAmount';
+import { SUBSCRIBE_LIFECYCLE_STATUS, MAX_UINT48 } from '../constants';
+
+export function SubscribeStatus({ className }: SubscribeStatusReact) {
+  const componentTheme = useTheme();
+  const { lifecycleStatus, isCheckingPermissions } = useSubscribeContext();
+
+  // Don't render anything if in initial state
+  if (lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.INIT) {
+    return null;
+  }
+
+  // Checking permissions state
+  if (isCheckingPermissions) {
+    return (
+      <div
+        className={cn(
+          componentTheme,
+          'flex items-center justify-center p-3 rounded-lg',
+          background.alternate,
+          color.foreground,
+          className,
+        )}
+        data-testid="ockSubscribeStatus-checking"
+      >
+        <Spinner />
+      </div>
+    );
+  }
+
+  // Loading state
+  if (lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.LOADING) {
+    return (
+      <div
+        className={cn(
+          componentTheme,
+          'flex items-center gap-2 p-3 rounded-lg',
+          background.alternate,
+          color.foreground,
+          className,
+        )}
+        data-testid="ockSubscribeStatus-loading"
+      >
+        <Spinner />
+        <span className={cn(text.body)}>Processing...</span>
+      </div>
+    );
+  }
+
+  // Signing state - don't render anything, let button handle the UX
+  if (lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.SIGNING) {
+    return null;
+  }
+
+  // Already subscribed state (covers both new and existing subscriptions)
+  if (lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.SUBSCRIBED) {
+    const { subscriptionData, existingPermission } = lifecycleStatus.statusData;
+    const createdDate = new Date(
+      existingPermission.createdAt * 1000,
+    ).toLocaleDateString();
+    const formattedAmount = formatSubscriptionAmount(
+      subscriptionData.amount,
+      subscriptionData.token,
+    );
+    const period = formatPeriodShort(subscriptionData.interval);
+
+    // Format end date if subscription has an end time
+    const hasEndDate =
+      existingPermission.spendPermission.end &&
+      BigInt(existingPermission.spendPermission.end) < MAX_UINT48;
+    const endDate = hasEndDate
+      ? new Date(
+          existingPermission.spendPermission.end * 1000,
+        ).toLocaleDateString()
+      : null;
+
+    return (
+      <div
+        className={cn(
+          componentTheme,
+          'p-3 rounded-lg',
+          background.success,
+          color.inverse,
+          className,
+        )}
+        data-testid="ockSubscribeStatus-subscribed"
+      >
+        <div className={cn(text.headline, 'mb-1')}>Subscribed</div>
+        <div className={cn(text.body, 'opacity-90')}>
+          Subscribed to {formattedAmount}/{period}
+        </div>
+        <div className={cn(text.caption, 'opacity-75')}>
+          Subscribed on {createdDate}
+          {endDate && ` ending on ${endDate}`}
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (lifecycleStatus.statusName === SUBSCRIBE_LIFECYCLE_STATUS.ERROR) {
+    const { message } = lifecycleStatus.statusData;
+
+    return (
+      <div
+        className={cn(
+          componentTheme,
+          'p-3 rounded-lg',
+          background.error,
+          color.inverse,
+          className,
+        )}
+        data-testid="ockSubscribeStatus-error"
+      >
+        <div className={cn(text.headline, 'mb-1')}>Subscription Failed</div>
+        <div className={cn(text.body, 'opacity-90')}>{message}</div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/packages/onchainkit/src/subscribe/constants.ts
+++ b/packages/onchainkit/src/subscribe/constants.ts
@@ -1,0 +1,79 @@
+// 🌲☀🌲
+import type { Address } from 'viem';
+
+/**
+ * SpendPermissionManager contract address - deployed on multiple chains
+ * @see https://github.com/coinbase/spend-permissions
+ */
+export const SPEND_PERMISSION_MANAGER_ADDRESS: Address =
+  '0xf85210B21cC50302F477BA56686d2019dC9b67Ad';
+
+/**
+ * ETH token address for spend permissions (EIP-7528)
+ * @see https://eips.ethereum.org/EIPS/eip-7528
+ */
+export const ETH_TOKEN_ADDRESS: Address =
+  '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+
+/**
+ * ERC-712 domain for SpendPermissionManager
+ */
+export const SPEND_PERMISSION_ERC712_DOMAIN = {
+  name: 'Spend Permission Manager',
+  version: '1',
+} as const;
+
+/**
+ * ERC-712 types for SpendPermission
+ */
+export const SPEND_PERMISSION_ERC712_TYPES = {
+  SpendPermission: [
+    { name: 'account', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'token', type: 'address' },
+    { name: 'allowance', type: 'uint160' },
+    { name: 'period', type: 'uint48' },
+    { name: 'start', type: 'uint48' },
+    { name: 'end', type: 'uint48' },
+    { name: 'salt', type: 'uint256' },
+    { name: 'extraData', type: 'bytes' },
+  ],
+} as const;
+
+/**
+ * Maximum uint48 value for unlimited subscription end time
+ */
+export const MAX_UINT48 = 281474976710655n;
+
+/**
+ * Time conversion constants
+ */
+export const TIME_UNITS = {
+  SECOND: 1,
+  MINUTE: 60,
+  HOUR: 3600,
+  DAY: 86400,
+  WEEK: 604800,
+  MONTH: 2592000,
+  YEAR: 31536000,
+} as const;
+
+/**
+ * Subscribe lifecycle status constants
+ * Note: exported as public constants
+ */
+export const SUBSCRIBE_LIFECYCLE_STATUS = {
+  INIT: 'init',
+  LOADING: 'loading',
+  SIGNING: 'signing',
+  SUCCESS: 'success',
+  SUBSCRIBED: 'subscribed',
+  ERROR: 'error',
+} as const;
+
+/**
+ * Type for subscribe lifecycle status values
+ * Note: exported as public Type
+ */
+export type SubscribeLifecycleStatusName =
+  (typeof SUBSCRIBE_LIFECYCLE_STATUS)[keyof typeof SUBSCRIBE_LIFECYCLE_STATUS];

--- a/packages/onchainkit/src/subscribe/hooks/useSubscriptionPermissions.ts
+++ b/packages/onchainkit/src/subscribe/hooks/useSubscriptionPermissions.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { Address } from 'viem';
+import { parseUnits } from 'viem';
+import type { APIError } from '@/api/types';
+import type { FetchPermissionsResultItem } from '../types';
+import type { Token } from '@/token';
+import {
+  fetchPermissions,
+  hasMatchingPermission,
+} from '../utils/fetchPermissions';
+import { calculateDurationInSeconds } from '../utils/calculateDuration';
+import type { Duration } from '../types';
+
+export type UseSubscriptionPermissionsProps = {
+  account?: Address;
+  chainId?: number;
+  spender: Address;
+  token: Token;
+  amount: string;
+  interval: Duration;
+};
+
+export type UseSubscriptionPermissionsResult = {
+  existingPermission: FetchPermissionsResultItem | null;
+  isLoading: boolean;
+  error: APIError | null;
+  refetch: () => void;
+};
+
+export function useSubscriptionPermissions({
+  account,
+  chainId,
+  spender,
+  token,
+  amount,
+  interval,
+}: UseSubscriptionPermissionsProps): UseSubscriptionPermissionsResult {
+  const [existingPermission, setExistingPermission] =
+    useState<FetchPermissionsResultItem | null>(null);
+  const [isLoading, setIsLoading] = useState(true); // Start as loading until we have data
+  const [error, setError] = useState<APIError | null>(null);
+
+  const checkPermissions = useCallback(async () => {
+    // If we don't have the required data, don't check yet but stop loading
+    if (!account || !chainId || !token.address) {
+      setExistingPermission(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const permissions = await fetchPermissions({
+        chainId: `0x${chainId.toString(16)}`,
+        account,
+        spender,
+      });
+
+      const periodInSeconds = calculateDurationInSeconds(interval);
+      // Use parseUnits to handle decimal amounts and avoid precision loss for high decimals
+      const allowanceAmount = parseUnits(amount, token.decimals);
+
+      const matchingPermission = hasMatchingPermission(
+        permissions.permissions,
+        token.address as `0x${string}`,
+        periodInSeconds,
+        allowanceAmount,
+      );
+
+      setExistingPermission(matchingPermission);
+    } catch (err) {
+      const errorData: APIError = {
+        code: 'SuPr01', // Subscribe Provider 01 error
+        error: JSON.stringify(err),
+        message:
+          err instanceof Error ? err.message : 'Failed to fetch permissions',
+      };
+      setError(errorData);
+      setExistingPermission(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [
+    account,
+    chainId,
+    spender,
+    token.address,
+    token.decimals,
+    amount,
+    interval,
+  ]);
+
+  useEffect(() => {
+    checkPermissions();
+  }, [checkPermissions]);
+
+  return {
+    existingPermission,
+    isLoading,
+    error,
+    refetch: checkPermissions,
+  };
+}

--- a/packages/onchainkit/src/subscribe/hooks/useSubscriptionStatus.ts
+++ b/packages/onchainkit/src/subscribe/hooks/useSubscriptionStatus.ts
@@ -1,0 +1,102 @@
+// 🌲☀🌲
+import type { APIError } from '@/api/types';
+import { useCallback, useEffect, useState } from 'react';
+import type {
+  SubscriptionStatus,
+  UseSubscriptionStatusParams,
+  UseSubscriptionStatusResult,
+  SpendPermission,
+} from '../types';
+
+// Mock implementation for now - in a real implementation this would:
+// 1. Query the SpendPermissionManager contract to check if permission is approved
+// 2. Check spending history to see current period usage
+// 3. Calculate time-based information
+async function fetchSubscriptionStatus(
+  spendPermission: SpendPermission,
+): Promise<SubscriptionStatus> {
+  // This is a placeholder implementation
+  // In reality, you would:
+  // - Call SpendPermissionManager.isApproved()
+  // - Query spending events from the contract
+  // - Calculate current period information
+
+  return {
+    isActive: true,
+    isRevoked: false,
+    currentPeriod: {
+      start: Math.floor(Date.now() / 1000),
+      end: Math.floor(Date.now() / 1000) + spendPermission.period,
+      spend: 0n,
+    },
+    remainingAllowance: spendPermission.allowance,
+    currentPeriodSpent: false,
+    timeUntilReset: spendPermission.period,
+    subscriptionEnd: spendPermission.end,
+  };
+}
+
+/**
+ * Hook for checking the status of a subscription
+ * @param params - Hook parameters
+ * @returns Subscription status information and utilities
+ *
+ * Note: exported as public Hook
+ */
+export function useSubscriptionStatus({
+  spendPermission,
+  refreshInterval = 30000, // 30 seconds default
+}: UseSubscriptionStatusParams): UseSubscriptionStatusResult {
+  const [status, setStatus] = useState<SubscriptionStatus | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<APIError | undefined>();
+
+  const fetchStatus = useCallback(async () => {
+    if (!spendPermission) {
+      setStatus(undefined);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(undefined);
+
+    try {
+      const subscriptionStatus = await fetchSubscriptionStatus(spendPermission);
+      setStatus(subscriptionStatus);
+    } catch (err) {
+      const errorData: APIError = {
+        code: 'SuPr02', // Subscribe Provider 02 error
+        error: JSON.stringify(err),
+        message:
+          err instanceof Error
+            ? err.message
+            : 'Failed to fetch subscription status',
+      };
+      setError(errorData);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [spendPermission]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Set up polling if refresh interval is provided
+  useEffect(() => {
+    if (!refreshInterval || !spendPermission) {
+      return;
+    }
+
+    const intervalId = setInterval(fetchStatus, refreshInterval);
+    return () => clearInterval(intervalId);
+  }, [fetchStatus, refreshInterval, spendPermission]);
+
+  return {
+    status,
+    isLoading,
+    error,
+    refetch: fetchStatus,
+  };
+}

--- a/packages/onchainkit/src/subscribe/index.ts
+++ b/packages/onchainkit/src/subscribe/index.ts
@@ -1,0 +1,68 @@
+// 🌲☀🌲
+
+// Components
+export { Subscribe } from './components/Subscribe';
+export { SubscribeButton } from './components/SubscribeButton';
+export { SubscribeProvider } from './components/SubscribeProvider';
+export { SubscribeStatus } from './components/SubscribeStatus';
+
+// Hooks
+export { useSubscribeContext } from './components/SubscribeProvider';
+export { useSubscriptionStatus } from './hooks/useSubscriptionStatus';
+export { useSubscriptionPermissions } from './hooks/useSubscriptionPermissions';
+
+// Utils
+export { buildSpendPermission } from './utils/buildSpendPermission';
+export {
+  calculatePermissionHash,
+  type FlexibleSpendPermission,
+} from './utils/calculatePermissionHash';
+export {
+  calculateDurationInSeconds,
+  calculatePeriodCount,
+} from './utils/calculateDuration';
+export {
+  fetchPermissions,
+  hasMatchingPermission,
+} from './utils/fetchPermissions';
+export {
+  getCurrentPeriod,
+  getPermissionStatus,
+  isPermissionApproved,
+  isPermissionRevoked,
+} from './utils/getCurrentPeriod';
+export {
+  formatSubscriptionAmount,
+  formatPeriodShort,
+  formatSubscriptionText,
+} from './utils/formatAmount';
+
+// Constants
+export {
+  SPEND_PERMISSION_MANAGER_ADDRESS,
+  ETH_TOKEN_ADDRESS,
+  SPEND_PERMISSION_ERC712_DOMAIN,
+  SPEND_PERMISSION_ERC712_TYPES,
+  SUBSCRIBE_LIFECYCLE_STATUS,
+} from './constants';
+export type { SubscribeLifecycleStatusName } from './constants';
+
+// Types
+export type {
+  Duration,
+  PeriodSpend,
+  SpendPermission,
+  SubscribeReact,
+  SubscribeButtonReact,
+  SubscribeStatusReact,
+  SubscribeSuccessResult,
+  SubscribeLifecycleStatus,
+  SubscriptionStatus,
+  UseSubscriptionStatusParams,
+  UseSubscriptionStatusResult,
+  FetchPermissionsRequest,
+  FetchPermissionsResult,
+  FetchPermissionsResultItem,
+  UseSubscriptionPermissionsProps,
+  UseSubscriptionPermissionsResult,
+} from './types';

--- a/packages/onchainkit/src/subscribe/types.ts
+++ b/packages/onchainkit/src/subscribe/types.ts
@@ -1,0 +1,299 @@
+// 🌲☀🌲
+import type { APIError } from '@/api/types';
+import type { Token } from '@/token';
+import type { ReactNode } from 'react';
+import type { Address, Hex } from 'viem';
+import { SUBSCRIBE_LIFECYCLE_STATUS } from './constants';
+
+/**
+ * Duration object supporting arbitrary time unit combinations
+ * Note: exported as public Type
+ */
+export type Duration = {
+  seconds?: number;
+  minutes?: number;
+  hours?: number;
+  days?: number;
+  weeks?: number;
+  months?: number;
+  years?: number;
+};
+
+/**
+ * SpendPermission struct matching the contract
+ * Note: exported as public Type
+ */
+export type SpendPermission = {
+  account: Address;
+  spender: Address;
+  token: Address;
+  allowance: bigint;
+  period: number;
+  start: number;
+  end: number;
+  salt: bigint;
+  extraData: Hex;
+};
+
+/**
+ * Current period information from SpendPermissionManager.getCurrentPeriod()
+ * Note: exported as public Type
+ */
+export type PeriodSpend = {
+  start: number; // unix timestamp
+  end: number; // unix timestamp
+  spend: bigint; // accumulated spend amount for period
+};
+
+/**
+ * Subscribe component success result
+ * Note: exported as public Type
+ */
+export type SubscribeSuccessResult = {
+  signature: Hex;
+  spendPermission: SpendPermission;
+  permissionHash: string; // Unique identifier for the spend permission
+  currentPeriod?: PeriodSpend; // Current period info if permission exists
+  isExistingPermission: boolean; // Whether this was an existing or new permission
+  metadata: {
+    amount: string;
+    token: Token;
+    interval: Duration;
+    spender: Address;
+    subscriptionLength?: Duration;
+    extraData?: Hex;
+  };
+};
+
+/**
+ * Subscribe lifecycle statuses
+ * Note: exported as public Type
+ */
+export type SubscribeLifecycleStatus =
+  | {
+      statusName: typeof SUBSCRIBE_LIFECYCLE_STATUS.INIT;
+      statusData: null;
+    }
+  | {
+      statusName: typeof SUBSCRIBE_LIFECYCLE_STATUS.LOADING;
+      statusData: {
+        isFetching?: boolean;
+      };
+    }
+  | {
+      statusName: typeof SUBSCRIBE_LIFECYCLE_STATUS.SIGNING;
+      statusData: Record<string, never>;
+    }
+  | {
+      statusName: typeof SUBSCRIBE_LIFECYCLE_STATUS.SUCCESS;
+      statusData: SubscribeSuccessResult;
+    }
+  | {
+      statusName: typeof SUBSCRIBE_LIFECYCLE_STATUS.SUBSCRIBED;
+      statusData: {
+        existingPermission: FetchPermissionsResultItem;
+        currentPeriod?: PeriodSpend;
+        subscriptionData: {
+          amount: string;
+          token: Token;
+          interval: Duration;
+          spender: Address;
+          subscriptionLength?: Duration;
+          extraData?: Hex;
+          salt?: bigint | 'auto';
+        };
+      };
+    }
+  | {
+      statusName: typeof SUBSCRIBE_LIFECYCLE_STATUS.ERROR;
+      statusData: APIError;
+    };
+
+/**
+ * Main Subscribe component props
+ * Note: exported as public Type
+ */
+export type SubscribeReact = {
+  /** Amount to charge per period */
+  amount: string;
+  /** Token to charge (supports Token object or string) */
+  token: Token;
+  /** Subscription interval duration */
+  interval: Duration;
+  /** Address authorized to spend user's tokens */
+  spender: Address;
+  /** Optional total subscription duration (defaults to unlimited) */
+  subscriptionLength?: Duration;
+  /** Optional button text (defaults to "Subscribe") */
+  buttonText?: string;
+  /** Optional custom styling */
+  className?: string;
+  /** Optional disabled state */
+  disabled?: boolean;
+  /** Optional extra data to include in spend permission (e.g., order ID, user ID) */
+  extraData?: Hex;
+  /** Optional salt for spend permission uniqueness (defaults to 0, use 'auto' for timestamp-based) */
+  salt?: bigint | 'auto';
+  /** Success callback with signature and metadata */
+  onSuccess?: (result: SubscribeSuccessResult) => void;
+  /** Error callback */
+  onError?: (error: APIError) => void;
+  /** Status change callback */
+  onStatus?: (status: SubscribeLifecycleStatus) => void;
+};
+
+/**
+ * SubscribeButton component props
+ * Note: exported as public Type
+ */
+export type SubscribeButtonReact = {
+  /** Optional button text (defaults to "Subscribe") */
+  text?: string;
+  /** Optional custom styling */
+  className?: string;
+  /** Optional disabled state */
+  disabled?: boolean;
+};
+
+/**
+ * SubscribeStatus component props
+ * Note: exported as public Type
+ */
+export type SubscribeStatusReact = {
+  /** Optional custom styling */
+  className?: string;
+};
+
+/**
+ * SubscribeProvider context props
+ */
+export type SubscribeProviderReact = {
+  children: ReactNode;
+  amount: string;
+  token: Token;
+  interval: Duration;
+  spender: Address;
+  subscriptionLength?: Duration;
+  extraData?: Hex;
+  salt?: bigint | 'auto';
+  onSuccess?: (result: SubscribeSuccessResult) => void;
+  onError?: (error: APIError) => void;
+  onStatus?: (status: SubscribeLifecycleStatus) => void;
+};
+
+/**
+ * SubscribeProvider context type
+ */
+export type SubscribeContextType = {
+  amount: string;
+  token: Token;
+  interval: Duration;
+  spender: Address;
+  subscriptionLength?: Duration;
+  extraData?: Hex;
+  salt?: bigint | 'auto';
+  lifecycleStatus: SubscribeLifecycleStatus;
+  spendPermission?: SpendPermission;
+  signature?: Hex;
+  existingPermission?: FetchPermissionsResultItem | null;
+  isCheckingPermissions?: boolean;
+  permissionsError?: APIError | null;
+  currentPeriod?: PeriodSpend;
+  handleSubscribe: () => Promise<void>;
+  updateLifecycleStatus: (status: SubscribeLifecycleStatus) => void;
+  refresh: () => Promise<void>;
+};
+
+/**
+ * Subscription status information
+ * Note: exported as public Type
+ */
+export type SubscriptionStatus = {
+  /** Whether the spend permission is approved and active */
+  isActive: boolean;
+  /** Whether the spend permission is revoked */
+  isRevoked: boolean;
+  /** Current period information */
+  currentPeriod?: PeriodSpend;
+  /** Remaining allowance for current period */
+  remainingAllowance: bigint;
+  /** Whether the current period allowance is fully spent */
+  currentPeriodSpent: boolean;
+  /** Days/hours until current period resets */
+  timeUntilReset?: number; // seconds
+  /** Subscription end time (if limited) */
+  subscriptionEnd?: number;
+};
+
+/**
+ * useSubscriptionStatus hook params
+ * Note: exported as public Type
+ */
+export type UseSubscriptionStatusParams = {
+  spendPermission?: SpendPermission;
+  /** Optional refresh interval in milliseconds */
+  refreshInterval?: number;
+};
+
+/**
+ * useSubscriptionStatus hook return type
+ * Note: exported as public Type
+ */
+export type UseSubscriptionStatusResult = {
+  status?: SubscriptionStatus;
+  isLoading: boolean;
+  error?: APIError;
+  refetch: () => void;
+};
+
+// Add types for coinbase_fetchPermissions RPC
+export type FetchPermissionsRequest = {
+  chainId: string; // hex, uint256
+  account: string; // address
+  spender: string; // address
+  pageOptions?: {
+    pageSize: number; // number of items requested, defaults to 50
+    cursor: string; // identifier for where the page should start
+  };
+};
+
+export type FetchPermissionsResult = {
+  permissions: FetchPermissionsResultItem[];
+  pageDescription: {
+    pageSize: number; // number of items returned
+    nextCursor: string; // identifier for where the next page should start
+  };
+};
+
+export type FetchPermissionsResultItem = {
+  createdAt: number; // UTC timestamp for when the permission was granted
+  permissionHash: string; // hex
+  signature: string; // hex
+  spendPermission: {
+    account: string; // address
+    spender: string; // address
+    token: string; // address
+    allowance: string; // base 10 numeric string
+    period: number; // unix seconds
+    start: number; // unix seconds
+    end: number; // unix seconds
+    salt: string; // base 10 numeric string
+    extraData: string; // hex
+  };
+};
+
+export type UseSubscriptionPermissionsProps = {
+  account?: Address;
+  chainId?: number;
+  spender: Address;
+  token: Token;
+  amount: string;
+  interval: Duration;
+};
+
+export type UseSubscriptionPermissionsResult = {
+  existingPermission: FetchPermissionsResultItem | null;
+  isLoading: boolean;
+  error: APIError | null;
+  refetch: () => void;
+};

--- a/packages/onchainkit/src/subscribe/utils/buildSpendPermission.test.ts
+++ b/packages/onchainkit/src/subscribe/utils/buildSpendPermission.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import { parseUnits } from 'viem';
+import { ethToken, usdcToken } from '@/token/constants';
+import { ETH_TOKEN_ADDRESS, MAX_UINT48 } from '../constants';
+import {
+  buildSpendPermission,
+  validateSpendPermission,
+} from './buildSpendPermission';
+
+describe('buildSpendPermission', () => {
+  const mockAccount = '0x1234567890123456789012345678901234567890' as const;
+  const mockSpender = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as const;
+
+  it('should build spend permission for ETH', () => {
+    const spendPermission = buildSpendPermission({
+      account: mockAccount,
+      spender: mockSpender,
+      amount: '1',
+      token: ethToken,
+      interval: { days: 30 },
+    });
+
+    expect(spendPermission.account).toBe(mockAccount);
+    expect(spendPermission.spender).toBe(mockSpender);
+    expect(spendPermission.token).toBe(ETH_TOKEN_ADDRESS);
+    expect(spendPermission.allowance).toBe(parseUnits('1', 18)); // 1 ETH
+    expect(spendPermission.period).toBe(86400 * 30); // 30 days in seconds
+    expect(spendPermission.start).toBe(0);
+    expect(spendPermission.end).toBe(Number(MAX_UINT48)); // Unlimited
+    expect(spendPermission.salt).toBe(0n);
+    expect(spendPermission.extraData).toBe('0x');
+  });
+
+  it('should build spend permission for USDC', () => {
+    const spendPermission = buildSpendPermission({
+      account: mockAccount,
+      spender: mockSpender,
+      amount: '100',
+      token: usdcToken,
+      interval: { weeks: 1 },
+    });
+
+    expect(spendPermission.token).toBe(usdcToken.address);
+    expect(spendPermission.allowance).toBe(parseUnits('100', 6)); // 100 USDC (6 decimals)
+    expect(spendPermission.period).toBe(604800); // 1 week in seconds
+  });
+
+  it('should calculate allowance for limited subscription', () => {
+    const spendPermission = buildSpendPermission({
+      account: mockAccount,
+      spender: mockSpender,
+      amount: '10',
+      token: usdcToken,
+      interval: { months: 1 },
+      subscriptionLength: { years: 1 }, // 12 periods
+    });
+
+    const expectedAllowance = parseUnits('10', 6) * 12n; // 10 USDC * 12 months
+    expect(spendPermission.allowance).toBe(expectedAllowance);
+
+    // Should have a calculated end time (not unlimited)
+    expect(spendPermission.end).toBeLessThan(Number(MAX_UINT48));
+    expect(spendPermission.end).toBeGreaterThan(0);
+  });
+
+  it('should handle complex duration combinations', () => {
+    const spendPermission = buildSpendPermission({
+      account: mockAccount,
+      spender: mockSpender,
+      amount: '5',
+      token: usdcToken,
+      interval: { days: 7 }, // Weekly
+      subscriptionLength: { months: 6, days: 15 }, // ~6.5 months
+    });
+
+    // Should calculate correct number of periods
+    expect(spendPermission.allowance).toBeGreaterThan(parseUnits('5', 6));
+    expect(spendPermission.period).toBe(86400 * 7); // 7 days
+  });
+
+  it('should throw error for invalid amount', () => {
+    expect(() =>
+      buildSpendPermission({
+        account: mockAccount,
+        spender: mockSpender,
+        amount: '0',
+        token: usdcToken,
+        interval: { days: 30 },
+      }),
+    ).toThrow('Amount must be greater than 0');
+
+    expect(() =>
+      buildSpendPermission({
+        account: mockAccount,
+        spender: mockSpender,
+        amount: '',
+        token: usdcToken,
+        interval: { days: 30 },
+      }),
+    ).toThrow('Amount must be greater than 0');
+  });
+
+  it('should allow custom salt and extraData', () => {
+    const customSalt = BigInt(12345);
+    const customExtraData = '0x1234' as const;
+
+    const spendPermission = buildSpendPermission({
+      account: mockAccount,
+      spender: mockSpender,
+      amount: '10',
+      token: usdcToken,
+      interval: { days: 30 },
+      salt: customSalt,
+      extraData: customExtraData,
+    });
+
+    expect(spendPermission.salt).toBe(customSalt);
+    expect(spendPermission.extraData).toBe(customExtraData);
+  });
+
+  it('should handle dynamic extraData for order/user IDs', () => {
+    const orderNumber = '12345';
+    const userId = 'user-abc-def';
+
+    // Simulate encoding order info as extraData
+    const encodedOrderData =
+      `0x${Buffer.from(JSON.stringify({ orderNumber, userId })).toString('hex')}` as const;
+
+    const spendPermission = buildSpendPermission({
+      account: mockAccount,
+      spender: mockSpender,
+      amount: '25',
+      token: usdcToken,
+      interval: { months: 1 },
+      extraData: encodedOrderData,
+    });
+
+    expect(spendPermission.extraData).toBe(encodedOrderData);
+    expect(spendPermission.allowance).toBe(parseUnits('25', 6));
+
+    // Verify we can decode the data back
+    const decodedData = JSON.parse(
+      Buffer.from(encodedOrderData.slice(2), 'hex').toString(),
+    );
+    expect(decodedData.orderNumber).toBe(orderNumber);
+    expect(decodedData.userId).toBe(userId);
+  });
+
+  it('should handle auto salt generation', () => {
+    const mockNow = 1640995200000; // Mock timestamp
+    const originalDateNow = Date.now;
+    Date.now = vi.fn(() => mockNow);
+
+    try {
+      const spendPermission = buildSpendPermission({
+        account: mockAccount,
+        spender: mockSpender,
+        amount: '10',
+        token: usdcToken,
+        interval: { days: 30 },
+        salt: 'auto',
+      });
+
+      expect(spendPermission.salt).toBe(BigInt(mockNow));
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+
+  it('should handle high-decimal amounts correctly', () => {
+    // Test with a token that has high decimals (like some DeFi tokens)
+    const highDecimalToken = {
+      ...usdcToken,
+      decimals: 24, // Very high decimals
+    };
+
+    const spendPermission = buildSpendPermission({
+      account: mockAccount,
+      spender: mockSpender,
+      amount: '0.123456789012345678901234',
+      token: highDecimalToken,
+      interval: { days: 30 },
+    });
+
+    // Should handle the high precision correctly without losing data
+    expect(spendPermission.allowance).toBe(
+      parseUnits('0.123456789012345678901234', 24),
+    );
+    expect(spendPermission.allowance).toBeGreaterThan(0n);
+  });
+
+  it('should handle decimal amounts with standard tokens', () => {
+    // Test with USDC (6 decimals) and a decimal amount
+    const spendPermission = buildSpendPermission({
+      account: mockAccount,
+      spender: mockSpender,
+      amount: '123.456789', // More decimals than USDC supports
+      token: usdcToken,
+      interval: { days: 30 },
+    });
+
+    // Should handle the decimal amount correctly (parseUnits will handle truncation)
+    expect(spendPermission.allowance).toBe(parseUnits('123.456789', 6));
+    expect(spendPermission.allowance).toBeGreaterThan(0n);
+  });
+});
+
+describe('validateSpendPermission', () => {
+  const validSpendPermission = {
+    account: '0x1234567890123456789012345678901234567890' as const,
+    spender: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as const,
+    token: usdcToken.address as `0x${string}`,
+    allowance: parseUnits('100', 6),
+    period: 86400 * 30,
+    start: 0,
+    end: Number(MAX_UINT48),
+    salt: 0n,
+    extraData: '0x' as const,
+  };
+
+  it('should pass validation for valid spend permission', () => {
+    expect(() => validateSpendPermission(validSpendPermission)).not.toThrow();
+  });
+
+  it('should throw for invalid account', () => {
+    expect(() =>
+      validateSpendPermission({
+        ...validSpendPermission,
+        account: '0x0' as const,
+      }),
+    ).toThrow('Account address is required');
+  });
+
+  it('should throw for invalid spender', () => {
+    expect(() =>
+      validateSpendPermission({
+        ...validSpendPermission,
+        spender: '0x0' as const,
+      }),
+    ).toThrow('Spender address is required');
+  });
+
+  it('should throw for zero allowance', () => {
+    expect(() =>
+      validateSpendPermission({
+        ...validSpendPermission,
+        allowance: 0n,
+      }),
+    ).toThrow('Allowance must be greater than 0');
+  });
+
+  it('should throw for invalid time range', () => {
+    expect(() =>
+      validateSpendPermission({
+        ...validSpendPermission,
+        start: 100,
+        end: 50,
+      }),
+    ).toThrow('End time must be after start time');
+  });
+});

--- a/packages/onchainkit/src/subscribe/utils/buildSpendPermission.ts
+++ b/packages/onchainkit/src/subscribe/utils/buildSpendPermission.ts
@@ -1,0 +1,161 @@
+// 🌲☀🌲
+import type { Token } from '@/token';
+import { parseUnits } from 'viem';
+import type { Address, Hex } from 'viem';
+import { ETH_TOKEN_ADDRESS, MAX_UINT48 } from '../constants';
+import type { Duration, SpendPermission } from '../types';
+import {
+  calculateDurationInSeconds,
+  calculatePeriodCount,
+  calculateSubscriptionEnd,
+} from './calculateDuration';
+import {
+  validateSubscriptionInterval,
+  validateSubscriptionLength,
+} from './validateDuration';
+
+/**
+ * Resolves token address for spend permissions
+ * ETH uses the special EIP-7528 address, ERC-20s use their contract address
+ */
+function resolveTokenAddress(token: Token): Address {
+  // ETH token has empty address, use EIP-7528 address for spend permissions
+  if (token.address === '') {
+    return ETH_TOKEN_ADDRESS;
+  }
+  return token.address as Address;
+}
+
+/**
+ * Calculates the total allowance based on amount and subscription length
+ * @param amount - Amount per period
+ * @param token - Token object for decimals
+ * @param interval - Period interval
+ * @param subscriptionLength - Optional total subscription duration
+ * @returns Total allowance in token units
+ */
+function calculateAllowance(
+  amount: string,
+  token: Token,
+  interval: Duration,
+  subscriptionLength?: Duration,
+): bigint {
+  const baseAmount = parseUnits(amount, token.decimals);
+
+  // If no subscription length specified, use base amount per period
+  // Note: This creates an unlimited subscription where the spender can collect
+  // the base amount every period until the user revokes the permission
+  if (!subscriptionLength) {
+    return baseAmount;
+  }
+
+  // Calculate number of periods and multiply by base amount
+  const periodCount = calculatePeriodCount(subscriptionLength, interval);
+  return baseAmount * BigInt(periodCount);
+}
+
+/**
+ * Build SpendPermission object from Subscribe component props
+ * @param params - Parameters for building spend permission
+ * @returns Complete SpendPermission object
+ */
+export function buildSpendPermission({
+  account,
+  spender,
+  amount,
+  token,
+  interval,
+  subscriptionLength,
+  salt = BigInt(0),
+  extraData = '0x' as Hex,
+}: {
+  account: Address;
+  spender: Address;
+  amount: string;
+  token: Token;
+  interval: Duration;
+  subscriptionLength?: Duration;
+  salt?: bigint | 'auto';
+  extraData?: Hex;
+}): SpendPermission {
+  // Validate inputs
+  validateSubscriptionInterval(interval);
+  if (subscriptionLength) {
+    validateSubscriptionLength(subscriptionLength, interval);
+  }
+
+  // Validate amount
+  if (!amount || amount === '0') {
+    throw new Error('Amount must be greater than 0');
+  }
+
+  // Handle salt - convert 'auto' to timestamp-based bigint
+  const resolvedSalt = salt === 'auto' ? BigInt(Date.now()) : salt;
+
+  // Calculate values
+  const tokenAddress = resolveTokenAddress(token);
+  const allowance = calculateAllowance(
+    amount,
+    token,
+    interval,
+    subscriptionLength,
+  );
+  const period = calculateDurationInSeconds(interval);
+  const start = 0; // Always start immediately
+
+  // Calculate end time
+  let end: number;
+  if (subscriptionLength) {
+    end = calculateSubscriptionEnd(subscriptionLength, start);
+  } else {
+    // Use max uint48 for unlimited subscriptions
+    // Note: MAX_UINT48 (281474976710655) is safely within JavaScript's MAX_SAFE_INTEGER
+    // (9007199254740991), so this cast is safe. If the spec ever changes to uint64,
+    // we should consider making SpendPermission.end a bigint in a breaking change.
+    end = Number(MAX_UINT48);
+  }
+
+  return {
+    account,
+    spender,
+    token: tokenAddress,
+    allowance,
+    period,
+    start,
+    end,
+    salt: resolvedSalt,
+    extraData,
+  };
+}
+
+/**
+ * Validates that a spend permission is properly formed
+ * @param spendPermission - SpendPermission to validate
+ */
+export function validateSpendPermission(
+  spendPermission: SpendPermission,
+): void {
+  if (!spendPermission.account || spendPermission.account === '0x0') {
+    throw new Error('Account address is required');
+  }
+
+  if (!spendPermission.spender || spendPermission.spender === '0x0') {
+    throw new Error('Spender address is required');
+  }
+
+  if (!spendPermission.token) {
+    throw new Error('Token address is required');
+  }
+
+  if (spendPermission.allowance <= 0n) {
+    throw new Error('Allowance must be greater than 0');
+  }
+
+  if (spendPermission.period <= 0) {
+    throw new Error('Period must be greater than 0');
+  }
+
+  if (spendPermission.end <= spendPermission.start) {
+    throw new Error('End time must be after start time');
+  }
+}

--- a/packages/onchainkit/src/subscribe/utils/calculateDuration.test.ts
+++ b/packages/onchainkit/src/subscribe/utils/calculateDuration.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateDurationInSeconds,
+  calculatePeriodCount,
+  calculateSubscriptionEnd,
+  formatSubscriptionPeriod,
+} from './calculateDuration';
+import type { Duration } from '../types';
+
+describe('calculateDurationInSeconds', () => {
+  it('should convert single time units correctly', () => {
+    expect(calculateDurationInSeconds({ seconds: 1 })).toBe(1);
+    expect(calculateDurationInSeconds({ minutes: 1 })).toBe(60);
+    expect(calculateDurationInSeconds({ hours: 1 })).toBe(3600);
+    expect(calculateDurationInSeconds({ days: 1 })).toBe(86400);
+    expect(calculateDurationInSeconds({ weeks: 1 })).toBe(604800);
+    expect(calculateDurationInSeconds({ months: 1 })).toBe(2629746);
+    expect(calculateDurationInSeconds({ years: 1 })).toBe(31556952);
+  });
+
+  it('should handle multiple time units', () => {
+    const duration: Duration = {
+      days: 1,
+      hours: 2,
+      minutes: 30,
+      seconds: 45,
+    };
+    const expected = 86400 + 7200 + 1800 + 45; // 95445
+    expect(calculateDurationInSeconds(duration)).toBe(expected);
+  });
+
+  it('should handle empty duration', () => {
+    expect(calculateDurationInSeconds({})).toBe(0);
+  });
+});
+
+describe('formatSubscriptionPeriod', () => {
+  it('should format single time units correctly', () => {
+    expect(formatSubscriptionPeriod({ years: 1 })).toBe('Every year');
+    expect(formatSubscriptionPeriod({ years: 2 })).toBe('Every 2 years');
+    expect(formatSubscriptionPeriod({ months: 1 })).toBe('Every month');
+    expect(formatSubscriptionPeriod({ months: 3 })).toBe('Every 3 months');
+    expect(formatSubscriptionPeriod({ weeks: 1 })).toBe('Every week');
+    expect(formatSubscriptionPeriod({ weeks: 2 })).toBe('Every 2 weeks');
+    expect(formatSubscriptionPeriod({ days: 1 })).toBe('Every day');
+    expect(formatSubscriptionPeriod({ days: 30 })).toBe('Every 30 days');
+    expect(formatSubscriptionPeriod({ hours: 1 })).toBe('Every hour');
+    expect(formatSubscriptionPeriod({ hours: 12 })).toBe('Every 12 hours');
+    expect(formatSubscriptionPeriod({ minutes: 1 })).toBe('Every minute');
+    expect(formatSubscriptionPeriod({ minutes: 15 })).toBe('Every 15 minutes');
+    expect(formatSubscriptionPeriod({ seconds: 1 })).toBe('Every second');
+    expect(formatSubscriptionPeriod({ seconds: 30 })).toBe('Every 30 seconds');
+  });
+
+  it('should format two time units correctly', () => {
+    expect(formatSubscriptionPeriod({ months: 1, days: 15 })).toBe(
+      'Every 1 month and 15 days',
+    );
+    expect(formatSubscriptionPeriod({ weeks: 2, days: 3 })).toBe(
+      'Every 2 weeks and 3 days',
+    );
+    expect(formatSubscriptionPeriod({ hours: 1, minutes: 30 })).toBe(
+      'Every 1 hour and 30 minutes',
+    );
+  });
+
+  it('should format multiple time units correctly', () => {
+    expect(
+      formatSubscriptionPeriod({
+        years: 1,
+        months: 2,
+        days: 15,
+      }),
+    ).toBe('Every 1 year, 2 months and 15 days');
+
+    expect(
+      formatSubscriptionPeriod({
+        days: 1,
+        hours: 12,
+        minutes: 30,
+        seconds: 45,
+      }),
+    ).toBe('Every 1 day, 12 hours, 30 minutes and 45 seconds');
+  });
+
+  it('should handle empty duration', () => {
+    expect(formatSubscriptionPeriod({})).toBe('No period defined');
+  });
+});
+
+describe('calculatePeriodCount', () => {
+  it('should calculate period count correctly', () => {
+    const yearlySubscription: Duration = { years: 1 };
+    const monthlyInterval: Duration = { months: 1 };
+    expect(calculatePeriodCount(yearlySubscription, monthlyInterval)).toBe(12);
+  });
+
+  it('should handle partial periods', () => {
+    const twoMonthSubscription: Duration = { months: 2 };
+    const monthlyInterval: Duration = { months: 1 };
+    expect(calculatePeriodCount(twoMonthSubscription, monthlyInterval)).toBe(2);
+  });
+
+  it('should handle complex durations', () => {
+    const complexSubscription: Duration = { days: 45 };
+    const weeklyInterval: Duration = { weeks: 1 };
+    expect(calculatePeriodCount(complexSubscription, weeklyInterval)).toBe(6); // 45 days / 7 days = 6.4... -> 6
+  });
+
+  it('should throw error for zero interval', () => {
+    const subscription: Duration = { months: 1 };
+    const emptyInterval: Duration = {};
+    expect(() => calculatePeriodCount(subscription, emptyInterval)).toThrow(
+      'Interval duration cannot be zero',
+    );
+  });
+});
+
+describe('calculateSubscriptionEnd', () => {
+  it('should calculate end time correctly', () => {
+    const duration: Duration = { days: 30 };
+    const startTime = 1640995200; // 2022-01-01 00:00:00 UTC
+    const endTime = calculateSubscriptionEnd(duration, startTime);
+    expect(endTime).toBe(startTime + 30 * 86400);
+  });
+
+  it('should use default start time when not provided', () => {
+    const duration: Duration = { hours: 1 };
+    const endTime = calculateSubscriptionEnd(duration);
+    expect(endTime).toBe(3600); // 1 hour in seconds
+  });
+});

--- a/packages/onchainkit/src/subscribe/utils/calculateDuration.ts
+++ b/packages/onchainkit/src/subscribe/utils/calculateDuration.ts
@@ -1,0 +1,172 @@
+import { TIME_UNITS } from '../constants';
+import type { Duration } from '../types';
+
+/**
+ * Converts a Duration object to total seconds
+ * Supports arbitrary combinations of time units
+ */
+export function calculateDurationInSeconds(duration: Duration): number {
+  let totalSeconds = 0;
+
+  if (duration.seconds) {
+    totalSeconds += duration.seconds * TIME_UNITS.SECOND;
+  }
+  if (duration.minutes) {
+    totalSeconds += duration.minutes * TIME_UNITS.MINUTE;
+  }
+  if (duration.hours) {
+    totalSeconds += duration.hours * TIME_UNITS.HOUR;
+  }
+  if (duration.days) {
+    totalSeconds += duration.days * TIME_UNITS.DAY;
+  }
+  if (duration.weeks) {
+    totalSeconds += duration.weeks * TIME_UNITS.WEEK;
+  }
+  if (duration.months) {
+    totalSeconds += duration.months * TIME_UNITS.MONTH;
+  }
+  if (duration.years) {
+    totalSeconds += duration.years * TIME_UNITS.YEAR;
+  }
+
+  return Math.floor(totalSeconds);
+}
+
+/**
+ * Helper function to format single unit
+ */
+function formatSingleUnit(
+  value: number,
+  singular: string,
+  plural: string,
+): string {
+  return value === 1 ? `Every ${singular}` : `Every ${value} ${plural}`;
+}
+
+/**
+ * Helper function to format unit for multi-unit case
+ */
+function formatUnitPart(
+  value: number,
+  singular: string,
+  plural: string,
+): string {
+  return value === 1 ? `1 ${singular}` : `${value} ${plural}`;
+}
+
+/**
+ * Helper function to join parts with proper grammar
+ */
+function joinParts(parts: string[]): string {
+  if (parts.length === 0) {
+    return 'No period defined';
+  }
+  if (parts.length === 1) {
+    return `Every ${parts[0]}`;
+  }
+  if (parts.length === 2) {
+    return `Every ${parts[0]} and ${parts[1]}`;
+  }
+  const lastPart = parts.pop();
+  return `Every ${parts.join(', ')} and ${lastPart}`;
+}
+
+/**
+ * Formats a Duration object into a human-readable string for subscription periods
+ * @param duration - Duration object to format
+ * @returns Formatted string like "Every 30 days" or "Every 1 month"
+ */
+export function formatSubscriptionPeriod(duration: Duration): string {
+  const definedKeys = Object.keys(duration).filter(
+    (key) =>
+      duration[key as keyof Duration] !== undefined &&
+      duration[key as keyof Duration] !== 0,
+  );
+
+  // Handle simple cases first (single unit)
+  if (definedKeys.length === 1) {
+    const key = definedKeys[0] as keyof Duration;
+    const value = duration[key]!;
+
+    switch (key) {
+      case 'years':
+        return formatSingleUnit(value, 'year', 'years');
+      case 'months':
+        return formatSingleUnit(value, 'month', 'months');
+      case 'weeks':
+        return formatSingleUnit(value, 'week', 'weeks');
+      case 'days':
+        return formatSingleUnit(value, 'day', 'days');
+      case 'hours':
+        return formatSingleUnit(value, 'hour', 'hours');
+      case 'minutes':
+        return formatSingleUnit(value, 'minute', 'minutes');
+      case 'seconds':
+        return formatSingleUnit(value, 'second', 'seconds');
+      default:
+        return 'No period defined';
+    }
+  }
+
+  // Handle complex cases (multiple units)
+  const parts: string[] = [];
+
+  if (duration.years) {
+    parts.push(formatUnitPart(duration.years, 'year', 'years'));
+  }
+  if (duration.months) {
+    parts.push(formatUnitPart(duration.months, 'month', 'months'));
+  }
+  if (duration.weeks) {
+    parts.push(formatUnitPart(duration.weeks, 'week', 'weeks'));
+  }
+  if (duration.days) {
+    parts.push(formatUnitPart(duration.days, 'day', 'days'));
+  }
+  if (duration.hours) {
+    parts.push(formatUnitPart(duration.hours, 'hour', 'hours'));
+  }
+  if (duration.minutes) {
+    parts.push(formatUnitPart(duration.minutes, 'minute', 'minutes'));
+  }
+  if (duration.seconds) {
+    parts.push(formatUnitPart(duration.seconds, 'second', 'seconds'));
+  }
+
+  return joinParts(parts);
+}
+
+/**
+ * Calculates the number of periods within a subscription length
+ * @param subscriptionLength - Total duration of subscription
+ * @param interval - Duration of each period
+ * @returns Number of periods (rounded down)
+ */
+export function calculatePeriodCount(
+  subscriptionLength: Duration,
+  interval: Duration,
+): number {
+  const subscriptionSeconds = calculateDurationInSeconds(subscriptionLength);
+  const intervalSeconds = calculateDurationInSeconds(interval);
+
+  if (intervalSeconds === 0) {
+    throw new Error('Interval duration cannot be zero');
+  }
+
+  return Math.floor(subscriptionSeconds / intervalSeconds);
+}
+
+/**
+ * Calculates the subscription end timestamp
+ * @param subscriptionLength - Total duration of subscription
+ * @param startTime - Start timestamp (defaults to current time)
+ * @returns End timestamp in seconds
+ */
+export function calculateSubscriptionEnd(
+  subscriptionLength: Duration,
+  startTime: number = 0,
+): number {
+  const durationSeconds = calculateDurationInSeconds(subscriptionLength);
+  return startTime + durationSeconds;
+}

--- a/packages/onchainkit/src/subscribe/utils/calculatePermissionHash.ts
+++ b/packages/onchainkit/src/subscribe/utils/calculatePermissionHash.ts
@@ -1,0 +1,74 @@
+import { hashTypedData } from 'viem';
+import type { SpendPermission } from '../types';
+import type { Address, Hex } from 'viem';
+import {
+  SPEND_PERMISSION_ERC712_DOMAIN,
+  SPEND_PERMISSION_ERC712_TYPES,
+  SPEND_PERMISSION_MANAGER_ADDRESS,
+} from '../constants';
+
+/**
+ * Flexible SpendPermission type that can handle both bigint and string values
+ * This is useful when working with RPC responses that return strings
+ */
+export type FlexibleSpendPermission = {
+  account: Address;
+  spender: Address;
+  token: Address;
+  allowance: bigint | string;
+  period: number;
+  start: number;
+  end: number;
+  salt: bigint | string;
+  extraData: Hex;
+};
+
+/**
+ * Calculate the EIP-712 typed data hash for a SpendPermission
+ * This matches the hash calculation used by the SpendPermissionManager contract's getHash function
+ * @param spendPermission - The SpendPermission to hash (accepts both bigint and string values)
+ * @param chainId - The chain ID for the domain separator
+ * @returns The permission hash as a hex string
+ */
+export function calculatePermissionHash(
+  spendPermission: SpendPermission | FlexibleSpendPermission,
+  chainId: number,
+): string {
+  try {
+    // Normalize the spend permission to ensure correct types
+    const normalizedPermission = {
+      account: spendPermission.account,
+      spender: spendPermission.spender,
+      token: spendPermission.token,
+      allowance:
+        typeof spendPermission.allowance === 'string'
+          ? BigInt(spendPermission.allowance)
+          : spendPermission.allowance,
+      period: Number(spendPermission.period),
+      start: Number(spendPermission.start),
+      end: Number(spendPermission.end),
+      salt:
+        typeof spendPermission.salt === 'string'
+          ? BigInt(spendPermission.salt)
+          : spendPermission.salt,
+      extraData: spendPermission.extraData,
+    };
+
+    // Use EIP-712 typed data hashing, same as the contract's _hashTypedData()
+    // This follows the same pattern as the contract's getHash function
+    const hash = hashTypedData({
+      domain: {
+        ...SPEND_PERMISSION_ERC712_DOMAIN,
+        chainId,
+        verifyingContract: SPEND_PERMISSION_MANAGER_ADDRESS,
+      },
+      types: SPEND_PERMISSION_ERC712_TYPES,
+      primaryType: 'SpendPermission',
+      message: normalizedPermission,
+    });
+
+    return hash;
+  } catch (error) {
+    throw new Error(`Failed to calculate permission hash: ${error}`);
+  }
+}

--- a/packages/onchainkit/src/subscribe/utils/fetchPermissions.ts
+++ b/packages/onchainkit/src/subscribe/utils/fetchPermissions.ts
@@ -1,0 +1,69 @@
+import type { Address } from 'viem';
+import type {
+  FetchPermissionsRequest,
+  FetchPermissionsResult,
+  FetchPermissionsResultItem,
+} from '../types';
+
+/**
+ * Fetches active spend permissions for a user from Coinbase Wallet
+ */
+export async function fetchPermissions({
+  chainId,
+  account,
+  spender,
+  pageOptions,
+}: FetchPermissionsRequest): Promise<FetchPermissionsResult> {
+  const response = await fetch('https://rpc.wallet.coinbase.com', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'coinbase_fetchPermissions',
+      params: [
+        {
+          account,
+          chainId,
+          spender,
+          ...(pageOptions && { pageOptions }),
+        },
+      ],
+      id: 1,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch permissions: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+
+  if (data.error) {
+    throw new Error(data.error.message || 'Failed to fetch permissions');
+  }
+
+  return data.result;
+}
+
+/**
+ * Checks if there's an active permission that matches the given criteria
+ */
+export function hasMatchingPermission(
+  permissions: FetchPermissionsResultItem[],
+  targetToken: Address,
+  targetPeriod: number,
+  targetAllowance: bigint,
+): FetchPermissionsResultItem | null {
+  return (
+    permissions.find((permission) => {
+      const { spendPermission } = permission;
+      return (
+        spendPermission.token.toLowerCase() === targetToken.toLowerCase() &&
+        spendPermission.period === targetPeriod &&
+        BigInt(spendPermission.allowance) >= targetAllowance
+      );
+    }) || null
+  );
+}

--- a/packages/onchainkit/src/subscribe/utils/formatAmount.test.ts
+++ b/packages/onchainkit/src/subscribe/utils/formatAmount.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatSubscriptionAmount,
+  formatPeriodShort,
+  formatSubscriptionText,
+} from './formatAmount';
+import type { Duration } from '../types';
+import type { Token } from '@/token';
+
+describe('formatSubscriptionAmount', () => {
+  it('should format USD stablecoins with $ prefix', () => {
+    const usdcToken: Token = {
+      name: 'USD Coin',
+      symbol: 'USDC',
+      decimals: 6,
+      address: '0xA0b86a33E6441a8e7f0c4e2e7b4b3c7d8e9f0a1b',
+      chainId: 1,
+      image: '',
+    };
+
+    expect(formatSubscriptionAmount('10', usdcToken)).toBe('$10');
+    expect(formatSubscriptionAmount('100.50', usdcToken)).toBe('$100.50');
+  });
+
+  it('should format other tokens with symbol suffix', () => {
+    const ethToken: Token = {
+      name: 'Ethereum',
+      symbol: 'ETH',
+      decimals: 18,
+      address: '',
+      chainId: 1,
+      image: '',
+    };
+
+    expect(formatSubscriptionAmount('1', ethToken)).toBe('1 ETH');
+    expect(formatSubscriptionAmount('0.5', ethToken)).toBe('0.5 ETH');
+  });
+
+  it('should handle case-insensitive stablecoin detection', () => {
+    const daiToken: Token = {
+      name: 'Dai Stablecoin',
+      symbol: 'dai', // lowercase
+      decimals: 18,
+      address: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+      chainId: 1,
+      image: '',
+    };
+
+    expect(formatSubscriptionAmount('25', daiToken)).toBe('$25');
+  });
+});
+
+describe('formatPeriodShort', () => {
+  it('should format single time units correctly', () => {
+    expect(formatPeriodShort({ days: 30 })).toBe('month'); // Special case for 30 days
+    expect(formatPeriodShort({ days: 28 })).toBe('month'); // Special case for 28 days
+    expect(formatPeriodShort({ days: 31 })).toBe('month'); // Special case for 31 days
+    expect(formatPeriodShort({ days: 7 })).toBe('day'); // Regular days
+    expect(formatPeriodShort({ weeks: 1 })).toBe('week');
+    expect(formatPeriodShort({ months: 1 })).toBe('month');
+    expect(formatPeriodShort({ years: 1 })).toBe('year');
+  });
+
+  it('should prioritize larger time units', () => {
+    expect(formatPeriodShort({ months: 1, days: 15 })).toBe('month');
+    expect(formatPeriodShort({ years: 1, months: 6 })).toBe('year');
+  });
+
+  it('should only apply monthly special case for days-only durations', () => {
+    // Should not apply special case when other units are present
+    expect(formatPeriodShort({ days: 30, hours: 1 })).toBe('day');
+    expect(formatPeriodShort({ weeks: 1, days: 30 })).toBe('week');
+  });
+});
+
+describe('formatSubscriptionText', () => {
+  const usdcToken: Token = {
+    name: 'USD Coin',
+    symbol: 'USDC',
+    decimals: 6,
+    address: '0xA0b86a33E6441a8e7f0c4e2e7b4b3c7d8e9f0a1b',
+    chainId: 1,
+    image: '',
+  };
+
+  it('should format subscription text for USD stablecoins', () => {
+    const interval: Duration = { days: 30 };
+    expect(formatSubscriptionText('10', usdcToken, interval)).toBe(
+      'Subscribe $10/month',
+    );
+  });
+
+  it('should format subscribed text', () => {
+    const interval: Duration = { months: 1 };
+    expect(
+      formatSubscriptionText('25', usdcToken, interval, 'subscribed'),
+    ).toBe('Subscribed to $25/month');
+  });
+});

--- a/packages/onchainkit/src/subscribe/utils/formatAmount.ts
+++ b/packages/onchainkit/src/subscribe/utils/formatAmount.ts
@@ -1,0 +1,82 @@
+import type { Duration } from '../types';
+import type { Token } from '@/token';
+
+/**
+ * Formats subscription amount with proper currency/token display
+ * For USDC and other stablecoins, shows as $X
+ * For other tokens, shows as X TOKEN
+ */
+export function formatSubscriptionAmount(amount: string, token: Token): string {
+  // List of stablecoins and USD-pegged tokens that should show with $ prefix
+  const usdStablecoins = ['USDC', 'USDT', 'DAI', 'BUSD', 'FRAX'];
+
+  if (usdStablecoins.includes(token.symbol.toUpperCase())) {
+    return `$${amount}`;
+  }
+
+  return `${amount} ${token.symbol}`;
+}
+
+/**
+ * Formats duration into a short period string for button/status display
+ * Examples: "month", "week", "day", "year"
+ * Special-cases common monthly intervals (28, 30, 31 days) to display as "month"
+ */
+export function formatPeriodShort(duration: Duration): string {
+  // Special case: common monthly intervals should display as "month"
+  // Only apply when ONLY days are specified (no other time units)
+  if (
+    duration.days &&
+    !duration.weeks &&
+    !duration.months &&
+    !duration.years &&
+    !duration.hours &&
+    !duration.minutes &&
+    !duration.seconds
+  ) {
+    const days = duration.days;
+    if (days === 28 || days === 30 || days === 31) {
+      return 'month';
+    }
+  }
+
+  // Check each time unit in order of preference (largest to smallest)
+  const timeUnits = [
+    'years',
+    'months',
+    'weeks',
+    'days',
+    'hours',
+    'minutes',
+    'seconds',
+  ] as const;
+
+  for (const unit of timeUnits) {
+    if (duration[unit] && duration[unit]! > 0) {
+      // Return singular form for all units
+      return unit.slice(0, -1); // Remove 's' suffix
+    }
+  }
+
+  return 'period';
+}
+
+/**
+ * Formats a complete subscription display text
+ * Examples: "Subscribe $10/month", "Subscribe 1 ETH/month"
+ */
+export function formatSubscriptionText(
+  amount: string,
+  token: Token,
+  interval: Duration,
+  action: 'subscribe' | 'subscribed' = 'subscribe',
+): string {
+  const formattedAmount = formatSubscriptionAmount(amount, token);
+  const period = formatPeriodShort(interval);
+
+  if (action === 'subscribed') {
+    return `Subscribed to ${formattedAmount}/${period}`;
+  }
+
+  return `Subscribe ${formattedAmount}/${period}`;
+}

--- a/packages/onchainkit/src/subscribe/utils/getCurrentPeriod.ts
+++ b/packages/onchainkit/src/subscribe/utils/getCurrentPeriod.ts
@@ -1,0 +1,194 @@
+import type { Chain } from 'viem';
+import { getChainPublicClient } from '../../core/network/getChainPublicClient';
+import { SPEND_PERMISSION_MANAGER_ADDRESS } from '../constants';
+import type { PeriodSpend, SpendPermission } from '../types';
+
+/**
+ * ABI for the getCurrentPeriod function on SpendPermissionManager
+ */
+const GET_CURRENT_PERIOD_ABI = [
+  {
+    name: 'getCurrentPeriod',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      {
+        name: 'spendPermission',
+        type: 'tuple',
+        components: [
+          { name: 'account', type: 'address' },
+          { name: 'spender', type: 'address' },
+          { name: 'token', type: 'address' },
+          { name: 'allowance', type: 'uint160' },
+          { name: 'period', type: 'uint48' },
+          { name: 'start', type: 'uint48' },
+          { name: 'end', type: 'uint48' },
+          { name: 'salt', type: 'uint256' },
+          { name: 'extraData', type: 'bytes' },
+        ],
+      },
+    ],
+    outputs: [
+      {
+        name: '',
+        type: 'tuple',
+        components: [
+          { name: 'start', type: 'uint48' },
+          { name: 'end', type: 'uint48' },
+          { name: 'spend', type: 'uint160' },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * ABI for contract status check functions
+ */
+const PERMISSION_STATUS_ABI = [
+  {
+    name: 'isApproved',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      {
+        name: 'spendPermission',
+        type: 'tuple',
+        components: [
+          { name: 'account', type: 'address' },
+          { name: 'spender', type: 'address' },
+          { name: 'token', type: 'address' },
+          { name: 'allowance', type: 'uint160' },
+          { name: 'period', type: 'uint48' },
+          { name: 'start', type: 'uint48' },
+          { name: 'end', type: 'uint48' },
+          { name: 'salt', type: 'uint256' },
+          { name: 'extraData', type: 'bytes' },
+        ],
+      },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+  {
+    name: 'isRevoked',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      {
+        name: 'spendPermission',
+        type: 'tuple',
+        components: [
+          { name: 'account', type: 'address' },
+          { name: 'spender', type: 'address' },
+          { name: 'token', type: 'address' },
+          { name: 'allowance', type: 'uint160' },
+          { name: 'period', type: 'uint48' },
+          { name: 'start', type: 'uint48' },
+          { name: 'end', type: 'uint48' },
+          { name: 'salt', type: 'uint256' },
+          { name: 'extraData', type: 'bytes' },
+        ],
+      },
+    ],
+    outputs: [{ name: '', type: 'bool' }],
+  },
+] as const;
+
+/**
+ * Fetch current period information for a spend permission
+ * @param spendPermission - The spend permission to check
+ * @param chain - Chain to query
+ * @returns Current period information
+ */
+export async function getCurrentPeriod(
+  spendPermission: SpendPermission,
+  chain: Chain,
+): Promise<PeriodSpend> {
+  const client = getChainPublicClient(chain);
+
+  const result = await client.readContract({
+    address: SPEND_PERMISSION_MANAGER_ADDRESS,
+    abi: GET_CURRENT_PERIOD_ABI,
+    functionName: 'getCurrentPeriod',
+    args: [spendPermission],
+  });
+
+  return {
+    start: Number(result.start),
+    end: Number(result.end),
+    spend: result.spend,
+  };
+}
+
+/**
+ * Check if a spend permission is approved
+ * @param spendPermission - The spend permission to check
+ * @param chain - Chain to query
+ * @returns Whether the permission is approved
+ *
+ * Note: This function makes a contract call and may be redundant if the permission
+ * was fetched via coinbase_fetchPermissions, which only returns approved permissions.
+ */
+export async function isPermissionApproved(
+  spendPermission: SpendPermission,
+  chain: Chain,
+): Promise<boolean> {
+  const client = getChainPublicClient(chain);
+
+  const result = await client.readContract({
+    address: SPEND_PERMISSION_MANAGER_ADDRESS,
+    abi: PERMISSION_STATUS_ABI,
+    functionName: 'isApproved',
+    args: [spendPermission],
+  });
+
+  return result;
+}
+
+/**
+ * Check if a spend permission is revoked
+ * @param spendPermission - The spend permission to check
+ * @param chain - Chain to query
+ * @returns Whether the permission is revoked
+ *
+ * Note: This function makes a contract call and may be redundant if the permission
+ * was fetched via coinbase_fetchPermissions, which filters out revoked permissions.
+ */
+export async function isPermissionRevoked(
+  spendPermission: SpendPermission,
+  chain: Chain,
+): Promise<boolean> {
+  const client = getChainPublicClient(chain);
+
+  const result = await client.readContract({
+    address: SPEND_PERMISSION_MANAGER_ADDRESS,
+    abi: PERMISSION_STATUS_ABI,
+    functionName: 'isRevoked',
+    args: [spendPermission],
+  });
+
+  return result;
+}
+
+/**
+ * Get current period information for a spend permission
+ * @param spendPermission - The spend permission to check
+ * @param chain - Chain to query
+ * @returns Current period information if available
+ *
+ * Note: This function only fetches current period data since coinbase_fetchPermissions
+ * already filters to only include active (approved and not revoked) permissions.
+ */
+export async function getPermissionStatus(
+  spendPermission: SpendPermission,
+  chain: Chain,
+) {
+  try {
+    const currentPeriod = await getCurrentPeriod(spendPermission, chain);
+    return { currentPeriod };
+  } catch {
+    // If getCurrentPeriod fails, the permission might not exist or be outside valid time range
+    // This is not critical since components don't use this data for display
+    return { currentPeriod: undefined };
+  }
+}

--- a/packages/onchainkit/src/subscribe/utils/validateDuration.test.ts
+++ b/packages/onchainkit/src/subscribe/utils/validateDuration.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import {
+  validateDuration,
+  validateSubscriptionInterval,
+  validateSubscriptionLength,
+} from './validateDuration';
+import type { Duration } from '../types';
+
+describe('validateDuration', () => {
+  it('should pass for valid durations', () => {
+    expect(() => validateDuration({ days: 1 })).not.toThrow();
+    expect(() => validateDuration({ hours: 2, minutes: 30 })).not.toThrow();
+    expect(() => validateDuration({ seconds: 1 })).not.toThrow();
+  });
+
+  it('should throw for empty duration', () => {
+    expect(() => validateDuration({})).toThrow(
+      'Duration must specify at least one time unit',
+    );
+  });
+
+  it('should throw for negative values', () => {
+    expect(() => validateDuration({ days: -1 })).toThrow(
+      'Duration must specify at least one time unit',
+    );
+    expect(() => validateDuration({ hours: -5 })).toThrow(
+      'Duration must specify at least one time unit',
+    );
+    // Test with positive and negative mixed - should throw for negative
+    expect(() => validateDuration({ days: 1, hours: -5 })).toThrow(
+      'Duration hours cannot be negative',
+    );
+  });
+
+  it('should throw for non-integer values', () => {
+    expect(() => validateDuration({ days: 1.5 })).toThrow(
+      'Duration days must be an integer',
+    );
+    expect(() => validateDuration({ hours: 2.7 })).toThrow(
+      'Duration hours must be an integer',
+    );
+  });
+
+  it('should throw for duration less than 1 second', () => {
+    expect(() => validateDuration({ seconds: 0 })).toThrow(
+      'Duration must specify at least one time unit',
+    );
+  });
+});
+
+describe('validateSubscriptionInterval', () => {
+  it('should pass for valid whole-day intervals', () => {
+    expect(() => validateSubscriptionInterval({ days: 1 })).not.toThrow();
+    expect(() => validateSubscriptionInterval({ days: 7 })).not.toThrow();
+    expect(() => validateSubscriptionInterval({ days: 30 })).not.toThrow();
+    expect(() => validateSubscriptionInterval({ weeks: 1 })).not.toThrow(); // 7 days
+    expect(() => validateSubscriptionInterval({ weeks: 2 })).not.toThrow(); // 14 days
+    expect(() => validateSubscriptionInterval({ months: 1 })).not.toThrow(); // 30 days
+    expect(() => validateSubscriptionInterval({ years: 1 })).not.toThrow(); // 365 days
+  });
+
+  it('should throw for intervals less than 1 minute', () => {
+    expect(() => validateSubscriptionInterval({ seconds: 30 })).toThrow(
+      'Subscription interval must be at least 1 minute',
+    );
+  });
+
+  it('should throw for intervals greater than 1 year', () => {
+    expect(() => validateSubscriptionInterval({ years: 2 })).toThrow(
+      'Subscription interval cannot exceed 1 year',
+    );
+  });
+
+  it('should throw for intervals not divisible by 1 day', () => {
+    expect(() => validateSubscriptionInterval({ hours: 1 })).toThrow(
+      'Subscription interval must be in whole days (e.g., 1 day, 7 days, 30 days)',
+    );
+    expect(() => validateSubscriptionInterval({ hours: 12 })).toThrow(
+      'Subscription interval must be in whole days (e.g., 1 day, 7 days, 30 days)',
+    );
+    expect(() => validateSubscriptionInterval({ minutes: 90 })).toThrow(
+      'Subscription interval must be in whole days (e.g., 1 day, 7 days, 30 days)',
+    );
+    expect(() => validateSubscriptionInterval({ days: 1, hours: 1 })).toThrow(
+      'Subscription interval must be in whole days (e.g., 1 day, 7 days, 30 days)',
+    );
+  });
+});
+
+describe('validateSubscriptionLength', () => {
+  it('should pass for valid subscription lengths', () => {
+    const interval: Duration = { days: 7 };
+    expect(() =>
+      validateSubscriptionLength({ weeks: 4 }, interval),
+    ).not.toThrow();
+    expect(() =>
+      validateSubscriptionLength({ days: 365 }, interval),
+    ).not.toThrow();
+  });
+
+  it('should throw if subscription length is shorter than interval', () => {
+    const interval: Duration = { days: 7 };
+    expect(() => validateSubscriptionLength({ days: 3 }, interval)).toThrow(
+      'Subscription length must be at least one interval period',
+    );
+  });
+
+  it('should throw if subscription results in too many periods', () => {
+    const interval: Duration = { days: 1 };
+    const longSubscription: Duration = { days: 1001 }; // 1001 periods
+    expect(() =>
+      validateSubscriptionLength(longSubscription, interval),
+    ).toThrow('Subscription length results in too many periods (max: 1000)');
+  });
+});

--- a/packages/onchainkit/src/subscribe/utils/validateDuration.ts
+++ b/packages/onchainkit/src/subscribe/utils/validateDuration.ts
@@ -1,0 +1,107 @@
+// 🌲☀🌲
+import type { Duration } from '../types';
+import { calculateDurationInSeconds } from './calculateDuration';
+
+/**
+ * Validates a Duration object
+ * @param duration - Duration to validate
+ * @param fieldName - Name of the field for error messages
+ * @throws Error if duration is invalid
+ */
+export function validateDuration(
+  duration: Duration,
+  fieldName = 'Duration',
+): void {
+  // Check if duration is empty
+  const hasAnyValue = Object.values(duration).some(
+    (value) => typeof value === 'number' && value > 0,
+  );
+
+  if (!hasAnyValue) {
+    throw new Error(`${fieldName} must specify at least one time unit`);
+  }
+
+  // Check for negative values
+  Object.entries(duration).forEach(([unit, value]) => {
+    if (typeof value === 'number' && value < 0) {
+      throw new Error(`${fieldName} ${unit} cannot be negative`);
+    }
+  });
+
+  // Check for non-integer values
+  Object.entries(duration).forEach(([unit, value]) => {
+    if (typeof value === 'number' && !Number.isInteger(value)) {
+      throw new Error(`${fieldName} ${unit} must be an integer`);
+    }
+  });
+
+  // Check minimum duration (1 second)
+  const totalSeconds = calculateDurationInSeconds(duration);
+  if (totalSeconds < 1) {
+    throw new Error(`${fieldName} must be at least 1 second`);
+  }
+
+  // Check maximum duration (to prevent overflow)
+  const MAX_DURATION_SECONDS = 2147483647; // Max int32
+  if (totalSeconds > MAX_DURATION_SECONDS) {
+    throw new Error(`${fieldName} exceeds maximum allowed duration`);
+  }
+}
+
+/**
+ * Validates that interval is reasonable for subscriptions
+ * @param interval - Interval duration to validate
+ */
+export function validateSubscriptionInterval(interval: Duration): void {
+  validateDuration(interval, 'Subscription interval');
+
+  const intervalSeconds = calculateDurationInSeconds(interval);
+
+  // Minimum interval of 1 minute for subscriptions
+  if (intervalSeconds < 60) {
+    throw new Error('Subscription interval must be at least 1 minute');
+  }
+
+  // Maximum interval of 1 year for subscriptions
+  if (intervalSeconds > 31556952) {
+    throw new Error('Subscription interval cannot exceed 1 year');
+  }
+
+  // Coinbase Wallet requires periods to be divisible by 86400 (1 day)
+  // This ensures compatibility with the spend permission system
+  if (intervalSeconds % 86400 !== 0) {
+    throw new Error(
+      'Subscription interval must be in whole days (e.g., 1 day, 7 days, 30 days)',
+    );
+  }
+}
+
+/**
+ * Validates subscription length against interval
+ * @param subscriptionLength - Total subscription duration
+ * @param interval - Period interval
+ */
+export function validateSubscriptionLength(
+  subscriptionLength: Duration,
+  interval: Duration,
+): void {
+  validateDuration(subscriptionLength, 'Subscription length');
+
+  const subscriptionSeconds = calculateDurationInSeconds(subscriptionLength);
+  const intervalSeconds = calculateDurationInSeconds(interval);
+
+  // Subscription length must be at least one interval
+  if (subscriptionSeconds < intervalSeconds) {
+    throw new Error('Subscription length must be at least one interval period');
+  }
+
+  // Calculate number of periods
+  const periodCount = Math.floor(subscriptionSeconds / intervalSeconds);
+
+  // Maximum of 1000 periods to prevent excessive allowances
+  if (periodCount > 1000) {
+    throw new Error(
+      'Subscription length results in too many periods (max: 1000)',
+    );
+  }
+}

--- a/packages/onchainkit/src/token/index.ts
+++ b/packages/onchainkit/src/token/index.ts
@@ -11,6 +11,17 @@ export { TokenBalance } from './components/TokenBalance';
 // Utils
 export { formatAmount } from './utils/formatAmount';
 
+// Constants
+export {
+  ethToken,
+  ethSepoliaToken,
+  usdcToken,
+  usdcSepoliaToken,
+  degenToken,
+  daiToken,
+  baseTokens,
+} from './constants';
+
 // Types
 export type {
   FormatAmountOptions,

--- a/packages/onchainkit/src/wallet/index.ts
+++ b/packages/onchainkit/src/wallet/index.ts
@@ -28,6 +28,7 @@ export { isWalletACoinbaseSmartWallet } from './utils/isWalletACoinbaseSmartWall
 // Hooks
 export { useWalletContext } from './components/WalletProvider';
 export { usePortfolio } from './hooks/usePortfolio';
+export { useIsWalletACoinbaseSmartWallet } from './hooks/useIsWalletACoinbaseSmartWallet';
 
 // Types
 export type {

--- a/packages/playground/components/AppProvider.tsx
+++ b/packages/playground/components/AppProvider.tsx
@@ -1,6 +1,7 @@
 // AppContext.js
 import { ENVIRONMENT, ENVIRONMENT_VARIABLES } from '@/lib/constants';
 import { useStateWithStorage } from '@/lib/hooks';
+import { wagmiConfig } from '@/lib/wagmi';
 import {
   type CheckoutOptions,
   CheckoutTypes,
@@ -14,6 +15,7 @@ import { OnchainKitProvider } from '@coinbase/onchainkit';
 import type React from 'react';
 import { createContext, useEffect, useState } from 'react';
 import type { Address } from 'viem';
+import { WagmiProvider } from 'wagmi';
 import { base } from 'wagmi/chains';
 
 type State = {
@@ -43,6 +45,16 @@ type State = {
   setVaultAddress: (vaultAddress: Address) => void;
   isSignUpEnabled: boolean;
   setIsSignUpEnabled: (isSignUpEnabled: boolean) => void;
+  subscribeAmount?: string;
+  setSubscribeAmount: (amount: string) => void;
+  subscribeToken?: string;
+  setSubscribeToken: (token: string) => void;
+  subscribeIntervalValue?: string;
+  setSubscribeIntervalValue: (value: string) => void;
+  subscribeIntervalType?: string;
+  setSubscribeIntervalType: (type: string) => void;
+  subscribeSpender?: string;
+  setSubscribeSpender: (spender: string) => void;
 };
 
 export const defaultState: State = {
@@ -57,6 +69,11 @@ export const defaultState: State = {
   setVaultAddress: () => {},
   isSignUpEnabled: true,
   setIsSignUpEnabled: () => {},
+  setSubscribeAmount: () => {},
+  setSubscribeToken: () => {},
+  setSubscribeIntervalValue: () => {},
+  setSubscribeIntervalType: () => {},
+  setSubscribeSpender: () => {},
 };
 
 export const AppContext = createContext(defaultState);
@@ -135,6 +152,34 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     parser: (v) => v === 'true',
   });
 
+  const [subscribeAmount, setSubscribeAmount] = useStateWithStorage<string>({
+    key: 'subscribeAmount',
+    defaultValue: '10',
+  });
+
+  const [subscribeToken, setSubscribeToken] = useStateWithStorage<string>({
+    key: 'subscribeToken',
+    defaultValue: 'USDC',
+  });
+
+  const [subscribeIntervalValue, setSubscribeIntervalValue] =
+    useStateWithStorage<string>({
+      key: 'subscribeIntervalValue',
+      defaultValue: '30',
+    });
+
+  const [subscribeIntervalType, setSubscribeIntervalType] =
+    useStateWithStorage<string>({
+      key: 'subscribeIntervalType',
+      defaultValue: 'days',
+    });
+
+  const [subscribeSpender, setSubscribeSpender] =
+    useStateWithStorage<string>({
+      key: 'subscribeSpender',
+      defaultValue: '0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32',
+    });
+
   // Load initial values from localStorage
   useEffect(() => {
     const storedPaymasters = localStorage.getItem('paymasters');
@@ -154,7 +199,8 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   return (
-    <AppContext.Provider
+    <WagmiProvider config={wagmiConfig}>
+      <AppContext.Provider
       value={{
         activeComponent,
         setActiveComponent,
@@ -182,6 +228,16 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         setVaultAddress,
         isSignUpEnabled,
         setIsSignUpEnabled,
+        subscribeAmount,
+        setSubscribeAmount,
+        subscribeToken,
+        setSubscribeToken,
+        subscribeIntervalValue,
+        setSubscribeIntervalValue,
+        subscribeIntervalType,
+        setSubscribeIntervalType,
+        subscribeSpender,
+        setSubscribeSpender,
       }}
     >
       <OnchainKitProvider
@@ -212,6 +268,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
       >
         {children}
       </OnchainKitProvider>
-    </AppContext.Provider>
+      </AppContext.Provider>
+    </WagmiProvider>
   );
 };

--- a/packages/playground/components/Demo.tsx
+++ b/packages/playground/components/Demo.tsx
@@ -17,6 +17,7 @@ import NFTCardDefaultDemo from './demo/NFTCardDefault';
 import NFTMintCardDemo from './demo/NFTMintCard';
 import NFTMintCardDefaultDemo from './demo/NFTMintCardDefault';
 import SignatureDemo from './demo/Signature';
+import SubscribeDemo from './demo/Subscribe';
 import SwapDemo from './demo/Swap';
 import SwapDefaultDemo from './demo/SwapDefault';
 import TransactionDemo from './demo/Transaction';
@@ -47,6 +48,7 @@ const activeComponentMapping: Record<OnchainKitComponent, React.FC> = {
   [OnchainKitComponent.IdentityCard]: IdentityCardDemo,
   [OnchainKitComponent.Earn]: EarnDemo,
   [OnchainKitComponent.Signature]: SignatureDemo,
+  [OnchainKitComponent.Subscribe]: SubscribeDemo,
 };
 
 export default function Demo() {

--- a/packages/playground/components/DemoOptions.tsx
+++ b/packages/playground/components/DemoOptions.tsx
@@ -4,6 +4,7 @@ import { EarnOptions } from '@/components/form/earn-options';
 import { PaymasterUrl } from '@/components/form/paymaster';
 import { OnchainKitComponent } from '@/types/onchainkit';
 import { ActiveComponent } from './form/active-component';
+import { SubscribeOptions } from './form/subscribe-options';
 import { Chain } from './form/chain';
 import { CheckoutOptions } from './form/checkout-options';
 import { IsSponsored } from './form/is-sponsored';
@@ -65,6 +66,7 @@ const COMPONENT_CONFIG: Partial<
   ],
   [OnchainKitComponent.Earn]: [EarnOptions],
   [OnchainKitComponent.Signature]: [Chain],
+  [OnchainKitComponent.Subscribe]: [Chain, SubscribeOptions],
   [OnchainKitComponent.Wallet]: [WalletSignUp],
   [OnchainKitComponent.WalletDefault]: [WalletSignUp],
   [OnchainKitComponent.WalletAdvancedDefault]: [WalletSignUp],

--- a/packages/playground/components/demo/Subscribe.tsx
+++ b/packages/playground/components/demo/Subscribe.tsx
@@ -1,0 +1,243 @@
+import type { APIError } from '@coinbase/onchainkit/api';
+import {
+  Subscribe,
+  type SubscribeLifecycleStatus,
+  type SubscribeSuccessResult,
+} from '@coinbase/onchainkit/subscribe';
+import { usdcToken, ethToken } from '@coinbase/onchainkit/token';
+import { useIsWalletACoinbaseSmartWallet } from '@coinbase/onchainkit/wallet';
+import { useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { getAddress } from 'viem';
+import { useAccount } from 'wagmi';
+import { AppContext } from '../AppProvider';
+
+// Validation helpers
+function validateAmount(amount: string): string | null {
+  if (!amount || amount.trim() === '') {
+    return 'Amount is required';
+  }
+  const numericValue = parseFloat(amount);
+  if (isNaN(numericValue) || !isFinite(numericValue)) {
+    return 'Amount must be a valid number';
+  }
+  if (numericValue <= 0) {
+    return 'Amount must be greater than 0';
+  }
+  return null;
+}
+
+function validateIntervalValue(value: string): string | null {
+  if (!value || value.trim() === '') {
+    return 'Interval value is required';
+  }
+  const numericValue = parseInt(value, 10);
+  if (isNaN(numericValue) || numericValue <= 0) {
+    return 'Interval must be a positive number';
+  }
+  return null;
+}
+
+function validateSpender(address: string): string | null {
+  if (!address || address.trim() === '') {
+    return 'Spender address is required';
+  }
+  try {
+    getAddress(address);
+    return null;
+  } catch {
+    return 'Invalid spender address format';
+  }
+}
+
+export default function SubscribeDemo() {
+  const {
+    subscribeAmount,
+    subscribeToken,
+    subscribeIntervalValue,
+    subscribeIntervalType,
+    subscribeSpender,
+  } = useContext(AppContext);
+
+  const { address } = useAccount();
+  const isSmartWalletConnected = useIsWalletACoinbaseSmartWallet();
+
+  const saltRef = useRef<bigint | null>(null);
+  const [validationErrors, setValidationErrors] = useState<{
+    amount?: string;
+    intervalValue?: string;
+    spender?: string;
+  }>({});
+
+  const token = subscribeToken === 'USDC' ? usdcToken : ethToken;
+
+  const formValidation = useMemo(() => {
+    const errors: typeof validationErrors = {};
+
+    const amountError = validateAmount(subscribeAmount || '');
+    if (amountError) errors.amount = amountError;
+
+    const intervalError = validateIntervalValue(subscribeIntervalValue || '');
+    if (intervalError) errors.intervalValue = intervalError;
+
+    const spenderError = validateSpender(subscribeSpender || '');
+    if (spenderError) errors.spender = spenderError;
+
+    const isValid = Object.keys(errors).length === 0;
+
+    setValidationErrors((prev) => {
+      const hasChanged = JSON.stringify(prev) !== JSON.stringify(errors);
+      return hasChanged ? errors : prev;
+    });
+
+    return { errors, isValid };
+  }, [subscribeAmount, subscribeIntervalValue, subscribeSpender]);
+
+  const interval = useMemo(() => {
+    const value = parseInt(subscribeIntervalValue || '30', 10);
+    if (isNaN(value) || value <= 0) {
+      return { days: 30 };
+    }
+    return {
+      [subscribeIntervalType || 'days']: value,
+    };
+  }, [subscribeIntervalType, subscribeIntervalValue]);
+
+  const spender = useMemo(() => {
+    const addressToUse =
+      subscribeSpender || '0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32';
+    try {
+      return getAddress(addressToUse);
+    } catch {
+      return getAddress('0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32');
+    }
+  }, [subscribeSpender]);
+
+  const extraData = useMemo(() => {
+    const timestamp = Date.now();
+    const orderData = {
+      orderId: `demo-${timestamp}`,
+      planType: `${subscribeAmount} ${subscribeToken} every ${subscribeIntervalValue} ${subscribeIntervalType}`,
+      timestamp,
+    };
+    return `0x${Buffer.from(JSON.stringify(orderData)).toString('hex')}` as const;
+  }, [
+    subscribeAmount,
+    subscribeToken,
+    subscribeIntervalValue,
+    subscribeIntervalType,
+  ]);
+
+  const getSalt = useCallback(() => {
+    if (!saltRef.current) {
+      const randomBytes = new Uint8Array(32);
+      crypto.getRandomValues(randomBytes);
+      let randomBigInt = 0n;
+      for (let i = 0; i < randomBytes.length; i++) {
+        randomBigInt = (randomBigInt << 8n) + BigInt(randomBytes[i]);
+      }
+      saltRef.current = randomBigInt;
+    }
+    return saltRef.current;
+  }, []);
+
+  const buttonText = useMemo(() => {
+    const intervalText =
+      subscribeIntervalValue === '1'
+        ? subscribeIntervalType?.slice(0, -1) || 'day'
+        : `${subscribeIntervalValue} ${subscribeIntervalType}`;
+    return `Subscribe for ${subscribeAmount} ${subscribeToken}/${intervalText}`;
+  }, [
+    subscribeAmount,
+    subscribeToken,
+    subscribeIntervalValue,
+    subscribeIntervalType,
+  ]);
+
+  const handleOnSuccess = useCallback((result: SubscribeSuccessResult) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('🎉 Subscription approved!', result);
+      console.log('🔑 Permission Hash:', result.permissionHash);
+      console.log('🎲 Salt (nonce):', saltRef.current?.toString());
+
+      try {
+        const decoded = JSON.parse(
+          Buffer.from(
+            result.metadata.extraData?.slice(2) || '',
+            'hex',
+          ).toString(),
+        );
+        console.log('📦 Order data:', decoded);
+      } catch (error) {
+        console.log('Could not decode extraData:', error);
+      }
+    }
+
+    saltRef.current = null;
+  }, []);
+
+  const handleOnError = useCallback((error: APIError) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('❌ Error:', error);
+    }
+
+    saltRef.current = null;
+  }, []);
+
+  const handleOnStatus = useCallback((status: SubscribeLifecycleStatus) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('Status:', status.statusName);
+    }
+  }, []);
+
+  const isDisabled =
+    !formValidation.isValid || !address || !isSmartWalletConnected;
+
+  const walletRequirementNotice = (!address || !isSmartWalletConnected) && (
+    <div className="mb-4 rounded-lg border border-yellow-200 bg-yellow-50 p-4">
+      <div className="mb-2 text-sm font-medium text-yellow-800">
+        Coinbase Smart Wallet Required
+      </div>
+      <div className="text-sm text-yellow-700">
+        {!address
+          ? 'Connect a Coinbase Smart Wallet to use subscription features'
+          : 'Spend permissions require a Coinbase Smart Wallet. Please switch to or create a Smart Wallet to continue.'}
+      </div>
+    </div>
+  );
+
+  const validationErrorsDisplay = Object.keys(validationErrors).length > 0 && (
+    <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-4">
+      <div className="mb-2 text-sm font-medium text-red-800">
+        Please fix the following errors:
+      </div>
+      <ul className="text-sm text-red-700 space-y-1">
+        {validationErrors.amount && <li>• {validationErrors.amount}</li>}
+        {validationErrors.intervalValue && (
+          <li>• {validationErrors.intervalValue}</li>
+        )}
+        {validationErrors.spender && <li>• {validationErrors.spender}</li>}
+      </ul>
+    </div>
+  );
+
+  return (
+    <div className="mx-auto max-w-md">
+      {walletRequirementNotice}
+      {validationErrorsDisplay}
+
+      <Subscribe
+        amount={subscribeAmount || '10'}
+        token={token}
+        interval={interval}
+        spender={spender}
+        extraData={extraData}
+        salt={getSalt()}
+        buttonText={buttonText}
+        disabled={isDisabled}
+        onSuccess={handleOnSuccess}
+        onError={handleOnError}
+        onStatus={handleOnStatus}
+      />
+    </div>
+  );
+}

--- a/packages/playground/components/form/active-component.tsx
+++ b/packages/playground/components/form/active-component.tsx
@@ -72,6 +72,9 @@ export function ActiveComponent() {
           <SelectItem value={OnchainKitComponent.Signature}>
             Signature
           </SelectItem>
+          <SelectItem value={OnchainKitComponent.Subscribe}>
+            Subscribe
+          </SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/packages/playground/components/form/subscribe-options.tsx
+++ b/packages/playground/components/form/subscribe-options.tsx
@@ -1,0 +1,194 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useContext, useMemo } from 'react';
+import { getAddress } from 'viem';
+import { AppContext } from '../AppProvider';
+
+function validateAmount(amount: string): string | null {
+  if (!amount || amount.trim() === '') {
+    return null;
+  }
+  const numericValue = parseFloat(amount);
+  if (isNaN(numericValue) || !isFinite(numericValue)) {
+    return 'Must be a valid number';
+  }
+  if (numericValue <= 0) {
+    return 'Must be greater than 0';
+  }
+  return null;
+}
+
+function validateIntervalValue(value: string): string | null {
+  if (!value || value.trim() === '') {
+    return null;
+  }
+  const numericValue = parseInt(value, 10);
+  if (isNaN(numericValue) || numericValue <= 0) {
+    return 'Must be a positive number';
+  }
+
+  // All interval types now work since we've rounded months/years to whole days
+  // Months = 30 days, Years = 365 days, Weeks = 7 days
+
+  return null;
+}
+
+function validateSpender(address: string): string | null {
+  if (!address || address.trim() === '') {
+    return null;
+  }
+  try {
+    getAddress(address);
+    return null;
+  } catch {
+    return 'Invalid address format';
+  }
+}
+
+export function SubscribeOptions() {
+  const {
+    subscribeAmount,
+    setSubscribeAmount,
+    subscribeToken,
+    setSubscribeToken,
+    subscribeIntervalValue,
+    setSubscribeIntervalValue,
+    subscribeIntervalType,
+    setSubscribeIntervalType,
+    subscribeSpender,
+    setSubscribeSpender,
+  } = useContext(AppContext);
+
+  const amountError = useMemo(
+    () => validateAmount(subscribeAmount || ''),
+    [subscribeAmount],
+  );
+  const intervalError = useMemo(
+    () => validateIntervalValue(subscribeIntervalValue || ''),
+    [subscribeIntervalValue],
+  );
+  const spenderError = useMemo(
+    () => validateSpender(subscribeSpender || ''),
+    [subscribeSpender],
+  );
+
+  return (
+    <fieldset className="grid gap-4">
+      <legend className="sr-only">Subscription Configuration</legend>
+
+      <div className="grid gap-2">
+        <Label htmlFor="subscribeToken">Token</Label>
+        <Select value={subscribeToken} onValueChange={setSubscribeToken}>
+          <SelectTrigger>
+            <SelectValue placeholder="Select token" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="USDC">USDC</SelectItem>
+            <SelectItem value="ETH">ETH</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="subscribeAmount">
+          Amount
+          {amountError && (
+            <span className="text-red-500 text-sm ml-2">({amountError})</span>
+          )}
+        </Label>
+        <Input
+          id="subscribeAmount"
+          type="number"
+          min="0"
+          step="any"
+          placeholder="10"
+          value={subscribeAmount}
+          onChange={(e) => setSubscribeAmount(e.target.value)}
+          className={amountError ? 'border-red-300 focus:border-red-500' : ''}
+          aria-invalid={!!amountError}
+          aria-describedby={amountError ? 'amount-error' : undefined}
+        />
+        {amountError && (
+          <div id="amount-error" className="text-red-500 text-sm">
+            {amountError}
+          </div>
+        )}
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="subscribeInterval">
+          Billing Interval
+          {intervalError && (
+            <span className="text-red-500 text-sm ml-2">({intervalError})</span>
+          )}
+        </Label>
+        <div className="flex gap-2">
+          <Input
+            id="subscribeIntervalValue"
+            type="number"
+            min="1"
+            step="1"
+            placeholder="30"
+            value={subscribeIntervalValue}
+            onChange={(e) => setSubscribeIntervalValue(e.target.value)}
+            className={`flex-1 ${intervalError ? 'border-red-300 focus:border-red-500' : ''}`}
+            aria-invalid={!!intervalError}
+            aria-describedby={intervalError ? 'interval-error' : undefined}
+          />
+          <Select
+            value={subscribeIntervalType}
+            onValueChange={setSubscribeIntervalType}
+          >
+            <SelectTrigger className="flex-1">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="days">Days</SelectItem>
+              <SelectItem value="weeks">Weeks</SelectItem>
+              <SelectItem value="months">Months</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="text-sm text-gray-600">
+          Intervals are rounded to whole days: 1 month = 30 days, 1 week = 7
+          days.
+        </div>
+        {intervalError && (
+          <div id="interval-error" className="text-red-500 text-sm">
+            {intervalError}
+          </div>
+        )}
+      </div>
+
+      <div className="grid gap-2">
+        <Label htmlFor="subscribeSpender">
+          Spender Address
+          {spenderError && (
+            <span className="text-red-500 text-sm ml-2">({spenderError})</span>
+          )}
+        </Label>
+        <Input
+          id="subscribeSpender"
+          placeholder="0x742d35Cc6635C0532925a3b8D4DDEC5764B72d32"
+          value={subscribeSpender}
+          onChange={(e) => setSubscribeSpender(e.target.value)}
+          className={spenderError ? 'border-red-300 focus:border-red-500' : ''}
+          aria-invalid={!!spenderError}
+          aria-describedby={spenderError ? 'spender-error' : undefined}
+        />
+        {spenderError && (
+          <div id="spender-error" className="text-red-500 text-sm">
+            {spenderError}
+          </div>
+        )}
+      </div>
+    </fieldset>
+  );
+}

--- a/packages/playground/lib/wagmi.ts
+++ b/packages/playground/lib/wagmi.ts
@@ -1,0 +1,28 @@
+import { createConfig } from 'wagmi';
+import { base, baseSepolia } from 'wagmi/chains';
+import { coinbaseWallet } from 'wagmi/connectors';
+import { http } from 'wagmi';
+
+// Create a custom transport that doesn't intercept wallet-specific methods
+const customTransport = http();
+
+export const wagmiConfig = createConfig({
+  chains: [base, baseSepolia],
+  connectors: [
+    coinbaseWallet({
+      appName: 'OnchainKit Playground',
+      appLogoUrl: 'https://onchainkit.xyz/favicon.ico',
+      preference: 'smartWalletOnly',
+      // Don't override wallet-specific RPC methods
+      overrides: {
+        // Ensure wallet_getCapabilities is handled by the wallet
+        wallet_getCapabilities: undefined,
+      },
+    }),
+  ],
+  transports: {
+    [base.id]: customTransport,
+    [baseSepolia.id]: customTransport,
+  },
+  ssr: true,
+}); 

--- a/packages/playground/types/onchainkit.ts
+++ b/packages/playground/types/onchainkit.ts
@@ -19,6 +19,7 @@ export enum OnchainKitComponent {
   NFTMintCardDefault = 'nft-mint-card-default',
   Earn = 'earn',
   Signature = 'signature',
+  Subscribe = 'subscribe',
 }
 
 export enum TransactionTypes {


### PR DESCRIPTION
**What changed? Why?**
This PR proposes adding a 'Subscribe' component to OnchainKit, which simplifies the devx of creating a Coinbase Smart Wallet Spend Permission ([docs](https://docs.base.org/smart-wallet/concepts/features/optional/spend-permissions), [guide](https://docs.base.org/smart-wallet/guides/spend-permissions)). Spend permissions allow apps to request approval to draw a certain amount of funds per month from a user's account.

This adds a new 'SubscribeButton' and 'SubscribeStatus' components for requesting spend permissions from a user. The component provides hooks for monitoring subscription status and will get signed spend permissions when they are available.

Once the app has a signed spend permission, they are responsible for actually orchestrating the spends on their backend.

Further docs are available in the component README.md

**Notes to reviewers**
I have no idea what I'm doing

**How has it been tested?**

Tested with both a playground and a demo app.

![image](https://github.com/user-attachments/assets/df625cf7-5ccf-4d31-b88b-c39b35b769a4)
![image](https://github.com/user-attachments/assets/99a39b2a-9e91-474f-8c52-e6a5524b949b)
![image](https://github.com/user-attachments/assets/992ea702-8257-41d6-8fa4-665fd2163ce7)
