### PR TITLE
fix: correct "worskapce" to "workspace" in ESLint config comment

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,7 +43,7 @@ export default [
       ],
 
       // TODO: These rules are temporarily disabled due to existing errors in codebase
-      // They will be enabled and fixed as soon as the worskapce PR is merged
+      // They will be enabled and fixed as soon as the workspace PR is merged
       complexity: ['error', 20],
       'no-unused-vars': 'off',
       'sort-keys': [


### PR DESCRIPTION
**What changed? Why?**
Fixed spelling error in ESLint configuration comment where "worskapce" was misspelled instead of "workspace"