### PR TITLE
Use Base Account connector for sign up

### DIFF
--- a/packages/onchainkit/src/wallet/components/WalletModal.test.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletModal.test.tsx
@@ -165,13 +165,13 @@ describe('WalletModal', () => {
     expect(screen.getByText('Test App')).toBeInTheDocument();
   });
 
-  it('connects with Coinbase Wallet when clicking Sign up', () => {
+  it('connects with Base Account when clicking Sign up', () => {
     render(<WalletModal isOpen={true} onClose={mockOnClose} />);
 
     fireEvent.click(screen.getByText('Sign up'));
 
     expect(mockConnect).toHaveBeenCalledWith({
-      connector: { preference: 'all' },
+      connector: { appName: 'OnchainKit App', appLogoUrl: undefined },
     });
     expect(mockOnClose).toHaveBeenCalled();
   });

--- a/packages/onchainkit/src/wallet/components/WalletModal.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletModal.tsx
@@ -318,7 +318,7 @@ export function WalletModal({
           {isSignUpEnabled && (
             <button
               type="button"
-              onClick={handleCoinbaseWalletConnection}
+              onClick={handleBaseAccountConnection}
               className={cn(
                 border.radius,
                 text.body,


### PR DESCRIPTION
**What changed? Why?**

- For the "Sign up" button, instead of using the coinbase wallet connector, we should use the new Base account connector

**Notes to reviewers**

**How has it been tested?**

- Unit test


https://github.com/user-attachments/assets/d56391c7-6a14-4a39-8993-5c3436bd1292


