### PR TITLE
fix(utils): remove trailing decimal point in getRoundedAmount

### DIFF
--- a/packages/onchainkit/src/internal/utils/getRoundedAmount.test.ts
+++ b/packages/onchainkit/src/internal/utils/getRoundedAmount.test.ts
@@ -28,4 +28,10 @@ describe('getRoundedAmount', () => {
     const result = getRoundedAmount(balance, fractionDigits);
     expect(result).toBe('0');
   });
+
+  it('removes trailing decimal point when all decimal digits are zeros', () => {
+    expect(getRoundedAmount('5.00001', 2)).toBe('5');
+    expect(getRoundedAmount('10.00', 2)).toBe('10');
+    expect(getRoundedAmount('100.0', 1)).toBe('100');
+  });
 });

--- a/packages/onchainkit/src/internal/utils/getRoundedAmount.ts
+++ b/packages/onchainkit/src/internal/utils/getRoundedAmount.ts
@@ -5,7 +5,7 @@ export function getRoundedAmount(balance: string, fractionDigits: number) {
   const parsedBalance = Number.parseFloat(balance);
   const result = Number(parsedBalance)
     ?.toFixed(fractionDigits)
-    .replace(/0+$/, '');
+    .replace(/\.?0+$/, '');
 
   // checking if balance is more than 0 but less than fractionDigits
   // without this prints "0."


### PR DESCRIPTION
### Problem                                                                      
                                                                                  
 getRoundedAmount returns values with trailing decimal points when all decimal    
 digits are zeros after rounding:                                                 
                                                                                  
 ```javascript                                                                    
   getRoundedAmount('5.00001', 2)  // Returns "5." ❌                             
   getRoundedAmount('10.00', 2)    // Returns "10." ❌                            
   getRoundedAmount('100.0', 1)    // Returns "100." ❌                           
 ```                                                                              
                                                                                  
 This causes malformed number strings to be displayed in the UI.                  
                                                                                  
 ### Solution                                                                     
                                                                                  
 Changed the regex from /0+$/ to /\.?0+$/ to also strip the trailing decimal      
 point when present.                                                              
                                                                                  
 ```javascript                                                                    
   getRoundedAmount('5.00001', 2)  // Returns "5" ✓                               
   getRoundedAmount('10.00', 2)    // Returns "10" ✓                              
   getRoundedAmount('100.0', 1)    // Returns "100" ✓                             
 ```                                                                              
                                                                                  
 ### Testing                                                                      
                                                                                  
 Added test case removes trailing decimal point when all decimal digits are       
 zeros.