### PR TITLE
docs: add Base quickstart (chain IDs, minimal config, tips)

### DIFF
--- a/docs/base-quickstart.md
+++ b/docs/base-quickstart.md
@@ -1,0 +1,34 @@
+# Base Quickstart for OnchainKit
+
+This short note helps new builders enable **Base** quickly with OnchainKit.
+
+---
+
+## Chain IDs
+- **Base Mainnet**: `8453`
+- **Base Sepolia**: `84532`
+
+---
+
+## Minimal Next.js + wagmi Setup
+```ts
+import { createConfig, http } from 'wagmi'
+import { base, baseSepolia } from 'wagmi/chains'
+
+export const config = createConfig({
+  chains: [base, baseSepolia],
+  transports: {
+    [base.id]: http('https://base-mainnet.g.alchemy.com/v2/<API_KEY>'),
+    [baseSepolia.id]: http('https://sepolia.base.org'),
+  },
+})
+Tips for Base UX
+
+Auto-switch network to Base right after wallet connect
+
+Show explorer links via https://basescan.org
+
+Provide RPC fallback to avoid rate limits
+
+Goal: reduce time-to-first-deploy for Base builders using OnchainKit.
+


### PR DESCRIPTION
Adds a Base-focused quickstart for OnchainKit to speed up onboarding.

**What changed? Why?**
- Added official Base chain IDs (8453 / 84532)
- Included a minimal Next.js + wagmi config snippet
- Added UX tips (auto-switch to Base, BaseScan links, RPC fallback)
→ Goal: reduce time-to-first-deploy for Base builders.

**Notes to reviewers**
- New doc lives at `docs/base-quickstart.md`
- Content is additive; no code paths or packages touched

**How has it been tested?**
- Config snippet validated with wagmi `base` / `baseSepolia`
- Links checked (BaseScan / RPC)
