### PR TITLE
fix: allow MiniKit auto-connect to retry after disconnect

### DIFF
--- a/packages/onchainkit/src/minikit/components/AutoConnect.test.tsx
+++ b/packages/onchainkit/src/minikit/components/AutoConnect.test.tsx
@@ -315,4 +315,73 @@ describe('AutoConnect', () => {
 
     expect(mockConnect).not.toHaveBeenCalled();
   });
+
+  it('should attempt reconnection after disconnect', async () => {
+    Object.defineProperty(sdk, 'context', {
+      value: Promise.resolve({ user: { fid: 123 } }),
+      writable: true,
+      configurable: true,
+    });
+
+    // Start disconnected
+    mockUseAccount.mockReturnValue({
+      isConnected: false,
+      isConnecting: false,
+    });
+
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <WagmiProvider config={createConfig(mockConfig)}>
+          <AutoConnect enabled={true}>
+            <div>Test Child</div>
+          </AutoConnect>
+        </WagmiProvider>
+      </QueryClientProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    // First connection attempt
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+
+    // Simulate connected state
+    mockUseAccount.mockReturnValue({
+      isConnected: true,
+      isConnecting: false,
+    });
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <WagmiProvider config={createConfig(mockConfig)}>
+          <AutoConnect enabled={true}>
+            <div>Test Child</div>
+          </AutoConnect>
+        </WagmiProvider>
+      </QueryClientProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    // Simulate disconnect
+    mockUseAccount.mockReturnValue({
+      isConnected: false,
+      isConnecting: false,
+    });
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <WagmiProvider config={createConfig(mockConfig)}>
+          <AutoConnect enabled={true}>
+            <div>Test Child</div>
+          </AutoConnect>
+        </WagmiProvider>
+      </QueryClientProvider>,
+    );
+
+    await act(() => Promise.resolve());
+
+    // Should attempt reconnection after disconnect
+    expect(mockConnect).toHaveBeenCalledTimes(2);
+    expect(mockConnect).toHaveBeenLastCalledWith({ connector: mockFarcasterFrame });
+  });
 });

--- a/packages/onchainkit/src/minikit/components/AutoConnect.tsx
+++ b/packages/onchainkit/src/minikit/components/AutoConnect.tsx
@@ -21,6 +21,14 @@ export function AutoConnect({
   const connector = connectors[0];
   const { isInMiniApp, isSuccess: isInMiniAppSuccess } = useIsInMiniApp();
 
+  // Reset the connection attempt flag when user disconnects
+  // This allows auto-connect to run again after a disconnect
+  useEffect(() => {
+    if (!isConnected && !isConnecting) {
+      hasAttemptedConnection.current = false;
+    }
+  }, [isConnected, isConnecting]);
+
   useEffect(() => {
     if (
       !enabled ||


### PR DESCRIPTION
## Summary

Fixes #2596

The `AutoConnect` component was only attempting to connect once due to the `hasAttemptedConnection` ref never being reset. After a user disconnects in Base App, the ref would remain `true`, preventing auto-connect from running again — causing the Connect button to do nothing.

## The Problem

```typescript
// This ref is set to true on first connect attempt and never reset
hasAttemptedConnection.current = true;
```

After disconnect:
1. User taps Connect
2. `hasAttemptedConnection.current` is still `true`
3. Early return prevents auto-connect
4. Connect button appears to do nothing

## The Fix

Reset `hasAttemptedConnection` when the user disconnects:

```typescript
useEffect(() => {
  if (!isConnected && !isConnecting) {
    hasAttemptedConnection.current = false;
  }
}, [isConnected, isConnecting]);
```

## Testing

Added test case: "should attempt reconnection after disconnect" that verifies:
1. Initial auto-connect works
2. After simulating connect → disconnect cycle
3. Auto-connect runs again (connect called twice total)