### PR TITLE
Add Docker setup for local development

### DIFF
--- a/.github/workflows/storybook-build.yml
+++ b/.github/workflows/storybook-build.yml
@@ -1,0 +1,25 @@
+name: Storybook Build Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  storybook-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Storybook
+        run: pnpm --filter @coinbase/onchainkit run build-storybook

--- a/README.md
+++ b/README.md
@@ -139,3 +139,14 @@ Then, you can view the playground at [http://localhost:3000](http://localhost:30
 ## 🌊 License
 
 This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+
+## 🐳 Running with Docker
+
+You can build and run the project locally using Docker without installing Node.js or pnpm manually.
+
+```bash
+# Build the image
+docker build -f tools/docker/Dockerfile -t onchainkit .
+
+# Run the app
+docker run -it --rm -p 3000:3000 onchainkit

--- a/tools/docker/.dockerignore
+++ b/tools/docker/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+build
+.cache
+.git
+.github
+.vscode
+*.log
+*.tsbuildinfo

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+RUN npm install -g pnpm
+
+COPY . .
+
+RUN pnpm install --frozen-lockfile
+
+EXPOSE 3000
+
+CMD ["pnpm", "--filter", "playground", "dev"]


### PR DESCRIPTION
This PR adds a lightweight Docker setup to make it easier for contributors to run the OnchainKit playground and other packages locally without needing to install Node.js or pnpm manually.