### PR TITLE
docs: add supported networks section to README

### DIFF
--- a/packages/onchainkit/README.md
+++ b/packages/onchainkit/README.md
@@ -57,6 +57,34 @@ Run `npm create onchain` to bootstrap an example onchain app with all the batter
 
 For documentation and guides, visit [onchainkit.xyz](https://onchainkit.xyz/).
 
+## 🌐 Supported Networks
+
+OnchainKit is optimized for the **Base ecosystem** and officially supports:
+
+| Network | Chain ID | Type |
+|---|---|---|
+| Base Mainnet | 8453 | Production |
+| Base Sepolia | 84532 | Testnet |
+
+While OnchainKit components work on any EVM-compatible chain, full feature support — including gasless transactions, Coinbase Smart Wallet, and paymaster integration — is only available on Base and Base Sepolia.
+
+To configure your app for Base networks:
+
+```ts
+import { base, baseSepolia } from 'viem/chains';
+import { OnchainKitProvider } from '@coinbase/onchainkit';
+
+// Production (Base Mainnet)
+<OnchainKitProvider chain={base} apiKey={process.env.PUBLIC_ONCHAINKIT_API_KEY}>
+  {children}
+</OnchainKitProvider>
+
+// Development (Base Sepolia testnet)
+<OnchainKitProvider chain={baseSepolia} apiKey={process.env.PUBLIC_ONCHAINKIT_API_KEY}>
+  {children}
+</OnchainKitProvider>
+```
+
 ## 🛠️ Contributing
 
 ### Overview


### PR DESCRIPTION
Closes #2586

**What changed? Why?**
Added a "Supported Networks" section to the README that clarifies which networks OnchainKit officially supports and how to configure them.

**Notes to reviewers**
- Base Mainnet (chain ID 8453) and Base Sepolia (84532) listed as officially supported
- Full features (gasless tx, Smart Wallet, paymaster) require Base/Base Sepolia
- Code example showing OnchainKitProvider configuration for both networks

**How has it been tested?**
Markdown rendering verified visually.
