### PR TITLE
chore(ci): add Storybook build check workflow

### DIFF
--- a/.github/workflows/storybook-build.yml
+++ b/.github/workflows/storybook-build.yml
@@ -1,0 +1,25 @@
+name: Storybook Build Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  storybook-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Storybook
+        run: pnpm --filter @coinbase/onchainkit run build-storybook


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that runs `pnpm build-storybook` 
to verify Storybook builds successfully on every PR and push.

✅ Helps catch broken stories early  
✅ Keeps UI components in sync  
✅ Follows existing CI conventions in .github/workflows