### PR TITLE
feat(wallet): add useNetworkGuard hook and NetworkGuard component

### DIFF
--- a/packages/onchainkit/src/wallet/components/NetworkGuard.tsx
+++ b/packages/onchainkit/src/wallet/components/NetworkGuard.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useNetworkGuard } from '../hooks/useNetworkGuard';
+import { cn, text, border, pressable } from '@/styles/theme';
+
+export function NetworkGuard({ className }: { className?: string }) {
+  const { isWrongNetwork, isSwitching, targetChain, switchNetwork } = useNetworkGuard();
+
+  const handleSwitch = useCallback(async () => {
+    await switchNetwork();
+  }, [switchNetwork]);
+
+  if (!isWrongNetwork) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between gap-3 px-4 py-3',
+        'bg-warning text-warning-foreground',
+        border.radius,
+        className,
+      )}
+      data-testid="ock-network-guard"
+    >
+      <span className={cn(text.label2)}>
+        Wrong network. Please switch to {targetChain.name}.
+      </span>
+      <button
+        type="button"
+        onClick={handleSwitch}
+        disabled={isSwitching}
+        className={cn(
+          pressable.primary,
+          border.radius,
+          'px-3 py-1.5 text-sm font-medium',
+          'disabled:opacity-50 disabled:cursor-not-allowed',
+        )}
+        data-testid="ock-network-guard-switch"
+      >
+        {isSwitching ? 'Switching...' : `Switch to ${targetChain.name}`}
+      </button>
+    </div>
+  );
+}

--- a/packages/onchainkit/src/wallet/hooks/useNetworkGuard.test.ts
+++ b/packages/onchainkit/src/wallet/hooks/useNetworkGuard.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAccount, useSwitchChain } from 'wagmi';
+import { useOnchainKit } from '@/useOnchainKit';
+import { base, baseSepolia } from 'viem/chains';
+import { useNetworkGuard } from './useNetworkGuard';
+
+vi.mock('wagmi', () => ({
+  useAccount: vi.fn(),
+  useSwitchChain: vi.fn(),
+}));
+
+vi.mock('@/useOnchainKit', () => ({
+  useOnchainKit: vi.fn(),
+}));
+
+describe('useNetworkGuard', () => {
+  const mockSwitchChainAsync = vi.fn();
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should return isWrongNetwork=false when not connected', () => {
+    (useOnchainKit as Mock).mockReturnValue({ chain: base });
+    (useAccount as Mock).mockReturnValue({ chainId: undefined, isConnected: false });
+    (useSwitchChain as Mock).mockReturnValue({ switchChainAsync: mockSwitchChainAsync, isPending: false });
+
+    const { result } = renderHook(() => useNetworkGuard());
+
+    expect(result.current.isWrongNetwork).toBe(false);
+    expect(result.current.targetChain).toBe(base);
+  });
+
+  it('should return isWrongNetwork=false when on correct chain', () => {
+    (useOnchainKit as Mock).mockReturnValue({ chain: base });
+    (useAccount as Mock).mockReturnValue({ chainId: base.id, isConnected: true });
+    (useSwitchChain as Mock).mockReturnValue({ switchChainAsync: mockSwitchChainAsync, isPending: false });
+
+    const { result } = renderHook(() => useNetworkGuard());
+
+    expect(result.current.isWrongNetwork).toBe(false);
+    expect(result.current.connectedChainId).toBe(base.id);
+  });
+
+  it('should return isWrongNetwork=true when on wrong chain', () => {
+    (useOnchainKit as Mock).mockReturnValue({ chain: base });
+    (useAccount as Mock).mockReturnValue({ chainId: 1, isConnected: true }); // Ethereum mainnet
+    (useSwitchChain as Mock).mockReturnValue({ switchChainAsync: mockSwitchChainAsync, isPending: false });
+
+    const { result } = renderHook(() => useNetworkGuard());
+
+    expect(result.current.isWrongNetwork).toBe(true);
+    expect(result.current.targetChain).toBe(base);
+    expect(result.current.connectedChainId).toBe(1);
+  });
+
+  it('should call switchChainAsync with target chain id', async () => {
+    (useOnchainKit as Mock).mockReturnValue({ chain: baseSepolia });
+    (useAccount as Mock).mockReturnValue({ chainId: 1, isConnected: true });
+    (useSwitchChain as Mock).mockReturnValue({ switchChainAsync: mockSwitchChainAsync, isPending: false });
+
+    const { result } = renderHook(() => useNetworkGuard());
+
+    await result.current.switchNetwork();
+
+    expect(mockSwitchChainAsync).toHaveBeenCalledWith({ chainId: baseSepolia.id });
+  });
+
+  it('should not call switchChainAsync when on correct chain', async () => {
+    (useOnchainKit as Mock).mockReturnValue({ chain: base });
+    (useAccount as Mock).mockReturnValue({ chainId: base.id, isConnected: true });
+    (useSwitchChain as Mock).mockReturnValue({ switchChainAsync: mockSwitchChainAsync, isPending: false });
+
+    const { result } = renderHook(() => useNetworkGuard());
+
+    await result.current.switchNetwork();
+
+    expect(mockSwitchChainAsync).not.toHaveBeenCalled();
+  });
+
+  it('should expose isSwitching state', () => {
+    (useOnchainKit as Mock).mockReturnValue({ chain: base });
+    (useAccount as Mock).mockReturnValue({ chainId: 1, isConnected: true });
+    (useSwitchChain as Mock).mockReturnValue({ switchChainAsync: mockSwitchChainAsync, isPending: true });
+
+    const { result } = renderHook(() => useNetworkGuard());
+
+    expect(result.current.isSwitching).toBe(true);
+  });
+});

--- a/packages/onchainkit/src/wallet/hooks/useNetworkGuard.ts
+++ b/packages/onchainkit/src/wallet/hooks/useNetworkGuard.ts
@@ -1,0 +1,23 @@
+import { useAccount, useSwitchChain } from 'wagmi';
+import { useOnchainKit } from '@/useOnchainKit';
+
+export function useNetworkGuard() {
+  const { chain: targetChain } = useOnchainKit();
+  const { chainId: connectedChainId, isConnected } = useAccount();
+  const { switchChainAsync, isPending: isSwitching } = useSwitchChain();
+
+  const isWrongNetwork = isConnected && connectedChainId !== targetChain.id;
+
+  const switchNetwork = async () => {
+    if (!isWrongNetwork) return;
+    await switchChainAsync({ chainId: targetChain.id });
+  };
+
+  return {
+    isWrongNetwork,
+    isSwitching,
+    targetChain,
+    connectedChainId,
+    switchNetwork,
+  };
+}

--- a/packages/onchainkit/src/wallet/index.ts
+++ b/packages/onchainkit/src/wallet/index.ts
@@ -42,3 +42,7 @@ export type {
   WalletDropdownProps,
   WalletProps,
 } from './types';
+
+// Network Guard
+export { useNetworkGuard } from './hooks/useNetworkGuard';
+export { NetworkGuard } from './components/NetworkGuard';


### PR DESCRIPTION
## Description

Fixes #2571: Wallet connected on wrong network shows no guidance.

Currently, developers must implement their own wrong-network detection and switch UI. This leads to inconsistent UX across Base ecosystem apps.

## What changed

- **`useNetworkGuard` hook**: Detects when connected chain ≠ target chain from `OnchainKitProvider`. Exposes `isWrongNetwork`, `switchNetwork()`, `isSwitching`, `targetChain`.
- **`NetworkGuard` component**: Banner that renders only when `isWrongNetwork` is true. Shows target chain name and a "Switch to [Chain]" button. Handles loading state during switch.
- **Public exports**: Added to `src/wallet/index.ts` so developers can `import { useNetworkGuard, NetworkGuard } from '@coinbase/onchainkit/wallet'`

## Usage


```
import { NetworkGuard } from '@coinbase/onchainkit/wallet';

function App() {
  return (
    <>
      <NetworkGuard />
      <Wallet>
        <ConnectWallet />
      </Wallet>
    </>
  );
}
```

Or with the hook directly:

```
import { useNetworkGuard } from '@coinbase/onchainkit/wallet';

function CustomUI() {
  const { isWrongNetwork, switchNetwork, targetChain } = useNetworkGuard();
  if (isWrongNetwork) {
    return <button onClick={switchNetwork}>Switch to {targetChain.name}</button>;
  }
}
```

**Testing**

[x] useNetworkGuard.test.ts — 6 tests covering:
-Not connected → isWrongNetwork: false
-Correct chain → isWrongNetwork: false
-Wrong chain (mainnet vs base) → isWrongNetwork: true
-switchNetwork() calls switchChainAsync with target chain id
-switchNetwork() no-op when on correct chain
-isSwitching state exposed
[x] All 388 test files pass (2694 tests)


**Low Risk**
Low risk: adds new optional hook/component without modifying existing wallet or transaction logic. NetworkGuard renders `null `when network is correct.


**Notes**
Follows the same pattern as `CheckoutProvider` which already uses `useSwitchChain`
Works with any chain configured in `OnchainKitProvider`, not just Base