### PR TITLE
docs: fix grammar phrasing in README

### DIFF
--- a/examples/minikit-example/README.md
+++ b/examples/minikit-example/README.md
@@ -27,7 +27,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) in your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 


### PR DESCRIPTION
Changed "open with your browser" to the more idiomatic "open in your browser".