### PR TITLE
Fix test description and add missing test case for useIsWalletACoinbaseSmartWalle

### DIFF
--- a/packages/onchainkit/src/wallet/hooks/useIsWalletACoinbaseSmartWallet.test.ts
+++ b/packages/onchainkit/src/wallet/hooks/useIsWalletACoinbaseSmartWallet.test.ts
@@ -44,9 +44,21 @@ describe('useIsWalletACoinbaseSmartWallet', () => {
     expect(result.current).toBe(false);
   });
 
-  it('should return true if the wallet is a Coinbase Smart Wallet', () => {
+  it('should return false if the wallet is not a Coinbase Wallet', () => {
     (useOnchainKit as Mock).mockReturnValue({ chain: { id: 'chainId' } });
     (useAccount as Mock).mockReturnValue({ connector: { id: 'someOtherId' } });
+    (useCapabilitiesSafe as Mock).mockReturnValue({
+      atomicBatch: { supported: true },
+    });
+
+    const { result } = renderHook(() => useIsWalletACoinbaseSmartWallet());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should return false if no connector is connected', () => {
+    (useOnchainKit as Mock).mockReturnValue({ chain: { id: 'chainId' } });
+    (useAccount as Mock).mockReturnValue({ connector: undefined });
     (useCapabilitiesSafe as Mock).mockReturnValue({
       atomicBatch: { supported: true },
     });


### PR DESCRIPTION
  Corrected the test description from 'should return true' to 'should return false' for non-Coinbase wallet case
- Added test case for when no connector is connected 
- Corrected the test description from 'should return true' to 'should return false' for non-Coinbase wallet case
- Added test case for when no connector is connected

**What changed? Why?**

**Notes to reviewers**

**How has it been tested?**
