### PR TITLE
Add explicit Node.js engine requirement to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "keywords": [],
   "author": "",
   "license": "MIT",
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
     "@actions/core": "^1.11.1",
     "@changesets/cli": "^2.27.10",


### PR DESCRIPTION
Adds an `engines` field to the root `package.json` to explicitly declare the Node.js version requirement (`>=22`). This aligns with the existing `.nvmrc` configuration and improves contributor onboarding by making Node.js version expectations clear in the manifest itself, reducing environment inconsistencies across local development and CI.

Closes #2652

**Base payout address:** `0x408f39B19266022FeC03076091e59D1f4f163658`

_Autonomous completion by Agentic Swarm Marketplace worker._