### PR TITLE
fix(create-onchain): enable alpha version detection to put appropriat…

### DIFF
--- a/.github/workflows/cli-basic.yml
+++ b/.github/workflows/cli-basic.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   test:
-    if: github.head_ref != 'alpha'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/cli-minikit.yml
+++ b/.github/workflows/cli-minikit.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   test:
-    if: github.head_ref != 'alpha'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/packages/create-onchain/src/minikit.test.ts
+++ b/packages/create-onchain/src/minikit.test.ts
@@ -21,6 +21,7 @@ vi.mock('./utils.js', () => ({
   createClickableLink: vi.fn(),
   isValidPackageName: vi.fn().mockReturnValue(true),
   toValidPackageName: vi.fn().mockImplementation((name) => name),
+  resolveOnchainKitVersion: vi.fn().mockResolvedValue('latest'),
 }));
 vi.mock('ora', () => ({
   default: vi.fn(),

--- a/packages/create-onchain/src/minikit.ts
+++ b/packages/create-onchain/src/minikit.ts
@@ -10,6 +10,7 @@ import {
   isValidPackageName,
   toValidPackageName,
   copyDir,
+  resolveOnchainKitVersion,
 } from './utils.js';
 import open from 'open';
 import express from 'express';
@@ -217,6 +218,12 @@ export async function createMiniKitTemplate(
   const pkgPath = path.join(root, 'package.json');
   const pkg = JSON.parse(await fs.promises.readFile(pkgPath, 'utf-8'));
   pkg.name = packageName || toValidPackageName(projectName);
+
+  const resolvedVersion = await resolveOnchainKitVersion();
+  if (pkg.dependencies?.['@coinbase/onchainkit']) {
+    pkg.dependencies['@coinbase/onchainkit'] = resolvedVersion;
+  }
+
   await fs.promises.writeFile(pkgPath, JSON.stringify(pkg, null, 2));
 
   // Create .env file from template

--- a/packages/create-onchain/src/onchainkit.test.ts
+++ b/packages/create-onchain/src/onchainkit.test.ts
@@ -224,7 +224,6 @@ describe('CLI', () => {
 
     (fs.promises.readFile as Mock).mockResolvedValue(JSON.stringify(mockPackageJson));
     
-    // Mock resolveOnchainKitVersion to return a specific version
     vi.mocked(resolveOnchainKitVersion).mockResolvedValueOnce('0.38.19');
 
     await createOnchainKitTemplate();
@@ -254,7 +253,6 @@ describe('CLI', () => {
 
     (fs.promises.readFile as Mock).mockResolvedValue(JSON.stringify(mockPackageJson));
     
-    // Mock resolveOnchainKitVersion to return 'alpha' for this test
     vi.mocked(resolveOnchainKitVersion).mockResolvedValueOnce('alpha');
 
     await createOnchainKitTemplate();

--- a/packages/create-onchain/src/onchainkit.ts
+++ b/packages/create-onchain/src/onchainkit.ts
@@ -8,6 +8,7 @@ import {
   toValidPackageName,
   createClickableLink,
   copyDir,
+  resolveOnchainKitVersion,
 } from './utils.js';
 import { fileURLToPath } from 'url';
 import { analyticsPrompt } from './analytics.js';
@@ -103,6 +104,12 @@ export async function createOnchainKitTemplate() {
   const pkgPath = path.join(root, 'package.json');
   const pkg = JSON.parse(await fs.promises.readFile(pkgPath, 'utf-8'));
   pkg.name = packageName || toValidPackageName(projectName);
+  
+  const resolvedVersion = await resolveOnchainKitVersion();
+  if (pkg.dependencies?.['@coinbase/onchainkit']) {
+    pkg.dependencies['@coinbase/onchainkit'] = resolvedVersion;
+  }
+  
   await fs.promises.writeFile(pkgPath, JSON.stringify(pkg, null, 2));
 
   // Customize .env file from template

--- a/packages/create-onchain/src/utils.ts
+++ b/packages/create-onchain/src/utils.ts
@@ -12,6 +12,41 @@ export const getVersion = async () => {
   return packageJson.version;
 };
 
+export const getOnchainKitWorkspaceVersion = async () => {
+  const pkgPath = path.resolve(
+    fileURLToPath(import.meta.url),
+    '../../../onchainkit/package.json',
+  );
+  try {
+    const packageJsonContent = await fs.readFile(pkgPath, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+    return packageJson.version;
+  } catch (error) {
+    console.warn('Warning: Could not read workspace OnchainKit version. Using "latest".');
+    return 'latest';
+  }
+}
+
+export const resolveOnchainKitVersion = async (versionFlag?: string): Promise<string> => {
+  if (versionFlag) {
+    if (versionFlag === 'workspace') {
+      return await getOnchainKitWorkspaceVersion();
+    }
+    return versionFlag;
+  }
+  
+  // Auto-detect version based on create-onchain version
+  const createOnchainVersion = await getVersion();
+  
+  // If create-onchain is an alpha version, use alpha OnchainKit
+  if (createOnchainVersion.includes('alpha')) {
+    return 'alpha';
+  }
+  
+  // Otherwise use latest
+  return 'latest';
+}
+
 const renameFiles: Record<string, string | undefined> = {
   _gitignore: '.gitignore',
   '_env.local': '.env.local',


### PR DESCRIPTION
**What changed? Why?**

Fixes #2453 

Updated `create-onchain` CLI to automatically detect `ock` version based on create-onchain's own version. When `create-onchain` is an alpha version (contains "alpha" in version string), it now uses `@coinbase/onchainkit@alpha` instead of `@coinbase/onchainkit@latest`. This prevents API compatibility issues when testing alpha releases where ock APIs may have changed.

**Notes to reviewers**

**How has it been tested?**

- All existing unit tests pass with updated mocks
- Added new test cases for version auto-detection logic
- Verified that alpha versions correctly resolve to "alpha" OnchainKit
- Confirmed stable versions continue to use "latest" OnchainKit