### PR TITLE
fix: Minikit template prepends process.env.VERCEL_URL with https://

### DIFF
--- a/examples/minikit-example/minikit.config.ts
+++ b/examples/minikit-example/minikit.config.ts
@@ -1,9 +1,12 @@
-const ROOT_URL = process.env.NEXT_PUBLIC_URL || process.env.VERCEL_URL;
+const ROOT_URL =
+  process.env.NEXT_PUBLIC_URL ||
+  (process.env.VERCEL_URL && `https://${process.env.VERCEL_URL}`) ||
+  "http://localhost:3000";
 
 /**
- * MiniApp configuration object. Must follow the Farcaster MiniApp specification.
+ * MiniApp configuration object. Must follow the mini app manifest specification.
  *
- * @see {@link https://miniapps.farcaster.xyz/docs/guides/publishing}
+ * @see {@link https://docs.base.org/mini-apps/features/manifest}
  */
 export const minikitConfig = {
   accountAssociation: {
@@ -26,7 +29,7 @@ export const minikitConfig = {
     homeUrl: ROOT_URL,
     webhookUrl: `${ROOT_URL}/api/webhook`,
     primaryCategory: "utility",
-    tags: [],
+    tags: ["example"],
     heroImageUrl: `${ROOT_URL}/hero.png`,
     tagline: "",
     ogTitle: "",

--- a/templates/minikit-nextjs/minikit.config.ts
+++ b/templates/minikit-nextjs/minikit.config.ts
@@ -1,9 +1,12 @@
-const ROOT_URL = process.env.NEXT_PUBLIC_URL || process.env.VERCEL_URL;
+const ROOT_URL =
+  process.env.NEXT_PUBLIC_URL ||
+  (process.env.VERCEL_URL && `https://${process.env.VERCEL_URL}`) ||
+  "http://localhost:3000";
 
 /**
- * MiniApp configuration object. Must follow the Farcaster MiniApp specification.
+ * MiniApp configuration object. Must follow the mini app manifest specification.
  *
- * @see {@link https://miniapps.farcaster.xyz/docs/guides/publishing}
+ * @see {@link https://docs.base.org/mini-apps/features/manifest}
  */
 export const minikitConfig = {
   accountAssociation: {
@@ -23,7 +26,7 @@ export const minikitConfig = {
     homeUrl: ROOT_URL,
     webhookUrl: `${ROOT_URL}/api/webhook`,
     primaryCategory: "utility",
-    tags: [],
+    tags: ["example"],
     heroImageUrl: `${ROOT_URL}/hero.png`,
     tagline: "",
     ogTitle: "",


### PR DESCRIPTION
**What changed? Why?**

- Updates the minikit template to prepend VERCEL_URL with https:// since it doesn't include the protocol
- Adds an example tag to manifest so it's fully validated

**Notes to reviewers**

**How has it been tested?**
