### PR TITLE
fix: improve .env.template with descriptive comments and Base Sepolia RPC example

### DIFF
--- a/packages/playground/.env.template
+++ b/packages/playground/.env.template
@@ -1,5 +1,50 @@
+# OnchainKit Playground — Environment Variables
+# Copy this file to .env.local and fill in your values.
+# Never commit .env.local to version control.
+
+# ─── RPC URLs ────────────────────────────────────────────────────────────────
+
+# Ethereum Mainnet RPC URL (optional).
+# Used by AppProvider to create a public viem client for mainnet reads.
+# Get a free endpoint from Coinbase Developer Platform, Alchemy, or Infura:
+#   https://portal.cdp.coinbase.com/  (Coinbase — recommended for Base projects)
+#   https://www.alchemy.com/
+#   https://www.infura.io/
+# Leave empty to use the default public RPC (rate-limited, not for production).
 NEXT_PUBLIC_ETHEREUM_MAINNET_RPC_URL=""
+
+# Base Sepolia RPC URL (optional, recommended for local development & testing).
+# Base Sepolia is the testnet for Base. Use it to test transactions without
+# spending real ETH. Get a free endpoint from:
+#   https://portal.cdp.coinbase.com/  (Coinbase Developer Platform)
+#   https://www.alchemy.com/
+# Public fallback (rate-limited): https://sepolia.base.org
+NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL=""
+
+# ─── OnchainKit ──────────────────────────────────────────────────────────────
+
+# OnchainKit API key (required).
+# Passed to <OnchainKitProvider apiKey={...}>.
+# Get your key at: https://portal.cdp.coinbase.com/
 NEXT_PUBLIC_OCK_API_KEY=""
+
+# ─── Vercel ──────────────────────────────────────────────────────────────────
+
+# Vercel environment name (optional).
+# Automatically set by Vercel on deploy: "production" | "preview" | "development"
+# Only needed if you deploy this playground to Vercel.
 NEXT_PUBLIC_VERCEL_ENV=""
+
+# ─── WalletConnect ───────────────────────────────────────────────────────────
+
+# WalletConnect / Reown Project ID (required for WalletConnect support).
+# Passed to <OnchainKitProvider projectId={...}>.
+# Create a free project at: https://cloud.reown.com/
 NEXT_PUBLIC_PROJECT_ID=""
+
+# ─── Reservoir ───────────────────────────────────────────────────────────────
+
+# Reservoir API key (optional).
+# Used for NFT data in the playground.
+# Get a free key at: https://reservoir.tools/
 NEXT_PUBLIC_RESERVOIR_API_KEY=""


### PR DESCRIPTION
## Summary

Improves `packages/playground/.env.template` to reduce setup friction for developers, as requested in #2644.

## Changes

### Descriptive comments for every variable
Each env var now explains:
- what it is used for (with a reference to the exact code location)
- whether it is required or optional
- where to get the value, with direct links

### New `NEXT_PUBLIC_BASE_SEPOLIA_RPC_URL` entry
Adds the missing Base Sepolia RPC variable for local development and testing, with a note about the public fallback endpoint (`https://sepolia.base.org`) for developers who don't yet have a dedicated RPC key.

### Source links verified from the codebase
- `NEXT_PUBLIC_OCK_API_KEY` → used in `AppProvider.tsx` as `OnchainKitProvider apiKey`
- `NEXT_PUBLIC_PROJECT_ID` → used in `AppProvider.tsx` as `OnchainKitProvider projectId`
- `NEXT_PUBLIC_ETHEREUM_MAINNET_RPC_URL` → used in `AppProvider.tsx` to create a viem public client for mainnet
- `NEXT_PUBLIC_VERCEL_ENV` → set automatically by Vercel on deploy
- `NEXT_PUBLIC_RESERVOIR_API_KEY` → used for NFT data features

## Before / After

**Before:**
```
NEXT_PUBLIC_ETHEREUM_MAINNET_RPC_URL=""
NEXT_PUBLIC_OCK_API_KEY=""
NEXT_PUBLIC_VERCEL_ENV=""
NEXT_PUBLIC_PROJECT_ID=""
NEXT_PUBLIC_RESERVOIR_API_KEY=""
```

**After:** each variable has a section header, explanation, required/optional label, and direct links to where to get the value.

Fixes #2644