### PR TITLE
Fix misleading default and some typos

### DIFF
--- a/packages/onchainkit/src/swap/types.ts
+++ b/packages/onchainkit/src/swap/types.ts
@@ -204,7 +204,7 @@ export type SwapButtonProps = {
 };
 
 export type SwapConfig = {
-  maxSlippage: number; // Maximum acceptable slippage for a swap. (default: 10) This is as a percent, not basis points;
+  maxSlippage: number; // Maximum acceptable slippage for a swap. (default: 3) This is as a percent, not basis points;
 };
 
 export type SwapContextType = {
@@ -293,7 +293,7 @@ export type SwapParams = {
 export type SwapProviderProps = {
   children: React.ReactNode;
   config?: {
-    maxSlippage: number; // Maximum acceptable slippage for a swap. (default: 10) This is as a percent, not basis points
+    maxSlippage: number; // Maximum acceptable slippage for a swap. (default: 3) This is as a percent, not basis points
   };
   experimental: {
     useAggregator: boolean; // Whether to use a DEX aggregator. (default: false)

--- a/packages/onchainkit/src/transaction/components/TransactionProvider.tsx
+++ b/packages/onchainkit/src/transaction/components/TransactionProvider.tsx
@@ -130,7 +130,7 @@ export function TransactionProvider({
       return {
         paymasterService: { url: paymaster },
         // this needs to be below so devs can override default paymaster
-        // with their personal paymaster in production playgroundd
+        // with their personal paymaster in production playground
         ...transactionCapabilities,
       };
     }

--- a/packages/playground/components/demo/TransactionWithRenderProp.tsx
+++ b/packages/playground/components/demo/TransactionWithRenderProp.tsx
@@ -56,7 +56,7 @@ function customRender({
   if (status === 'error') {
     return (
       <button disabled={isDisabled} onClick={onSubmit} className={className}>
-        Oops there is an error
+        Oops, there is an error
       </button>
     );
   }


### PR DESCRIPTION
Align docs with implementation: the default Swap maxSlippage is 3, not 10. This is enforced by the constant and the component’s default config: `export const FALLBACK_DEFAULT_MAX_SLIPPAGE = 3;` in packages\onchainkit\src\swap\constants.ts.