### PR TITLE
chore: fix fund components to mandate session-token

### DIFF
--- a/packages/onchainkit/src/fund/components/FundButton.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.test.tsx
@@ -218,6 +218,29 @@ describe('FundButton', () => {
     expect(screen.getByText('click')).toBeInTheDocument();
   });
 
+  it('throws when neither sessionToken nor fundingUrl is provided', () => {
+    expect(() =>
+      render(
+        <FundButton
+          fundingUrl={undefined as unknown as string}
+          sessionToken={undefined as unknown as string}
+        />,
+      ),
+    ).toThrow('FundButton requires either sessionToken or fundingUrl');
+  });
+
+  it('renders custom children instead of default content', () => {
+    render(
+      <FundButton fundingUrl="https://funding.url">
+        <span data-testid="customChild">Top Up</span>
+      </FundButton>,
+    );
+    expect(screen.getByTestId('customChild')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('ockFundButtonTextContent'),
+    ).not.toHaveTextContent('Fund');
+  });
+
   it('shows ConnectWallet when no wallet is connected', () => {
     (useAccount as Mock).mockReturnValue({
       address: undefined,

--- a/packages/onchainkit/src/fund/components/FundButton.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.test.tsx
@@ -111,7 +111,7 @@ describe('FundButton', () => {
     (useGetFundingUrl as Mock).mockReturnValue(fundingUrl);
     (getFundingPopupSize as Mock).mockReturnValue({ height, width });
 
-    render(<FundButton />);
+    render(<FundButton sessionToken="test-session-token" />);
 
     expect(useGetFundingUrl).toHaveBeenCalled();
     const buttonElement = screen.getByRole('button');
@@ -148,21 +148,21 @@ describe('FundButton', () => {
   });
 
   it('displays success text when in success state', () => {
-    render(<FundButton state="success" />);
+    render(<FundButton state="success" fundingUrl="https://funding.url" />);
     expect(screen.getByTestId('ockFundButtonTextContent')).toHaveTextContent(
       'Success',
     );
   });
 
   it('displays error text when in error state', () => {
-    render(<FundButton state="error" />);
+    render(<FundButton state="error" fundingUrl="https://funding.url" />);
     expect(screen.getByTestId('ockFundButtonTextContent')).toHaveTextContent(
       'Something went wrong',
     );
   });
 
   it('adds disabled class when the button is disabled', () => {
-    render(<FundButton disabled={true} />);
+    render(<FundButton disabled={true} fundingUrl="https://funding.url" />);
     expect(screen.getByRole('button')).toHaveClass(pressable.disabled);
   });
 
@@ -212,7 +212,9 @@ describe('FundButton', () => {
   });
 
   it('renders custom implementation when render prop is passed', () => {
-    render(<FundButton render={customRender} />);
+    render(
+      <FundButton render={customRender} fundingUrl="https://funding.url" />,
+    );
     expect(screen.getByText('click')).toBeInTheDocument();
   });
 
@@ -221,7 +223,9 @@ describe('FundButton', () => {
       address: undefined,
     });
 
-    render(<FundButton className="custom-class" />);
+    render(
+      <FundButton className="custom-class" fundingUrl="https://funding.url" />,
+    );
 
     expect(
       screen.queryByTestId('ockConnectWallet_Container'),
@@ -230,7 +234,7 @@ describe('FundButton', () => {
   });
 
   it('shows Fund button when wallet is connected', () => {
-    render(<FundButton />);
+    render(<FundButton fundingUrl="https://funding.url" />);
 
     expect(screen.queryByTestId('ockFundButton')).toBeInTheDocument();
     expect(
@@ -305,7 +309,7 @@ describe('FundButton', () => {
     });
 
     it('does not send analytics when button is disabled', () => {
-      render(<FundButton disabled={true} />);
+      render(<FundButton disabled={true} fundingUrl="https://funding.url" />);
 
       const buttonElement = screen.getByRole('button');
       fireEvent.click(buttonElement);
@@ -316,7 +320,7 @@ describe('FundButton', () => {
     it('does not send analytics when no funding URL is available', () => {
       (useGetFundingUrl as Mock).mockReturnValue(undefined);
 
-      render(<FundButton />);
+      render(<FundButton sessionToken="test-session-token" />);
 
       const buttonElement = screen.getByRole('button');
       fireEvent.click(buttonElement);

--- a/packages/onchainkit/src/fund/components/FundButton.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.test.tsx
@@ -238,7 +238,7 @@ describe('FundButton', () => {
     expect(screen.getByTestId('customChild')).toBeInTheDocument();
     expect(
       screen.queryByTestId('ockFundButtonTextContent'),
-    ).not.toHaveTextContent('Fund');
+    ).not.toBeInTheDocument();
   });
 
   it('shows ConnectWallet when no wallet is connected', () => {

--- a/packages/onchainkit/src/fund/components/FundButton.tsx
+++ b/packages/onchainkit/src/fund/components/FundButton.tsx
@@ -32,6 +32,10 @@ export function FundButton({
   render,
   sessionToken,
 }: FundButtonProps) {
+  // Ensure a funding source is provided
+  if (!fundingUrl && !sessionToken) {
+    throw new Error('FundButton requires either sessionToken or fundingUrl');
+  }
   // If the fundingUrl prop is undefined, fallback to our recommended funding URL based on the wallet type
   const fallbackFundingUrl = useGetFundingUrl({
     fiatCurrency,

--- a/packages/onchainkit/src/fund/components/FundCard.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundCard.test.tsx
@@ -105,11 +105,13 @@ const renderComponent = async (presetAmountInputs?: PresetAmountInputs) => {
       <FundCardProvider
         asset="BTC"
         country="US"
+        sessionToken="test-session-token"
         presetAmountInputs={presetAmountInputs}
       >
         <FundCard
           assetSymbol="BTC"
           country="US"
+          sessionToken="test-session-token"
           presetAmountInputs={presetAmountInputs}
         />
         <TestComponent />
@@ -287,7 +289,11 @@ describe('FundCard', () => {
   it('renders custom children instead of default children', async () => {
     await act(async () => {
       render(
-        <FundCard assetSymbol="ETH" country="US">
+        <FundCard
+          assetSymbol="ETH"
+          country="US"
+          sessionToken="test-session-token"
+        >
           <div data-testid="custom-child">Custom Content</div>
         </FundCard>,
       );

--- a/packages/onchainkit/src/fund/components/FundCard.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundCard.test.tsx
@@ -2,7 +2,7 @@ import { setOnchainKitConfig } from '@/core/OnchainKitConfig';
 import { openPopup } from '@/internal/utils/openPopup';
 import '@testing-library/jest-dom';
 import { act } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
 import { useFundCardFundingUrl } from '../hooks/useFundCardFundingUrl';
@@ -12,7 +12,7 @@ import { fetchOnrampOptions } from '../utils/fetchOnrampOptions';
 import { fetchOnrampQuote } from '../utils/fetchOnrampQuote';
 import { getFundingPopupSize } from '../utils/getFundingPopupSize';
 import { FundCard } from './FundCard';
-import { FundCardProvider, useFundContext } from './FundCardProvider';
+import { useFundContext } from './FundCardProvider';
 
 const mockUpdateInputWidth = vi.fn();
 vi.mock('../../internal/hooks/useInputResize', () => ({
@@ -61,63 +61,14 @@ vi.mock('../../wallet/components/ConnectWallet', () => ({
   ),
 }));
 
-// Test component to access context values
-const TestComponent = () => {
-  const {
-    fundAmountFiat,
-    fundAmountCrypto,
-    exchangeRate,
-    exchangeRateLoading,
-    setFundAmountFiat,
-    setSelectedInputType,
-  } = useFundContext();
-
+// Probe component to read context provided by FundCard's internal provider
+const ContextProbe = () => {
+  const context = useFundContext();
   return (
     <div>
-      <span data-testid="test-value-fiat">{fundAmountFiat}</span>
-      <span data-testid="test-value-crypto">{fundAmountCrypto}</span>
-      <span data-testid="test-value-exchange-rate">{exchangeRate}</span>
-      <span data-testid="loading-state">
-        {exchangeRateLoading ? 'loading' : 'not-loading'}
-      </span>
-      <button
-        type="button"
-        data-testid="set-fiat-amount"
-        onClick={() => setFundAmountFiat('100')}
-      />
-      <button
-        type="button"
-        data-testid="set-crypto-input-type"
-        onClick={() => setSelectedInputType('crypto')}
-      />
-      <button
-        type="button"
-        data-testid="set-fiat-input-type"
-        onClick={() => setSelectedInputType('fiat')}
-      />
+      <span data-testid="session-token-probe">{context.sessionToken}</span>
     </div>
   );
-};
-
-const renderComponent = async (presetAmountInputs?: PresetAmountInputs) => {
-  await act(async () => {
-    render(
-      <FundCardProvider
-        asset="BTC"
-        country="US"
-        sessionToken="test-session-token"
-        presetAmountInputs={presetAmountInputs}
-      >
-        <FundCard
-          assetSymbol="BTC"
-          country="US"
-          sessionToken="test-session-token"
-          presetAmountInputs={presetAmountInputs}
-        />
-        <TestComponent />
-      </FundCardProvider>,
-    );
-  });
 };
 
 describe('FundCard', () => {
@@ -137,28 +88,75 @@ describe('FundCard', () => {
     });
   });
 
+  it('throws when sessionToken is missing or empty', () => {
+    expect(() =>
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken={undefined as unknown as string}
+        />,
+      ),
+    ).toThrow('FundCard requires a sessionToken');
+    expect(() =>
+      render(<FundCard assetSymbol="BTC" country="US" sessionToken="" />),
+    ).toThrow('FundCard requires a sessionToken');
+  });
+
   it('renders without crashing', async () => {
-    await renderComponent();
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
+      );
+    });
     expect(screen.getByTestId('ockFundCardHeader')).toBeInTheDocument();
     expect(screen.getByTestId('ockFundButtonTextContent')).toBeInTheDocument();
   });
 
   it('displays the correct header text', async () => {
-    await renderComponent();
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
+      );
+    });
     expect(screen.getByTestId('ockFundCardHeader')).toHaveTextContent(
       'Buy BTC',
     );
   });
 
   it('displays the correct button text', async () => {
-    await renderComponent();
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
+      );
+    });
     expect(screen.getByTestId('ockFundButtonTextContent')).toHaveTextContent(
       'Buy',
     );
   });
 
   it('handles input changes for fiat amount', async () => {
-    await renderComponent();
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
+      );
+    });
 
     const input = screen.getByTestId('ockTextInput_Input') as HTMLInputElement;
 
@@ -170,120 +168,127 @@ describe('FundCard', () => {
   });
 
   it('switches input type from fiat to crypto', async () => {
-    await renderComponent();
-
-    await waitFor(() => {
-      const switchButton = screen.getByTestId('ockAmountTypeSwitch');
-      fireEvent.click(switchButton);
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
+      );
     });
+
+    const switchButton = screen.getByTestId('ockAmountTypeSwitch');
+    fireEvent.click(switchButton);
 
     expect(screen.getByTestId('ockCurrencySpan')).toHaveTextContent('BTC');
   });
 
-  it('disables the submit button when fund amount is zero and type is fiat', async () => {
-    await renderComponent();
-    const setFiatAmountButton = screen.getByTestId('set-fiat-amount');
-    fireEvent.click(setFiatAmountButton);
-
+  it('disables the submit button by default (zero amount, fiat)', async () => {
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
+      );
+    });
     const button = screen.getByTestId('ockFundButton');
     expect(button).toBeDisabled();
   });
 
   it('disables the submit button when fund amount is zero and input type is crypto', async () => {
-    await renderComponent();
-    const setCryptoInputTypeButton = screen.getByTestId(
-      'set-crypto-input-type',
-    );
-    fireEvent.click(setCryptoInputTypeButton);
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
+      );
+    });
+    const switchButton = screen.getByTestId('ockAmountTypeSwitch');
+    fireEvent.click(switchButton);
 
     const button = screen.getByTestId('ockFundButton');
     expect(button).toBeDisabled();
   });
 
   it('enables the submit button when fund amount is greater than zero and type is fiat', async () => {
-    await renderComponent();
-    const setFiatAmountButton = screen.getByTestId('set-fiat-amount');
-    fireEvent.click(setFiatAmountButton);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-state').textContent).toBe(
-        'not-loading',
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
       );
-      const input = screen.getByTestId('ockTextInput_Input');
-      fireEvent.change(input, { target: { value: '1000' } });
-
-      const button = screen.getByTestId('ockFundButton');
-      expect(button).not.toBeDisabled();
     });
+    const input = screen.getByTestId('ockTextInput_Input');
+    fireEvent.change(input, { target: { value: '1000' } });
+    const button = screen.getByTestId('ockFundButton');
+    expect(button).not.toBeDisabled();
   });
 
   it('enables the submit button when fund amount is greater than zero and type is crypto', async () => {
-    await renderComponent();
-    const setCryptoInputTypeButton = screen.getByTestId(
-      'set-crypto-input-type',
-    );
-    fireEvent.click(setCryptoInputTypeButton);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-state').textContent).toBe(
-        'not-loading',
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
       );
-      const input = screen.getByTestId('ockTextInput_Input');
-      fireEvent.change(input, { target: { value: '1000' } });
-
-      const button = screen.getByTestId('ockFundButton');
-      expect(button).not.toBeDisabled();
     });
+    const switchButton = screen.getByTestId('ockAmountTypeSwitch');
+    fireEvent.click(switchButton);
+    const input = screen.getByTestId('ockTextInput_Input');
+    fireEvent.change(input, { target: { value: '1000' } });
+    const button = screen.getByTestId('ockFundButton');
+    expect(button).not.toBeDisabled();
   });
 
   it('shows loading state when submitting', async () => {
-    await renderComponent();
-
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-state').textContent).toBe(
-        'not-loading',
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
       );
-      const input = screen.getByTestId('ockTextInput_Input');
-
-      fireEvent.change(input, { target: { value: '1000' } });
-
-      const button = screen.getByTestId('ockFundButton');
-
-      expect(screen.queryByTestId('ockSpinner')).not.toBeInTheDocument();
-      act(() => {
-        fireEvent.click(button);
-      });
-
-      expect(screen.getByTestId('ockSpinner')).toBeInTheDocument();
     });
+    const input = screen.getByTestId('ockTextInput_Input');
+    fireEvent.change(input, { target: { value: '1000' } });
+    const button = screen.getByTestId('ockFundButton');
+    expect(screen.queryByTestId('ockSpinner')).not.toBeInTheDocument();
+    act(() => {
+      fireEvent.click(button);
+    });
+    expect(screen.getByTestId('ockSpinner')).toBeInTheDocument();
   });
 
   it('sets submit button state to default on popup close', async () => {
     (openPopup as Mock).mockImplementation(() => ({ closed: true }));
 
-    await renderComponent();
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        />,
+      );
+    });
 
     const button = screen.getByTestId('ockFundButton');
 
-    const submitButton = screen.getByTestId('ockFundButton');
-
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-state').textContent).toBe(
-        'not-loading',
-      );
-
-      // Simulate entering a valid amount
-      const input = screen.getByTestId(
-        'ockTextInput_Input',
-      ) as HTMLInputElement;
-
-      fireEvent.change(input, { target: { value: '100' } });
-
-      fireEvent.click(button);
-
-      // Assert that the submit button state is set to 'default'
-      expect(submitButton).not.toBeDisabled();
-    });
+    const input = screen.getByTestId('ockTextInput_Input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '100' } });
+    fireEvent.click(button);
+    // After popup close, state should reset, button should be enabled again
+    expect(screen.getByTestId('ockFundButton')).not.toBeDisabled();
   });
 
   it('renders custom children instead of default children', async () => {
@@ -306,59 +311,37 @@ describe('FundCard', () => {
   it('handles preset amount input click correctly', async () => {
     const presetAmountInputs: PresetAmountInputs = ['12345', '20', '30'];
 
-    await renderComponent(presetAmountInputs);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-state').textContent).toBe(
-        'not-loading',
+    await act(async () => {
+      render(
+        <FundCard
+          assetSymbol="BTC"
+          country="US"
+          sessionToken="test-session-token"
+          presetAmountInputs={presetAmountInputs}
+        />,
       );
-
-      // Click the preset amount input
-      const presetAmountInput = screen.getByText('$12,345');
-
-      // Verify the input value was updated
-      expect(presetAmountInput).toBeInTheDocument();
     });
+
+    // Click the preset amount input
+    const presetAmountInput = screen.getByText('$12,345');
+    expect(presetAmountInput).toBeInTheDocument();
+    fireEvent.click(presetAmountInput);
+    const input = screen.getByTestId('ockTextInput_Input') as HTMLInputElement;
+    expect(input.value.replace(/,/g, '')).toBe('12345');
   });
 
-  it('passes sessionToken to FundCardProvider', async () => {
+  it('exposes sessionToken via context to children', async () => {
     const sessionToken = 'test-session-token';
     await act(async () => {
       render(
         <FundCard assetSymbol="ETH" country="US" sessionToken={sessionToken}>
-          <TestComponent />
+          <ContextProbe />
         </FundCard>,
       );
     });
 
-    // Verify the component renders correctly with sessionToken
-    await waitFor(() => {
-      expect(screen.getByTestId('loading-state').textContent).toBe(
-        'not-loading',
-      );
-    });
-  });
-
-  it('handles sessionToken correctly in FundCardProvider context', async () => {
-    const sessionToken = 'test-session-token';
-    const TestSessionComponent = () => {
-      const context = useFundContext();
-      return <div data-testid="session-token">{context.sessionToken}</div>;
-    };
-
-    await act(async () => {
-      render(
-        <FundCardProvider
-          asset="ETH"
-          country="US"
-          currency="USD"
-          sessionToken={sessionToken}
-        >
-          <TestSessionComponent />
-        </FundCardProvider>,
-      );
-    });
-
-    expect(screen.getByTestId('session-token').textContent).toBe(sessionToken);
+    expect(screen.getByTestId('session-token-probe').textContent).toBe(
+      sessionToken,
+    );
   });
 });

--- a/packages/onchainkit/src/fund/components/FundCard.tsx
+++ b/packages/onchainkit/src/fund/components/FundCard.tsx
@@ -14,6 +14,7 @@ import { FundCardSubmitButton } from './FundCardSubmitButton';
 
 export function FundCard({
   assetSymbol,
+  sessionToken,
   buttonText = 'Buy',
   headerText,
   country = 'US',
@@ -25,7 +26,6 @@ export function FundCard({
   onError,
   onStatus,
   onSuccess,
-  sessionToken,
 }: FundCardProps) {
   return (
     <FundCardProvider

--- a/packages/onchainkit/src/fund/components/FundCard.tsx
+++ b/packages/onchainkit/src/fund/components/FundCard.tsx
@@ -27,6 +27,10 @@ export function FundCard({
   onStatus,
   onSuccess,
 }: FundCardProps) {
+  // Ensure a session token is provided
+  if (!sessionToken) {
+    throw new Error('FundCard requires a sessionToken');
+  }
   return (
     <FundCardProvider
       asset={assetSymbol}

--- a/packages/onchainkit/src/fund/components/FundCardProvider.test.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardProvider.test.tsx
@@ -49,7 +49,11 @@ describe('FundCardProvider', () => {
       const { result } = await act(async () =>
         renderHook(() => useFundContext(), {
           wrapper: ({ children }) => (
-            <FundCardProvider asset="ETH" country="US">
+            <FundCardProvider
+              asset="ETH"
+              country="US"
+              sessionToken="test-session-token"
+            >
               {children}
             </FundCardProvider>
           ),
@@ -73,7 +77,11 @@ describe('FundCardProvider', () => {
       const { result } = await act(async () =>
         renderHook(() => useFundContext(), {
           wrapper: ({ children }) => (
-            <FundCardProvider asset="ETH" country="US">
+            <FundCardProvider
+              asset="ETH"
+              country="US"
+              sessionToken="test-session-token"
+            >
               {children}
             </FundCardProvider>
           ),
@@ -91,7 +99,11 @@ describe('FundCardProvider', () => {
       const { result } = await act(async () =>
         renderHook(() => useFundContext(), {
           wrapper: ({ children }) => (
-            <FundCardProvider asset="ETH" country="US">
+            <FundCardProvider
+              asset="ETH"
+              country="US"
+              sessionToken="test-session-token"
+            >
               {children}
             </FundCardProvider>
           ),
@@ -122,7 +134,12 @@ describe('FundCardProvider', () => {
       const { result } = await act(async () =>
         renderHook(() => useFundContext(), {
           wrapper: ({ children }) => (
-            <FundCardProvider asset="ETH" country="GB" currency="GBP">
+            <FundCardProvider
+              asset="ETH"
+              country="GB"
+              currency="GBP"
+              sessionToken="test-session-token"
+            >
               {children}
             </FundCardProvider>
           ),
@@ -146,7 +163,11 @@ describe('FundCardProvider', () => {
   it('provides default context values', async () => {
     await act(async () => {
       render(
-        <FundCardProvider asset="BTC" country="US">
+        <FundCardProvider
+          asset="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        >
           <TestComponent />
         </FundCardProvider>,
       );
@@ -157,7 +178,11 @@ describe('FundCardProvider', () => {
   it('fetches and sets exchange rate on mount', async () => {
     act(() => {
       render(
-        <FundCardProvider asset="BTC" country="US">
+        <FundCardProvider
+          asset="BTC"
+          country="US"
+          sessionToken="test-session-token"
+        >
           <TestComponent />
         </FundCardProvider>,
       );
@@ -203,7 +228,12 @@ describe('FundCardProvider', () => {
     global.fetch = vi.fn(() => Promise.reject(mockError)) as Mock;
 
     render(
-      <FundCardProvider asset="ETH" country="US" onError={mockOnError}>
+      <FundCardProvider
+        asset="ETH"
+        country="US"
+        onError={mockOnError}
+        sessionToken="test-session-token"
+      >
         <TestComponent />
       </FundCardProvider>,
     );

--- a/packages/onchainkit/src/fund/components/FundCardProvider.tsx
+++ b/packages/onchainkit/src/fund/components/FundCardProvider.tsx
@@ -25,6 +25,7 @@ import type {
 type FundCardContextType = {
   asset: string;
   currency: string;
+  sessionToken: string; // REQUIRED session token used to create funding url upon submit button click
   selectedPaymentMethod?: PaymentMethod;
   setSelectedPaymentMethod: (paymentMethod: PaymentMethod) => void;
   selectedInputType: AmountInputType;
@@ -48,7 +49,6 @@ type FundCardContextType = {
   country: string;
   subdivision?: string;
   inputType?: 'fiat' | 'crypto';
-  sessionToken?: string;
   lifecycleStatus: LifecycleStatus;
 
   presetAmountInputs?: PresetAmountInputs;

--- a/packages/onchainkit/src/fund/hooks/useFundCardFundingUrl.test.ts
+++ b/packages/onchainkit/src/fund/hooks/useFundCardFundingUrl.test.ts
@@ -20,33 +20,10 @@ describe('useFundCardFundingUrl', () => {
     vi.resetAllMocks();
   });
 
-  it('should return undefined if projectId is null', () => {
-    (useFundContext as Mock).mockReturnValue({
-      selectedPaymentMethod: { id: 'FIAT_WALLET' },
-      selectedInputType: 'fiat',
-      fundAmountFiat: '100',
-      fundAmountCrypto: '0',
-      asset: 'ETH',
-    });
+  // With sessionToken required in FundCard flow, the URL is always constructed with it
+  // These tests assert the URL contains sessionToken and correct amount param
 
-    const { result } = renderHook(() => useFundCardFundingUrl());
-    expect(result.current).toBeUndefined();
-  });
-
-  it('should return undefined if address is undefined', () => {
-    (useFundContext as Mock).mockReturnValue({
-      selectedPaymentMethod: { id: 'FIAT_WALLET' },
-      selectedInputType: 'fiat',
-      fundAmountFiat: '100',
-      fundAmountCrypto: '0',
-      asset: 'ETH',
-    });
-
-    const { result } = renderHook(() => useFundCardFundingUrl());
-    expect(result.current).toBeUndefined();
-  });
-
-  it('should return valid URL when input type is fiat', () => {
+  it('should return valid URL with sessionToken when input type is fiat', () => {
     (useFundContext as Mock).mockReturnValue({
       sessionToken: 'sessionToken',
       selectedPaymentMethod: { id: 'FIAT_WALLET' },
@@ -54,13 +31,15 @@ describe('useFundCardFundingUrl', () => {
       fundAmountFiat: '100',
       fundAmountCrypto: '0',
       asset: 'ETH',
+      currency: 'USD',
     });
 
     const { result } = renderHook(() => useFundCardFundingUrl());
+    expect(result.current).toContain('sessionToken=sessionToken');
     expect(result.current).toContain('presetFiatAmount=100');
   });
 
-  it('should return valid URL when input type is crypto', () => {
+  it('should return valid URL with sessionToken when input type is crypto', () => {
     (useFundContext as Mock).mockReturnValue({
       sessionToken: 'sessionToken',
       selectedPaymentMethod: { id: 'CRYPTO_WALLET' },
@@ -68,9 +47,11 @@ describe('useFundCardFundingUrl', () => {
       fundAmountFiat: '0',
       fundAmountCrypto: '1.5',
       asset: 'ETH',
+      currency: 'USD',
     });
 
     const { result } = renderHook(() => useFundCardFundingUrl());
+    expect(result.current).toContain('sessionToken=sessionToken');
     expect(result.current).toContain('presetCryptoAmount=1.5');
   });
 });

--- a/packages/onchainkit/src/fund/hooks/useFundCardFundingUrl.ts
+++ b/packages/onchainkit/src/fund/hooks/useFundCardFundingUrl.ts
@@ -12,10 +12,6 @@ export const useFundCardFundingUrl = () => {
     sessionToken,
   } = useFundContext();
   return useMemo(() => {
-    if (!sessionToken) {
-      return undefined;
-    }
-
     const fundAmount =
       selectedInputType === 'fiat' ? fundAmountFiat : fundAmountCrypto;
 

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -354,6 +354,7 @@ export type FundCardPaymentMethodDropdownProps = {
  * Note: exported as public Type
  */
 export type FundCardProps = {
+  sessionToken: string; // REQUIRED session token used to create funding url upon submit button click
   children?: ReactNode;
   assetSymbol: string;
   placeholder?: string | React.ReactNode;
@@ -364,7 +365,6 @@ export type FundCardProps = {
   currency?: string;
   className?: string;
   presetAmountInputs?: PresetAmountInputs;
-  sessionToken?: string;
 } & LifecycleEvents;
 
 export type FundCardContentProps = {
@@ -391,6 +391,7 @@ export type FundCardPaymentMethodSelectRowProps = {
 export type FundCardProviderProps = {
   children: ReactNode;
   asset: string;
+  sessionToken: string; // REQUIRED session token used to create funding url upon submit button click
   /**
    * Three letter currency code. Defaults to USD.
    */
@@ -402,7 +403,6 @@ export type FundCardProviderProps = {
   subdivision?: string;
   inputType?: AmountInputType;
   presetAmountInputs?: PresetAmountInputs;
-  sessionToken?: string;
 } & LifecycleEvents;
 
 export type LifecycleEvents = {

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -75,8 +75,6 @@ type FundButtonBaseProps = {
   disabled?: boolean;
   /* The state of the button component */
   state?: FundButtonState;
-  /* An optional prop to provide a custom funding URL */
-  fundingUrl?: string;
   /* Whether to open the funding flow in a tab or a popup window */
   openIn?: 'popup' | 'tab';
   /**
@@ -93,8 +91,6 @@ type FundButtonBaseProps = {
   onPopupClose?: () => void;
   /* A callback function that will be called when the button is clicked */
   onClick?: () => void;
-  /* An optional prop to provide a session token */
-  sessionToken?: string;
 };
 
 export type FundButtonRenderParams = {
@@ -106,20 +102,27 @@ export type FundButtonRenderParams = {
   isDisabled: boolean;
 };
 
+// Require at least one funding source for FundButton
+type FundButtonSourceProps =
+  | { fundingUrl: string; sessionToken?: string }
+  | { sessionToken: string; fundingUrl?: string };
+
 /**
  * Note: exported as public Type
  */
 export type FundButtonProps =
-  | (FundButtonBaseProps & {
-      render?: (props: FundButtonRenderParams) => React.ReactNode;
-      /* An optional React node to be displayed in the button component */
-      children?: never;
-    })
-  | (FundButtonBaseProps & {
-      render?: never;
-      /* An optional React node to be displayed in the button component */
-      children?: ReactNode;
-    });
+  | (FundButtonBaseProps &
+      FundButtonSourceProps & {
+        render?: (props: FundButtonRenderParams) => React.ReactNode;
+        /* An optional React node to be displayed in the button component */
+        children?: never;
+      })
+  | (FundButtonBaseProps &
+      FundButtonSourceProps & {
+        render?: never;
+        /* An optional React node to be displayed in the button component */
+        children?: ReactNode;
+      });
 
 /**
  * Note: exported as public Type

--- a/packages/onchainkit/src/fund/types.ts
+++ b/packages/onchainkit/src/fund/types.ts
@@ -69,8 +69,6 @@ type GetOnrampBuyUrlOptionalProps = {
 type FundButtonBaseProps = {
   /* An optional CSS class name for styling the button component */
   className?: string;
-  /* An optional React node to be displayed in the button component */
-  children?: ReactNode;
   /* A optional prop to disable the fund button */
   disabled?: boolean;
   /* The state of the button component */
@@ -93,6 +91,23 @@ type FundButtonBaseProps = {
   onClick?: () => void;
 };
 
+// Require exactly one funding source for FundButton (not both)
+type FundButtonSourceProps =
+  | { fundingUrl: string; sessionToken?: string }
+  | { sessionToken: string; fundingUrl?: string };
+
+type FundButtonRenderProps =
+  | {
+      render?: (props: FundButtonRenderParams) => React.ReactNode;
+      /* An optional React node to be displayed in the button component */
+      children?: never;
+    }
+  | {
+      render?: never;
+      /* An optional React node to be displayed in the button component */
+      children?: ReactNode;
+    };
+
 export type FundButtonRenderParams = {
   /* The state of the button component, only relevant when using FundCardSubmitButton */
   status: FundButtonState;
@@ -102,27 +117,12 @@ export type FundButtonRenderParams = {
   isDisabled: boolean;
 };
 
-// Require at least one funding source for FundButton
-type FundButtonSourceProps =
-  | { fundingUrl: string; sessionToken?: string }
-  | { sessionToken: string; fundingUrl?: string };
-
 /**
  * Note: exported as public Type
  */
-export type FundButtonProps =
-  | (FundButtonBaseProps &
-      FundButtonSourceProps & {
-        render?: (props: FundButtonRenderParams) => React.ReactNode;
-        /* An optional React node to be displayed in the button component */
-        children?: never;
-      })
-  | (FundButtonBaseProps &
-      FundButtonSourceProps & {
-        render?: never;
-        /* An optional React node to be displayed in the button component */
-        children?: ReactNode;
-      });
+export type FundButtonProps = FundButtonBaseProps &
+  FundButtonSourceProps &
+  FundButtonRenderProps;
 
 /**
  * Note: exported as public Type

--- a/packages/playground/components/demo/FundButton.tsx
+++ b/packages/playground/components/demo/FundButton.tsx
@@ -3,7 +3,7 @@ import { FundButton } from '@coinbase/onchainkit/fund';
 export default function FundButtonDemo() {
   return (
     <div className="mx-auto grid w-1/2 gap-8">
-      <FundButton />
+      <FundButton sessionToken="demo-session-token" />
     </div>
   );
 }


### PR DESCRIPTION
**What changed? Why?**

Making session token required upon compilation time for FundCard. Making either session token or funding URL required for FundButton component

**Notes to reviewers**

**How has it been tested?**
