### PR TITLE
chore: improve env gitignore rules

### DIFF
--- a/templates/onchainkit-nextjs/.gitignore
+++ b/templates/onchainkit-nextjs/.gitignore
@@ -31,7 +31,14 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+# local env files
+.env
+.env.local
+.env.*.local
+
+# allow example env files
+!.env.example
+!.template.env
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary

Improves environment file gitignore rules by allowing example environment templates while continuing to protect local environment secrets.

Closes #2644

## Changes

* replaced broad `.env*` ignore rule
* added safer local env ignore patterns
* allowed `.env.example` and `.template.env`

