### PR TITLE
fix: Allow additional properties in `withValidManifest`

### DIFF
--- a/.changeset/tangy-geese-retire.md
+++ b/.changeset/tangy-geese-retire.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+fix: Allow additional properties in withValidManifest

--- a/packages/onchainkit/src/minikit/utils/manifestUtils.test.ts
+++ b/packages/onchainkit/src/minikit/utils/manifestUtils.test.ts
@@ -9,13 +9,11 @@ import type {
 function getMiniAppValue(
   manifest: MiniAppManifest | LegacyMiniAppManifest,
 ): MiniAppFields {
+  // After withValidManifest processing, the result always has 'miniapp' field
   if ('miniapp' in manifest && manifest.miniapp) {
     return manifest.miniapp;
   }
-  if ('frame' in manifest && manifest.frame) {
-    return manifest.frame;
-  }
-  throw new Error('Invalid manifest: no miniapp or frame found');
+  throw new Error('Invalid manifest: no miniapp found');
 }
 
 describe('withValidManifest', () => {
@@ -198,7 +196,7 @@ describe('withValidManifest', () => {
 
       const result = withValidManifest(manifest);
       expect(result).toEqual({
-        frame: validMiniappBase,
+        miniapp: validMiniappBase,
       });
     });
 
@@ -226,7 +224,7 @@ describe('withValidManifest', () => {
 
       const result = withValidManifest(manifest);
       expect(result).toEqual({
-        frame: validMiniappBase,
+        miniapp: validMiniappBase,
         accountAssociation: {
           header: 'test-header',
           payload: 'test-payload',
@@ -594,8 +592,8 @@ describe('deprecated frame field fallback', () => {
 
     const result = withValidManifest(manifest);
 
-    // The result should preserve the frame structure when input has frame
-    expect(result).toHaveProperty('frame');
-    expect(result.frame).toEqual(validFrameBase);
+    // The result should always have 'miniapp' field, even when input has 'frame'
+    expect(result).toHaveProperty('miniapp');
+    expect(result.miniapp).toEqual(validFrameBase);
   });
 });

--- a/packages/onchainkit/src/minikit/utils/manifestUtils.ts
+++ b/packages/onchainkit/src/minikit/utils/manifestUtils.ts
@@ -64,10 +64,10 @@ export function withValidManifest<
   }
 
   return {
-    ...rest,
     ...(hasValidAccountAssociation && {
       accountAssociation: manifest.accountAssociation,
     }),
     miniapp: cleanedMiniapp,
+    ...rest,
   } as T;
 }

--- a/packages/onchainkit/src/minikit/utils/manifestUtils.ts
+++ b/packages/onchainkit/src/minikit/utils/manifestUtils.ts
@@ -7,9 +7,10 @@ import type {
 export function withValidManifest<
   T extends MiniAppManifest | LegacyMiniAppManifest,
 >(manifest: T): T {
+  const { accountAssociation, miniapp, frame, ...rest } = manifest;
+
   const miniappObject =
-    ('miniapp' in manifest && manifest.miniapp) ||
-    ('frame' in manifest && manifest.frame);
+    ('miniapp' in manifest && miniapp) || ('frame' in manifest && frame);
 
   // Validate that miniapp object exists
   if (!miniappObject) {
@@ -51,25 +52,19 @@ export function withValidManifest<
   ) as MiniAppFields;
 
   const hasValidAccountAssociation =
-    manifest.accountAssociation &&
-    manifest.accountAssociation.header &&
-    manifest.accountAssociation.payload &&
-    manifest.accountAssociation.signature;
+    accountAssociation &&
+    accountAssociation.header &&
+    accountAssociation.payload &&
+    accountAssociation.signature;
 
-  if (manifest.accountAssociation && !hasValidAccountAssociation) {
+  if (accountAssociation && !hasValidAccountAssociation) {
     console.warn(
       'Invalid manifest accountAssociation. Omitting from manifest.',
     );
   }
 
-  if ('frame' in manifest) {
-    return {
-      ...manifest,
-      frame: cleanedMiniapp,
-    };
-  }
-
   return {
+    ...rest,
     ...(hasValidAccountAssociation && {
       accountAssociation: manifest.accountAssociation,
     }),


### PR DESCRIPTION
**What changed? Why?**

- Allows users to specify additional properties in `withValidManifest`

**Notes to reviewers**

**How has it been tested?**
