### PR TITLE
docs: add Base Sepolia faucet link to setup guide

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ This project is set up as a monorepo with pnpm workspaces.
 - pnpm v10
 
 ### Getting Started
+### Base Sepolia Faucet
+
+To test applications on Base Sepolia, you can request test ETH from the official Base faucet:
+
+https://www.coinbase.com/faucets/base-ethereum-sepolia-faucet
 
 1. Clone the repository
 


### PR DESCRIPTION
## Summary

Adds the official Base Sepolia faucet link to improve the onboarding experience for developers testing applications on Base Sepolia.

## Changes

- added Base Sepolia faucet section
- included official faucet link
