### PR TITLE
fix: mandate session-token regular expression injection

### DIFF
--- a/packages/onchainkit/package.json
+++ b/packages/onchainkit/package.json
@@ -47,7 +47,8 @@
     "graphql-request": "^6.1.0",
     "qrcode": "^1.5.4",
     "tailwind-merge": "^3.2.0",
-    "usehooks-ts": "^3.1.1"
+    "usehooks-ts": "^3.1.1",
+    "lodash.escaperegexp": "^4.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.26.10",

--- a/packages/onchainkit/scripts/publish-prerelease.js
+++ b/packages/onchainkit/scripts/publish-prerelease.js
@@ -3,6 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import process from 'process';
 import { fileURLToPath } from 'url';
+import escapeRegExp from 'lodash.escaperegexp';
 import * as core from '@actions/core';
 
 const DIST_TAGS_URL =
@@ -114,7 +115,8 @@ export function getNextVersionNumber({
     return nextVersionAtTagZero;
   }
 
-  const [tagBase, tagCount] = currentTagVersion.split(new RegExp(`-${tag}\\.`));
+  const escapedTag = escapeRegExp(tag);
+  const [tagBase, tagCount] = currentTagVersion.split(new RegExp(`-${escapedTag}\\.`));
 
   // If the base version is the same as the current tag version...
   if (baseVersion === tagBase) {


### PR DESCRIPTION
https://github.com/coinbase/onchainkit/blob/de893d77b33de6f7d47bc1aadc3f9516c9fd046c/packages/onchainkit/scripts/publish-prerelease.js#L117
fix this issue, we need to ensure that the value of `tag`—which is passed from user input via `process.argv`—is properly escaped for use in a regular expression. The recommended, reliable way to do this is to use a well-established sanitization helper, such as Lodash's `escapeRegExp` function. As Lodash is a mainstream dependency, it's safe and reasonable to add it as an import to this script. 

The fix involves:
- Adding an import for Lodash (ideally just `escapeRegExp` to keep the import minimal).
- Escaping `tag` before incorporating it into the regex in line 117. Assign the result to a local variable (e.g., `escapedTag`).
- Use this sanitized `escapedTag` in the regex construction.

These edits should be made within the `getNextVersionNumber` function in `packages/onchainkit/scripts/publish-prerelease.js`. 