### PR TITLE
BUGFIX: Add `baseBuilder` property in MiniAppManifest type and let it include in `withValidManifest`

### DIFF
--- a/packages/onchainkit/src/minikit/utils/manifestUtils.test.ts
+++ b/packages/onchainkit/src/minikit/utils/manifestUtils.test.ts
@@ -460,6 +460,98 @@ describe('withValidManifest', () => {
     });
   });
 
+  describe('baseBuilder handling', () => {
+    it('should omit baseBuilder when ownerAddress is missing', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const manifest: MiniAppManifest = {
+        miniapp: validMiniappBase,
+        baseBuilder: {
+          ownerAddress: undefined as unknown as string,
+        },
+      };
+
+      const result = withValidManifest(manifest);
+      expect(result.baseBuilder).toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Invalid manifest baseBuilder. Omitting from manifest.',
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should omit baseBuilder when ownerAddress is empty string', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const manifest: MiniAppManifest = {
+        miniapp: validMiniappBase,
+        baseBuilder: {
+          ownerAddress: '',
+        },
+      };
+
+      const result = withValidManifest(manifest);
+      expect(result.baseBuilder).toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Invalid manifest baseBuilder. Omitting from manifest.',
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should not warn when baseBuilder is not provided', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const manifest: MiniAppManifest = {
+        miniapp: validMiniappBase,
+      };
+
+      const result = withValidManifest(manifest);
+      expect(result.baseBuilder).toBeUndefined();
+      expect(consoleSpy).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should include baseBuilder when ownerAddress is present', () => {
+      const manifest: MiniAppManifest = {
+        miniapp: validMiniappBase,
+        baseBuilder: {
+          ownerAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        },
+      };
+
+      const result = withValidManifest(manifest);
+      expect(result.baseBuilder).toEqual({
+        ownerAddress: '0x1234567890abcdef1234567890abcdef12345678',
+      });
+    });
+
+    it('should include baseBuilder alongside accountAssociation', () => {
+      const manifest: MiniAppManifest = {
+        miniapp: validMiniappBase,
+        accountAssociation: {
+          header: 'test-header',
+          payload: 'test-payload',
+          signature: 'test-signature',
+        },
+        baseBuilder: {
+          ownerAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        },
+      };
+
+      const result = withValidManifest(manifest);
+      expect(result.accountAssociation).toEqual({
+        header: 'test-header',
+        payload: 'test-payload',
+        signature: 'test-signature',
+      });
+      expect(result.baseBuilder).toEqual({
+        ownerAddress: '0x1234567890abcdef1234567890abcdef12345678',
+      });
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle all primaryCategory values', () => {
       const categories = [

--- a/packages/onchainkit/src/minikit/utils/manifestUtils.ts
+++ b/packages/onchainkit/src/minikit/utils/manifestUtils.ts
@@ -7,7 +7,7 @@ import type {
 export function withValidManifest<
   T extends MiniAppManifest | LegacyMiniAppManifest,
 >(manifest: T): T {
-  const { accountAssociation, miniapp, frame, ...rest } = manifest;
+  const { accountAssociation, miniapp, frame, baseBuilder, ...rest } = manifest as MiniAppManifest & LegacyMiniAppManifest;
 
   const miniappObject =
     ('miniapp' in manifest && miniapp) || ('frame' in manifest && frame);
@@ -63,11 +63,20 @@ export function withValidManifest<
     );
   }
 
+  const hasValidBaseBuilder = baseBuilder && baseBuilder.ownerAddress;
+
+  if (baseBuilder && !hasValidBaseBuilder) {
+    console.warn('Invalid manifest baseBuilder. Omitting from manifest.');
+  }
+
   return {
     ...(hasValidAccountAssociation && {
       accountAssociation: manifest.accountAssociation,
     }),
     miniapp: cleanedMiniapp,
+    ...(hasValidBaseBuilder && {
+      baseBuilder: (manifest as MiniAppManifest).baseBuilder,
+    }),
     ...rest,
   } as T;
 }

--- a/packages/onchainkit/src/minikit/utils/types.ts
+++ b/packages/onchainkit/src/minikit/utils/types.ts
@@ -48,9 +48,14 @@ export type MiniAppFields = {
   buttonTitle?: string;
 };
 
+export type BaseBuilderFields = {
+  ownerAddress: string;
+}
+
 export type MiniAppManifest = {
   accountAssociation?: AccountAssociationFields;
   miniapp: MiniAppFields;
+  baseBuilder?: BaseBuilderFields;
   frame?: never;
 };
 


### PR DESCRIPTION
**What changed? Why?**
Resolved #2512 
On the miniapp registration page on base.dev, you’re required to add `baseBuilders.ownerAddress` to `manifest.json`, but it’s being omitted by `withValidManifest()`.
![basedev_registerminiapp](https://github.com/user-attachments/assets/15c6ac16-5f83-4368-bc52-4155342d55ac)

Added `baseBuilder` field support to `MiniAppManifest`.
- Added new `BaseBuilderFields` type with `ownerAddress` as a required field
- Implemented `baseBuilder` validation in `withValidManifest` function
  - Only includes `baseBuilder` in manifest when `ownerAddress` is present
  - Logs a warning and omits from manifest when invalid

**Notes to reviewers**
Follows the same validation pattern as `accountAssociation`. When `baseBuilder` is provided but `ownerAddress` is empty/undefined, it logs a warning and omits from the manifest.

**How has it been tested?**
Added unit tests for `baseBuilder` handling:
- Verifies omission when `ownerAddress` is undefined/empty string
- Verifies no warning when `baseBuilder` is not provided
- Verifies inclusion when valid `ownerAddress` is present
- Verifies `accountAssociation` and `baseBuilder` can coexist
