### PR TITLE
fix(token): validate numeric input in formatAmount to prevent NaN/Infinity

### DIFF
--- a/packages/onchainkit/src/token/utils/formatAmount.ts
+++ b/packages/onchainkit/src/token/utils/formatAmount.ts
@@ -13,8 +13,15 @@ export function formatAmount(
   }
 
   const { locale, minimumFractionDigits, maximumFractionDigits } = options;
+  
+  const numericAmount = Number(amount);
+  
+  // Return empty string for invalid inputs (NaN, Infinity)
+  if (!Number.isFinite(numericAmount)) {
+    return '';
+  }
 
-  return Number(amount).toLocaleString(locale, {
+  return numericAmount.toLocaleString(locale, {
     minimumFractionDigits,
     maximumFractionDigits,
   });


### PR DESCRIPTION
**What changed? Why?**

`formatAmount` now validates input and returns empty string for invalid values instead of "NaN" or "∞".

**Notes to reviewers**

Without validation:
```js
formatAmount('abc')       // Returns "NaN" ❌
formatAmount('Infinity')  // Returns "∞" ❌
```

With fix:
```js
formatAmount('abc')       // Returns "" ✓
formatAmount('Infinity')  // Returns "" ✓
```

Uses `Number.isFinite()` to catch both NaN and Infinity.

**How has it been tested?**

Manual testing with edge cases:
- Non-numeric strings: returns empty string
- Infinity: returns empty string
- Valid numbers: formatted correctly