### PR TITLE
docs: specified the paths

### DIFF
--- a/packages/create-onchain/README.md
+++ b/packages/create-onchain/README.md
@@ -106,4 +106,4 @@ When using `--manifest`, the tool will:
 
 ## 🌊 License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License - see the [LICENSE.md](../../LICENSE.md) file for details

--- a/packages/miniapp-manifest-generator/README.md
+++ b/packages/miniapp-manifest-generator/README.md
@@ -68,4 +68,4 @@ pnpm test:coverage
 
 ## 🌊 License
 
-This project is licensed under the MIT License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the MIT License - see the [LICENSE.md](../../LICENSE.md) file for details


### PR DESCRIPTION
**What changed? Why?**
The paths to the license were incorrectly specified in the 2 README documents. I have corrected this.

**Notes to reviewers**
Minor hygienic correction.

**How has it been tested?**
I checked, the links work fine!