### PR TITLE
fix: give TransactionButton an accessible name while a transaction is in progress

### DIFF
--- a/.changeset/transaction-button-accessible-name.md
+++ b/.changeset/transaction-button-accessible-name.md
@@ -1,0 +1,5 @@
+---
+"@coinbase/onchainkit": patch
+---
+
+fix: Give TransactionButton an accessible name and aria-busy while a transaction is in progress

--- a/packages/onchainkit/src/transaction/components/TransactionButton.test.tsx
+++ b/packages/onchainkit/src/transaction/components/TransactionButton.test.tsx
@@ -325,4 +325,50 @@ describe('TransactionButton', () => {
     fireEvent.click(button);
     expect(onSubmit).toHaveBeenCalled();
   });
+
+  it('exposes an accessible name and busy state while the transaction is in progress', () => {
+    (useTransactionContext as Mock).mockReturnValue({
+      isLoading: true,
+      lifecycleStatus: { statusName: 'init', statusData: null },
+    });
+    render(<TransactionButton text="Transact" />);
+    const button = screen.getByRole('button', {
+      name: 'Transaction in progress',
+    });
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByTestId('ockSpinner')).toBeInTheDocument();
+  });
+
+  it('uses the visible text as the accessible name when not in progress', () => {
+    (useTransactionContext as Mock).mockReturnValue({
+      isLoading: false,
+      lifecycleStatus: { statusName: 'init', statusData: null },
+    });
+    render(<TransactionButton text="Transact" />);
+    const button = screen.getByRole('button', { name: 'Transact' });
+    expect(button).not.toHaveAttribute('aria-label');
+    expect(button).not.toHaveAttribute('aria-busy');
+  });
+
+  it('keeps the result text as the accessible name once the transaction has settled', () => {
+    (useTransactionContext as Mock).mockReturnValue({
+      isLoading: true,
+      lifecycleStatus: { statusName: 'init', statusData: null },
+      receipt: '123',
+    });
+    const { rerender } = render(<TransactionButton text="Transact" />);
+    const successButton = screen.getByRole('button', {
+      name: 'View transaction',
+    });
+    expect(successButton).not.toHaveAttribute('aria-busy');
+
+    (useTransactionContext as Mock).mockReturnValue({
+      isLoading: true,
+      lifecycleStatus: { statusName: 'init', statusData: null },
+      errorMessage: 'blah blah',
+    });
+    rerender(<TransactionButton text="Transact" />);
+    const errorButton = screen.getByRole('button', { name: 'Try again' });
+    expect(errorButton).not.toHaveAttribute('aria-busy');
+  });
 });

--- a/packages/onchainkit/src/transaction/components/TransactionButton.tsx
+++ b/packages/onchainkit/src/transaction/components/TransactionButton.tsx
@@ -95,6 +95,10 @@ export function TransactionButton({
     return 'default';
   }, [isLoading, errorMessage, receipt]);
 
+  // The spinner has no text, so while it is showing the button would have no
+  // accessible name. Give it one, and mark it busy, until the pending state ends.
+  const isPending = status === 'pending';
+
   if (render) {
     return render({
       status,
@@ -120,6 +124,8 @@ export function TransactionButton({
       onClick={handleSubmit}
       type="button"
       disabled={isDisabled}
+      aria-busy={isPending || undefined}
+      aria-label={isPending ? 'Transaction in progress' : undefined}
       data-testid="ockTransactionButton_Button"
     >
       {buttonContent}


### PR DESCRIPTION
**What changed? Why?**

Fixes #2675.

`TransactionButton` replaces its label with a bare `<Spinner />` while a transaction is being signed or is pending. `Spinner` renders no text, so the `<button>` has no accessible name for the whole time it is disabled. axe-core reports it as `button-name` (WCAG 4.1.2), and a screen reader user who has just submitted a transaction is told nothing about the control they were on.

This adds `aria-label="Transaction in progress"` and `aria-busy="true"` to the button for exactly the branch that shows the spinner (no receipt, no error, `isLoading`). Both come off again as soon as the button reads "View transaction", "Try again" or the idle text, so the visible label stays the accessible name in every other state.

The wording is the one the codebase already uses: `CheckoutButton` sets `aria-label={isLoading ? 'Transaction in progress' : buttonText}`, and `TransactionToastLabel` shows "Transaction in progress" for the same state, so the button and the status line now say the same thing.

The `render` prop path is unchanged. Custom renderers already receive `status` and own their own markup.

**Notes to reviewers**

- Scoped to `TransactionButton`, which is what the issue reports. The same spinner swap happens in `SwapButton`, `BuyButton`, `FundButton`, `NFTMintButton`, `ConnectWallet` and the earn and send render buttons, and none of them set a name while loading. Happy to follow up on those separately if wanted.
- `aria-busy` is only rendered while pending rather than as `aria-busy="false"` the rest of the time, so the idle DOM is exactly as before.
- Changeset included (patch).

**How has it been tested?**

- Three new tests in `TransactionButton.test.tsx`: the button is found by role with the name "Transaction in progress" and carries `aria-busy="true"` while loading; the visible text is the name and neither attribute is present when idle; and the "View transaction" and "Try again" states are unaffected even with `isLoading` still true. `pnpm f:ock test:coverage`, `pnpm f:ock lint` and prettier all pass locally.
- Re-ran the axe-core and IBM Equal Access scans that found the issue against the built package, in a small Vite app with an injected test EIP-1193 wallet that can hold a transaction in the approving and pending states. axe `button-name`: 2 occurrences before (approving, pending), 0 after. Equal Access `input_label_exists`: 2 before, 0 after. No other finding changed, apart from two unrelated `color-contrast` hits on the confirmed state's toast that did not recur on the second run.
