### PR TITLE
chore: Remove deprecated schemaId prop

### DIFF
--- a/packages/onchainkit/src/OnchainKitProvider.test.tsx
+++ b/packages/onchainkit/src/OnchainKitProvider.test.tsx
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 import { setOnchainKitConfig } from '@/core/OnchainKitConfig';
 import type { AppConfig } from '@/core/types';
-import type { EASSchemaUid } from '@/identity/types';
 import type { MiniKitOptions } from '@/minikit/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -87,10 +86,9 @@ const mockConfig = createConfig({
 });
 
 const TestComponent = () => {
-  const { schemaId, apiKey } = useOnchainKit();
+  const { apiKey } = useOnchainKit();
   return (
     <>
-      <div>{schemaId}</div>
       <div>{apiKey}</div>
     </>
   );
@@ -102,13 +100,11 @@ vi.mock('@/core/OnchainKitConfig', () => ({
     apiKey: null,
     chain: { name: 'base', id: 8453 },
     rpcUrl: null,
-    schemaId: null,
     projectId: null,
   },
 }));
 
 describe('OnchainKitProvider', () => {
-  const schemaId: EASSchemaUid = `0x${'1'.repeat(64)}`;
   const apiKey = 'test-api-key';
   const paymasterUrl =
     'https://api.developer.coinbase.com/rpc/v1/base/test-api-key';
@@ -128,7 +124,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider chain={base} schemaId={schemaId} apiKey={apiKey}>
+          <OnchainKitProvider chain={base} apiKey={apiKey}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>
@@ -136,7 +132,6 @@ describe('OnchainKitProvider', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(schemaId)).toBeInTheDocument();
       expect(screen.getByText(apiKey)).toBeInTheDocument();
     });
   });
@@ -147,31 +142,16 @@ describe('OnchainKitProvider', () => {
       providedQueryClient: null,
     });
     render(
-      <OnchainKitProvider chain={base} schemaId={schemaId} apiKey={apiKey}>
+      <OnchainKitProvider chain={base} apiKey={apiKey}>
         <TestComponent />
       </OnchainKitProvider>,
     );
     await waitFor(() => {
-      expect(screen.getByText(schemaId)).toBeInTheDocument();
       expect(screen.getByText(apiKey)).toBeInTheDocument();
     });
   });
 
-  it('throws an error if schemaId does not meet the required length', () => {
-    expect(() => {
-      render(
-        <WagmiProvider config={mockConfig}>
-          <QueryClientProvider client={queryClient}>
-            <OnchainKitProvider chain={base} schemaId={'0x123'} apiKey={apiKey}>
-              <TestComponent />
-            </OnchainKitProvider>
-          </QueryClientProvider>
-        </WagmiProvider>,
-      );
-    }).toThrow('EAS schemaId must be 64 characters prefixed with "0x"');
-  });
-
-  it('does not throw an error if schemaId is not provided', () => {
+  it('renders successfully with minimal props', () => {
     expect(() => {
       render(
         <WagmiProvider config={mockConfig}>
@@ -205,7 +185,6 @@ describe('OnchainKitProvider', () => {
         <QueryClientProvider client={queryClient}>
           <OnchainKitProvider
             chain={base}
-            schemaId={schemaId}
             apiKey={apiKey}
             miniKit={{ enabled: true }}
           >
@@ -233,7 +212,6 @@ describe('OnchainKitProvider', () => {
         <QueryClientProvider client={queryClient}>
           <OnchainKitProvider
             chain={base}
-            schemaId={schemaId}
             apiKey={apiKey}
             miniKit={miniKitOptions}
           >
@@ -258,7 +236,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider chain={base} schemaId={schemaId} apiKey={apiKey}>
+          <OnchainKitProvider chain={base} apiKey={apiKey}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>
@@ -293,7 +271,6 @@ describe('OnchainKitProvider', () => {
           },
           chain: base,
           rpcUrl: null,
-          schemaId,
           projectId: null,
           sessionId: 'test-session-id',
         }),
@@ -305,7 +282,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider chain={base} schemaId={schemaId}>
+          <OnchainKitProvider chain={base}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>
@@ -346,11 +323,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider
-            chain={base}
-            schemaId={schemaId}
-            analytics={false}
-          >
+          <OnchainKitProvider chain={base} analytics={false}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>
@@ -383,7 +356,6 @@ describe('OnchainKitProvider', () => {
         <QueryClientProvider client={queryClient}>
           <OnchainKitProvider
             chain={base}
-            schemaId={schemaId}
             apiKey={apiKey}
             config={customConfig}
             analytics={false}
@@ -423,7 +395,6 @@ describe('OnchainKitProvider', () => {
           },
           projectId: null,
           rpcUrl: null,
-          schemaId: schemaId,
           sessionId: 'test-session-id',
         }),
       );
@@ -434,7 +405,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider chain={base} schemaId={schemaId}>
+          <OnchainKitProvider chain={base}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>
@@ -472,11 +443,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider
-            chain={base}
-            schemaId={schemaId}
-            config={customConfig}
-          >
+          <OnchainKitProvider chain={base} config={customConfig}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>
@@ -512,11 +479,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider
-            chain={base}
-            schemaId={schemaId}
-            config={customConfig}
-          >
+          <OnchainKitProvider chain={base} config={customConfig}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>
@@ -536,7 +499,6 @@ describe('OnchainKitProvider', () => {
             }),
           }),
           chain: expect.any(Object),
-          schemaId: schemaId,
           sessionId: 'test-session-id',
           apiKey: null,
           projectId: null,
@@ -564,11 +526,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider
-            chain={base}
-            schemaId={schemaId}
-            config={customConfig}
-          >
+          <OnchainKitProvider chain={base} config={customConfig}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>
@@ -606,7 +564,7 @@ describe('OnchainKitProvider', () => {
     render(
       <WagmiProvider config={mockConfig}>
         <QueryClientProvider client={queryClient}>
-          <OnchainKitProvider chain={base} schemaId={schemaId}>
+          <OnchainKitProvider chain={base}>
             <TestComponent />
           </OnchainKitProvider>
         </QueryClientProvider>

--- a/packages/onchainkit/src/OnchainKitProvider.tsx
+++ b/packages/onchainkit/src/OnchainKitProvider.tsx
@@ -4,8 +4,6 @@ import { useContext, useEffect, useLayoutEffect, useMemo } from 'react';
 import { DefaultOnchainKitProviders } from './DefaultOnchainKitProviders';
 import OnchainKitProviderBoundary from './OnchainKitProviderBoundary';
 import { DEFAULT_PRIVACY_URL, DEFAULT_TERMS_URL } from './core/constants';
-import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from './identity/constants';
-import { checkHashLength } from './internal/utils/checkHashLength';
 import { generateUUIDWithInsecureFallback } from './internal/utils/crypto';
 import { OnchainKitContext } from './useOnchainKit';
 import { useThemeRoot } from './internal/hooks/useTheme';
@@ -18,7 +16,6 @@ import type { Chain } from 'wagmi/chains';
 import type { AppConfig } from './core/types';
 import type { MiniKitOptions } from './minikit/types';
 import { MiniKitProvider } from '@/minikit/MiniKitProvider';
-import type { EASSchemaUid } from '@/identity/types';
 import { type PublicClient } from 'viem';
 
 export type OnchainKitProviderReact = {
@@ -30,7 +27,6 @@ export type OnchainKitProviderReact = {
   sessionId?: string;
   projectId?: string;
   rpcUrl?: string;
-  schemaId?: EASSchemaUid;
   miniKit?: MiniKitOptions;
   defaultPublicClients?: {
     [chainId: number]: PublicClient;
@@ -48,16 +44,11 @@ export function OnchainKitProvider({
   config,
   projectId,
   rpcUrl,
-  schemaId,
   miniKit = {
     enabled: false,
   },
   defaultPublicClients,
 }: OnchainKitProviderReact) {
-  if (schemaId && !checkHashLength(schemaId, 64)) {
-    throw Error('EAS schemaId must be 64 characters prefixed with "0x"');
-  }
-
   const [sessionId] = useSessionStorage(
     'ock-session-id',
     generateUUIDWithInsecureFallback(),
@@ -112,7 +103,6 @@ export function OnchainKitProvider({
       },
       projectId: projectId ?? null,
       rpcUrl: rpcUrl ?? null,
-      schemaId: schemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
       sessionId,
       defaultPublicClients,
       miniKit,
@@ -126,7 +116,6 @@ export function OnchainKitProvider({
     config,
     projectId,
     rpcUrl,
-    schemaId,
     sessionId,
     defaultPublicClients,
     miniKit,

--- a/packages/onchainkit/src/core/OnchainKitConfig.test.ts
+++ b/packages/onchainkit/src/core/OnchainKitConfig.test.ts
@@ -22,14 +22,12 @@ describe('OnchainKitConfig', () => {
 
   it('should return the correct config value', () => {
     const chain = baseSepolia;
-    const schemaId = '0x123';
     const apiKey = 'test-api-key';
     const projectId = 'test-project-id';
     const rpcUrl =
       'https://api.developer.coinbase.com/rpc/v1/base-sepolia/test-api-key';
-    setOnchainKitConfig({ chain, schemaId, apiKey, projectId });
+    setOnchainKitConfig({ chain, apiKey, projectId });
     expect(getOnchainKitConfig('chain')).toEqual(chain);
-    expect(getOnchainKitConfig('schemaId')).toEqual(schemaId);
     expect(getOnchainKitConfig('apiKey')).toEqual(apiKey);
     expect(getOnchainKitConfig('projectId')).toEqual(projectId);
     expect(getRPCUrl()).toEqual(rpcUrl);
@@ -37,20 +35,17 @@ describe('OnchainKitConfig', () => {
 
   it('should update the config value', () => {
     const chain = baseSepolia;
-    const schemaId = '0x123';
     const apiKey = 'updated-api-key';
     const rpcUrl =
       'https://api.developer.coinbase.com/rpc/v1/base-sepolia/updated-api-key';
-    setOnchainKitConfig({ chain, schemaId, apiKey, rpcUrl });
+    setOnchainKitConfig({ chain, apiKey, rpcUrl });
     expect(getOnchainKitConfig('chain')).toEqual(chain);
-    expect(getOnchainKitConfig('schemaId')).toEqual(schemaId);
     expect(getOnchainKitConfig('apiKey')).toEqual(apiKey);
     expect(getRPCUrl()).toEqual(rpcUrl);
 
-    const newSchemaId = '0x456';
-    setOnchainKitConfig({ schemaId: newSchemaId });
+    const newApiKey = 'another-api-key';
+    setOnchainKitConfig({ apiKey: newApiKey });
     expect(getOnchainKitConfig('chain')).toEqual(chain);
-    expect(getOnchainKitConfig('schemaId')).toEqual(newSchemaId);
-    expect(getOnchainKitConfig('apiKey')).toEqual(apiKey);
+    expect(getOnchainKitConfig('apiKey')).toEqual(newApiKey);
   });
 });

--- a/packages/onchainkit/src/core/OnchainKitConfig.ts
+++ b/packages/onchainkit/src/core/OnchainKitConfig.ts
@@ -30,7 +30,6 @@ export const ONCHAIN_KIT_CONFIG: OnchainKitConfig = {
     },
   },
   rpcUrl: null,
-  schemaId: null,
   projectId: null,
   sessionId: null,
   miniKit: {

--- a/packages/onchainkit/src/core/types.ts
+++ b/packages/onchainkit/src/core/types.ts
@@ -1,4 +1,3 @@
-import type { EASSchemaUid } from '@/identity/types';
 import { MiniKitOptions } from '@/minikit/types';
 import type { Chain, PublicClient } from 'viem';
 import type { CreateConnectorFn } from 'wagmi';
@@ -114,8 +113,6 @@ export type OnchainKitConfig = {
   config?: AppConfig;
   /** RPC URL for onchain requests. Defaults to using CDP Node if the API Key is set */
   rpcUrl: string | null;
-  /** SchemaId is optional as not all apps need to use EAS */
-  schemaId: EASSchemaUid | null;
   /** ProjectId from Coinbase Developer Platform, only required for Coinbase Onramp support */
   projectId: string | null;
   /** SessionId, used for analytics */

--- a/packages/onchainkit/src/identity/components/Badge.test.tsx
+++ b/packages/onchainkit/src/identity/components/Badge.test.tsx
@@ -24,7 +24,6 @@ describe('Badge Component', () => {
       apiKey: null,
       chain: base,
       rpcUrl: null,
-      schemaId: null,
       projectId: null,
       sessionId: null,
       config: {
@@ -227,7 +226,6 @@ describe('Badge Component', () => {
       apiKey: null,
       chain: base,
       rpcUrl: null,
-      schemaId: '0xkitSchema',
       projectId: null,
       sessionId: null,
       config: {
@@ -254,7 +252,6 @@ describe('Badge Component', () => {
       apiKey: null,
       chain: base,
       rpcUrl: null,
-      schemaId: '0xkitSchema',
       projectId: null,
       sessionId: null,
       config: {
@@ -271,7 +268,7 @@ describe('Badge Component', () => {
     });
   });
 
-  it('should fall back to kit schemaId if context schemaId is not available and tooltip is enabled', async () => {
+  it('should pass null schemaId when context schemaId is not available and tooltip is enabled', async () => {
     vi.mocked(useIdentityContext).mockReturnValue({
       address: '0x123',
       schemaId: null,
@@ -281,7 +278,6 @@ describe('Badge Component', () => {
       apiKey: null,
       chain: base,
       rpcUrl: null,
-      schemaId: '0xkitSchema',
       projectId: null,
       sessionId: null,
       config: {
@@ -294,7 +290,7 @@ describe('Badge Component', () => {
     expect(useAttestations).toHaveBeenCalledWith({
       address: '0x123',
       chain: base,
-      schemaId: '0xkitSchema',
+      schemaId: null,
     });
   });
 

--- a/packages/onchainkit/src/identity/components/Badge.tsx
+++ b/packages/onchainkit/src/identity/components/Badge.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useAttestations } from '@/identity/hooks/useAttestations';
+import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from '@/identity/constants';
 import type { BadgeProps } from '@/identity/types';
 import { badgeSvg } from '@/internal/svg/badgeSvg';
 import { zIndex } from '@/styles/constants';
@@ -26,12 +27,14 @@ type ExtractAttestationNameParams = {
 export function Badge({ className, tooltip = false }: BadgeProps) {
   const [showTooltip, setShowTooltip] = useState(false);
   const { address, schemaId: contextSchemaId } = useIdentityContext();
-  const { chain, schemaId: kitSchemaId } = useOnchainKit();
+  const { chain } = useOnchainKit();
 
   const attestations = useAttestations({
     address,
     chain,
-    schemaId: tooltip ? (contextSchemaId ?? kitSchemaId) : null,
+    schemaId: tooltip
+      ? (contextSchemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID)
+      : null,
   });
 
   // Get tooltip text from tooltip prop or attestation

--- a/packages/onchainkit/src/identity/components/DisplayBadge.test.tsx
+++ b/packages/onchainkit/src/identity/components/DisplayBadge.test.tsx
@@ -1,5 +1,6 @@
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom';
+import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from '@/identity/constants';
 import { useAttestations } from '@/identity/hooks/useAttestations';
 import { useOnchainKit } from '@/useOnchainKit';
 import { render, screen } from '@testing-library/react';
@@ -33,10 +34,9 @@ describe('DisplayBadge', () => {
     vi.clearAllMocks();
   });
 
-  it('should throw an error if neither contextSchemaId nor schemaId is provided', () => {
+  it('should use default schema when no contextSchemaId is provided', () => {
     useOnchainKitMock.mockReturnValue({
       chain: 'test-chain',
-      schemaId: null,
     });
     useIdentityContextMock.mockReturnValue({
       schemaId: null,
@@ -44,21 +44,22 @@ describe('DisplayBadge', () => {
     });
     useAttestationsMock.mockReturnValue([]);
 
-    expect(() =>
-      render(
-        <DisplayBadge>
-          <Badge />
-        </DisplayBadge>,
-      ),
-    ).toThrow(
-      'Name: a SchemaId must be provided to the OnchainKitProvider or Identity component.',
+    render(
+      <DisplayBadge>
+        <Badge />
+      </DisplayBadge>,
     );
+
+    expect(useAttestations).toHaveBeenCalledWith({
+      address: testIdentityProviderAddress,
+      chain: 'test-chain',
+      schemaId: COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
+    });
   });
 
   it('should return null if attestations are empty', () => {
     useOnchainKitMock.mockReturnValue({
       chain: 'test-chain',
-      schemaId: 'test-schema-id',
     });
     useIdentityContextMock.mockReturnValue({
       schemaId: null,
@@ -77,7 +78,6 @@ describe('DisplayBadge', () => {
   it('should render children if attestations are not empty', () => {
     useOnchainKitMock.mockReturnValue({
       chain: 'test-chain',
-      schemaId: 'test-schema-id',
     });
     useIdentityContextMock.mockReturnValue({
       schemaId: null,
@@ -94,8 +94,12 @@ describe('DisplayBadge', () => {
   });
 
   it('use identity context address if provided', () => {
+    useOnchainKitMock.mockReturnValue({
+      chain: 'test-chain',
+    });
     useIdentityContextMock.mockReturnValue({
       address: testIdentityProviderAddress,
+      schemaId: 'test-schema-id',
     });
 
     render(
@@ -112,8 +116,12 @@ describe('DisplayBadge', () => {
   });
 
   it('use component address over identity context if both are provided', () => {
+    useOnchainKitMock.mockReturnValue({
+      chain: 'test-chain',
+    });
     useIdentityContextMock.mockReturnValue({
       address: testIdentityProviderAddress,
+      schemaId: 'test-schema-id',
     });
 
     render(

--- a/packages/onchainkit/src/identity/components/DisplayBadge.tsx
+++ b/packages/onchainkit/src/identity/components/DisplayBadge.tsx
@@ -1,4 +1,5 @@
 import { useAttestations } from '@/identity/hooks/useAttestations';
+import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from '@/identity/constants';
 import type { ReactNode } from 'react';
 import type { Address } from 'viem';
 import { useOnchainKit } from '../../useOnchainKit';
@@ -10,18 +11,13 @@ type DisplayBadgeProps = {
 };
 
 export function DisplayBadge({ children, address }: DisplayBadgeProps) {
-  const { chain, schemaId } = useOnchainKit();
+  const { chain } = useOnchainKit();
   const { schemaId: contextSchemaId, address: contextAddress } =
     useIdentityContext();
-  if (!contextSchemaId && !schemaId) {
-    throw new Error(
-      'Name: a SchemaId must be provided to the OnchainKitProvider or Identity component.',
-    );
-  }
   const attestations = useAttestations({
     address: address ?? contextAddress,
     chain: chain,
-    schemaId: contextSchemaId ?? schemaId,
+    schemaId: contextSchemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID,
   });
 
   if (attestations.length === 0) {

--- a/packages/onchainkit/src/nft/components/mint/NFTCreator.tsx
+++ b/packages/onchainkit/src/nft/components/mint/NFTCreator.tsx
@@ -1,14 +1,15 @@
 import { Avatar, Badge, Identity, Name } from '@/identity';
+import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from '@/identity/constants';
 import { useNFTContext } from '@/nft/components/NFTProvider';
 import { cn } from '@/styles/theme';
-import { useOnchainKit } from '@/useOnchainKit';
+import type { EASSchemaUid } from '@/identity/types';
 
 type NFTCreatorProps = {
   className?: string;
+  schemaId?: EASSchemaUid | null;
 };
 
-export function NFTCreator({ className }: NFTCreatorProps) {
-  const { schemaId } = useOnchainKit();
+export function NFTCreator({ className, schemaId }: NFTCreatorProps) {
   const { creatorAddress } = useNFTContext();
 
   if (!creatorAddress) {
@@ -20,7 +21,7 @@ export function NFTCreator({ className }: NFTCreatorProps) {
       <Identity
         className="px-0 py-0 [&>div]:space-x-2"
         address={creatorAddress}
-        schemaId={schemaId}
+        schemaId={schemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID}
       >
         <Avatar className="h-4 w-4" />
         <Name>

--- a/packages/onchainkit/src/nft/components/mint/NFTMinters.tsx
+++ b/packages/onchainkit/src/nft/components/mint/NFTMinters.tsx
@@ -1,14 +1,15 @@
 import { Avatar, Identity, Name } from '@/identity';
+import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from '@/identity/constants';
 import { useNFTContext } from '@/nft/components/NFTProvider';
 import { cn, text } from '@/styles/theme';
-import { useOnchainKit } from '@/useOnchainKit';
+import type { EASSchemaUid } from '@/identity/types';
 
 type NFTMintersProps = {
   className?: string;
+  schemaId?: EASSchemaUid | null;
 };
 
-export function NFTMinters({ className }: NFTMintersProps) {
-  const { schemaId } = useOnchainKit();
+export function NFTMinters({ className, schemaId }: NFTMintersProps) {
   const { totalOwners, recentOwners } = useNFTContext();
 
   if (!recentOwners || recentOwners.length === 0) {
@@ -30,7 +31,7 @@ export function NFTMinters({ className }: NFTMintersProps) {
             key={address}
             className="space-x-0 px-0 py-0 [&>div]:space-x-2"
             address={address}
-            schemaId={schemaId}
+            schemaId={schemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID}
           >
             <Avatar className="h-4 w-4" />
           </Identity>

--- a/packages/onchainkit/src/nft/components/view/NFTOwner.tsx
+++ b/packages/onchainkit/src/nft/components/view/NFTOwner.tsx
@@ -1,6 +1,7 @@
 import { useNFTContext } from '@/nft/components/NFTProvider';
-import { useOnchainKit } from '@/useOnchainKit';
+import { COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID } from '@/identity/constants';
 import type { ReactNode } from 'react';
+import type { EASSchemaUid } from '@/identity/types';
 
 import { Avatar, Badge, Identity, Name } from '@/identity';
 import { cn, text } from '../../../styles/theme';
@@ -8,10 +9,14 @@ import { cn, text } from '../../../styles/theme';
 type NFTOwnerProps = {
   className?: string;
   label?: ReactNode;
+  schemaId?: EASSchemaUid | null;
 };
 
-export function NFTOwner({ className, label = 'Owned by' }: NFTOwnerProps) {
-  const { schemaId } = useOnchainKit();
+export function NFTOwner({
+  className,
+  label = 'Owned by',
+  schemaId,
+}: NFTOwnerProps) {
   const { ownerAddress } = useNFTContext();
 
   if (!ownerAddress) {
@@ -30,7 +35,7 @@ export function NFTOwner({ className, label = 'Owned by' }: NFTOwnerProps) {
       <Identity
         className={cn('!bg-inherit space-x-1 px-0 [&>div]:space-x-2')}
         address={ownerAddress}
-        schemaId={schemaId}
+        schemaId={schemaId ?? COINBASE_VERIFIED_ACCOUNT_SCHEMA_ID}
       >
         <Avatar className="h-4 w-4" />
         <Name>

--- a/packages/onchainkit/src/useOnchainKit.test.tsx
+++ b/packages/onchainkit/src/useOnchainKit.test.tsx
@@ -5,23 +5,21 @@ import { setOnchainKitConfig } from './core/OnchainKitConfig';
 import { useOnchainKit } from './useOnchainKit';
 
 const TestComponent = () => {
-  const { schemaId, apiKey } = useOnchainKit();
+  const { apiKey } = useOnchainKit();
   return (
     <div>
-      {apiKey} + {schemaId}
+      {apiKey}
     </div>
   );
 };
 
 describe('useOnchainKit', () => {
   it('should return the correct value', () => {
-    const schemaId = '0x123';
     const apiKey = 'test-api-key';
-    setOnchainKitConfig({ schemaId, apiKey });
+    setOnchainKitConfig({ apiKey });
     const { container } = render(<TestComponent />, {
       wrapper: ({ children }) => <div>{children}</div>,
     });
-    expect(container).toHaveTextContent(schemaId);
     expect(container).toHaveTextContent(apiKey);
   });
 });

--- a/packages/onchainkit/src/useOnchainKit.test.tsx
+++ b/packages/onchainkit/src/useOnchainKit.test.tsx
@@ -6,11 +6,7 @@ import { useOnchainKit } from './useOnchainKit';
 
 const TestComponent = () => {
   const { apiKey } = useOnchainKit();
-  return (
-    <div>
-      {apiKey}
-    </div>
-  );
+  return <div>{apiKey}</div>;
 };
 
 describe('useOnchainKit', () => {

--- a/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/RenderSendButton.test.tsx
+++ b/packages/onchainkit/src/wallet/components/wallet-advanced-send/components/RenderSendButton.test.tsx
@@ -87,7 +87,6 @@ describe('RenderSendButton', () => {
       chain: base,
       apiKey: '',
       rpcUrl: '0x123' as `0x${string}`,
-      schemaId: '0x123',
       projectId: '',
       sessionId: '0x123',
     });


### PR DESCRIPTION
**What changed? Why?**

- Removes deprecated `schemaId` OnchainKitProvider prop

**Notes to reviewers**

**How has it been tested?**
