### PR TITLE
fix: harden create-onchain --manifest websocket against CSWSH and code injection

### DIFF
--- a/.changeset/eighty-donkeys-shave.md
+++ b/.changeset/eighty-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+"create-onchain": patch
+---
+
+fix: Harden the `create-onchain --manifest` WebSocket server against cross-origin connections and config file code injection

--- a/packages/create-onchain/src/cli.ts
+++ b/packages/create-onchain/src/cli.ts
@@ -72,8 +72,8 @@ Available Templates:
   }
 
   if (isManifest) {
-    await createMiniKitManifest();
-    process.exit(0);
+    const succeeded = await createMiniKitManifest();
+    process.exit(succeeded ? 0 : 1);
   }
 
   if (isMiniKit) {

--- a/packages/create-onchain/src/minikit.manifest-server.test.ts
+++ b/packages/create-onchain/src/minikit.manifest-server.test.ts
@@ -1,0 +1,288 @@
+/**
+ * End-to-end coverage for SECBUGS-22415.
+ *
+ * `minikit.test.ts` mocks `http` and `ws`, so it can only assert that the
+ * hardening options are passed. These tests run the real server and drive real
+ * WebSocket clients against it, which is the only way to prove that a hostile
+ * client never reaches the code that writes `minikit.config.ts`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { WebSocket } from 'ws';
+import { createMiniKitManifest } from './minikit';
+
+vi.mock('open', () => ({ default: vi.fn() }));
+// `analyticsPrompt` is unused by the manifest flow but pulls in prompts on import.
+vi.mock('./analytics.js', () => ({ analyticsPrompt: vi.fn() }));
+
+const open = (await import('open')).default as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+const CONFIG_TEMPLATE = `export const minikitConfig = {
+  accountAssociation: {
+    header: "",
+    payload: "",
+    signature: "",
+  },
+};
+`;
+
+const validAssociation = {
+  header: 'eyJmaWQiOjEyMywidHlwZSI6ImN1c3RvZHkifQ',
+  payload: 'eyJkb21haW4iOiJleGFtcGxlLmNvbSJ9',
+  signature: 'MHgxMjM0NTY3ODkwYWJjZGVm',
+  domain: 'https://example.com',
+};
+
+const EXPECTED_ORIGIN = 'http://127.0.0.1:3333';
+
+let projectDir: string;
+let previousCwd: string;
+
+function readOpenedUrl() {
+  const url = open.mock.calls[0]?.[0] as string | undefined;
+  if (!url) {
+    throw new Error('the manifest flow never opened a browser');
+  }
+  return url;
+}
+
+function tokenFromOpenedUrl() {
+  return new URL(readOpenedUrl()).hash.replace('#token=', '');
+}
+
+/**
+ * Resolves `'connected'` once the handshake succeeds, or `'rejected'` if the
+ * server refuses the upgrade.
+ */
+function handshake({
+  origin,
+  token,
+  host = '127.0.0.1',
+  message,
+}: {
+  origin?: string;
+  token?: string;
+  host?: string;
+  message?: string;
+}): Promise<'connected' | 'rejected'> {
+  return new Promise((resolve) => {
+    const query = token === undefined ? '' : `/?token=${token}`;
+    const client = new WebSocket(`ws://${host}:3333${query}`, {
+      headers: origin ? { Origin: origin } : {},
+    });
+
+    client.on('open', () => {
+      if (message !== undefined) {
+        client.send(message);
+      }
+      setTimeout(() => {
+        client.close();
+        resolve('connected');
+      }, 50);
+    });
+    client.on('error', () => resolve('rejected'));
+  });
+}
+
+async function waitForServer() {
+  await vi.waitFor(() => expect(open).toHaveBeenCalled());
+}
+
+/**
+ * `server.close()` frees the port asynchronously, so without this the next test
+ * hits EADDRINUSE.
+ */
+function waitForPortRelease() {
+  return vi.waitFor(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        const probe = net.createServer();
+        probe.once('error', reject);
+        probe.listen(3333, '127.0.0.1', () => probe.close(() => resolve()));
+      }),
+    { timeout: 5000, interval: 25 },
+  );
+}
+
+/** Resolves true when a TCP connection to `host:3333` is established. */
+function canConnect(host: string, timeout = 1500) {
+  return new Promise<boolean>((resolve) => {
+    const socket = net.connect({ host, port: 3333, timeout });
+    const finish = (result: boolean) => {
+      socket.destroy();
+      resolve(result);
+    };
+    socket.once('connect', () => finish(true));
+    socket.once('timeout', () => finish(false));
+    socket.once('error', () => finish(false));
+  });
+}
+
+beforeEach(() => {
+  previousCwd = process.cwd();
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'minikit-manifest-'));
+  fs.writeFileSync(path.join(projectDir, '.env'), 'NEXT_PUBLIC_URL=""\n');
+  fs.writeFileSync(path.join(projectDir, 'minikit.config.ts'), CONFIG_TEMPLATE);
+  process.chdir(projectDir);
+  open.mockReset();
+});
+
+afterEach(async () => {
+  await waitForPortRelease();
+  process.chdir(previousCwd);
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+function readConfig() {
+  return fs.readFileSync(path.join(projectDir, 'minikit.config.ts'), 'utf-8');
+}
+
+function readEnv() {
+  return fs.readFileSync(path.join(projectDir, '.env'), 'utf-8');
+}
+
+describe('create-onchain --manifest server', () => {
+  it('accepts the page it opened and writes the account association', async () => {
+    const run = createMiniKitManifest();
+    await waitForServer();
+
+    expect(readOpenedUrl()).toMatch(
+      /^http:\/\/127\.0\.0\.1:3333\/#token=[\w-]{43}$/,
+    );
+
+    await expect(
+      handshake({
+        origin: EXPECTED_ORIGIN,
+        token: tokenFromOpenedUrl(),
+        message: JSON.stringify(validAssociation),
+      }),
+    ).resolves.toBe('connected');
+
+    await expect(run).resolves.toBe(true);
+    expect(readConfig()).toContain(`header: "${validAssociation.header}"`);
+    expect(readConfig()).toContain(`payload: "${validAssociation.payload}"`);
+    expect(readConfig()).toContain(
+      `signature: "${validAssociation.signature}"`,
+    );
+    expect(readEnv()).toContain('NEXT_PUBLIC_URL="https://example.com"');
+  });
+
+  it.each([
+    [
+      'a cross-origin page that stole the token',
+      (token: string) => ({ origin: 'https://attacker.example.com', token }),
+    ],
+    [
+      'a cross-origin page with no token',
+      () => ({ origin: 'https://attacker.example.com' }),
+    ],
+    ['a client that sends no Origin header', (token: string) => ({ token })],
+    ['the right origin with no token', () => ({ origin: EXPECTED_ORIGIN })],
+    [
+      'the right origin with a wrong token',
+      () => ({ origin: EXPECTED_ORIGIN, token: 'not-the-session-token' }),
+    ],
+    [
+      'the right origin with a same-length wrong token',
+      (token: string) => ({
+        origin: EXPECTED_ORIGIN,
+        token: 'a'.repeat(token.length),
+      }),
+    ],
+  ])('refuses the handshake from %s', async (_label, buildAttempt) => {
+    const run = createMiniKitManifest();
+    await waitForServer();
+    const token = tokenFromOpenedUrl();
+
+    const evil = JSON.stringify({
+      ...validAssociation,
+      header: `" + require('child_process').execSync('id') + "`,
+    });
+
+    await expect(
+      handshake({ ...buildAttempt(token), message: evil }),
+    ).resolves.toBe('rejected');
+
+    expect(readConfig()).toBe(CONFIG_TEMPLATE);
+
+    // Let the legitimate client finish so the server shuts down.
+    await handshake({
+      origin: EXPECTED_ORIGIN,
+      token,
+      message: JSON.stringify(validAssociation),
+    });
+    await run;
+  });
+
+  it('listens on loopback but not on a non-loopback interface', async () => {
+    const lanAddress = Object.values(os.networkInterfaces())
+      .flat()
+      .find(
+        (iface) => iface && iface.family === 'IPv4' && !iface.internal,
+      )?.address;
+
+    const run = createMiniKitManifest();
+    await waitForServer();
+    const token = tokenFromOpenedUrl();
+
+    expect(await canConnect('127.0.0.1')).toBe(true);
+    if (lanAddress) {
+      expect(await canConnect(lanAddress)).toBe(false);
+    }
+
+    await handshake({
+      origin: EXPECTED_ORIGIN,
+      token,
+      message: JSON.stringify(validAssociation),
+    });
+    await run;
+  });
+
+  it.each([
+    [
+      'a header that escapes the string literal',
+      { header: `" + require('child_process').execSync('id') + "` },
+    ],
+    [
+      'a domain that opens a second .env assignment',
+      { domain: 'https://example.com"\nEVIL="1' },
+    ],
+    ['a domain with credentials', { domain: 'https://user:pw@example.com' }],
+    ['a non-http domain', { domain: 'javascript:alert(1)' }],
+  ])(
+    'rejects %s sent over the authorised connection',
+    async (_label, override) => {
+      const run = createMiniKitManifest();
+      await waitForServer();
+
+      await handshake({
+        origin: EXPECTED_ORIGIN,
+        token: tokenFromOpenedUrl(),
+        message: JSON.stringify({ ...validAssociation, ...override }),
+      });
+
+      await expect(run).resolves.toBe(false);
+      expect(readConfig()).toBe(CONFIG_TEMPLATE);
+      expect(readEnv()).toBe('NEXT_PUBLIC_URL=""\n');
+    },
+  );
+
+  it('does not crash on a frame larger than maxPayload', async () => {
+    const run = createMiniKitManifest();
+    await waitForServer();
+
+    await handshake({
+      origin: EXPECTED_ORIGIN,
+      token: tokenFromOpenedUrl(),
+      message: 'x'.repeat(256 * 1024 + 1),
+    });
+
+    await expect(run).resolves.toBe(false);
+    expect(readConfig()).toBe(CONFIG_TEMPLATE);
+  });
+});

--- a/packages/create-onchain/src/minikit.test.ts
+++ b/packages/create-onchain/src/minikit.test.ts
@@ -12,8 +12,17 @@ import path from 'path';
 import prompts from 'prompts';
 import open from 'open';
 import ora from 'ora';
+import express from 'express';
 import { WebSocketServer } from 'ws';
 import { createMiniKitManifest, createMiniKitTemplate } from './minikit';
+
+const { mockHttpServer } = vi.hoisted(() => ({
+  mockHttpServer: {
+    listen: vi.fn(),
+    close: vi.fn(),
+    on: vi.fn(),
+  },
+}));
 
 vi.mock('./utils.js', () => ({
   copyDir: vi.fn().mockResolvedValue(undefined),
@@ -38,10 +47,7 @@ vi.mock('ws', () => ({
 }));
 vi.mock('http', () => ({
   default: {
-    createServer: vi.fn(() => ({
-      listen: vi.fn().mockImplementation((_, callback) => callback()),
-      close: vi.fn(),
-    })),
+    createServer: vi.fn(() => mockHttpServer),
   },
 }));
 vi.mock('open', () => ({ default: vi.fn() }));
@@ -107,11 +113,37 @@ NEXT_PUBLIC_ONCHAINKIT_API_KEY="${clientKey}"
 NEXT_PUBLIC_URL=""
 `;
 
+const validAccountAssociation = {
+  header: 'test-header',
+  payload: 'test-payload',
+  signature: 'test-signature',
+  domain: 'https://example.com',
+};
+
+// `vi.resetAllMocks()` in afterEach strips the implementations declared in the
+// `vi.mock` factories above, so the server mocks have to be re-armed each test.
+function setupServerMocks() {
+  (express as unknown as Mock).mockImplementation(() => ({
+    use: vi.fn(),
+    listen: vi.fn(),
+  }));
+  (express.static as unknown as Mock).mockReturnValue(vi.fn());
+
+  mockHttpServer.listen.mockImplementation((...args: unknown[]) => {
+    const callback = args.find((arg) => typeof arg === 'function');
+    (callback as (() => void) | undefined)?.();
+    return mockHttpServer;
+  });
+  mockHttpServer.close.mockReturnValue(mockHttpServer);
+  mockHttpServer.on.mockReturnValue(mockHttpServer);
+}
+
 describe('MiniKit', () => {
   const originalGetArgs = process.argv;
 
   beforeEach(() => {
     process.argv = [...originalGetArgs];
+    setupServerMocks();
 
     (fs.promises.mkdir as Mock).mockResolvedValue(true);
     (fs.promises.readdir as Mock)
@@ -224,22 +256,15 @@ describe('MiniKit', () => {
     });
 
     (WebSocketServer as unknown as Mock).mockImplementation(() => ({
+      clients: new Set(),
+      close: vi.fn(),
       on: vi.fn((event, cb) => {
         if (event === 'connection') {
           setTimeout(() => {
             cb({
               on: vi.fn((event, msgCb) => {
                 if (event === 'message') {
-                  msgCb(
-                    Buffer.from(
-                      JSON.stringify({
-                        header: 'test-header',
-                        payload: 'test-payload',
-                        signature: 'test-signature',
-                        domain: 'test-domain',
-                      }),
-                    ),
-                  );
+                  msgCb(Buffer.from(JSON.stringify(validAccountAssociation)));
                   resolveWebSocket(true);
                 }
               }),
@@ -271,10 +296,12 @@ describe('MiniKit', () => {
       createManifestPromise,
     ]);
 
-    expect(open).toHaveBeenCalledWith('http://localhost:3333');
+    expect(open).toHaveBeenCalledWith(
+      expect.stringMatching(/^http:\/\/127\.0\.0\.1:3333\/#token=[\w-]{43}$/),
+    );
     expect(fs.promises.writeFile).toHaveBeenCalledWith(
       expect.any(String),
-      expect.stringContaining('NEXT_PUBLIC_URL="test-domain"'),
+      expect.stringContaining('NEXT_PUBLIC_URL="https://example.com"'),
     );
     expect(fs.promises.writeFile).toHaveBeenCalledWith(
       expect.any(String),
@@ -296,5 +323,252 @@ describe('MiniKit', () => {
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining('Created new MiniKit project in'),
     );
+  });
+
+  describe('manifest WebSocket hardening', () => {
+    type VerifyClientInfo = {
+      origin?: string;
+      req: { url?: string };
+    };
+
+    function startManifestFlow() {
+      let connectionHandler: ((ws: unknown) => void) | undefined;
+      let serverOptions:
+        | {
+            maxPayload: number;
+            verifyClient: (info: VerifyClientInfo) => boolean;
+          }
+        | undefined;
+
+      (WebSocketServer as unknown as Mock).mockImplementation(
+        (options: typeof serverOptions) => {
+          serverOptions = options;
+          return {
+            clients: new Set(),
+            close: vi.fn(),
+            on: vi.fn((event: string, cb: (ws: unknown) => void) => {
+              if (event === 'connection') {
+                connectionHandler = cb;
+              }
+            }),
+          };
+        },
+      );
+
+      const result = createMiniKitManifest();
+
+      return {
+        result,
+        async ready() {
+          await vi.waitFor(() => expect(connectionHandler).toBeDefined());
+        },
+        get options() {
+          if (!serverOptions) {
+            throw new Error('WebSocketServer was not constructed');
+          }
+          return serverOptions;
+        },
+        get token() {
+          const url = (open as unknown as Mock).mock.calls[0][0] as string;
+          return new URL(url).hash.replace('#token=', '');
+        },
+        send(raw: string) {
+          let messageHandler: ((data: Buffer) => void) | undefined;
+          connectionHandler?.({
+            on: (event: string, cb: (data: Buffer) => void) => {
+              if (event === 'message') {
+                messageHandler = cb;
+              }
+            },
+          });
+          messageHandler?.(Buffer.from(raw));
+        },
+      };
+    }
+
+    it('binds the manifest server to loopback only', async () => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      expect(mockHttpServer.listen).toHaveBeenCalledWith(
+        3333,
+        '127.0.0.1',
+        expect.any(Function),
+      );
+
+      flow.send(JSON.stringify(validAccountAssociation));
+      await expect(flow.result).resolves.toBe(true);
+    });
+
+    it('accepts a handshake from the page it opened', async () => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      expect(
+        flow.options.verifyClient({
+          origin: 'http://127.0.0.1:3333',
+          req: { url: `/?token=${flow.token}` },
+        }),
+      ).toBe(true);
+
+      flow.send(JSON.stringify(validAccountAssociation));
+      await flow.result;
+    });
+
+    it('rejects a handshake from a cross-origin page', async () => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      expect(
+        flow.options.verifyClient({
+          origin: 'https://attacker.example.com',
+          req: { url: `/?token=${flow.token}` },
+        }),
+      ).toBe(false);
+
+      flow.send(JSON.stringify(validAccountAssociation));
+      await flow.result;
+    });
+
+    it('rejects a handshake with no Origin header', async () => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      expect(
+        flow.options.verifyClient({
+          req: { url: `/?token=${flow.token}` },
+        }),
+      ).toBe(false);
+
+      flow.send(JSON.stringify(validAccountAssociation));
+      await flow.result;
+    });
+
+    it('rejects a handshake with a missing or wrong session token', async () => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      expect(
+        flow.options.verifyClient({
+          origin: 'http://127.0.0.1:3333',
+          req: { url: '/' },
+        }),
+      ).toBe(false);
+      expect(
+        flow.options.verifyClient({
+          origin: 'http://127.0.0.1:3333',
+          req: { url: '/?token=not-the-real-token' },
+        }),
+      ).toBe(false);
+      expect(
+        flow.options.verifyClient({
+          origin: 'http://127.0.0.1:3333',
+          req: { url: `/?token=${'a'.repeat(flow.token.length)}` },
+        }),
+      ).toBe(false);
+
+      flow.send(JSON.stringify(validAccountAssociation));
+      await flow.result;
+    });
+
+    it('issues a different session token on every run', async () => {
+      const first = startManifestFlow();
+      await first.ready();
+      const firstToken = first.token;
+      first.send(JSON.stringify(validAccountAssociation));
+      await first.result;
+
+      (open as unknown as Mock).mockClear();
+
+      const second = startManifestFlow();
+      await second.ready();
+      const secondToken = second.token;
+      second.send(JSON.stringify(validAccountAssociation));
+      await second.result;
+
+      expect(firstToken).toHaveLength(43);
+      expect(secondToken).not.toBe(firstToken);
+    });
+
+    it('caps the accepted message size', async () => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      expect(flow.options.maxPayload).toBe(256 * 1024);
+
+      flow.send(JSON.stringify(validAccountAssociation));
+      await flow.result;
+    });
+
+    it.each([
+      [
+        'a header that escapes the string literal',
+        {
+          ...validAccountAssociation,
+          header: `" + require('child_process').execSync('id') + "`,
+        },
+      ],
+      [
+        'a payload that escapes the string literal',
+        { ...validAccountAssociation, payload: '","evil":"' },
+      ],
+      [
+        'a signature that escapes the string literal',
+        { ...validAccountAssociation, signature: '\\", process.exit(1), "' },
+      ],
+      [
+        'a domain that escapes the .env value',
+        {
+          ...validAccountAssociation,
+          domain: 'https://example.com"\nEVIL="1',
+        },
+      ],
+      [
+        'a domain with a non-http protocol',
+        { ...validAccountAssociation, domain: 'javascript:alert(1)' },
+      ],
+      [
+        'a non-string field',
+        { ...validAccountAssociation, header: { toString: 'nope' } },
+      ],
+    ])('rejects %s', async (_label, association) => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      flow.send(JSON.stringify(association));
+
+      await expect(flow.result).resolves.toBe(false);
+      expect(fs.promises.writeFile).not.toHaveBeenCalled();
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to generate account association'),
+      );
+    });
+
+    it('rejects malformed JSON', async () => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      flow.send('not json');
+
+      await expect(flow.result).resolves.toBe(false);
+      expect(fs.promises.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('writes account association values as escaped string literals', async () => {
+      const flow = startManifestFlow();
+      await flow.ready();
+
+      flow.send(JSON.stringify(validAccountAssociation));
+      await expect(flow.result).resolves.toBe(true);
+
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('.env'),
+        expect.stringContaining('NEXT_PUBLIC_URL="https://example.com"'),
+      );
+      expect(fs.promises.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('minikit.config.ts'),
+        expect.stringContaining('header: "test-header"'),
+      );
+    });
   });
 });

--- a/packages/create-onchain/src/minikit.ts
+++ b/packages/create-onchain/src/minikit.ts
@@ -14,6 +14,8 @@ import {
 import open from 'open';
 import express from 'express';
 import { createServer } from 'http';
+import type { IncomingMessage } from 'http';
+import { randomBytes, timingSafeEqual } from 'crypto';
 import { WebSocketServer, WebSocket } from 'ws';
 import { analyticsPrompt } from './analytics.js';
 
@@ -24,10 +26,167 @@ type WebpageData = {
   domain: string;
 };
 
+const MANIFEST_PORT = 3333;
+
+// Bind to loopback only. Binding to every interface exposes the manifest
+// generator to any host on the local network.
+//
+// This must be a literal address rather than `localhost`. `localhost` can
+// resolve to either `::1` or `127.0.0.1`, so the browser could be sent to a
+// different process than the one this CLI bound, and that process would then
+// hold the session token below.
+const MANIFEST_HOST = '127.0.0.1';
+const MANIFEST_ORIGIN = `http://${MANIFEST_HOST}:${MANIFEST_PORT}`;
+
+// The generator base64url-encodes each field, so the alphabet is fixed and
+// contains no character that can terminate a string literal.
+const BASE64URL_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+// RFC 3986 unreserved and reserved characters, minus `"`, `'`, `` ` ``, `\` and
+// `$`. Those are legal in a URL but would let the value escape the quoted
+// value written to `.env`, or be expanded by a shell-style `.env` loader.
+const DOMAIN_PATTERN = /^[A-Za-z0-9\-._~:/?#[\]@!&()*+,;=%]+$/;
+
+// Smart-wallet signatures (ERC-6492 wrapped) can run to several kilobytes, so
+// this is a denial-of-service guard rather than a format check. The character
+// allowlists above are what prevent injection.
+const MAX_FIELD_LENGTH = 64 * 1024;
+
+// Generous enough for any legitimate account association, small enough that a
+// local client cannot make the CLI buffer an unbounded message. The ws default
+// is 100 MiB.
+const MAX_MESSAGE_BYTES = 256 * 1024;
+
+function isEqualToken(provided: string, expected: string): boolean {
+  const providedBuffer = Buffer.from(provided);
+  const expectedBuffer = Buffer.from(expected);
+  if (providedBuffer.length !== expectedBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(providedBuffer, expectedBuffer);
+}
+
+function isAuthorizedRequest(
+  origin: string | undefined,
+  req: IncomingMessage,
+  sessionToken: string,
+): boolean {
+  // Only the page this CLI serves may open a WebSocket. Without this check any
+  // cross-origin page open in the developer's browser can connect, because the
+  // same-origin policy does not apply to WebSockets. A browser always sends
+  // `Origin` on a WebSocket handshake, so an absent value means the client is
+  // not the page we served.
+  if (origin !== MANIFEST_ORIGIN) {
+    return false;
+  }
+
+  let requestUrl: URL;
+  try {
+    requestUrl = new URL(req.url ?? '/', MANIFEST_ORIGIN);
+  } catch {
+    return false;
+  }
+
+  return isEqualToken(requestUrl.searchParams.get('token') ?? '', sessionToken);
+}
+
+function parseBase64UrlField(name: string, value: unknown): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_FIELD_LENGTH ||
+    !BASE64URL_PATTERN.test(value)
+  ) {
+    throw new Error(
+      `Received an invalid "${name}" value from the manifest generator.`,
+    );
+  }
+  return value;
+}
+
+function parseDomainField(value: unknown): string {
+  const invalid = () =>
+    new Error(
+      'Received an invalid "domain" value from the manifest generator.',
+    );
+
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > MAX_FIELD_LENGTH ||
+    !DOMAIN_PATTERN.test(value)
+  ) {
+    throw invalid();
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw invalid();
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    throw invalid();
+  }
+
+  // This becomes NEXT_PUBLIC_URL, which the app concatenates onto to build the
+  // manifest's homeUrl, webhookUrl and iconUrl. Credentials, a query or a
+  // fragment either leak into a committed file or break that concatenation.
+  if (url.username || url.password || url.search || url.hash) {
+    throw invalid();
+  }
+
+  return value;
+}
+
+function parseWebpageData(raw: string): WebpageData {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('The manifest generator sent malformed JSON.');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('The manifest generator sent an unexpected payload.');
+  }
+
+  const { header, payload, signature, domain } = parsed as Record<
+    string,
+    unknown
+  >;
+
+  return {
+    header: parseBase64UrlField('header', header),
+    payload: parseBase64UrlField('payload', payload),
+    signature: parseBase64UrlField('signature', signature),
+    domain: parseDomainField(domain),
+  };
+}
+
 async function getWebpageData(): Promise<WebpageData> {
   const app = express();
   const server = createServer(app);
-  const wss = new WebSocketServer({ server });
+
+  // Single-use secret shared with the browser through the URL fragment below.
+  // A fragment is never sent to any server, so only the page this CLI opened
+  // can present it.
+  const sessionToken = randomBytes(32).toString('base64url');
+
+  const wss = new WebSocketServer({
+    server,
+    maxPayload: MAX_MESSAGE_BYTES,
+    // `origin` is typed as `string` by @types/ws but is `req.headers.origin`,
+    // which is absent for non-browser clients.
+    verifyClient: ({
+      origin,
+      req,
+    }: {
+      origin: string | undefined;
+      req: IncomingMessage;
+    }) => isAuthorizedRequest(origin, req, sessionToken),
+  });
 
   app.use(
     express.static(
@@ -35,17 +194,51 @@ async function getWebpageData(): Promise<WebpageData> {
     ),
   );
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
+    let isSettled = false;
+
+    // `server.close()` alone leaves upgraded WebSocket connections open, which
+    // keeps the process alive for any caller that does not immediately exit.
+    function settle(complete: () => void) {
+      if (isSettled) {
+        return;
+      }
+      isSettled = true;
+      for (const client of wss.clients) {
+        client.terminate();
+      }
+      wss.close();
+      server.close();
+      complete();
+    }
+
     wss.on('connection', (ws: WebSocket) => {
+      // Without this listener a protocol-level failure, such as a frame over
+      // `maxPayload`, is an unhandled 'error' event and terminates the process.
+      ws.on('error', (error: Error) => settle(() => reject(error)));
+
       ws.on('message', (data: Buffer) => {
-        const parsedData = JSON.parse(data.toString());
-        server.close();
-        resolve(parsedData);
+        try {
+          const webpageData = parseWebpageData(data.toString());
+          settle(() => resolve(webpageData));
+        } catch (error) {
+          settle(() => reject(error));
+        }
       });
     });
 
-    server.listen(3333, () => {
-      open('http://localhost:3333');
+    wss.on('error', (error: Error) => settle(() => reject(error)));
+    server.on('error', (error: Error) => settle(() => reject(error)));
+
+    server.listen(MANIFEST_PORT, MANIFEST_HOST, () => {
+      const pageUrl = `${MANIFEST_ORIGIN}/#token=${sessionToken}`;
+      Promise.resolve(open(pageUrl)).catch(() => {
+        console.log(
+          pc.yellow(
+            `\n* Could not open a browser automatically. Open this URL to continue:\n  ${pageUrl}`,
+          ),
+        );
+      });
     });
   });
 }
@@ -86,12 +279,15 @@ export async function createMiniKitManifest(envPath?: string) {
   try {
     const webpageData = await getWebpageData();
 
-    // Update NEXT_PUBLIC_URL in .env file
+    // Update NEXT_PUBLIC_URL in .env file. Every value below is written with
+    // JSON.stringify so it stays inside its string literal even if validation
+    // is ever relaxed. minikit.config.ts is executed by the scaffolded app, so
+    // a value that escapes its literal is arbitrary code execution.
     const updatedEnv = existingEnv
       .split('\n')
       .map((line) => {
         if (line.startsWith('NEXT_PUBLIC_URL=')) {
-          return `NEXT_PUBLIC_URL="${webpageData.domain}"`;
+          return `NEXT_PUBLIC_URL=${JSON.stringify(webpageData.domain)}`;
         }
         return line;
       })
@@ -99,12 +295,23 @@ export async function createMiniKitManifest(envPath?: string) {
 
     await fs.promises.writeFile(envPath, updatedEnv);
 
-    // Update minikit.config.ts with account association
+    // Update minikit.config.ts with account association. The replacements are
+    // functions so that `$` sequences in the value are not treated as
+    // String.prototype.replace substitution patterns.
     const configContent = await fs.promises.readFile(configPath, 'utf-8');
     const updatedConfig = configContent
-      .replace(/header: ".*"/, `header: "${webpageData.header}"`)
-      .replace(/payload: ".*"/, `payload: "${webpageData.payload}"`)
-      .replace(/signature: ".*"/, `signature: "${webpageData.signature}"`);
+      .replace(
+        /header: ".*"/,
+        () => `header: ${JSON.stringify(webpageData.header)}`,
+      )
+      .replace(
+        /payload: ".*"/,
+        () => `payload: ${JSON.stringify(webpageData.payload)}`,
+      )
+      .replace(
+        /signature: ".*"/,
+        () => `signature: ${JSON.stringify(webpageData.signature)}`,
+      );
 
     await fs.promises.writeFile(configPath, updatedConfig);
 
@@ -117,6 +324,9 @@ export async function createMiniKitManifest(envPath?: string) {
     console.log(
       pc.red('\n* Failed to generate account association. Please try again.'),
     );
+    if (error instanceof Error && error.message) {
+      console.log(pc.red(`  ${error.message}`));
+    }
     return false;
   }
 

--- a/packages/miniapp-manifest-generator/src/components/Page.test.tsx
+++ b/packages/miniapp-manifest-generator/src/components/Page.test.tsx
@@ -49,6 +49,7 @@ describe('Page', () => {
   });
 
   afterEach(() => {
+    window.location.hash = '';
     vi.clearAllMocks();
     vi.resetAllMocks();
     vi.useRealTimers();
@@ -66,7 +67,27 @@ describe('Page', () => {
   it('should initialize WebSocket connection', () => {
     render(<Page />);
 
-    expect(WebSocketMock).toHaveBeenCalledWith('ws://localhost:3333');
+    expect(WebSocketMock).toHaveBeenCalledWith('ws://127.0.0.1:3333');
+  });
+
+  it('should forward the session token from the URL fragment', () => {
+    window.location.hash = '#token=abc123_-';
+
+    render(<Page />);
+
+    expect(WebSocketMock).toHaveBeenCalledWith(
+      'ws://127.0.0.1:3333/?token=abc123_-',
+    );
+  });
+
+  it('should escape a session token containing URL-unsafe characters', () => {
+    window.location.hash = '#token=a%26b';
+
+    render(<Page />);
+
+    expect(WebSocketMock).toHaveBeenCalledWith(
+      'ws://127.0.0.1:3333/?token=a%26b',
+    );
   });
 
   it('should reconnect on WebSocket close', () => {

--- a/packages/miniapp-manifest-generator/src/components/Page.tsx
+++ b/packages/miniapp-manifest-generator/src/components/Page.tsx
@@ -7,7 +7,23 @@ import { Sign } from './steps/Sign';
 
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_DELAY = 1000;
-const WEBSOCKET_URL = 'ws://localhost:3333';
+// Must be the literal loopback address the CLI binds and serves this page from.
+// `localhost` can resolve to either `::1` or `127.0.0.1`, so it could address a
+// different process than the one holding the session token.
+const WEBSOCKET_URL = 'ws://127.0.0.1:3333';
+
+/**
+ * `create-onchain --manifest` opens this page with a single-use token in the
+ * URL fragment and rejects any WebSocket handshake that does not present it.
+ * A fragment is never sent to a server, so only this page holds the token.
+ */
+function getWebSocketUrl() {
+  const fragment = window.location.hash.replace(/^#/, '');
+  const token = new URLSearchParams(fragment).get('token');
+  return token
+    ? `${WEBSOCKET_URL}/?token=${encodeURIComponent(token)}`
+    : WEBSOCKET_URL;
+}
 
 function Page() {
   const wsRef = useRef<WebSocket | null>(null);
@@ -24,7 +40,7 @@ function Page() {
     let reconnectAttempts = 0;
 
     function connectWebSocket() {
-      wsRef.current = new WebSocket(WEBSOCKET_URL);
+      wsRef.current = new WebSocket(getWebSocketUrl());
 
       wsRef.current.onclose = () => {
         if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {


### PR DESCRIPTION
**What changed? Why?**

Fixes SECBUGS-22415 (HackerOne #3858933).

`create-onchain --manifest` served an HTTP + WebSocket server on `0.0.0.0:3333` with no Origin validation and no authentication, then wrote the first message it received verbatim into `minikit.config.ts` and `.env`. `minikit.config.ts` is imported and executed by the scaffolded Next.js app, so a quote character in any field escaped the string literal and ran arbitrary code on every `next dev`, `next build`, and server render. The injected code persisted in the file, and the `domain` field poisoned `NEXT_PUBLIC_URL`, which controls `homeUrl`, `webhookUrl`, and `iconUrl` in the shipped Farcaster manifest.

Any LAN host, or any cross-origin page already open in the developer's browser, could win the race against the wallet-signing flow. The same-origin policy does not restrict WebSocket connections, so this was reachable from a malicious ad or a compromised site.

The ticket proposed three layered fixes. All three are implemented, since each closes a different step of the chain:

| Control | Change | Stops |
| --- | --- | --- |
| Transport | Bind `127.0.0.1` only; accept a handshake only from `http://127.0.0.1:3333` | LAN hosts, cross-origin browser pages, DNS rebinding |
| Authentication | Single-use 256-bit token, delivered in the URL fragment of the page the CLI opens, checked during the handshake with `timingSafeEqual` | Any client that did not receive the page |
| Output encoding | Validate `header`/`payload`/`signature` as base64url and `domain` as a plain `http(s)` URL, then write every value with `JSON.stringify` | The CWE-94 injection primitive itself |

Everything uses the literal `127.0.0.1` rather than `localhost`. `localhost` can resolve to either `::1` or `127.0.0.1`, so a local process squatting `[::1]:3333` could have received the opened page, read the token from the fragment, and then connected to `127.0.0.1:3333` under an allowlisted origin.

**Notes to reviewers**

The fragment is the delivery channel for the token because fragments are stripped before the request is sent and are not included in `Referer`, so the wallet-connect popups the page opens cannot leak it.

This also fixes lifecycle bugs surfaced while adding the above:

- Setting `maxPayload` made an oversized frame emit an unhandled `'error'` on the client socket, which terminates Node. The denial-of-service guard was itself a denial of service. Added `'error'` handlers on the socket, the `WebSocketServer`, and the HTTP server.
- `server.close()` leaves upgraded WebSocket connections open, so an exported call to `createMiniKitManifest()` could keep the process alive. Replaced with an idempotent `settle()` that terminates clients first. The CLI masked this by calling `process.exit(0)` immediately.
- `open()` rejection was an unhandled rejection and an indefinite hang. It now prints the URL so the developer can continue manually.
- `cli.ts` always exited `0`. It now exits `1` on failure, which matters because malformed payloads now intentionally take the failure path.
- `domain` now rejects credentials, a query, and a fragment. These land in `NEXT_PUBLIC_URL`, which the app concatenates onto to build the manifest URLs.

The `JSON.stringify` layer is unreachable given the character allowlists that run before it. That is intentional defence in depth, and it is not separately testable, so no test asserts it in isolation.

Not included: no session timeout. That is pre-existing behaviour, and the token now prevents an attacker from holding the flow open.

**How has it been tested?**

`packages/create-onchain/src/minikit.test.ts` (unit, `http` and `ws` mocked) covers the loopback bind argument, the `verifyClient` predicate for each allow and deny case, `maxPayload`, per-run token uniqueness, and rejection of each malicious field shape.

`packages/create-onchain/src/minikit.manifest-server.test.ts` is new. `minikit.test.ts` mocks the transport, so it can only assert which options were passed. This file runs the real server and drives real WebSocket clients against it, which is the only way to prove a hostile client never reaches the code that writes `minikit.config.ts`. It asserts the config file is byte-identical to the template after each attack.

Verified the new tests are load-bearing by mutating the source:

| Mutation | Result |
| --- | --- |
| Remove the Origin check | 2 tests fail |
| Remove the token check | 3 tests fail |
| Remove the loopback bind argument | 8 tests fail |
| Remove token forwarding in `Page.tsx` | 2 tests fail |

Also ran the built CLI end to end against live WebSocket clients. Every attack variant from the report is refused at the handshake with a 401, the LAN interface is unreachable, an injection payload sent over an authorised connection is rejected by validation and leaves both files untouched, and the legitimate flow writes exactly what it wrote before.

Commands run:

- `pnpm f:create test` — 84 passed, 7 files
- `pnpm f:create test:coverage` — thresholds met
- `pnpm f:create check:types` — clean
- `pnpm f:create build` — clean
- `pnpm f:manifest test` — 61 passed
- `pnpm f:manifest test:coverage` — 100% maintained
- `npx tsc -b --noEmit` in `miniapp-manifest-generator` — clean
- `npx prettier --check` on all touched files — clean
