### PR TITLE
chore(license): update year to 2026

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Coinbase
+Copyright (c) 2026 Coinbase
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
New Year Update!

This PR updates the copyright year from 2025 to 2026 in the license files.

Happy coding in 2026!