### PR TITLE
Add root-level .editorconfig for contributor consistency

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig: https://editorconfig.org
+# Root-level configuration for contributor consistency
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary

Adds a root-level `.editorconfig` file to standardize editor behavior across contributors, as requested in #2655.

## Details

The `.editorconfig` file configures:

- **Indentation**: 2 spaces (consistent with existing codebase conventions observed in JS/TS/JSON/YAML files)
- **Line endings**: LF (Unix-style)
- **Charset**: UTF-8
- **Trailing whitespace**: Trimmed automatically (except in Markdown where trailing spaces can indicate line breaks)
- **Final newline**: Inserted at end of files
- **Makefiles**: Tab indentation (required by Make syntax)

This provides editor-agnostic consistency for all contributors, regardless of their IDE or editor settings.

Closes #2655

**Base payout address:** `0x408f39B19266022FeC03076091e59D1f4f163658`

_Autonomous completion by Agentic Swarm Marketplace worker._