### PR TITLE
docs: correct class-prefix token in alpha-api-changes (ock- -> ock:)

### DIFF
--- a/alpha-api-changes.md
+++ b/alpha-api-changes.md
@@ -158,7 +158,7 @@ All hooks maintain backward compatibility:
 ### Scoped Styling System
 
 #### New Features
-- **Class Prefixing**: All OnchainKit classes automatically prefixed with `ock-`
+- **Class Prefixing**: All OnchainKit classes automatically prefixed with `ock:`
 - **CSS Variable Scoping**: Theme variables use `--ock-` prefix
 - **Data Attribute Theming**: Themes applied via `data-ock-theme` attributes
 


### PR DESCRIPTION
### Why

The **Scoped Styling System > New Features** section in `alpha-api-changes.md` states:

> Class Prefixing: All OnchainKit classes automatically prefixed with `ock-`

But the actual build-time prefix — defined in [`packages/onchainkit/vite.config.ts`](https://github.com/coinbase/onchainkit/blob/main/packages/onchainkit/vite.config.ts) as:

```ts
const CLASSNAME_PREFIX = 'ock:';
```

and applied by the `postcss-prefix-classnames` plugin (same file, `prefix: \`ock\\:\``) — is **`ock:`** (Tailwind v4 variant-style), not `ock-`.

`alpha-upgrade-guide.md` already documents it correctly:

> Class Prefixing: All OnchainKit classes are automatically prefixed with `ock:`

This one-character fix aligns `alpha-api-changes.md` with both the upgrade guide and the source of truth, so consumers migrating to v1.0 don't look for the wrong prefix when auditing their styles.

### Scope

- Single line changed in `alpha-api-changes.md`
- Docs-only; no code, no API, no deps
- 1 LOC

Co-authored-by: kcolbchain contrib-bot <bot@kcolbchain.com>

---
_Part of open-source blockchain work from [kcolbchain.com](https://kcolbchain.com) — maintained by [Abhishek Krishna](https://abhishekkrishna.com). PR opened via [kcolbchain contrib-bot](https://github.com/kcolbchain/kcolbchain.github.io/blob/master/deploy/contrib-bot/README.md)._