### PR TITLE
fix(miniapp-manifest-generator): accept auth-type associations and raw-byte signatures

### DIFF
--- a/packages/miniapp-manifest-generator/src/constants.ts
+++ b/packages/miniapp-manifest-generator/src/constants.ts
@@ -1,5 +1,11 @@
 export const ID_REGISTRY_ADDRESS = '0x00000000Fc6c5F01Fc30151999387Bb99A9f489b';
 
+/**
+ * Auth addresses are not on chain -- they are verifications held by the hubs -- so
+ * validating a `type: "auth"` association needs a hub to ask.
+ */
+export const FARCASTER_HUB_URL = 'https://snap.farcaster.xyz:3381';
+
 export const ID_REGISTRY_ABI = [
   {
     inputs: [{ internalType: 'address', name: 'owner', type: 'address' }],

--- a/packages/miniapp-manifest-generator/src/hooks/useValidateManifest.test.tsx
+++ b/packages/miniapp-manifest-generator/src/hooks/useValidateManifest.test.tsx
@@ -1,11 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useValidateManifest } from './useValidateManifest';
-import { verifyMessage } from 'viem';
 
 const mockReadContract = vi.fn();
+const mockVerifyMessage = vi.fn();
 const mockClient = {
   readContract: mockReadContract,
+  verifyMessage: mockVerifyMessage,
 };
 
 const mockAccountAssociation = {
@@ -16,19 +17,40 @@ const mockAccountAssociation = {
   domain: 'example.com',
 };
 
+const authAccountAssociation = {
+  ...mockAccountAssociation,
+  header: 'eyJmaWQiOjEyMywidHlwZSI6ImF1dGgiLCJrZXkiOiIweGFiYzEyMyJ9', // {"fid":123,"type":"auth","key":"0xabc123"}
+};
+
 vi.mock('viem', () => ({
-  verifyMessage: vi.fn(),
   createPublicClient: vi.fn(() => mockClient),
   http: vi.fn(),
 }));
+
+function mockHubVerifications(addresses: string[]) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      messages: addresses.map((address) => ({
+        data: { verificationAddAddressBody: { address } },
+      })),
+    }),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
 
 describe('useValidateManifest', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('should validate a valid manifest', async () => {
-    vi.mocked(verifyMessage).mockResolvedValue(true);
+    mockVerifyMessage.mockResolvedValue(true);
     mockReadContract.mockResolvedValue('0xabc123');
 
     const { result } = renderHook(() =>
@@ -39,7 +61,7 @@ describe('useValidateManifest', () => {
   });
 
   it('should throw error for invalid signature', async () => {
-    vi.mocked(verifyMessage).mockResolvedValue(false);
+    mockVerifyMessage.mockResolvedValue(false);
 
     const { result } = renderHook(() =>
       useValidateManifest({ accountAssociation: mockAccountAssociation }),
@@ -48,7 +70,7 @@ describe('useValidateManifest', () => {
     await expect(result.current()).rejects.toThrow('Invalid signature');
   });
 
-  it('should throw error for non-custody type', async () => {
+  it('should throw error for a type that is neither custody nor auth', async () => {
     const invalidTypeAssociation = {
       ...mockAccountAssociation,
       header:
@@ -60,12 +82,12 @@ describe('useValidateManifest', () => {
     );
 
     await expect(result.current()).rejects.toThrow(
-      'Invalid type: type must be "custody"',
+      'Invalid type: type must be "custody" or "auth"',
     );
   });
 
   it('should throw error for mismatched custody address', async () => {
-    vi.mocked(verifyMessage).mockResolvedValue(true);
+    mockVerifyMessage.mockResolvedValue(true);
     mockReadContract.mockResolvedValue('0xdifferentAddress');
 
     const { result } = renderHook(() =>
@@ -81,5 +103,62 @@ describe('useValidateManifest', () => {
     );
 
     await expect(result.current()).resolves.toBeUndefined();
+  });
+
+  it('should accept an auth address that the FID has verified', async () => {
+    mockVerifyMessage.mockResolvedValue(true);
+    mockReadContract.mockResolvedValue('0xsomeOtherCustodyAddress');
+    const fetchMock = mockHubVerifications(['0xABC123']);
+
+    const { result } = renderHook(() =>
+      useValidateManifest({ accountAssociation: authAccountAssociation }),
+    );
+
+    await expect(result.current()).resolves.not.toThrow();
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('verificationsByFid?fid=123'),
+    );
+  });
+
+  it('should reject an auth address the FID has not verified', async () => {
+    mockVerifyMessage.mockResolvedValue(true);
+    mockReadContract.mockResolvedValue('0xsomeOtherCustodyAddress');
+    mockHubVerifications(['0xsomeoneElse']);
+
+    const { result } = renderHook(() =>
+      useValidateManifest({ accountAssociation: authAccountAssociation }),
+    );
+
+    await expect(result.current()).rejects.toThrow(
+      'Invalid auth address: not verified for this FID',
+    );
+  });
+
+  it('should accept an auth-typed association signed by the custody address', async () => {
+    // Mislabelled, but the key really does belong to the FID, so the domain is bound.
+    mockVerifyMessage.mockResolvedValue(true);
+    mockReadContract.mockResolvedValue('0xabc123');
+    const fetchMock = mockHubVerifications([]);
+
+    const { result } = renderHook(() =>
+      useValidateManifest({ accountAssociation: authAccountAssociation }),
+    );
+
+    await expect(result.current()).resolves.not.toThrow();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should surface a hub failure rather than silently passing', async () => {
+    mockVerifyMessage.mockResolvedValue(true);
+    mockReadContract.mockResolvedValue('0xsomeOtherCustodyAddress');
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+
+    const { result } = renderHook(() =>
+      useValidateManifest({ accountAssociation: authAccountAssociation }),
+    );
+
+    await expect(result.current()).rejects.toThrow(
+      'Could not reach a Farcaster hub',
+    );
   });
 });

--- a/packages/miniapp-manifest-generator/src/hooks/useValidateManifest.ts
+++ b/packages/miniapp-manifest-generator/src/hooks/useValidateManifest.ts
@@ -1,13 +1,37 @@
-import { createPublicClient, Hex, http, verifyMessage } from 'viem';
+import { createPublicClient, Hex, http } from 'viem';
 import { optimism } from 'viem/chains';
 import type { AccountAssociation } from './useSignManifest';
-import { fromBase64Url } from '../utilities/base64';
+import { decodeSignature, fromBase64Url } from '../utilities/base64';
 import { ID_REGISTRY_ABI } from '../constants';
 import { ID_REGISTRY_ADDRESS } from '../constants';
+import { FARCASTER_HUB_URL } from '../constants';
 
 type ValidateManifestProps = {
   accountAssociation: AccountAssociation | null;
 };
+
+/**
+ * Is `key` one of the addresses this FID has verified? Auth addresses live in hub state
+ * rather than on chain, so this is the only place to ask.
+ */
+async function isAuthAddressForFid(fid: number, key: string): Promise<boolean> {
+  const response = await fetch(
+    `${FARCASTER_HUB_URL}/v1/verificationsByFid?fid=${fid}`,
+  );
+
+  if (!response.ok) {
+    throw new Error('Could not reach a Farcaster hub to check the auth address');
+  }
+
+  const body = await response.json();
+  return (body.messages ?? []).some(
+    (message: {
+      data?: { verificationAddAddressBody?: { address?: string } };
+    }) =>
+      message.data?.verificationAddAddressBody?.address?.toLowerCase() ===
+      key.toLowerCase(),
+  );
+}
 
 export function useValidateManifest({
   accountAssociation,
@@ -26,26 +50,34 @@ export function useValidateManifest({
     const headerData = JSON.parse(fromBase64Url(encodedHeader));
     const { fid, type, key } = headerData;
 
-    if (type !== 'custody') {
-      throw new Error('Invalid type: type must be "custody"');
+    // The spec: `The header.type must be "custody" or "auth".` Both are valid, and "auth"
+    // is now the more common of the two across live manifests.
+    if (type !== 'custody' && type !== 'auth') {
+      throw new Error('Invalid type: type must be "custody" or "auth"');
     }
 
-    const signature = fromBase64Url(encodedSignature) as Hex;
-    const valid = await verifyMessage({
-      address: key,
-      message: `${encodedHeader}.${encodedPayload}`,
-      signature: signature,
-    });
-
-    if (!valid) {
-      throw new Error('Invalid signature');
-    }
+    const signature = decodeSignature(encodedSignature);
 
     const client = createPublicClient({
       chain: optimism,
       transport: http(),
     });
 
+    // Verify against the client rather than viem's offline verifyMessage: smart accounts
+    // sign via ERC-1271, and via ERC-6492 while they are still counterfactual on the
+    // verifying chain. Offline ecrecover reports both as forgeries.
+    const valid = await client.verifyMessage({
+      address: key as Hex,
+      message: `${encodedHeader}.${encodedPayload}`,
+      signature,
+    });
+
+    if (!valid) {
+      throw new Error('Invalid signature');
+    }
+
+    // A valid signature only shows the blob is self-consistent. What binds the domain to
+    // an account is that the key really belongs to the FID.
     const resolvedCustodyAddress = await client.readContract({
       address: ID_REGISTRY_ADDRESS,
       abi: ID_REGISTRY_ABI,
@@ -53,8 +85,17 @@ export function useValidateManifest({
       args: [BigInt(fid)],
     });
 
-    if (resolvedCustodyAddress.toLowerCase() !== key.toLowerCase()) {
-      throw new Error('Invalid custody address');
+    if (resolvedCustodyAddress.toLowerCase() === key.toLowerCase()) {
+      return;
     }
+
+    if (type === 'auth') {
+      if (await isAuthAddressForFid(fid, key)) {
+        return;
+      }
+      throw new Error('Invalid auth address: not verified for this FID');
+    }
+
+    throw new Error('Invalid custody address');
   };
 }

--- a/packages/miniapp-manifest-generator/src/utilities/base64.test.ts
+++ b/packages/miniapp-manifest-generator/src/utilities/base64.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { fromBase64Url, toBase64Url } from './base64';
+import { decodeSignature, fromBase64Url, toBase64Url } from './base64';
 
 describe('toBase64Url', () => {
   it('should encode basic strings', () => {
@@ -36,5 +36,37 @@ describe('fromBase64Url', () => {
   it('should handle JSON strings', () => {
     const jsonStr = JSON.stringify({ key: 'value' });
     expect(fromBase64Url('eyJrZXkiOiJ2YWx1ZSJ9')).toBe(jsonStr);
+  });
+});
+
+describe('decodeSignature', () => {
+  const bytes = Array.from({ length: 65 }, (_, i) => (i * 7) % 256);
+  const hex = `0x${bytes.map((b) => b.toString(16).padStart(2, '0')).join('')}`;
+  const asRawBytes = toBase64Url(String.fromCharCode(...bytes));
+  const asHexText = toBase64Url(hex);
+
+  it('should decode base64url of the raw signature bytes', () => {
+    expect(decodeSignature(asRawBytes)).toBe(hex);
+  });
+
+  it('should decode base64url of the ASCII "0x..." string', () => {
+    expect(decodeSignature(asHexText)).toBe(hex);
+  });
+
+  it('should decode both encodings of one signature to the same hex', () => {
+    expect(decodeSignature(asRawBytes)).toBe(decodeSignature(asHexText));
+  });
+
+  it('should preserve a long smart-account signature', () => {
+    // ERC-6492 wrapped signatures run to a few hundred bytes and end in the magic
+    // suffix. They must survive decoding intact rather than being truncated or rejected.
+    const magic = '6492'.repeat(16);
+    const long = `0x${'ab'.repeat(200)}${magic}`;
+    expect(decodeSignature(toBase64Url(long))).toBe(long);
+  });
+
+  it('should not mistake a non-hex payload for hex text', () => {
+    const raw = String.fromCharCode(0x30, 0x78, 0x9f, 0x01); // starts with "0x", not hex
+    expect(decodeSignature(toBase64Url(raw))).toBe('0x30789f01');
   });
 });

--- a/packages/miniapp-manifest-generator/src/utilities/base64.ts
+++ b/packages/miniapp-manifest-generator/src/utilities/base64.ts
@@ -1,7 +1,39 @@
+import type { Hex } from 'viem';
+
 export const toBase64Url = (str: string) => {
   return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
 };
 
 export const fromBase64Url = (str: string) => {
   return atob(str.replace(/-/g, '+').replace(/_/g, '/'));
+};
+
+/**
+ * Decode an accountAssociation `signature` field to hex.
+ *
+ * Two encodings exist in the wild and both are legitimate:
+ *
+ *   - base64url of the raw signature bytes. This is the canonical form -- it is what
+ *     @farcaster/miniapp-node's JFS codec both emits and parses -- and it is the majority
+ *     of live manifests.
+ *   - base64url of the ASCII string "0x...", which is what this package's own
+ *     useSignManifest produces (toBase64Url of wagmi's hex signature).
+ *
+ * The spec's own examples use one of each, so a validator has to accept both. Decoding
+ * only the second form turns every manifest signed by other tooling into a bogus
+ * "invalid signature length".
+ */
+export const decodeSignature = (encoded: string): Hex => {
+  const binary = fromBase64Url(encoded);
+  const text = binary.trim();
+
+  if (/^0x[0-9a-fA-F]+$/.test(text) && text.length % 2 === 0) {
+    return text as Hex;
+  }
+
+  let hex = '';
+  for (let i = 0; i < binary.length; i++) {
+    hex += binary.charCodeAt(i).toString(16).padStart(2, '0');
+  }
+  return `0x${hex}` as Hex;
 };


### PR DESCRIPTION
Fixes the manifest validator in `packages/miniapp-manifest-generator`, which currently
rejects **130 of the 167** mini app manifests live in Farcaster's directory. None of the 130
are invalid — they all pass a spec-conformant check.

Full measurement, method and raw data in #2672.

| replaying the current hook over 167 live associations | count |
| --- | --- |
| accepted | 37 |
| `Invalid type: type must be "custody"` | 89 |
| `invalid signature length` | 41 |

## What changed

**1. Accept `header.type: "auth"`.** The specification says the type must be `"custody"` or
`"auth"`, and across live manifests `auth` is now the majority — 89 to 78. Those 89 were
being rejected before their signature was even read.

Relaxing the type check alone would be a regression, though: an auth key is *not* the
custody address, so `IdRegistry.custodyOf(fid)` is the wrong binding check for it, and
accepting `auth` without branching would trade a false rejection for a false acceptance.
So the binding step now branches — custody keys resolve through `custodyOf`, auth keys
through the FID's hub verifications (`/v1/verificationsByFid`). A key that *is* the custody
address is accepted either way, since it binds the domain regardless of how the header
labels it.

This is the one design decision worth a second opinion: it introduces a hub fetch, with the
public hub as a new `FARCASTER_HUB_URL` constant. If you would rather source that from
Neynar, your own API, or make it configurable, say so and I will rework it.

**2. Decode both signature encodings.** `fromBase64Url` is `atob`, so the previous
`fromBase64Url(sig) as Hex` only worked when the field was base64url of the ASCII text
`"0x…"` — which is what this package's own `useSignManifest` emits (`btoa` of wagmi's hex
string). The canonical form is base64url of the raw signature bytes: it is what
`@farcaster/miniapp-node`'s JFS codec both emits and parses, and it is 130 of the 167 live
manifests. For those, `atob` produced binary garbage and viem threw `invalid signature
length`.

The net effect today is that the validator accepts precisely the manifests its own
generator produced. The spec page's two examples happen to use one encoding each, which is
probably how the split arose, so the new `decodeSignature` helper accepts both.

**3. Verify against the public client.** The hook called viem's top-level `verifyMessage` —
the offline `ecrecover` utility — rather than the client action, despite already
constructing a public client ten lines later for `custodyOf`. Offline verification cannot
resolve ERC-1271, nor ERC-6492 for an account still counterfactual on the verifying chain,
so any smart-account signer was reported as a forgery.

No custody-type smart account happens to be in the current sample, so this one is latent
rather than firing today. `turbo-gum.xyz` (fid 452215) shows the shape of it — a 1440-byte
association ending in the ERC-6492 magic that fails offline and verifies true on OP
mainnet. Smart wallets are only getting more common.

## Behaviour changes

- `type: "auth"` is now accepted when the key is bound; previously always rejected.
- The type error message is now `Invalid type: type must be "custody" or "auth"`.
- New error `Invalid auth address: not verified for this FID` when an auth key is not bound.
- New error `Could not reach a Farcaster hub to check the auth address` — a hub outage
  fails closed rather than silently passing.
- `Invalid signature` and `Invalid custody address` are unchanged.

## Tests

`useValidateManifest.test.tsx` keeps all five existing cases (with the type-error message
and the `verifyMessage` mock updated to the client action) and adds four: an auth address
the FID has verified, one it has not, an auth-typed association signed by the custody
address, and a hub failure. `base64.test.ts` keeps its eight and adds five for
`decodeSignature`, covering both encodings, their equivalence, a long ERC-6492 signature,
and a raw payload that merely starts with the bytes `0x`.

22 tests pass. **Disclosure on how I ran them:** I could not install the full monorepo on
the machine I work from, so I ran these two suites in an isolated vitest project against
the package's real sources (`useValidateManifest.ts`, `base64.ts`, `constants.ts`,
`useSignManifest.ts` unmodified from this branch). Please let CI be the arbiter for the
workspace run — if lint or type-check has opinions I have not anticipated, point me at them
and I will fix them.

I also ran the patched logic over all 167 live associations: **166 accepted, 1 rejected** —
`sprinkles.wtf`, whose declared custody key is neither fid 209951's custody address nor
among that FID's hub verifications. (`faster-tasks.com`, whose association is signed for
`fastertasks.xyz`, is accepted here because the hook does not check the serving domain —
see *Not included* below.)

## Not included

No changeset — `miniapp-manifest-generator` is in the changesets `ignore` list.

The independent check that `payload.domain` matches the domain actually serving the
manifest is still absent from the hook. It is a different concern from this PR and the
generator may not know the serving domain at validation time, so I left it alone; happy to
add it separately if you want it.
