### PR TITLE
fix: Export useSendToken, add example

### DIFF
--- a/examples/minikit-example/app/actions/SendToken.tsx
+++ b/examples/minikit-example/app/actions/SendToken.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { useSendToken, useIsInMiniApp } from "@coinbase/onchainkit/minikit";
+import { Button } from "../ui/Button";
+
+export function SendToken() {
+  const { isInMiniApp } = useIsInMiniApp();
+  const { sendToken } = useSendToken();
+
+  return (
+    <Button
+      disabled={!isInMiniApp}
+      onClick={() => {
+        sendToken({
+          token: "eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913", // Base USDC
+          amount: "1000000", // 1 USDC (6 decimals)
+          recipientAddress: "0xfa6b3dF826636Eb76E23C1Ee38180dB3b8f60a86", // Example recipient address
+        });
+      }}
+    >
+      Send Token
+    </Button>
+  );
+}

--- a/examples/minikit-example/app/page.tsx
+++ b/examples/minikit-example/app/page.tsx
@@ -19,6 +19,7 @@ import { IsInMiniApp } from "./actions/IsInMiniApp";
 import { AddFrame } from "./actions/AddFrame";
 import { ComposeCast } from "./actions/ComposeCast";
 import { ViewCast } from "./actions/ViewCast";
+import { SendToken } from "./actions/SendToken";
 import { SwapToken } from "./actions/SwapToken";
 import { CloseFrame } from "./actions/CloseFrame";
 import { UserInfo } from "./components/UserInfo";
@@ -74,6 +75,7 @@ export default function App() {
               <AddFrame />
               <ComposeCast />
               <ViewCast />
+              <SendToken />
               <SwapToken />
               <CloseFrame />
             </div>

--- a/packages/onchainkit/src/minikit/index.ts
+++ b/packages/onchainkit/src/minikit/index.ts
@@ -12,3 +12,4 @@ export { useComposeCast } from './hooks/useComposeCast';
 export { useViewCast } from './hooks/useViewCast';
 export { useIsInMiniApp } from './hooks/useIsInMiniApp';
 export { useSwapToken } from './hooks/useSwapToken';
+export { useSendToken } from './hooks/useSendToken';


### PR DESCRIPTION
**What changed? Why?**

- Exports useSendToken
- Adds example to minikit-example-app

**Notes to reviewers**

**How has it been tested?**
