### PR TITLE
docs: fixed Nodejs version & added link

### DIFF
--- a/packages/onchainkit/README.md
+++ b/packages/onchainkit/README.md
@@ -65,7 +65,7 @@ This project is set up as a monorepo with pnpm workspaces.
 
 ### Requirements
 
-- Node.js v18
+- [Node.js v20](https://nodejs.org/en/download)
 - pnpm v10
 
 ### Getting Started


### PR DESCRIPTION
**What changed? Why?**
There were discrepancies in the onchainkit package and documentation regarding the required Node.js version: 
- packages/onchainkit/README.md specified v18

According to the root README the officially supported SDK version is Node.js v20.

Change:
- Updated packages/onchainkit/README.md from Node.js v18 > v20
- Added a link to the official Node.js website for user convenience

**Notes to reviewers**

**How has it been tested?**
