### PR TITLE
docs: add OnchainKitProvider setup guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,53 @@
 
 Run `npm create onchain` to bootstrap an example onchain app with all the batteries included.
 
+## ⚙️ OnchainKitProvider Setup
+
+Wrap your app with `OnchainKitProvider` to enable OnchainKit components:
+
+```tsx
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains';
+
+<OnchainKitProvider
+  chain={base}                    // Required: Target chain
+  apiKey="YOUR_CDP_API_KEY"       // Recommended: Enables Paymaster, Identity, etc.
+>
+  {children}
+</OnchainKitProvider>
+```
+
+### Configuration Options
+
+| Prop | Required | Description |
+|------|----------|-------------|
+| `chain` | ✅ Yes | Target chain (e.g., `base`, `baseSepolia` from `wagmi/chains`) |
+| `children` | ✅ Yes | Your app components |
+| `apiKey` | Recommended | [CDP API Key](https://portal.cdp.coinbase.com/projects/api-keys) - enables Paymaster, Identity resolution, and other features |
+| `projectId` | Optional | CDP Project ID for analytics |
+| `rpcUrl` | Optional | Custom RPC URL (defaults to chain's public RPC) |
+| `config` | Optional | Appearance and wallet configuration (see below) |
+| `miniKit` | Optional | Mini App configuration |
+
+### Config Object
+
+```tsx
+config={{
+  appearance: {
+    name: 'My App',           // App name shown in wallet prompts
+    logo: 'https://...',      // App logo URL
+    mode: 'auto',             // 'light' | 'dark' | 'auto'
+    theme: 'default',         // Theme preset
+  },
+  wallet: {
+    display: 'classic',       // 'classic' | 'modal'
+    preference: 'all',        // 'all' | 'smartWalletOnly' | 'eoaOnly'
+  },
+}}
+```
+
+> **Note:** Without an `apiKey`, features like sponsored transactions (Paymaster) and ENS/Basename resolution won't work. Get your free API key at [CDP Portal](https://portal.cdp.coinbase.com/projects/api-keys).
+
 ## ✨ Documentation
 
 For documentation and guides, visit [onchainkit.xyz](https://onchainkit.xyz/).

--- a/packages/onchainkit/README.md
+++ b/packages/onchainkit/README.md
@@ -53,6 +53,53 @@
 
 Run `npm create onchain` to bootstrap an example onchain app with all the batteries included.
 
+## ⚙️ OnchainKitProvider Setup
+
+Wrap your app with `OnchainKitProvider` to enable OnchainKit components:
+
+```tsx
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+import { base } from 'wagmi/chains';
+
+<OnchainKitProvider
+  chain={base}                    // Required: Target chain
+  apiKey="YOUR_CDP_API_KEY"       // Recommended: Enables Paymaster, Identity, etc.
+>
+  {children}
+</OnchainKitProvider>
+```
+
+### Configuration Options
+
+| Prop | Required | Description |
+|------|----------|-------------|
+| `chain` | ✅ Yes | Target chain (e.g., `base`, `baseSepolia` from `wagmi/chains`) |
+| `children` | ✅ Yes | Your app components |
+| `apiKey` | Recommended | [CDP API Key](https://portal.cdp.coinbase.com/projects/api-keys) - enables Paymaster, Identity resolution, and other features |
+| `projectId` | Optional | CDP Project ID for analytics |
+| `rpcUrl` | Optional | Custom RPC URL (defaults to chain's public RPC) |
+| `config` | Optional | Appearance and wallet configuration (see below) |
+| `miniKit` | Optional | Mini App configuration |
+
+### Config Object
+
+```tsx
+config={{
+  appearance: {
+    name: 'My App',           // App name shown in wallet prompts
+    logo: 'https://...',      // App logo URL
+    mode: 'auto',             // 'light' | 'dark' | 'auto'
+    theme: 'default',         // Theme preset
+  },
+  wallet: {
+    display: 'classic',       // 'classic' | 'modal'
+    preference: 'all',        // 'all' | 'smartWalletOnly' | 'eoaOnly'
+  },
+}}
+```
+
+> **Note:** Without an `apiKey`, features like sponsored transactions (Paymaster) and ENS/Basename resolution won't work. Get your free API key at [CDP Portal](https://portal.cdp.coinbase.com/projects/api-keys).
+
 ## ✨ Documentation
 
 For documentation and guides, visit [onchainkit.xyz](https://onchainkit.xyz/).


### PR DESCRIPTION
## Summary
Added a comprehensive setup section for `OnchainKitProvider` to both README files to help developers quickly understand required vs optional configuration.

## Changes
- Added "OnchainKitProvider Setup" section after Quickstart
- Basic usage example with required props
- Configuration options table with Required/Optional markers
- Config object structure documentation
- Note about API key requirements for Paymaster and Identity features

## Why
Developers were having trouble distinguishing required from optional fields, leading to cryptic runtime errors when critical setup steps were skipped.

## Configuration Table Preview

| Prop | Required | Description |
|------|----------|-------------|
| `chain` | ✅ Yes | Target chain |
| `children` | ✅ Yes | Your app components |
| `apiKey` | Recommended | CDP API Key |
| `projectId` | Optional | CDP Project ID |
| `rpcUrl` | Optional | Custom RPC URL |
| `config` | Optional | Appearance and wallet config |
| `miniKit` | Optional | Mini App configuration |

Fixes #2563