### PR TITLE
chore: remove duplicate import

### DIFF
--- a/packages/onchainkit/src/index.ts
+++ b/packages/onchainkit/src/index.ts
@@ -19,5 +19,3 @@ export type {
 import './styles/index.css';
 
 export { Connected } from './connected';
-
-import './styles/index.css';

--- a/packages/onchainkit/src/index.ts
+++ b/packages/onchainkit/src/index.ts
@@ -16,6 +16,7 @@ export type {
   OnchainKitConfig,
   OnchainKitContextType,
 } from './core/types';
-import './styles/index.css';
 
 export { Connected } from './connected';
+
+import './styles/index.css';


### PR DESCRIPTION
**What changed? Why?**

Remove duplicate import ...lol. Feel silly creating this but I was poking around and saw it so 🤷

**Notes to reviewers**

there's a few css branches like `danc/css-scoping-pr-2` with PRs open (was going to just leave this as review comment on PR but wasnt sure if it was stale so - PR here)

**How has it been tested?**

ES modules guarantee the same file is evaluated only once so no harm deleting 