### PR TITLE
fix: update wagmi/experimental imports to wagmi

### DIFF
--- a/.changeset/fix-wagmi-experimental-imports.md
+++ b/.changeset/fix-wagmi-experimental-imports.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+**fix:** update `wagmi/experimental` imports to `wagmi`. The `useCapabilities`, `useSendCalls`, and `useCallsStatus` hooks were stabilized and moved from `wagmi/experimental` to `wagmi` in wagmi v2.15.0. This fixes build/runtime errors for consumers using newer wagmi versions.

--- a/packages/onchainkit/src/buy/components/BuyProvider.test.tsx
+++ b/packages/onchainkit/src/buy/components/BuyProvider.test.tsx
@@ -28,7 +28,7 @@ import {
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import { base } from 'wagmi/chains';
 import { mock } from 'wagmi/connectors';
-import { useSendCalls } from 'wagmi/experimental';
+import { useSendCalls } from 'wagmi';
 import { buildSwapTransaction } from '../../api/buildSwapTransaction';
 import type { GetSwapQuoteResponse } from '../../api/types';
 import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
@@ -102,7 +102,7 @@ vi.mock('wagmi/actions', () => ({
   waitForTransactionReceipt: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useSendCalls: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/buy/components/BuyProvider.test.tsx
+++ b/packages/onchainkit/src/buy/components/BuyProvider.test.tsx
@@ -86,6 +86,7 @@ vi.mock('wagmi', async (importOriginal) => {
     useAccount: vi.fn(),
     useChainId: vi.fn(),
     useSwitchChain: vi.fn(),
+    useSendCalls: vi.fn(),
   };
 });
 
@@ -100,10 +101,6 @@ vi.mock('@/internal/hooks/useCapabilitiesSafe', () => ({
 
 vi.mock('wagmi/actions', () => ({
   waitForTransactionReceipt: vi.fn(),
-}));
-
-vi.mock('wagmi', () => ({
-  useSendCalls: vi.fn(),
 }));
 
 vi.mock('../path/to/maxSlippageModule', () => ({

--- a/packages/onchainkit/src/buy/components/BuyProvider.tsx
+++ b/packages/onchainkit/src/buy/components/BuyProvider.tsx
@@ -11,7 +11,7 @@ import {
 import { base } from 'viem/chains';
 import { useAccount, useConfig, useSendTransaction } from 'wagmi';
 import { useSwitchChain } from 'wagmi';
-import { useSendCalls } from 'wagmi/experimental';
+import { useSendCalls } from 'wagmi';
 import { buildSwapTransaction } from '../../api/buildSwapTransaction';
 import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
 import { BuyEvent } from '../../core/analytics/types';

--- a/packages/onchainkit/src/internal/hooks/useCapabilitiesSafe.test.ts
+++ b/packages/onchainkit/src/internal/hooks/useCapabilitiesSafe.test.ts
@@ -1,14 +1,14 @@
 import { renderHook } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAccount } from 'wagmi';
-import { useCapabilities } from 'wagmi/experimental';
+import { useCapabilities } from 'wagmi';
 import { useCapabilitiesSafe } from './useCapabilitiesSafe';
 
 vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useCapabilities: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/internal/hooks/useCapabilitiesSafe.test.ts
+++ b/packages/onchainkit/src/internal/hooks/useCapabilitiesSafe.test.ts
@@ -6,9 +6,6 @@ import { useCapabilitiesSafe } from './useCapabilitiesSafe';
 
 vi.mock('wagmi', () => ({
   useAccount: vi.fn(),
-}));
-
-vi.mock('wagmi', () => ({
   useCapabilities: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/internal/hooks/useCapabilitiesSafe.ts
+++ b/packages/onchainkit/src/internal/hooks/useCapabilitiesSafe.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { WalletCapabilities } from 'viem';
 import { useAccount } from 'wagmi';
-import { useCapabilities } from 'wagmi/experimental';
+import { useCapabilities } from 'wagmi';
 import type { UseCapabilitiesSafeParams } from '../../core/types';
 
 export function useCapabilitiesSafe({

--- a/packages/onchainkit/src/swap/components/SwapProvider.test.tsx
+++ b/packages/onchainkit/src/swap/components/SwapProvider.test.tsx
@@ -71,6 +71,7 @@ vi.mock('wagmi', async (importOriginal) => {
     useSendTransaction: vi.fn(() => ({
       sendTransactionAsync: vi.fn(),
     })),
+    useSendCalls: vi.fn(),
   };
 });
 
@@ -85,10 +86,6 @@ vi.mock('@/internal/hooks/useCapabilitiesSafe', () => ({
 
 vi.mock('wagmi/actions', () => ({
   waitForTransactionReceipt: vi.fn(),
-}));
-
-vi.mock('wagmi', () => ({
-  useSendCalls: vi.fn(),
 }));
 
 vi.mock('../path/to/maxSlippageModule', () => ({

--- a/packages/onchainkit/src/swap/components/SwapProvider.test.tsx
+++ b/packages/onchainkit/src/swap/components/SwapProvider.test.tsx
@@ -31,7 +31,7 @@ import {
 import { waitForTransactionReceipt } from 'wagmi/actions';
 import { base } from 'wagmi/chains';
 import { mock } from 'wagmi/connectors';
-import { useSendCalls } from 'wagmi/experimental';
+import { useSendCalls } from 'wagmi';
 import { buildSwapTransaction } from '../../api/buildSwapTransaction';
 import { getSwapQuote } from '../../api/getSwapQuote';
 import { useAnalytics } from '../../core/analytics/hooks/useAnalytics';
@@ -87,7 +87,7 @@ vi.mock('wagmi/actions', () => ({
   waitForTransactionReceipt: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useSendCalls: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/swap/components/SwapProvider.tsx
+++ b/packages/onchainkit/src/swap/components/SwapProvider.tsx
@@ -9,7 +9,7 @@ import {
 import { base } from 'viem/chains';
 import { useAccount, useConfig, useSendTransaction } from 'wagmi';
 import { useSwitchChain } from 'wagmi';
-import { useSendCalls } from 'wagmi/experimental';
+import { useSendCalls } from 'wagmi';
 import { buildSwapTransaction } from '@/api/buildSwapTransaction';
 import { getSwapQuote } from '@/api/getSwapQuote';
 import { useAnalytics } from '@/core/analytics/hooks/useAnalytics';

--- a/packages/onchainkit/src/swap/hooks/useAwaitCalls.test.ts
+++ b/packages/onchainkit/src/swap/hooks/useAwaitCalls.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { waitForTransactionReceipt } from 'wagmi/actions';
-import { useCallsStatus } from 'wagmi/experimental';
+import { useCallsStatus } from 'wagmi';
 import type { LifecycleStatus } from '../types';
 import { useAwaitCalls } from './useAwaitCalls';
 import { base } from 'viem/chains';
@@ -12,7 +12,7 @@ vi.mock('wagmi/actions', () => ({
   waitForTransactionReceipt: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/swap/hooks/useAwaitCalls.ts
+++ b/packages/onchainkit/src/swap/hooks/useAwaitCalls.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { waitForTransactionReceipt } from 'wagmi/actions';
-import { useCallsStatus } from 'wagmi/experimental';
+import { useCallsStatus } from 'wagmi';
 import type { UseAwaitCallsParams } from '../types';
 import { normalizeStatus } from '@/internal/utils/normalizeWagmi';
 

--- a/packages/onchainkit/src/transaction/components/TransactionToast.test.tsx
+++ b/packages/onchainkit/src/transaction/components/TransactionToast.test.tsx
@@ -1,7 +1,7 @@
 import { act } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useShowCallsStatus } from 'wagmi/experimental';
+import { useShowCallsStatus } from 'wagmi';
 import { useTransactionContext } from './TransactionProvider';
 import { TransactionToast } from './TransactionToast';
 
@@ -16,7 +16,7 @@ vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/components/TransactionToast.test.tsx
+++ b/packages/onchainkit/src/transaction/components/TransactionToast.test.tsx
@@ -14,9 +14,6 @@ vi.mock('wagmi', () => ({
   useConnect: vi.fn(),
   useConfig: vi.fn(),
   useChainId: vi.fn(),
-}));
-
-vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useCallsStatus.test.ts
+++ b/packages/onchainkit/src/transaction/hooks/useCallsStatus.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { useCallsStatus as useCallsStatusWagmi } from 'wagmi/experimental';
+import { useCallsStatus as useCallsStatusWagmi } from 'wagmi';
 import { useCallsStatus } from './useCallsStatus';
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useCallsStatus.ts
+++ b/packages/onchainkit/src/transaction/hooks/useCallsStatus.ts
@@ -1,4 +1,4 @@
-import { useCallsStatus as useCallsStatusWagmi } from 'wagmi/experimental';
+import { useCallsStatus as useCallsStatusWagmi } from 'wagmi';
 import type { UseCallsStatusParams } from '../types';
 import { normalizeStatus } from '@/internal/utils/normalizeWagmi';
 

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusAction.test.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusAction.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChainId } from 'wagmi';
-import { useShowCallsStatus } from 'wagmi/experimental';
+import { useShowCallsStatus } from 'wagmi';
 import { getChainExplorer } from '../../core/network/getChainExplorer';
 import { useTransactionContext } from '../components/TransactionProvider';
 import { useGetTransactionStatusAction } from './useGetTransactionStatusAction';
@@ -15,7 +15,7 @@ vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusAction.test.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusAction.test.tsx
@@ -13,9 +13,6 @@ vi.mock('../components/TransactionProvider', () => ({
 
 vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
-}));
-
-vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusAction.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusAction.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { useChainId } from 'wagmi';
-import { useShowCallsStatus } from 'wagmi/experimental';
+import { useShowCallsStatus } from 'wagmi';
 import { getChainExplorer } from '../../core/network/getChainExplorer';
 import { cn, text } from '../../styles/theme';
 import { useTransactionContext } from '../components/TransactionProvider';

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusLabel.test.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusLabel.test.tsx
@@ -12,9 +12,6 @@ vi.mock('../components/TransactionProvider', () => ({
 
 vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
-}));
-
-vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusLabel.test.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionStatusLabel.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChainId } from 'wagmi';
-import { useShowCallsStatus } from 'wagmi/experimental';
+import { useShowCallsStatus } from 'wagmi';
 import { getChainExplorer } from '../../core/network/getChainExplorer';
 import { useTransactionContext } from '../components/TransactionProvider';
 import { useGetTransactionStatusLabel } from './useGetTransactionStatusLabel';
@@ -14,7 +14,7 @@ vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionToastAction.test.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionToastAction.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChainId } from 'wagmi';
-import { useShowCallsStatus } from 'wagmi/experimental';
+import { useShowCallsStatus } from 'wagmi';
 import { getChainExplorer } from '../../core/network/getChainExplorer';
 import { useTransactionContext } from '../components/TransactionProvider';
 import { useGetTransactionToastAction } from './useGetTransactionToastAction';
@@ -15,7 +15,7 @@ vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionToastAction.test.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionToastAction.test.tsx
@@ -13,9 +13,6 @@ vi.mock('../components/TransactionProvider', () => ({
 
 vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
-}));
-
-vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionToastAction.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionToastAction.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { useChainId } from 'wagmi';
-import { useShowCallsStatus } from 'wagmi/experimental';
+import { useShowCallsStatus } from 'wagmi';
 import { getChainExplorer } from '../../core/network/getChainExplorer';
 import { cn, text } from '../../styles/theme';
 import { useTransactionContext } from '../components/TransactionProvider';

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionToastLabel.test.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionToastLabel.test.tsx
@@ -12,9 +12,6 @@ vi.mock('../components/TransactionProvider', () => ({
 
 vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
-}));
-
-vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useGetTransactionToastLabel.test.tsx
+++ b/packages/onchainkit/src/transaction/hooks/useGetTransactionToastLabel.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChainId } from 'wagmi';
-import { useShowCallsStatus } from 'wagmi/experimental';
+import { useShowCallsStatus } from 'wagmi';
 import { getChainExplorer } from '../../core/network/getChainExplorer';
 import { useTransactionContext } from '../components/TransactionProvider';
 import { useGetTransactionToastLabel } from './useGetTransactionToastLabel';
@@ -14,7 +14,7 @@ vi.mock('wagmi', () => ({
   useChainId: vi.fn(),
 }));
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useShowCallsStatus: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useSendCalls.test.ts
+++ b/packages/onchainkit/src/transaction/hooks/useSendCalls.test.ts
@@ -1,12 +1,12 @@
 import { renderHook } from '@testing-library/react';
 import type { TransactionExecutionError } from 'viem';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useSendCalls as useSendCallsWagmi } from 'wagmi/experimental';
+import { useSendCalls as useSendCallsWagmi } from 'wagmi';
 import { GENERIC_ERROR_MESSAGE } from '../constants';
 import { isUserRejectedRequestError } from '../utils/isUserRejectedRequestError';
 import { useSendCalls } from './useSendCalls';
 
-vi.mock('wagmi/experimental', () => ({
+vi.mock('wagmi', () => ({
   useSendCalls: vi.fn(),
 }));
 

--- a/packages/onchainkit/src/transaction/hooks/useSendCalls.ts
+++ b/packages/onchainkit/src/transaction/hooks/useSendCalls.ts
@@ -1,4 +1,4 @@
-import { useSendCalls as useSendCallsWagmi } from 'wagmi/experimental';
+import { useSendCalls as useSendCallsWagmi } from 'wagmi';
 import { GENERIC_ERROR_MESSAGE } from '../constants';
 import type { UseSendCallsParams } from '../types';
 import { isUserRejectedRequestError } from '../utils/isUserRejectedRequestError';


### PR DESCRIPTION
Fixes #2624.

The `useCapabilities`, `useSendCalls`, and `useCallsStatus` hooks were stabilized and moved from `wagmi/experimental` to `wagmi` in wagmi v2.15.0. Consumers using wagmi 3+ get a build error because `wagmi/experimental` no longer exports these hooks.

**Changes:**
- Updated all `wagmi/experimental` imports to `wagmi` in production and test files
- Merged duplicate `vi.mock('wagmi')` calls in test files where the experimental mock was separate
- Added changeset for patch release

**Files changed:**
- `BuyProvider.tsx`, `SwapProvider.tsx` — `useSendCalls`
- `useAwaitCalls.ts`, `useCallsStatus.ts`, `useSendCalls.ts`, `useCapabilitiesSafe.ts` — hook imports
- Associated test files — updated mocks

All tests pass.