### PR TITLE
feat: Accept farcasterMiniApp connector for autoconnect functionality

### DIFF
--- a/.changeset/huge-animals-push.md
+++ b/.changeset/huge-animals-push.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+feat: Accept farcasterMiniApp connector for autoconnect functionality

--- a/packages/onchainkit/src/minikit/components/AutoConnect.test.tsx
+++ b/packages/onchainkit/src/minikit/components/AutoConnect.test.tsx
@@ -18,6 +18,10 @@ const mockFarcasterFrame = {
   type: 'farcasterFrame',
 };
 
+const mockFarcasterMiniApp = {
+  type: 'farcasterMiniApp',
+};
+
 const mockOtherConnector = {
   type: 'otherConnector',
 };
@@ -119,7 +123,7 @@ describe('AutoConnect', () => {
     expect(mockConnect).not.toHaveBeenCalled();
   });
 
-  it('should not attempt connection if connector is not Farcaster Frame', async () => {
+  it('should not attempt connection if connector is not a supported Farcaster connector', async () => {
     Object.defineProperty(sdk, 'context', {
       value: Promise.resolve({ user: { fid: 123 } }),
       writable: true,
@@ -169,7 +173,7 @@ describe('AutoConnect', () => {
     expect(mockConnect).not.toHaveBeenCalled();
   });
 
-  it('should attempt connection when in Mini App, not connected, and enabled', async () => {
+  it('should attempt connection when in Mini App, not connected, and enabled with farcasterFrame connector', async () => {
     Object.defineProperty(sdk, 'context', {
       value: Promise.resolve({ user: { fid: 123 } }),
       writable: true,
@@ -189,6 +193,36 @@ describe('AutoConnect', () => {
     await act(() => Promise.resolve());
 
     expect(mockConnect).toHaveBeenCalledWith({ connector: mockFarcasterFrame });
+  });
+
+  it('should attempt connection when in Mini App, not connected, and enabled with farcasterMiniApp connector', async () => {
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
+
+    // Mock connectors to have farcasterMiniApp type
+    mockUseConnect.mockReturnValue({
+      connectors: [mockFarcasterMiniApp],
+      connect: mockConnect,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WagmiProvider config={createConfig(mockConfig)}>
+          <AutoConnect enabled={true}>
+            <div>Test Child</div>
+          </AutoConnect>
+        </WagmiProvider>
+      </QueryClientProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    expect(mockConnect).toHaveBeenCalledWith({
+      connector: mockFarcasterMiniApp,
+    });
   });
 
   it('should only attempt connection once', async () => {

--- a/packages/onchainkit/src/minikit/components/AutoConnect.tsx
+++ b/packages/onchainkit/src/minikit/components/AutoConnect.tsx
@@ -1,8 +1,12 @@
 'use client';
-import { farcasterFrame } from '@farcaster/frame-wagmi-connector';
 import { PropsWithChildren, useEffect, useRef } from 'react';
 import { useConnect, useAccount } from 'wagmi';
 import { useIsInMiniApp } from '../hooks/useIsInMiniApp';
+
+const FARCASTER_CONNECTOR_TYPES = new Set([
+  'farcasterFrame',
+  'farcasterMiniApp',
+]);
 
 /**
  * Automatically connects to the Farcaster connector if the user is in a Mini App
@@ -21,7 +25,7 @@ export function AutoConnect({
     if (
       !enabled ||
       hasAttemptedConnection.current ||
-      connector?.type !== farcasterFrame.type ||
+      !FARCASTER_CONNECTOR_TYPES.has(connector?.type) ||
       !isInMiniAppSuccess
     ) {
       return;


### PR DESCRIPTION
**What changed? Why?**

MiniKit will now autoconnect if the current connector is a "farcasterMiniApp" connector.

**Notes to reviewers**

**How has it been tested?**

Manually, unit tests.