### PR TITLE
fix: Move wallet click outside logic to WalletDropdown

### DIFF
--- a/packages/onchainkit/src/internal/components/Sheet.tsx
+++ b/packages/onchainkit/src/internal/components/Sheet.tsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import * as SheetPrimitive from '@radix-ui/react-dialog';
-import { cn, prefixClassName } from '@/styles/theme';
+import { cn } from '@/styles/theme';
 import { zIndex } from '@/styles/constants';
 
 const SheetRoot = SheetPrimitive.Root;

--- a/packages/onchainkit/src/wallet/components/Wallet.tsx
+++ b/packages/onchainkit/src/wallet/components/Wallet.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { Draggable } from '@/internal/components/Draggable/Draggable';
 import { useIsMounted } from '@/internal/hooks/useIsMounted';
-import { useOutsideClick } from '@/internal/hooks/useOutsideClick';
 import { cn } from '@/styles/theme';
 import { useRef } from 'react';
 import { getWalletDraggableProps } from '../utils/getWalletDraggableProps';
@@ -26,16 +25,9 @@ function WalletContent({
   draggable,
   draggableStartingPosition,
 }: WalletProps) {
-  const {
-    isSubComponentOpen,
-    isConnectModalOpen,
-    handleClose,
-    connectRef,
-    breakpoint,
-  } = useWalletContext();
+  const { isSubComponentOpen, isConnectModalOpen, connectRef, breakpoint } =
+    useWalletContext();
   const walletContainerRef = useRef<HTMLDivElement>(null);
-
-  useOutsideClick(walletContainerRef, handleClose);
 
   if (draggable) {
     return (

--- a/packages/onchainkit/src/wallet/components/WalletDropdown.test.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletDropdown.test.tsx
@@ -198,6 +198,82 @@ describe('WalletDropdown', () => {
     expect(dropdown).toHaveClass('z-50');
   });
 
+  it('does not call handleClose when clicking inside the dropdown', async () => {
+    // Create a floating ref that will be wired by setFloating
+    const floatingRef: { current: HTMLDivElement | null } = { current: null };
+
+    mockUseFloating.mockReturnValue({
+      refs: {
+        floating: floatingRef,
+        setReference: vi.fn(),
+        setFloating: (node: HTMLDivElement | null) => {
+          floatingRef.current = node;
+        },
+      },
+      floatingStyles: {
+        position: 'absolute' as const,
+        top: 0,
+        left: 0,
+      },
+    });
+
+    const handleClose = vi.fn();
+
+    useWalletContextMock.mockReturnValue({
+      breakpoint: 'md',
+      isSubComponentOpen: true,
+      showSubComponentAbove: false,
+      alignSubComponentRight: false,
+      handleClose,
+      animations: { container: '', content: '' },
+    });
+
+    render(<WalletDropdown>Content</WalletDropdown>);
+
+    const dropdown = screen.getByTestId('ockWalletDropdown');
+    // Click inside the dropdown
+    dropdown.click();
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('calls handleClose when clicking outside the dropdown', async () => {
+    const floatingRef: { current: HTMLDivElement | null } = { current: null };
+
+    mockUseFloating.mockReturnValue({
+      refs: {
+        floating: floatingRef,
+        setReference: vi.fn(),
+        setFloating: (node: HTMLDivElement | null) => {
+          floatingRef.current = node;
+        },
+      },
+      floatingStyles: {
+        position: 'absolute' as const,
+        top: 0,
+        left: 0,
+      },
+    });
+
+    const handleClose = vi.fn();
+
+    useWalletContextMock.mockReturnValue({
+      breakpoint: 'md',
+      isSubComponentOpen: true,
+      showSubComponentAbove: false,
+      alignSubComponentRight: false,
+      handleClose,
+      animations: { container: '', content: '' },
+    });
+
+    render(<WalletDropdown>Content</WalletDropdown>);
+
+    // Click outside the dropdown
+    document.body.click();
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
   it('uses top-end placement when showSubComponentAbove and alignSubComponentRight are both true', () => {
     useWalletContextMock.mockReturnValue({
       showSubComponentAbove: true,

--- a/packages/onchainkit/src/wallet/components/WalletDropdown.tsx
+++ b/packages/onchainkit/src/wallet/components/WalletDropdown.tsx
@@ -21,6 +21,7 @@ import { WalletDropdownLink } from './WalletDropdownLink';
 import { useWalletContext } from './WalletProvider';
 import { useAccount } from 'wagmi';
 import { Token } from '@/token';
+import { useOutsideClick } from '@/internal/hooks/useOutsideClick';
 
 export type WalletDropdownProps = {
   children?: React.ReactNode;
@@ -66,6 +67,7 @@ export function WalletDropdown({
     showSubComponentAbove,
     alignSubComponentRight,
     connectRef,
+    handleClose,
   } = useWalletContext();
   const { address } = useAccount();
 
@@ -92,6 +94,8 @@ export function WalletDropdown({
     ],
     whileElementsMounted: autoUpdate,
   });
+
+  useOutsideClick(refs.floating, handleClose);
 
   useEffect(() => {
     if (connectRef?.current) {


### PR DESCRIPTION
**What changed? Why?**

- Moves click outside logic that closes the wallet dropdown to the WalletDropdown component

**Notes to reviewers**

**How has it been tested?**
