### PR TITLE
chore(onchainkit): remove unused sessionId prop from OnchainKitProviderReact

### DIFF
--- a/packages/onchainkit/src/OnchainKitProvider.tsx
+++ b/packages/onchainkit/src/OnchainKitProvider.tsx
@@ -24,7 +24,6 @@ export type OnchainKitProviderReact = {
   chain: Chain;
   children: ReactNode;
   config?: AppConfig;
-  sessionId?: string;
   projectId?: string;
   rpcUrl?: string;
   miniKit?: MiniKitOptions;


### PR DESCRIPTION
Remove the sessionId prop from OnchainKitProviderReact since it was never consumed by OnchainKitProvider and sessionId is generated via useSessionStorage. This aligns the public type with the actual implementation and avoids API confusion. No runtime behavior changes.